### PR TITLE
Rulesets-BMS

### DIFF
--- a/osu.Desktop.slnf
+++ b/osu.Desktop.slnf
@@ -6,6 +6,8 @@
       "..\\osu-resources\\osu.Game.Resources\\osu.Game.Resources.csproj",
       "osu.Desktop\\osu.Desktop.csproj",
       "osu.Game.Benchmarks\\osu.Game.Benchmarks.csproj",
+      "osu.Game.Rulesets.BMS.Tests\\osu.Game.Rulesets.BMS.Tests.csproj",
+      "osu.Game.Rulesets.BMS\\osu.Game.Rulesets.BMS.csproj",
       "osu.Game.Rulesets.Catch.Tests\\osu.Game.Rulesets.Catch.Tests.csproj",
       "osu.Game.Rulesets.Catch\\osu.Game.Rulesets.Catch.csproj",
       "osu.Game.Rulesets.Mania.Tests\\osu.Game.Rulesets.Mania.Tests.csproj",

--- a/osu.Desktop/osu.Desktop.csproj
+++ b/osu.Desktop/osu.Desktop.csproj
@@ -32,6 +32,11 @@
     <ProjectReference Include="..\osu.Game.Rulesets.Mania\osu.Game.Rulesets.Mania.csproj" />
     <ProjectReference Include="..\osu.Game.Rulesets.Taiko\osu.Game.Rulesets.Taiko.csproj" />
   </ItemGroup>
+  <!-- BMS Ruleset only loads in Debug configuration -->
+<!--  <ItemGroup Label="Debug-Only References" Condition="'$(Configuration)' == 'Debug'">-->
+  <ItemGroup>
+    <ProjectReference Include="..\osu.Game.Rulesets.BMS\osu.Game.Rulesets.BMS.csproj" />
+  </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="System.IO.Packaging" Version="10.0.5" />
     <!-- Held back due to invite bug in newer versions. See https://github.com/Lachee/discord-rpc-csharp/issues/286-->

--- a/osu.Game.Rulesets.BMS.Tests/Analytics/BmsAnalyticsRepositoryTest.cs
+++ b/osu.Game.Rulesets.BMS.Tests/Analytics/BmsAnalyticsRepositoryTest.cs
@@ -1,0 +1,56 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.IO;
+using NUnit.Framework;
+using osu.Game.Rulesets.BMS.Beatmaps;
+using osu.Game.Rulesets.BMS.UI.BmsSongSelect.Analytics;
+
+namespace osu.Game.Rulesets.BMS.Tests.Analytics
+{
+    [TestFixture]
+    public class BmsAnalyticsRepositoryTest
+    {
+        [Test]
+        public void TestUpsertAndLoad()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bms-analytics-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                string dbPath = Path.Combine(tempDir, BmsStoragePaths.ANALYTICS_DATABASE_FILE);
+                var repository = new BmsAnalyticsSqliteRepository(dbPath);
+
+                const string path_key = "abc123";
+                repository.Upsert(new BmsAnalyticsRecord
+                {
+                    PathKey = path_key,
+                    Pp = 123.4,
+                    XxySr = 5.67,
+                    AvgKps = 8.1,
+                    MaxKps = 12.3,
+                    StarRating = 4.5,
+                    ColumnCountsJson = "{\"0\":10}",
+                });
+
+                Assert.That(repository.TryGet(path_key, out var record), Is.True);
+                Assert.That(record.Pp, Is.EqualTo(123.4).Within(0.01));
+                Assert.That(record.XxySr, Is.EqualTo(5.67).Within(0.01));
+                Assert.That(record.AvgKps, Is.EqualTo(8.1).Within(0.01));
+
+                var all = repository.LoadAll();
+                Assert.That(all.ContainsKey(path_key), Is.True);
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, true); }
+                catch
+                {
+                    /* ignore */
+                }
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS.Tests/BMSBeatmapConverterIsolationTest.cs
+++ b/osu.Game.Rulesets.BMS.Tests/BMSBeatmapConverterIsolationTest.cs
@@ -1,0 +1,45 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.BMS.Beatmaps;
+using osu.Game.Rulesets.BMS.Objects;
+
+namespace osu.Game.Rulesets.BMS.Tests
+{
+    [TestFixture]
+    public class BMSBeatmapConverterIsolationTest
+    {
+        [Test]
+        public void TestConvertedBeatmapsDoNotShareHitObjectInstances()
+        {
+            var sourceBeatmap = new Beatmap
+            {
+                HitObjects =
+                {
+                    new BMSHoldNote
+                    {
+                        StartTime = 1000,
+                        Duration = 500,
+                        Column = 0,
+                        IsScratch = true
+                    }
+                }
+            };
+
+            var ruleset = new BMSRuleset();
+            var converter = new BMSBeatmapConverter(sourceBeatmap, ruleset);
+
+            var convertedA = converter.Convert();
+            var convertedB = converter.Convert();
+
+            var holdA = convertedA.HitObjects.OfType<BMSHoldNote>().Single();
+            var holdB = convertedB.HitObjects.OfType<BMSHoldNote>().Single();
+
+            Assert.That(ReferenceEquals(holdA, holdB), Is.False, "conversions must not share mutable hitobject instances");
+            Assert.That(ReferenceEquals(holdA, sourceBeatmap.HitObjects.Single()), Is.False, "converted object must be detached from source beatmap");
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS.Tests/BMSBeatmapDecoderLoadTest.cs
+++ b/osu.Game.Rulesets.BMS.Tests/BMSBeatmapDecoderLoadTest.cs
@@ -1,0 +1,78 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.IO;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.IO;
+using osu.Game.Rulesets.BMS.Beatmaps;
+using osu.Game.Rulesets.BMS.Objects;
+
+namespace osu.Game.Rulesets.BMS.Tests
+{
+    [TestFixture]
+    public class BMSBeatmapDecoderLoadTest
+    {
+        [Test]
+        public void TestDecodeMinimalChartProducesPlayableBmsBeatmap()
+        {
+            const string bms = """
+                               #TITLE Unit Test Song
+                               #ARTIST Unit Test Artist
+                               #GENRE TEST
+                               #BPM 150
+                               #WAV01 kick.wav
+                               #STOP01 192
+                               #SCROLL 1.0
+                               #00111:0100
+                               #00109:0100
+                               """;
+
+            var decoder = new BMSBeatmapDecoder();
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(bms));
+            using var reader = new LineBufferedReader(stream);
+
+            Beatmap beatmap = decoder.Decode(reader);
+
+            Assert.That(beatmap, Is.TypeOf<BMSBeatmap>());
+            Assert.That(beatmap.HitObjects.OfType<BMSHitObject>().Any(), Is.True, "decoded beatmap should contain at least one BMS hit object");
+            Assert.That(beatmap.BeatmapInfo.Metadata.Title, Is.EqualTo("Unit Test Song"));
+            Assert.That(beatmap.BeatmapInfo.Metadata.Artist, Is.EqualTo("Unit Test Artist"));
+            Assert.That(beatmap.BeatmapInfo.Metadata.Tags, Does.Contain("bms"));
+            Assert.That(beatmap.BeatmapInfo.Metadata.Tags, Does.Contain("stop"));
+            Assert.That(beatmap.BeatmapInfo.Metadata.Tags, Does.Contain("scroll"));
+        }
+
+        [Test]
+        public void TestDecodeTenPlusTwoChartCompactsToTwelveColumns()
+        {
+            const string bms = """
+                               #TITLE 10+2
+                               #WAV01 hit.wav
+                               #00111:01
+                               #00112:01
+                               #00113:01
+                               #00114:01
+                               #00115:01
+                               #00116:01
+                               #00121:01
+                               #00122:01
+                               #00123:01
+                               #00124:01
+                               #00125:01
+                               #00126:01
+                               """;
+
+            var decoder = new BMSBeatmapDecoder();
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(bms));
+            using var reader = new LineBufferedReader(stream);
+
+            var beatmap = decoder.Decode(reader);
+            int columns = beatmap.HitObjects.OfType<BMSHitObject>().Select(h => h.Column).DefaultIfEmpty(-1).Max() + 1;
+
+            Assert.That(columns, Is.EqualTo(12));
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS.Tests/BMSBeatmapManagerSourceMapTest.cs
+++ b/osu.Game.Rulesets.BMS.Tests/BMSBeatmapManagerSourceMapTest.cs
@@ -1,0 +1,115 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using NUnit.Framework;
+using osu.Game.Rulesets.BMS.Beatmaps;
+using osu.Game.Rulesets.BMS.Beatmaps.Persistence;
+
+namespace osu.Game.Rulesets.BMS.Tests
+{
+    [TestFixture]
+    public class BMSBeatmapManagerSourceMapTest
+    {
+        [Test]
+        public void TestSourceMapReadWhileCatalogRebuildDoesNotThrow()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bms-source-map-test-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                var manager = new BMSBeatmapManager(tempDir);
+                var index = new BmsLibraryIndexRepository(Path.Combine(tempDir, BmsStoragePaths.INDEX_DATABASE_FILE));
+                index.ImportFromLibraryCache(new BMSLibraryCache
+                {
+                    Songs =
+                    {
+                        new BMSSongCache
+                        {
+                            FolderPath = @"E:\bms\song-a",
+                            Title = "Song A",
+                            Artist = "Artist A",
+                            LastModified = DateTime.UtcNow,
+                            Charts =
+                            {
+                                new BMSChartCache
+                                {
+                                    FolderPath = @"E:\bms\song-a",
+                                    FileName = "a.bms",
+                                    Md5Hash = BmsPathKeys.ComputeChartPathKey(@"E:\bms\song-a\a.bms"),
+                                    Title = "A",
+                                    Artist = "AA",
+                                    KeyCount = 7,
+                                }
+                            }
+                        },
+                        new BMSSongCache
+                        {
+                            FolderPath = @"E:\bms\song-b",
+                            Title = "Song B",
+                            Artist = "Artist B",
+                            LastModified = DateTime.UtcNow,
+                            Charts =
+                            {
+                                new BMSChartCache
+                                {
+                                    FolderPath = @"E:\bms\song-b",
+                                    FileName = "b.bms",
+                                    Md5Hash = BmsPathKeys.ComputeChartPathKey(@"E:\bms\song-b\b.bms"),
+                                    Title = "B",
+                                    Artist = "BB",
+                                    KeyCount = 7,
+                                }
+                            }
+                        }
+                    }
+                });
+                manager.LoadCache();
+
+                string pathKeyA = BmsPathKeys.ComputeChartPathKey(@"E:\bms\song-a\a.bms");
+                string pathKeyB = BmsPathKeys.ComputeChartPathKey(@"E:\bms\song-b\b.bms");
+
+                var rulesetInfo = new BMSRuleset().RulesetInfo;
+                var errors = new ConcurrentQueue<Exception>();
+
+                Parallel.For(0, 60, i =>
+                {
+                    try
+                    {
+                        manager.BuildVirtualBeatmapCatalog(rulesetInfo);
+                        manager.TryGetSourceReferenceByHash(pathKeyA, out _);
+                        manager.TryGetSourceReferenceByHash(pathKeyB, out _);
+                        _ = manager.GetCurrentSourceMap().Count;
+                    }
+                    catch (Exception ex)
+                    {
+                        errors.Enqueue(ex);
+                    }
+                });
+
+                Assert.That(errors.Count, Is.EqualTo(0), errors.TryPeek(out var e) ? e.ToString() : string.Empty);
+                Assert.That(manager.TryGetSourceReferenceByHash(pathKeyA, out _), Is.True);
+                Assert.That(manager.TryGetSourceReferenceByHash(pathKeyB, out _), Is.True);
+            }
+            finally
+            {
+                try
+                {
+                    SqliteConnection.ClearAllPools();
+                }
+                catch
+                {
+                    // Best effort.
+                }
+
+                if (Directory.Exists(tempDir))
+                    Directory.Delete(tempDir, true);
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS.Tests/BMSCollectionCreationTest.cs
+++ b/osu.Game.Rulesets.BMS.Tests/BMSCollectionCreationTest.cs
@@ -1,0 +1,227 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.Collections;
+using osu.Game.Rulesets.BMS.Beatmaps;
+
+namespace osu.Game.Rulesets.BMS.Tests
+{
+    [TestFixture]
+    public class BMSCollectionCreationTest
+    {
+        [Test]
+        public void TestCreateCollectionFromSinglePath()
+        {
+            // 创建临时目录和BMS文件
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bms-test-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                // 创建几个测试用的BMS文件
+                var bmsFiles = new List<string>();
+
+                for (int i = 0; i < 3; i++)
+                {
+                    string bmsFile = Path.Combine(tempDir, $"test{i}.bms");
+                    File.WriteAllText(bmsFile, "#TITLE test\n#ARTIST test\n");
+                    bmsFiles.Add(bmsFile);
+                }
+
+                // 计算MD5哈希值
+                var beatmapHashes = new List<string>();
+
+                foreach (string bmsFile in bmsFiles)
+                {
+                    string md5Hash = BmsPathKeys.ComputeChartPathKey(bmsFile);
+                    beatmapHashes.Add(md5Hash);
+                }
+
+                // 验证哈希值不为空
+                Assert.That(beatmapHashes.Count, Is.EqualTo(3));
+                Assert.That(beatmapHashes.All(h => !string.IsNullOrEmpty(h)), Is.True);
+
+                // 模拟创建收藏夹
+                string collectionName = Path.GetFileName(tempDir);
+                var collection = new BeatmapCollection(collectionName, beatmapHashes);
+
+                // 验证收藏夹创建成功
+                Assert.That(collection.Name, Is.EqualTo(collectionName));
+                Assert.That(collection.BeatmapMD5Hashes.Count, Is.EqualTo(3));
+                Assert.That(collection.BeatmapMD5Hashes, Is.EquivalentTo(beatmapHashes));
+            }
+            finally
+            {
+                // 清理临时目录
+                if (Directory.Exists(tempDir))
+                {
+                    Directory.Delete(tempDir, true);
+                }
+            }
+        }
+
+        [Test]
+        public void TestCreateMultipleCollectionsFromMultiplePaths()
+        {
+            // 创建多个临时目录
+            var tempDirs = new List<string>();
+            var allCollections = new List<BeatmapCollection>();
+
+            try
+            {
+                for (int dirIndex = 0; dirIndex < 3; dirIndex++)
+                {
+                    string tempDir = Path.Combine(Path.GetTempPath(), $"bms-test-dir{dirIndex}-{Guid.NewGuid():N}");
+                    Directory.CreateDirectory(tempDir);
+                    tempDirs.Add(tempDir);
+
+                    // 在每个目录中创建BMS文件
+                    var bmsFiles = new List<string>();
+
+                    for (int i = 0; i < 2; i++)
+                    {
+                        string bmsFile = Path.Combine(tempDir, $"test{i}.bms");
+                        File.WriteAllText(bmsFile, $"#TITLE test{dirIndex}\n#ARTIST test{dirIndex}\n");
+                        bmsFiles.Add(bmsFile);
+                    }
+
+                    // 计算该目录的哈希值并创建收藏夹
+                    var beatmapHashes = new List<string>();
+
+                    foreach (string bmsFile in bmsFiles)
+                    {
+                        string md5Hash = BmsPathKeys.ComputeChartPathKey(bmsFile);
+                        beatmapHashes.Add(md5Hash);
+                    }
+
+                    string collectionName = Path.GetFileName(tempDir);
+                    var collection = new BeatmapCollection(collectionName, beatmapHashes);
+                    allCollections.Add(collection);
+                }
+
+                // 验证每个收藏夹都正确创建
+                Assert.That(allCollections.Count, Is.EqualTo(3));
+
+                for (int i = 0; i < 3; i++)
+                {
+                    Assert.That(allCollections[i].BeatmapMD5Hashes.Count, Is.EqualTo(2));
+                    Assert.That(allCollections[i].Name, Does.Contain($"dir{i}"));
+                }
+            }
+            finally
+            {
+                // 清理所有临时目录
+                foreach (string tempDir in tempDirs)
+                {
+                    if (Directory.Exists(tempDir))
+                    {
+                        Directory.Delete(tempDir, true);
+                    }
+                }
+            }
+        }
+
+        [Test]
+        public void TestComputeChartPathKeyConsistency()
+        {
+            string testPath = @"E:\BMS\test.bms";
+
+            // 验证相同路径生成相同哈希
+            string hash1 = BmsPathKeys.ComputeChartPathKey(testPath);
+            string hash2 = BmsPathKeys.ComputeChartPathKey(testPath);
+
+            Assert.That(hash1, Is.EqualTo(hash2));
+            Assert.That(hash1, Is.Not.Empty);
+        }
+
+        [Test]
+        public void TestComputeChartPathKeyDifferentPaths()
+        {
+            string path1 = @"E:\BMS\test1.bms";
+            string path2 = @"E:\BMS\test2.bms";
+
+            // 验证不同路径生成不同哈希
+            string hash1 = BmsPathKeys.ComputeChartPathKey(path1);
+            string hash2 = BmsPathKeys.ComputeChartPathKey(path2);
+
+            Assert.That(hash1, Is.Not.EqualTo(hash2));
+        }
+
+        [Test]
+        public void TestCollectionNameFromPath()
+        {
+            // 测试从路径提取收藏夹名称
+            string path1 = @"E:\BMS\MySongs";
+            string path2 = @"E:\BMS\MySongs\";
+            string path3 = @"C:\Music\BMS Collection";
+
+            string name1 = Path.GetFileName(path1.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+            string name2 = Path.GetFileName(path2.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+            string name3 = Path.GetFileName(path3.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+
+            Assert.That(name1, Is.EqualTo("MySongs"));
+            Assert.That(name2, Is.EqualTo("MySongs"));
+            Assert.That(name3, Is.EqualTo("BMS Collection"));
+        }
+
+        [Test]
+        public void TestCollectionNameWithDuplicateHandling()
+        {
+            // 模拟处理重复名称的逻辑
+            var usedCollectionNames = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+            // 第一个 "BMS Collection"
+            string name1 = "BMS Collection";
+
+            if (usedCollectionNames.TryGetValue(name1, out int name1Count))
+            {
+                name1Count++;
+                usedCollectionNames[name1] = name1Count;
+                name1 = $"{name1} ({name1Count})";
+            }
+            else
+            {
+                usedCollectionNames[name1] = 0;
+            }
+
+            Assert.That(name1, Is.EqualTo("BMS Collection"));
+
+            // 第二个 "BMS Collection" -> 应该变成 "BMS Collection (1)"
+            string name2 = "BMS Collection";
+
+            if (usedCollectionNames.TryGetValue(name2, out int name2Count))
+            {
+                name2Count++;
+                usedCollectionNames[name2] = name2Count;
+                name2 = $"{name2} ({name2Count})";
+            }
+            else
+            {
+                usedCollectionNames[name2] = 0;
+            }
+
+            Assert.That(name2, Is.EqualTo("BMS Collection (1)"));
+
+            // 第三个 "BMS Collection" -> 应该变成 "BMS Collection (2)"
+            string name3 = "BMS Collection";
+
+            if (usedCollectionNames.TryGetValue(name3, out int name3Count))
+            {
+                name3Count++;
+                usedCollectionNames[name3] = name3Count;
+                name3 = $"{name3} ({name3Count})";
+            }
+            else
+            {
+                usedCollectionNames[name3] = 0;
+            }
+
+            Assert.That(name3, Is.EqualTo("BMS Collection (2)"));
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS.Tests/BMSExternalPathTest.cs
+++ b/osu.Game.Rulesets.BMS.Tests/BMSExternalPathTest.cs
@@ -1,0 +1,124 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.IO;
+using System.Text;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ExternalLibraries;
+using osu.Game.Rulesets.BMS.Beatmaps;
+
+namespace osu.Game.Rulesets.BMS.Tests
+{
+    [TestFixture]
+    public class BMSExternalPathTest
+    {
+        [Test]
+        public void TestEncodeProducesPrefixedBase64()
+        {
+            string encoded = BMSExternalPath.Encode("F:/MUG BMS/MUG.MAP.BMS/Some Folder");
+
+            Assert.That(encoded, Does.StartWith(ExternalBeatmapPathEncoding.HASH_PREFIX));
+        }
+
+        [Test]
+        public void TestEncodeDecodeRoundtrip()
+        {
+            const string folder = "F:/MUG BMS/MUG.MAP.BMS/Some Folder";
+
+            string encoded = BMSExternalPath.Encode(folder);
+
+            Assert.That(BMSExternalPath.TryDecodeRaw(encoded, out string decoded), Is.True);
+            Assert.That(decoded, Is.EqualTo(Path.GetFullPath(folder)));
+        }
+
+        [Test]
+        public void TestTryDecodeLegacyHashRoundtrip()
+        {
+            const string folder = "F:/legacy-bms/folder";
+
+            string legacyHash = BMSExternalPath.LEGACY_HASH_PREFIX + Convert.ToBase64String(Encoding.UTF8.GetBytes(folder));
+
+            Assert.That(BMSExternalPath.TryDecodeRaw(legacyHash, out string decoded), Is.True);
+            Assert.That(decoded, Is.EqualTo(Path.GetFullPath(folder)));
+        }
+
+        [Test]
+        public void TestTryGetContentRootPrefersExternalContentRootField()
+        {
+            string folder = Path.Combine(Path.GetTempPath(), "bms-content-root-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(folder);
+
+            try
+            {
+                var set = new BeatmapSetInfo
+                {
+                    Hash = "unrelated-hash",
+                    ExternalContentRoot = folder,
+                    HostingKind = BeatmapSetHostingKind.External,
+                };
+
+                Assert.That(BMSExternalPath.TryGetContentRoot(set, out string resolved), Is.True);
+                Assert.That(resolved, Is.EqualTo(folder));
+            }
+            finally
+            {
+                Directory.Delete(folder);
+            }
+        }
+
+        [Test]
+        public void TestTryDecodeRejectsNullOrEmpty()
+        {
+            Assert.That(BMSExternalPath.TryDecode(null, out _), Is.False);
+            Assert.That(BMSExternalPath.TryDecode(string.Empty, out _), Is.False);
+            Assert.That(BMSExternalPath.TryDecodeRaw(null, out _), Is.False);
+            Assert.That(BMSExternalPath.TryDecodeRaw(string.Empty, out _), Is.False);
+        }
+
+        [Test]
+        public void TestTryDecodeRejectsUnrelatedHashes()
+        {
+            Assert.That(BMSExternalPath.TryDecode("abc123", out _), Is.False);
+            Assert.That(BMSExternalPath.TryDecodeRaw("abc123", out _), Is.False);
+            Assert.That(BMSExternalPath.TryDecode("bms-other:set:abc", out _), Is.False);
+        }
+
+        [Test]
+        public void TestTryDecodeHandlesMalformedBase64()
+        {
+            string malformed = ExternalBeatmapPathEncoding.HASH_PREFIX + "@@@@@";
+
+            Assert.That(BMSExternalPath.TryDecode(malformed, out string folderPath), Is.False);
+            Assert.That(folderPath, Is.EqualTo(string.Empty));
+            Assert.That(BMSExternalPath.TryDecodeRaw(malformed, out folderPath), Is.False);
+            Assert.That(folderPath, Is.EqualTo(string.Empty));
+        }
+
+        [Test]
+        public void TestTryDecodeReturnsTrueOnlyWhenFolderExists()
+        {
+            string nonExistentFolder = Path.Combine(Path.GetTempPath(), "bms-ext-nonexistent-" + Guid.NewGuid().ToString("N"));
+            string encoded = BMSExternalPath.Encode(nonExistentFolder);
+
+            Assert.That(BMSExternalPath.TryDecode(encoded, out _), Is.False);
+            Assert.That(BMSExternalPath.TryDecodeRaw(encoded, out string decoded), Is.True);
+            Assert.That(decoded, Is.EqualTo(nonExistentFolder));
+
+            string existentFolder = Path.Combine(Path.GetTempPath(), "bms-ext-existent-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(existentFolder);
+
+            try
+            {
+                string existentEncoded = BMSExternalPath.Encode(existentFolder);
+                Assert.That(BMSExternalPath.TryDecode(existentEncoded, out string existentDecoded), Is.True);
+                Assert.That(existentDecoded, Is.EqualTo(existentFolder));
+            }
+            finally
+            {
+                Directory.Delete(existentFolder);
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS.Tests/BMSExternalSampleSkinTest.cs
+++ b/osu.Game.Rulesets.BMS.Tests/BMSExternalSampleSkinTest.cs
@@ -1,0 +1,175 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Audio.Sample;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Textures;
+using osu.Game.Audio;
+using osu.Game.Rulesets.BMS.Beatmaps;
+using osu.Game.Skinning;
+
+namespace osu.Game.Rulesets.BMS.Tests
+{
+    [TestFixture]
+    public class BMSExternalSampleSkinTest
+    {
+        [Test]
+        public void TestInnerSkinIsAlwaysAskedFirst()
+        {
+            var inner = new TrackingSkin();
+            string folder = createTempFolder();
+
+            try
+            {
+                var skin = new BMSExternalSampleSkin(inner, folder, () => null);
+                skin.GetSample(new TestSampleInfo(new[] { "kick.wav" }));
+
+                Assert.That(inner.SampleLookups, Has.Count.EqualTo(1));
+            }
+            finally
+            {
+                Directory.Delete(folder, true);
+            }
+        }
+
+        [Test]
+        public void TestNullAudioProviderDegradesGracefully()
+        {
+            var inner = new TrackingSkin();
+            string folder = createTempFolder();
+
+            try
+            {
+                File.WriteAllText(Path.Combine(folder, "kick.wav"), "x");
+
+                var skin = new BMSExternalSampleSkin(inner, folder, () => null);
+                Assert.That(skin.GetSample(new TestSampleInfo(new[] { "kick.wav" })), Is.Null);
+            }
+            finally
+            {
+                Directory.Delete(folder, true);
+            }
+        }
+
+        [Test]
+        public void TestMissingFolderDegradesGracefully()
+        {
+            var inner = new TrackingSkin();
+            string nonExistent = Path.Combine(Path.GetTempPath(), "bms-skin-missing-" + Guid.NewGuid().ToString("N"));
+
+            var skin = new BMSExternalSampleSkin(inner, nonExistent, () => null);
+            Assert.DoesNotThrow(() => skin.GetSample(new TestSampleInfo(new[] { "missing" })));
+        }
+
+        [Test]
+        public void TestEmptyLookupNamesReturnsNullWithoutThrowing()
+        {
+            var inner = new TrackingSkin();
+            string folder = createTempFolder();
+
+            try
+            {
+                var skin = new BMSExternalSampleSkin(inner, folder, () => null);
+
+                Assert.DoesNotThrow(() => skin.GetSample(new TestSampleInfo(Array.Empty<string>())));
+                Assert.DoesNotThrow(() => skin.GetSample(new TestSampleInfo(new[] { string.Empty, "  ", null! })));
+            }
+            finally
+            {
+                Directory.Delete(folder, true);
+            }
+        }
+
+        [Test]
+        public void TestPassThroughTextureAndConfig()
+        {
+            var inner = new TrackingSkin();
+            string folder = createTempFolder();
+
+            try
+            {
+                var skin = new BMSExternalSampleSkin(inner, folder, () => null);
+
+                Assert.That(skin.GetTexture("anything", default, default), Is.Null);
+                Assert.That(skin.GetConfig<string, string>("any"), Is.Null);
+                Assert.That(inner.TextureLookups, Has.Count.EqualTo(1));
+                Assert.That(inner.ConfigLookups, Has.Count.EqualTo(1));
+            }
+            finally
+            {
+                Directory.Delete(folder, true);
+            }
+        }
+
+        [Test]
+        public void TestNullInnerThrows()
+        {
+            string folder = createTempFolder();
+
+            try
+            {
+                Assert.That(() => new BMSExternalSampleSkin(null!, folder, () => null), Throws.ArgumentNullException);
+                Assert.That(() => new BMSExternalSampleSkin(new TrackingSkin(), folder, null!), Throws.ArgumentNullException);
+            }
+            finally
+            {
+                Directory.Delete(folder, true);
+            }
+        }
+
+        private static string createTempFolder()
+        {
+            string folder = Path.Combine(Path.GetTempPath(), "bms-skin-test-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(folder);
+            return folder;
+        }
+
+        private class TestSampleInfo : ISampleInfo
+        {
+            private readonly string[] lookupNames;
+
+            public TestSampleInfo(IEnumerable<string?> lookupNames)
+            {
+                this.lookupNames = lookupNames.Select(name => name ?? string.Empty).ToArray();
+            }
+
+            public IEnumerable<string> LookupNames => lookupNames;
+            public int Volume => 100;
+        }
+
+        private class TrackingSkin : ISkin
+        {
+            public List<ISampleInfo> SampleLookups { get; } = new List<ISampleInfo>();
+            public List<string> TextureLookups { get; } = new List<string>();
+            public List<object> ConfigLookups { get; } = new List<object>();
+
+            public Drawable? GetDrawableComponent(ISkinComponentLookup lookup) => null;
+
+            public Texture? GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT)
+            {
+                TextureLookups.Add(componentName);
+                return null;
+            }
+
+            public ISample? GetSample(ISampleInfo sampleInfo)
+            {
+                SampleLookups.Add(sampleInfo);
+                return null;
+            }
+
+            public IBindable<TValue>? GetConfig<TLookup, TValue>(TLookup lookup)
+                where TLookup : notnull
+                where TValue : notnull
+            {
+                ConfigLookups.Add(lookup);
+                return null;
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS.Tests/BMSHoldNoteNestedTest.cs
+++ b/osu.Game.Rulesets.BMS.Tests/BMSHoldNoteNestedTest.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using NUnit.Framework;
+using osu.Game.Rulesets.BMS.Objects;
+
+namespace osu.Game.Rulesets.BMS.Tests
+{
+    [TestFixture]
+    public class BMSHoldNoteNestedTest
+    {
+        [Test]
+        public void TestHoldNoteCreatesHeadBodyTailNestedObjects()
+        {
+            var hold = new BMSHoldNote
+            {
+                StartTime = 1000,
+                Duration = 600,
+                Column = 3,
+            };
+
+            typeof(BMSHoldNote).GetMethod("CreateNestedHitObjects", BindingFlags.Instance | BindingFlags.NonPublic)!
+                               .Invoke(hold, new object[] { CancellationToken.None });
+
+            Assert.That(hold.NestedHitObjects.Count, Is.EqualTo(3));
+            Assert.That(hold.NestedHitObjects.OfType<BMSHoldNoteHead>().Single().StartTime, Is.EqualTo(1000).Within(0.01));
+            Assert.That(hold.NestedHitObjects.OfType<BMSHoldNoteTail>().Single().StartTime, Is.EqualTo(1600).Within(0.01));
+            Assert.That(hold.NestedHitObjects.OfType<BMSHoldNoteBody>().Single().Duration, Is.EqualTo(600).Within(0.01));
+            Assert.That(hold.NestedHitObjects.All(n => ((BMSHitObject)n).Column == 3), Is.True);
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS.Tests/BMSJudgementObjectTest.cs
+++ b/osu.Game.Rulesets.BMS.Tests/BMSJudgementObjectTest.cs
@@ -1,0 +1,45 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Rulesets.BMS.Objects;
+using osu.Game.Rulesets.Judgements;
+
+namespace osu.Game.Rulesets.BMS.Tests
+{
+    [TestFixture]
+    public class BMSJudgementObjectTest
+    {
+        [Test]
+        public void TestBMSNoteUsesRegularJudgement()
+        {
+            var note = new BMSNote();
+
+            Assert.That(note.CreateJudgement(), Is.TypeOf<Judgement>());
+        }
+
+        [Test]
+        public void TestBMSHoldNoteUsesIgnoreJudgementForParent()
+        {
+            var hold = new BMSHoldNote();
+
+            Assert.That(hold.CreateJudgement(), Is.TypeOf<IgnoreJudgement>());
+        }
+
+        [Test]
+        public void TestBMSHoldNoteBodyUsesIgnoreJudgement()
+        {
+            var body = new BMSHoldNoteBody();
+
+            Assert.That(body.CreateJudgement(), Is.TypeOf<IgnoreJudgement>());
+        }
+
+        [Test]
+        public void TestBMSHoldNoteTailUsesRegularJudgement()
+        {
+            var tail = new BMSHoldNoteTail();
+
+            Assert.That(tail.CreateJudgement(), Is.TypeOf<Judgement>());
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS.Tests/BMSOrderedHitPolicyPrecedenceTest.cs
+++ b/osu.Game.Rulesets.BMS.Tests/BMSOrderedHitPolicyPrecedenceTest.cs
@@ -1,0 +1,89 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.Rulesets.Mania.EzMania.Helper;
+
+namespace osu.Game.Rulesets.BMS.Tests
+{
+    [TestFixture]
+    public class BMSOrderedHitPolicyPrecedenceTest
+    {
+        [Test]
+        public void TestComboPrecedencePrefersEarlierComboPath()
+        {
+            double[] notes = { 100, 200, 300 };
+            double[] presses = { 160, 220 };
+
+            var picked = selectByPrecedence(notes, presses, EzEnumJudgePrecedence.Combo, goodEarly: 112, goodLate: 112);
+
+            Assert.That(picked, Is.EqualTo(new[] { 100d, 200d }));
+        }
+
+        [Test]
+        public void TestDurationPrecedencePrefersNearestPath()
+        {
+            double[] notes = { 100, 200, 300 };
+            double[] presses = { 160, 220 };
+
+            var picked = selectByPrecedence(notes, presses, EzEnumJudgePrecedence.Duration, goodEarly: 112, goodLate: 112);
+
+            Assert.That(picked, Is.EqualTo(new[] { 200d, 300d }));
+        }
+
+        private static List<double> selectByPrecedence(
+            IEnumerable<double> noteTimes,
+            IEnumerable<double> pressTimes,
+            EzEnumJudgePrecedence precedence,
+            double goodEarly,
+            double goodLate)
+        {
+            var remaining = noteTimes.OrderBy(t => t).ToList();
+            var selected = new List<double>();
+
+            foreach (double press in pressTimes)
+            {
+                if (remaining.Count == 0)
+                    break;
+
+                double winner = remaining[0];
+
+                for (int i = 1; i < remaining.Count; i++)
+                {
+                    double candidate = remaining[i];
+                    bool shouldReplace = precedence switch
+                    {
+                        EzEnumJudgePrecedence.Combo => compareComboByPrecedence(
+                            winner,
+                            candidate,
+                            press,
+                            goodEarly,
+                            goodLate),
+                        EzEnumJudgePrecedence.Duration => compareDurationByPrecedence(
+                            winner,
+                            candidate,
+                            press),
+                        _ => false
+                    };
+
+                    if (shouldReplace)
+                        winner = candidate;
+                }
+
+                selected.Add(winner);
+                remaining.Remove(winner);
+            }
+
+            return selected;
+        }
+
+        private static bool compareComboByPrecedence(double t1, double t2, double pressTime, double goodEarly, double goodLate)
+            => OrderedHitPolicyHelper.CompareComboByPrecedence(t1, t2, pressTime, goodEarly, goodLate);
+
+        private static bool compareDurationByPrecedence(double t1, double t2, double pressTime)
+            => OrderedHitPolicyHelper.CompareDurationByPrecedence(t1, t2, pressTime);
+    }
+}

--- a/osu.Game.Rulesets.BMS.Tests/BMSRegressionGuardTest.cs
+++ b/osu.Game.Rulesets.BMS.Tests/BMSRegressionGuardTest.cs
@@ -1,0 +1,83 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Reflection;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.BMS.Beatmaps;
+using osu.Game.Rulesets.BMS.Objects;
+using osu.Game.Rulesets.BMS.Objects.Drawables;
+using osu.Game.Rulesets.Mania.Beatmaps;
+
+namespace osu.Game.Rulesets.BMS.Tests
+{
+    [TestFixture]
+    public class BMSRegressionGuardTest
+    {
+        [Test]
+        public void TestBeatmapManagerBuildTagsIncludesAllFeatureFlags()
+        {
+            var chart = new BMSChartCache
+            {
+                KeyCount = 7,
+                HasScratch = true,
+                HasLongNotes = true,
+                HasStopSequence = true,
+                HasScrollChanges = true,
+                HasBgaLayer = true
+            };
+
+            string tags = invokeBuildTags(chart);
+
+            Assert.That(tags, Does.Contain("bms"));
+            Assert.That(tags, Does.Contain("key7"));
+            Assert.That(tags, Does.Contain("scratch"));
+            Assert.That(tags, Does.Contain("ln"));
+            Assert.That(tags, Does.Contain("stop"));
+            Assert.That(tags, Does.Contain("scroll"));
+            Assert.That(tags, Does.Contain("bga"));
+        }
+
+        [Test]
+        public void TestDrawableBMSNoteLoadDoesNotThrowInvalidOperation()
+        {
+            var drawable = new DrawableBMSNote(new BMSNote());
+            MethodInfo loadMethod = typeof(DrawableBMSNote).GetMethod("load", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+            TestDelegate action = () => loadMethod.Invoke(drawable, null);
+
+            Assert.That(action, Throws.Nothing);
+        }
+
+        [Test]
+        public void TestManiaSkinBeatmapAdapterUsesBeatmapColumnCount()
+        {
+            var beatmap = new Beatmap<BMSHitObject>
+            {
+                Difficulty =
+                {
+                    CircleSize = 14
+                }
+            };
+            beatmap.HitObjects.Add(new BMSNote
+            {
+                StartTime = 1000,
+                Column = 0,
+                IsScratch = true
+            });
+
+            MethodInfo adapter = typeof(BMSRuleset).GetMethod("createManiaSkinBeatmap", BindingFlags.Static | BindingFlags.NonPublic)!;
+            var maniaBeatmap = (ManiaBeatmap)adapter.Invoke(null, new object[] { beatmap })!;
+
+            TestDelegate action = () => maniaBeatmap.GetStageForColumnIndex(13);
+
+            Assert.That(action, Throws.Nothing);
+        }
+
+        private static string invokeBuildTags(BMSChartCache chart)
+        {
+            MethodInfo buildTags = typeof(BMSBeatmapManager).GetMethod("buildTags", BindingFlags.Static | BindingFlags.NonPublic)!;
+            return (string)buildTags.Invoke(null, new object[] { chart })!;
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS.Tests/BMSRulesetConfigGameplayRouteTest.cs
+++ b/osu.Game.Rulesets.BMS.Tests/BMSRulesetConfigGameplayRouteTest.cs
@@ -1,0 +1,63 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using NUnit.Framework;
+using osu.Framework.Bindables;
+using osu.Game.Rulesets.BMS.Configuration;
+
+namespace osu.Game.Rulesets.BMS.Tests
+{
+    /// <summary>
+    /// Verifies that the gameplay-route preference exposed in BMS settings is wired up correctly:
+    /// it has a sensible default, persists round-trip, and shares state across managers (so any
+    /// entry into BMS gameplay reads the same flag).
+    /// </summary>
+    [TestFixture]
+    public class BMSRulesetConfigGameplayRouteTest
+    {
+        [Test]
+        public void TestDefaultsToManiaCompatibility()
+        {
+            var ruleset = new BMSRuleset();
+
+            using var manager = new BMSRulesetConfigManager(null, ruleset.RulesetInfo);
+
+            BMSGameplayRoute route = manager.Get<BMSGameplayRoute>(BMSRulesetSetting.GameplayRoute);
+
+            Assert.That(route, Is.EqualTo(BMSGameplayRoute.ManiaCompatibility));
+        }
+
+        [Test]
+        public void TestBindableReflectsSetValue()
+        {
+            var ruleset = new BMSRuleset();
+
+            using var manager = new BMSRulesetConfigManager(null, ruleset.RulesetInfo);
+
+            Bindable<BMSGameplayRoute> bindable = manager.GetBindable<BMSGameplayRoute>(BMSRulesetSetting.GameplayRoute);
+
+            Assert.That(bindable.Value, Is.EqualTo(BMSGameplayRoute.ManiaCompatibility));
+
+            bindable.Value = BMSGameplayRoute.BmsNative;
+
+            Assert.That(manager.Get<BMSGameplayRoute>(BMSRulesetSetting.GameplayRoute), Is.EqualTo(BMSGameplayRoute.BmsNative));
+        }
+
+        [Test]
+        public void TestEnumValuesAreStable()
+        {
+            // Guard against accidental enum-value reordering, which would silently flip every user's saved preference.
+            Assert.That((int)BMSGameplayRoute.ManiaCompatibility, Is.EqualTo(0));
+            Assert.That((int)BMSGameplayRoute.BmsNative, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void TestSettingEnumContainsGameplayRoute()
+        {
+            // Once added, the setting key is part of stored data; renaming would orphan existing values.
+            string[] names = Enum.GetNames(typeof(BMSRulesetSetting));
+            Assert.That(names, Contains.Item(nameof(BMSRulesetSetting.GameplayRoute)));
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS.Tests/BMSRulesetKeyCountDisplayTest.cs
+++ b/osu.Game.Rulesets.BMS.Tests/BMSRulesetKeyCountDisplayTest.cs
@@ -1,0 +1,52 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Reflection;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+
+namespace osu.Game.Rulesets.BMS.Tests
+{
+    [TestFixture]
+    public class BMSRulesetKeyCountDisplayTest
+    {
+        private static float invokeGetDisplayKeyCount(BeatmapInfo beatmapInfo)
+        {
+            var method = typeof(BMSRuleset).GetMethod("getDisplayKeyCount", BindingFlags.Static | BindingFlags.NonPublic)!;
+            return (float)method.Invoke(null, new object?[] { beatmapInfo, null })!;
+        }
+
+        [Test]
+        public void TestBmsBeatmapUsesStoredCircleSizeForKeyCount()
+        {
+            var ruleset = new BMSRuleset();
+            var beatmapInfo = new BeatmapInfo(ruleset.RulesetInfo, new BeatmapDifficulty { CircleSize = 10, OverallDifficulty = 7 }, new BeatmapMetadata());
+
+            Assert.That(invokeGetDisplayKeyCount(beatmapInfo), Is.EqualTo(10).Within(0.01));
+        }
+
+        [Test]
+        public void TestBmsBeatmapDoesNotCollapseToManiaHeuristicKeyCount()
+        {
+            var ruleset = new BMSRuleset();
+            var beatmapInfo = new BeatmapInfo(ruleset.RulesetInfo, new BeatmapDifficulty { CircleSize = 14, OverallDifficulty = 7 }, new BeatmapMetadata())
+            {
+                TotalObjectCount = 800,
+                EndTimeObjectCount = 800,
+            };
+
+            Assert.That(invokeGetDisplayKeyCount(beatmapInfo), Is.EqualTo(14).Within(0.01));
+        }
+
+        [Test]
+        public void TestGetAdjustedDisplayDifficultyPreservesKeyCount()
+        {
+            var ruleset = new BMSRuleset();
+            var beatmapInfo = new BeatmapInfo(ruleset.RulesetInfo, new BeatmapDifficulty { CircleSize = 10, OverallDifficulty = 7 }, new BeatmapMetadata());
+
+            var adjusted = ruleset.GetAdjustedDisplayDifficulty(beatmapInfo, []);
+
+            Assert.That(adjusted.CircleSize, Is.EqualTo(10).Within(0.01));
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS.Tests/BMSRulesetPipelineTest.cs
+++ b/osu.Game.Rulesets.BMS.Tests/BMSRulesetPipelineTest.cs
@@ -1,0 +1,33 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.Rulesets.BMS.Scoring;
+
+namespace osu.Game.Rulesets.BMS.Tests
+{
+    [TestFixture]
+    public class BMSRulesetPipelineTest
+    {
+        [Test]
+        public void TestCreateProcessorsReturnsBmsSpecificTypes()
+        {
+            var ruleset = new BMSRuleset();
+
+            Assert.That(ruleset.CreateScoreProcessor(), Is.TypeOf<BMSScoreProcessor>());
+            Assert.That(ruleset.CreateHealthProcessor(0), Is.TypeOf<BMSNoFailHealthProcessor>());
+        }
+
+        [Test]
+        public void TestVariantUsesGivenLaneCount()
+        {
+            var ruleset = new BMSRuleset();
+
+            var bindings = ruleset.GetDefaultKeyBindings(12).ToList();
+
+            Assert.That(bindings.Count, Is.EqualTo(12));
+            Assert.That(bindings.Any(b => b.Action.ToString() == "Key12"), Is.True);
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS.Tests/BMSSkinSandboxTest.cs
+++ b/osu.Game.Rulesets.BMS.Tests/BMSSkinSandboxTest.cs
@@ -1,0 +1,130 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using osu.Game.Audio;
+using osu.Game.Rulesets.BMS.Beatmaps;
+
+namespace osu.Game.Rulesets.BMS.Tests
+{
+    /// <summary>
+    /// Regression guards for <see cref="BMSSkin"/>'s sandbox-bypass behaviour.
+    ///
+    /// The previous implementation called <c>AudioManager.Samples.Get(absolutePath)</c>, which is silently
+    /// rejected by osu-framework's <c>NativeStorage</c> when the path lives outside the game data folder
+    /// ("traverses outside of …"). That manifested as song-select preview being silent and in-game keysounds
+    /// not playing for external BMS folders. The fix mounts the BMS folder as its own sample store via
+    /// <c>NativeStorage</c> + <c>StorageBackedResourceStore</c> + <c>AudioManager.GetSampleStore</c>.
+    ///
+    /// We can't easily exercise the audio pipeline end-to-end without a host, so these tests assert the
+    /// invariants statically: behaviour for graceful degradation, and a textual scan of the source file
+    /// to catch anyone re-introducing the absolute-path call.
+    /// </summary>
+    [TestFixture]
+    public class BMSSkinSandboxTest
+    {
+        [Test]
+        public void TestBMSSkinSourceDoesNotUseGlobalSampleStoreDirectly()
+        {
+            string sourcePath = locateBmsSkinSource();
+            string source = File.ReadAllText(sourcePath);
+
+            // Strip block comments and line comments so commentary explaining the previous bug doesn't trip the regex.
+            string stripped = Regex.Replace(source, @"/\*.*?\*/", string.Empty, RegexOptions.Singleline);
+            stripped = Regex.Replace(stripped, @"//.*?$", string.Empty, RegexOptions.Multiline);
+
+            // Match calls like `audioManager.Samples` or `AudioManager.Samples` (case-sensitive — these are the
+            // global stores rooted at NativeStorage(gameDataFolder)). Mounted-store usage looks like
+            // `audioManager.GetSampleStore(...)`, which won't match this pattern.
+            var match = Regex.Match(stripped, @"\b[Aa]udio[Mm]anager\.(?:Samples|Tracks)\b");
+
+            Assert.That(match.Success, Is.False,
+                $"BMSSkin must not access AudioManager.Samples or AudioManager.Tracks directly — those are " +
+                $"sandbox-rooted to the game data folder and reject external BMS paths. " +
+                $"Use AudioManager.GetSampleStore(new StorageBackedResourceStore(new NativeStorage(folder))) instead. " +
+                $"Offending fragment: '{match.Value}'.");
+        }
+
+        [Test]
+        public void TestMissingFolderDegradesGracefully()
+        {
+            // Constructing a BMSSkin against a non-existent folder must not throw, and GetSample should return null.
+            string missingFolder = Path.Combine(Path.GetTempPath(), "bms-skin-missing-" + Guid.NewGuid().ToString("N"));
+
+            // Reflectively construct so we don't pull in a real AudioManager. The implementation accepts null AudioManager.
+            object skin = constructSkin(missingFolder, audioManager: null);
+
+            Assert.DoesNotThrow(() => callGetSample(skin, new TestSampleInfo(new[] { "kick.wav" })));
+            Assert.That(callGetSample(skin, new TestSampleInfo(new[] { "kick.wav" })), Is.Null);
+        }
+
+        [Test]
+        public void TestEmptyLookupNamesIgnored()
+        {
+            string folder = Path.Combine(Path.GetTempPath(), "bms-skin-test-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(folder);
+
+            try
+            {
+                object skin = constructSkin(folder, audioManager: null);
+
+                Assert.DoesNotThrow(() => callGetSample(skin, new TestSampleInfo(Array.Empty<string>())));
+                Assert.DoesNotThrow(() => callGetSample(skin, new TestSampleInfo(new[] { string.Empty, "   ", null! })));
+            }
+            finally
+            {
+                Directory.Delete(folder, true);
+            }
+        }
+
+        private static object constructSkin(string folderPath, object? audioManager)
+        {
+            ConstructorInfo ctor = typeof(BMSSkin).GetConstructors().Single();
+            return ctor.Invoke(new[] { folderPath, audioManager });
+        }
+
+        private static object? callGetSample(object skin, ISampleInfo info)
+        {
+            MethodInfo? method = skin.GetType().GetMethod("GetSample", new[] { typeof(ISampleInfo) });
+            return method!.Invoke(skin, new object[] { info });
+        }
+
+        private static string locateBmsSkinSource()
+        {
+            // Tests run with cwd = test bin output. Walk up to repository root and locate the source by relative path.
+            string assemblyLocation = typeof(BMSSkinSandboxTest).Assembly.Location;
+            DirectoryInfo? cursor = new FileInfo(assemblyLocation).Directory;
+
+            while (cursor != null)
+            {
+                string candidate = Path.Combine(cursor.FullName, "osu.Game.Rulesets.BMS", "Beatmaps", "BMSSkin.cs");
+
+                if (File.Exists(candidate))
+                    return candidate;
+
+                cursor = cursor.Parent;
+            }
+
+            throw new FileNotFoundException("Could not locate BMSSkin.cs for source-level inspection.");
+        }
+
+        private class TestSampleInfo : ISampleInfo
+        {
+            private readonly string[] lookupNames;
+
+            public TestSampleInfo(IEnumerable<string?> lookupNames)
+            {
+                this.lookupNames = lookupNames.Select(name => name ?? string.Empty).ToArray();
+            }
+
+            public IEnumerable<string> LookupNames => lookupNames;
+            public int Volume => 100;
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS.Tests/BMSSoloSongSelectTest.cs
+++ b/osu.Game.Rulesets.BMS.Tests/BMSSoloSongSelectTest.cs
@@ -1,0 +1,170 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.BMS.Beatmaps;
+
+namespace osu.Game.Rulesets.BMS.Tests
+{
+    /// <summary>
+    /// Validates the chart-path resolution helper used when reconstructing a
+    /// <see cref="BMSWorkingBeatmap"/> for an external BMS entry coming from Realm.
+    /// </summary>
+    [TestFixture]
+    public class BMSSoloSongSelectTest
+    {
+        [Test]
+        public void TestResolveExternalChartPath_UsesExternalContentRootWithoutExtSetHash()
+        {
+            string folder = createTempBmsFolder(out string chartFile, "root-only.bms");
+
+            try
+            {
+                var set = new BeatmapSetInfo
+                {
+                    Hash = "not-ext-set",
+                    ExternalContentRoot = folder,
+                    HostingKind = BeatmapSetHostingKind.External,
+                };
+
+                bool resolved = BMSExternalPath.TryResolveExternalChartPath(
+                    beatmapSet: set,
+                    beatmapPath: "root-only.bms",
+                    setFilenames: Array.Empty<string>(),
+                    out string chartPath);
+
+                Assert.That(resolved, Is.True);
+                Assert.That(chartPath, Is.EqualTo(chartFile));
+            }
+            finally
+            {
+                Directory.Delete(folder, recursive: true);
+            }
+        }
+
+        [Test]
+        public void TestResolveExternalChartPath_FailsForNonBmsHash()
+        {
+            bool resolved = BMSExternalPath.TryResolveExternalChartPath(
+                beatmapSet: new BeatmapSetInfo { Hash = "not-a-bms-hash" },
+                beatmapPath: "foo.bms",
+                setFilenames: Array.Empty<string>(),
+                out string chartPath);
+
+            Assert.That(resolved, Is.False);
+            Assert.That(chartPath, Is.Empty);
+        }
+
+        [Test]
+        public void TestResolveExternalChartPath_PrefersBeatmapPath()
+        {
+            string folder = createTempBmsFolder(out string chartFile, "explicit.bms");
+
+            try
+            {
+                bool resolved = BMSExternalPath.TryResolveExternalChartPath(
+                    beatmapSet: createExternalSet(folder),
+                    beatmapPath: "explicit.bms",
+                    setFilenames: new[] { "wrong.bms" },
+                    out string chartPath);
+
+                Assert.That(resolved, Is.True);
+                Assert.That(chartPath, Is.EqualTo(chartFile));
+            }
+            finally
+            {
+                Directory.Delete(folder, recursive: true);
+            }
+        }
+
+        [Test]
+        public void TestResolveExternalChartPath_FallsBackToFirstChartFile()
+        {
+            string folder = createTempBmsFolder(out string chartFile, "fallback.bme");
+
+            try
+            {
+                bool resolved = BMSExternalPath.TryResolveExternalChartPath(
+                    beatmapSet: createExternalSet(folder),
+                    beatmapPath: null,
+                    setFilenames: new List<string> { "irrelevant.txt", "fallback.bme" },
+                    out string chartPath);
+
+                Assert.That(resolved, Is.True);
+                Assert.That(chartPath, Is.EqualTo(chartFile));
+            }
+            finally
+            {
+                Directory.Delete(folder, recursive: true);
+            }
+        }
+
+        [Test]
+        public void TestResolveExternalChartPath_FailsWhenChartMissing()
+        {
+            string folder = createTempBmsFolder(out _, "exists.bms");
+
+            try
+            {
+                bool resolved = BMSExternalPath.TryResolveExternalChartPath(
+                    beatmapSet: createExternalSet(folder),
+                    beatmapPath: "missing.bms",
+                    setFilenames: Array.Empty<string>(),
+                    out string chartPath);
+
+                Assert.That(resolved, Is.False);
+                Assert.That(chartPath, Is.Empty);
+            }
+            finally
+            {
+                Directory.Delete(folder, recursive: true);
+            }
+        }
+
+        [Test]
+        public void TestResolveExternalChartPath_RecognisesAllChartExtensions()
+        {
+            foreach (string extension in new[] { ".bms", ".bme", ".bml", ".pms" })
+            {
+                string filename = "song" + extension;
+                string folder = createTempBmsFolder(out string chartFile, filename);
+
+                try
+                {
+                    bool resolved = BMSExternalPath.TryResolveExternalChartPath(
+                        beatmapSet: createExternalSet(folder),
+                        beatmapPath: null,
+                        setFilenames: new[] { filename },
+                        out string chartPath);
+
+                    Assert.That(resolved, Is.True, $"Failed to resolve chart with extension {extension}");
+                    Assert.That(chartPath, Is.EqualTo(chartFile));
+                }
+                finally
+                {
+                    Directory.Delete(folder, recursive: true);
+                }
+            }
+        }
+
+        private static BeatmapSetInfo createExternalSet(string folder) => new BeatmapSetInfo
+        {
+            Hash = BMSExternalPath.Encode(folder),
+            ExternalContentRoot = folder,
+            HostingKind = BeatmapSetHostingKind.External,
+        };
+
+        private static string createTempBmsFolder(out string chartFile, string chartFilename)
+        {
+            string folder = Path.Combine(Path.GetTempPath(), "bms-test-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(folder);
+            chartFile = Path.Combine(folder, chartFilename);
+            File.WriteAllText(chartFile, "#TITLE test\n#ARTIST test\n");
+            return folder;
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS.Tests/BMSStageLayoutTest.cs
+++ b/osu.Game.Rulesets.BMS.Tests/BMSStageLayoutTest.cs
@@ -1,0 +1,49 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.BMS.Objects;
+using osu.Game.Rulesets.Mania;
+
+namespace osu.Game.Rulesets.BMS.Tests
+{
+    [TestFixture]
+    public class BMSStageLayoutTest
+    {
+        [Test]
+        public void TestFromBeatmapBuildsTotalColumnsAndScratchList()
+        {
+            var beatmap = new Beatmap();
+            beatmap.HitObjects.Add(new BMSNote { Column = 1 });
+            beatmap.HitObjects.Add(new BMSNote { Column = 7 });
+            beatmap.HitObjects.Add(new BMSNote { Column = 0, IsScratch = true });
+            beatmap.HitObjects.Add(new BMSNote { Column = 8, IsScratch = true });
+
+            var layout = BMSStageLayout.FromBeatmap(beatmap);
+
+            Assert.That(layout.TotalColumns, Is.EqualTo(9));
+            Assert.That(layout.ScratchColumnIndices, Is.EqualTo(new[] { 0, 8 }));
+        }
+
+        [Test]
+        public void TestActionForUsesContiguousManiaLikeLaneOrder()
+        {
+            var layout = new BMSStageLayout(9, new[] { 0, 8 });
+
+            Assert.That(layout.ActionFor(new BMSNote { Column = 0, IsScratch = true }), Is.EqualTo(BMSAction.Key1));
+            Assert.That(layout.ActionFor(new BMSNote { Column = 1 }), Is.EqualTo(BMSAction.Key2));
+            Assert.That(layout.ActionFor(new BMSNote { Column = 7 }), Is.EqualTo(BMSAction.Key8));
+            Assert.That(layout.ActionFor(new BMSNote { Column = 8, IsScratch = true }), Is.EqualTo(BMSAction.Key9));
+        }
+
+        [Test]
+        public void TestManiaSkinActionForColumnClamp()
+        {
+            Assert.That(BMSStageLayout.ManiaSkinActionForColumn(-1), Is.EqualTo(ManiaAction.Key1));
+            Assert.That(BMSStageLayout.ManiaSkinActionForColumn(0), Is.EqualTo(ManiaAction.Key1));
+            Assert.That(BMSStageLayout.ManiaSkinActionForColumn(5), Is.EqualTo(ManiaAction.Key6));
+            Assert.That(BMSStageLayout.ManiaSkinActionForColumn(999), Is.EqualTo(ManiaAction.Key20));
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS.Tests/BMSWorkingBeatmapResolveAudioPathTest.cs
+++ b/osu.Game.Rulesets.BMS.Tests/BMSWorkingBeatmapResolveAudioPathTest.cs
@@ -1,0 +1,84 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.IO;
+using System.Reflection;
+using NUnit.Framework;
+using osu.Game.Rulesets.BMS.Beatmaps;
+
+namespace osu.Game.Rulesets.BMS.Tests
+{
+    [TestFixture]
+    public class BMSWorkingBeatmapResolveAudioPathTest
+    {
+        [Test]
+        public void TestResolveAudioPathPrefersExplicitRelativePath()
+        {
+            string tempDir = createTempDir();
+
+            try
+            {
+                string explicitFile = Path.Combine(tempDir, "sub", "main.ogg");
+                Directory.CreateDirectory(Path.GetDirectoryName(explicitFile)!);
+                File.WriteAllText(explicitFile, "x");
+
+                string? resolved = resolveAudioPath(tempDir, @"sub/main.ogg");
+                Assert.That(resolved, Is.EqualTo(explicitFile));
+            }
+            finally
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+
+        [Test]
+        public void TestResolveAudioPathFallsBackToExtensionSearch()
+        {
+            string tempDir = createTempDir();
+
+            try
+            {
+                string fallback = Path.Combine(tempDir, "song.mp3");
+                File.WriteAllText(fallback, "x");
+
+                string? resolved = resolveAudioPath(tempDir, "song.wav");
+                Assert.That(resolved, Is.EqualTo(fallback));
+            }
+            finally
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+
+        [Test]
+        public void TestResolveAudioPathUsesTopLevelFileWhenRelativePathMissing()
+        {
+            string tempDir = createTempDir();
+
+            try
+            {
+                string topLevel = Path.Combine(tempDir, "aaa.ogg");
+                File.WriteAllText(topLevel, "x");
+
+                string? resolved = resolveAudioPath(tempDir, null);
+                Assert.That(resolved, Is.EqualTo(topLevel));
+            }
+            finally
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+
+        private static string? resolveAudioPath(string folderPath, string? relativePath) =>
+            (string?)typeof(BMSWorkingBeatmap).GetMethod("ResolveAudioPath", BindingFlags.Static | BindingFlags.NonPublic)!
+                                              .Invoke(null, new object?[] { folderPath, relativePath });
+
+        private static string createTempDir()
+        {
+            string dir = Path.Combine(Path.GetTempPath(), $"bms-audio-path-test-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(dir);
+            return dir;
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS.Tests/BmsBackgroundSoundDriverTest.cs
+++ b/osu.Game.Rulesets.BMS.Tests/BmsBackgroundSoundDriverTest.cs
@@ -1,0 +1,80 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.BMS.Beatmaps;
+
+namespace osu.Game.Rulesets.BMS.Tests
+{
+    [TestFixture]
+    public class BmsBackgroundSoundDriverTest
+    {
+        private static readonly Type driver_type = typeof(BMSRuleset).Assembly.GetType("osu.Game.Rulesets.BMS.UI.BmsBackgroundSoundDriver", throwOnError: true)!;
+
+        [Test]
+        public void TestConstructorAcceptsEmptyEvents()
+        {
+            object driver = createDriver("/some/folder", new List<BmsBackgroundSoundEvent>());
+
+            Assert.That(driver, Is.Not.Null);
+            Assert.That(driver, Is.AssignableTo<Drawable>());
+
+            var alwaysPresent = (bool)driver_type.GetProperty("AlwaysPresent")!.GetValue(driver)!;
+            Assert.That(alwaysPresent, Is.True);
+        }
+
+        [Test]
+        public void TestConstructorAcceptsBackgroundEvents()
+        {
+            var events = new List<BmsBackgroundSoundEvent>
+            {
+                new BmsBackgroundSoundEvent(0, "intro.wav"),
+                new BmsBackgroundSoundEvent(1000, "drop.wav"),
+            };
+
+            object driver = createDriver("/some/folder", events);
+
+            Assert.That(driver, Is.Not.Null);
+        }
+
+        [Test]
+        public void TestUpdateBeforeBackgroundDependencyLoadIsSafe()
+        {
+            object driver = createDriver("/some/folder", Array.Empty<BmsBackgroundSoundEvent>());
+
+            MethodInfo update = driver_type.GetMethod("Update", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+            Assert.DoesNotThrow(() => update.Invoke(driver, Array.Empty<object>()));
+        }
+
+        [Test]
+        public void TestDisposeBeforeBackgroundDependencyLoadIsSafe()
+        {
+            object driver = createDriver("/some/folder", Array.Empty<BmsBackgroundSoundEvent>());
+
+            // Drawable.Dispose() is public on the framework side and should be a no-op when no AudioManager
+            // has been wired up yet.
+            Assert.DoesNotThrow(() =>
+            {
+                MethodInfo? dispose = driver_type.GetMethod("Dispose", new[] { typeof(bool) })
+                                      ?? driver_type.GetMethod("Dispose", BindingFlags.Instance | BindingFlags.NonPublic, null, new[] { typeof(bool) }, null);
+
+                dispose?.Invoke(driver, new object[] { true });
+            });
+        }
+
+        private static object createDriver(string folder, IReadOnlyList<BmsBackgroundSoundEvent> events)
+        {
+            var ctor = driver_type.GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public,
+                binder: null,
+                types: new[] { typeof(string), typeof(IReadOnlyList<BmsBackgroundSoundEvent>) },
+                modifiers: null)!;
+
+            return ctor.Invoke(new object[] { folder, events });
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS.Tests/BmsChartPreviewPlayerTimelineTest.cs
+++ b/osu.Game.Rulesets.BMS.Tests/BmsChartPreviewPlayerTimelineTest.cs
@@ -1,0 +1,81 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.IO;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.IO;
+using osu.Game.Rulesets.BMS.Beatmaps;
+using osu.Game.Rulesets.Objects.Legacy;
+
+namespace osu.Game.Rulesets.BMS.Tests
+{
+    /// <summary>
+    /// <see cref="osu.Game.Rulesets.BMS.UI.SongSelect.BmsChartPreviewPlayer"/> walks the decoded chart and
+    /// builds its preview timeline from two sources: <see cref="BMSBeatmap.BackgroundSoundEvents"/>
+    /// (BMS background channels) and the <see cref="ConvertHitObjectParser.FileHitSampleInfo"/> samples
+    /// attached to playable note objects.
+    ///
+    /// These tests guard the contracts the player relies on, so refactors of the decoder/converter can't
+    /// silently break preview-time keysound playback again. They don't exercise the audio pipeline itself
+    /// (which needs a host) — only the data shape.
+    /// </summary>
+    [TestFixture]
+    public class BmsChartPreviewPlayerTimelineTest
+    {
+        [Test]
+        public void TestDecodedChartExposesBothBackgroundAndKeysoundSamples()
+        {
+            // Channel 11 is "player A, lane 1" (visible note); channel 01 is "BGM" (background).
+            const string bms = """
+                               #TITLE preview-timeline
+                               #ARTIST test
+                               #BPM 120
+                               #WAV01 bgm.wav
+                               #WAV02 hit.wav
+                               #00101:01
+                               #00111:0200
+                               """;
+
+            var decoder = new BMSBeatmapDecoder();
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(bms));
+            using var reader = new LineBufferedReader(stream);
+
+            Beatmap beatmap = decoder.Decode(reader);
+
+            Assert.That(beatmap, Is.TypeOf<BMSBeatmap>());
+
+            var bmsBeatmap = (BMSBeatmap)beatmap;
+
+            // BGM channel populated → preview player can collect background events.
+            Assert.That(bmsBeatmap.BackgroundSoundEvents, Is.Not.Empty,
+                "BMSBeatmap must expose a non-empty BackgroundSoundEvents list — the preview player relies on it for the BGM half of its timeline.");
+            Assert.That(bmsBeatmap.BackgroundSoundEvents.Any(e => e.Filename == "bgm.wav"), Is.True);
+
+            // Note samples are FileHitSampleInfo with the matching #WAVxx filename.
+            var fileSamples = bmsBeatmap.HitObjects
+                                        .SelectMany(h => h.Samples)
+                                        .OfType<ConvertHitObjectParser.FileHitSampleInfo>()
+                                        .ToList();
+
+            Assert.That(fileSamples, Is.Not.Empty,
+                "Hit objects must carry FileHitSampleInfo samples — the preview player extracts keysound filenames from them. " +
+                "If this regresses, refer to BMSBeatmapDecoder where samples are attached to BMSNote/BMSHoldNote.");
+            Assert.That(fileSamples.Any(s => s.Filename == "hit.wav"), Is.True);
+        }
+
+        [Test]
+        public void TestFileHitSampleInfoLookupNamesIncludeBareFilename()
+        {
+            // BmsChartPreviewPlayer's FilenameSampleInfo stores the bare filename ("hit.wav") and BMSSkin
+            // probes for it. We make sure FileHitSampleInfo's own LookupNames also expose the same form,
+            // because that's how the in-game audio path resolves keysounds — the two paths must agree.
+            var info = new ConvertHitObjectParser.FileHitSampleInfo("hit.wav", 100);
+
+            Assert.That(info.LookupNames, Does.Contain("hit.wav"));
+            Assert.That(info.LookupNames, Does.Contain("hit"), "LookupNames should also expose the extension-less form so BMSSkin can probe alternate audio extensions.");
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS.Tests/BmsFilterCriteriaTest.cs
+++ b/osu.Game.Rulesets.BMS.Tests/BmsFilterCriteriaTest.cs
@@ -1,0 +1,34 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Screens.Select;
+using osu.Game.Screens.Select.Filter;
+
+namespace osu.Game.Rulesets.BMS.Tests
+{
+    [TestFixture]
+    public class BmsFilterCriteriaTest
+    {
+        [Test]
+        public void Matches_uses_circle_size_as_key_count_not_mania_heuristic()
+        {
+            var filter = new BmsFilterCriteria();
+            var criteria = new FilterCriteria();
+
+            filter.TryParseCustomKeywordCriteria("keys", Operator.Equal, "14");
+
+            var beatmap = new BeatmapInfo(new BMSRuleset().RulesetInfo, new BeatmapDifficulty { CircleSize = 14 }, new BeatmapMetadata())
+            {
+                TotalObjectCount = 100,
+                EndTimeObjectCount = 10,
+            };
+
+            Assert.That(filter.Matches(beatmap, criteria), Is.True);
+
+            beatmap.Difficulty.CircleSize = 7;
+            Assert.That(filter.Matches(beatmap, criteria), Is.False);
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS.Tests/BmsKeysoundManagerLifecycleTest.cs
+++ b/osu.Game.Rulesets.BMS.Tests/BmsKeysoundManagerLifecycleTest.cs
@@ -1,0 +1,36 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Game.Rulesets.BMS.Beatmaps;
+using osu.Game.Rulesets.Objects;
+
+namespace osu.Game.Rulesets.BMS.Tests
+{
+    [TestFixture]
+    public class BmsKeysoundManagerLifecycleTest
+    {
+        [Test]
+        public void TestDisposedManagerGuardsAllPublicOperations()
+        {
+            var manager = TestReflectionHelpers.CreateUninitialisedBmsKeysoundManager();
+
+            Assert.DoesNotThrow(() => manager.Dispose());
+            Assert.That(manager.IsDisposed, Is.True);
+            Assert.DoesNotThrow(() => manager.Dispose());
+
+            Assert.DoesNotThrow(() => manager.SetOffset(12));
+            Assert.DoesNotThrow(() => manager.SetVolume(0.5));
+            Assert.DoesNotThrow(() => manager.SetBackgroundSoundEvents(new List<BmsBackgroundSoundEvent>
+            {
+                new BmsBackgroundSoundEvent(100, "a.wav"),
+            }));
+            Assert.DoesNotThrow(() => manager.Update(1000));
+            Assert.DoesNotThrow(() => manager.TriggerKeysound("a.wav"));
+            Assert.DoesNotThrow(() => manager.LoadKeysound("a.wav"));
+            Assert.DoesNotThrow(() => manager.PreloadKeysounds(Array.Empty<HitObject>()));
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS.Tests/BmsKeysoundManagerUpdatePolicyTest.cs
+++ b/osu.Game.Rulesets.BMS.Tests/BmsKeysoundManagerUpdatePolicyTest.cs
@@ -1,0 +1,66 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Game.Rulesets.BMS.Beatmaps;
+
+namespace osu.Game.Rulesets.BMS.Tests
+{
+    [TestFixture]
+    public class BmsKeysoundManagerUpdatePolicyTest
+    {
+        [Test]
+        public void TestUpdateCapsTriggeredEventsPerFrame()
+        {
+            var manager = TestReflectionHelpers.CreateUninitialisedBmsKeysoundManager();
+            var events = new List<BmsBackgroundSoundEvent>();
+
+            for (int i = 0; i < 100; i++)
+                events.Add(new BmsBackgroundSoundEvent(0, string.Empty));
+
+            manager.SetBackgroundSoundEvents(events);
+            manager.Update(0);
+
+            int nextIndex = TestReflectionHelpers.GetField<int>(manager, "nextBackgroundIndex");
+            Assert.That(nextIndex, Is.EqualTo(32), "update should cap background triggers to 32 per frame");
+        }
+
+        [Test]
+        public void TestUpdateDropsStaleEvents()
+        {
+            var manager = TestReflectionHelpers.CreateUninitialisedBmsKeysoundManager();
+
+            manager.SetBackgroundSoundEvents(new List<BmsBackgroundSoundEvent>
+            {
+                new BmsBackgroundSoundEvent(0, string.Empty),
+                new BmsBackgroundSoundEvent(50, string.Empty),
+                new BmsBackgroundSoundEvent(100, string.Empty),
+            });
+
+            manager.Update(1000);
+
+            int nextIndex = TestReflectionHelpers.GetField<int>(manager, "nextBackgroundIndex");
+            Assert.That(nextIndex, Is.EqualTo(3), "all events should be discarded as stale when far behind current time");
+        }
+
+        [Test]
+        public void TestUpdateRewindResetsIndexFromCurrentTime()
+        {
+            var manager = TestReflectionHelpers.CreateUninitialisedBmsKeysoundManager();
+
+            manager.SetBackgroundSoundEvents(new List<BmsBackgroundSoundEvent>
+            {
+                new BmsBackgroundSoundEvent(100, string.Empty),
+                new BmsBackgroundSoundEvent(200, string.Empty),
+                new BmsBackgroundSoundEvent(300, string.Empty),
+            });
+
+            manager.Update(350);
+            manager.Update(150);
+
+            int nextIndex = TestReflectionHelpers.GetField<int>(manager, "nextBackgroundIndex");
+            Assert.That(nextIndex, Is.EqualTo(1), "rewind should reposition index based on current time and then progress");
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS.Tests/BmsLaneMappingTest.cs
+++ b/osu.Game.Rulesets.BMS.Tests/BmsLaneMappingTest.cs
@@ -1,0 +1,28 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+
+namespace osu.Game.Rulesets.BMS.Tests
+{
+    [TestFixture]
+    public class BmsLaneMappingTest
+    {
+        [TestCase(16, true)]
+        [TestCase(56, true)]
+        [TestCase(26, true)]
+        [TestCase(66, true)]
+        [TestCase(11, false)]
+        [TestCase(21, false)]
+        public void TestScratchChannelDetection(int channel, bool expected) => Assert.That(BmsLaneMapping.IsScratchChannel(channel), Is.EqualTo(expected));
+
+        [TestCase(16, 0)]
+        [TestCase(11, 1)]
+        [TestCase(19, 7)]
+        [TestCase(26, 8)]
+        [TestCase(21, 9)]
+        [TestCase(29, 15)]
+        [TestCase(999, 0)]
+        public void TestChannelToColumnMapping(int channel, int expectedColumn) => Assert.That(BmsLaneMapping.ChannelToColumn(channel), Is.EqualTo(expectedColumn));
+    }
+}

--- a/osu.Game.Rulesets.BMS.Tests/BmsLibraryIndexRepositoryTest.cs
+++ b/osu.Game.Rulesets.BMS.Tests/BmsLibraryIndexRepositoryTest.cs
@@ -1,0 +1,131 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Data.Sqlite;
+using NUnit.Framework;
+using osu.Game.Rulesets.BMS.Beatmaps;
+using osu.Game.Rulesets.BMS.Beatmaps.Persistence;
+
+namespace osu.Game.Rulesets.BMS.Tests
+{
+    [TestFixture]
+    public class BmsLibraryIndexRepositoryTest
+    {
+        [Test]
+        public void TestIncrementalSnapshotAndDeleteOrphans()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bms-index-test-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                string dbPath = Path.Combine(tempDir, BmsStoragePaths.INDEX_DATABASE_FILE);
+                var repository = new BmsLibraryIndexRepository(dbPath);
+
+                var chart = new BMSChartCache
+                {
+                    FolderPath = @"E:\bms\song-a",
+                    FileName = "a.bms",
+                    FileSize = 100,
+                    LastModified = DateTime.UtcNow,
+                    Title = "Chart",
+                    Artist = "Artist",
+                    KeyCount = 7,
+                    TotalNotes = 10,
+                    Bpm = 140,
+                };
+
+                string chartPath = chart.FullPath;
+                string pathKey = BmsPathKeys.ComputeChartPathKey(chartPath);
+                Guid beatmapId = Guid.NewGuid();
+
+                repository.UpsertSong(new BMSSongCache
+                {
+                    FolderPath = chart.FolderPath,
+                    Title = "Song",
+                    Artist = "Artist",
+                    LastModified = DateTime.UtcNow,
+                });
+                repository.UpsertChart(chart, beatmapId, pathKey);
+
+                var snapshots = repository.GetChartSnapshots();
+                Assert.That(snapshots.ContainsKey(chartPath), Is.True);
+                Assert.That(repository.TryLoadChart(chartPath, out _), Is.True);
+                Assert.That(repository.TryGetSourceReference(beatmapId, out var reference), Is.True);
+                Assert.That(reference.ChartPath, Is.EqualTo(chartPath));
+
+                int deleted = repository.DeleteChartsNotIn(new List<string>());
+                Assert.That(deleted, Is.EqualTo(1));
+                Assert.That(repository.TryLoadChart(chartPath, out _), Is.False);
+            }
+            finally
+            {
+                cleanupTempDirectory(tempDir);
+            }
+        }
+
+        [Test]
+        public void TestImportLegacyLibraryCache()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bms-index-migrate-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                string dbPath = Path.Combine(tempDir, BmsStoragePaths.INDEX_DATABASE_FILE);
+                var repository = new BmsLibraryIndexRepository(dbPath);
+
+                var cache = new BMSLibraryCache
+                {
+                    RootPaths = { @"D:\BMS" },
+                    Songs =
+                    {
+                        new BMSSongCache
+                        {
+                            FolderPath = @"D:\BMS\song",
+                            Title = "Song",
+                            Charts =
+                            {
+                                new BMSChartCache
+                                {
+                                    FolderPath = @"D:\BMS\song",
+                                    FileName = "chart.bms",
+                                    Md5Hash = "legacy-md5",
+                                    KeyCount = 7,
+                                }
+                            }
+                        }
+                    }
+                };
+
+                repository.ImportFromLibraryCache(cache);
+
+                var loaded = repository.LoadLibraryCache();
+                Assert.That(loaded.TotalCharts, Is.EqualTo(1));
+                Assert.That(loaded.RootPaths, Contains.Item(@"D:\BMS"));
+            }
+            finally
+            {
+                cleanupTempDirectory(tempDir);
+            }
+        }
+
+        private static void cleanupTempDirectory(string tempDir)
+        {
+            try
+            {
+                SqliteConnection.ClearAllPools();
+            }
+            catch
+            {
+                // Best effort.
+            }
+
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS.Tests/BmsMainMenuButtonInjectorTest.cs
+++ b/osu.Game.Rulesets.BMS.Tests/BmsMainMenuButtonInjectorTest.cs
@@ -1,0 +1,146 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Screens;
+using osu.Game.Rulesets.BMS.UI.MenuEntry;
+using osu.Game.Rulesets.BMS.UI.SongSelect;
+using osu.Game.Screens.Menu;
+using osu.Game.Screens.Select;
+using osuTK;
+
+namespace osu.Game.Rulesets.BMS.Tests
+{
+    /// <summary>
+    /// Regression guards for the BMS main-menu injection pipeline. These tests assert that
+    /// the private osu.Game members the injector reflects against still exist and have
+    /// compatible types — if osu! upstream renames them, these tests will fail loudly
+    /// before users hit a silently disabled BMS Game button.
+    /// </summary>
+    [TestFixture]
+    public class BmsMainMenuButtonInjectorTest
+    {
+        private const BindingFlags instance_non_public = BindingFlags.Instance | BindingFlags.NonPublic;
+
+        [Test]
+        public void TestInjectorIsDrawableComponent()
+        {
+            Type injectorType = typeof(BmsMainMenuButtonInjector);
+
+            Assert.That(typeof(Drawable).IsAssignableFrom(injectorType), "BmsMainMenuButtonInjector must be a Drawable so it can enter the OsuGame tree via CreateIcon().");
+        }
+
+        [Test]
+        public void TestRulesetIconHostsTheInjector()
+        {
+            var icon = new BmsRulesetIcon();
+
+            // CompositeDrawable.InternalChildren is protected; reflect to read.
+            var internalChildrenProp = typeof(CompositeDrawable)
+                .GetProperty("InternalChildren", instance_non_public);
+
+            Assert.That(internalChildrenProp, Is.Not.Null, "InternalChildren property missing on CompositeDrawable (osu.Framework upstream change?).");
+
+            var children = (IReadOnlyList<Drawable>)internalChildrenProp!.GetValue(icon)!;
+
+            Assert.That(children.Any(c => c is BmsMainMenuButtonInjector), "BmsRulesetIcon must contain a BmsMainMenuButtonInjector as InternalChild.");
+        }
+
+        [Test]
+        public void TestRulesetIconAllowsSizeAssignment()
+        {
+            // Regression guard for: PanelBeatmapSet.SpreadDisplay (and other consumers of Ruleset.CreateIcon())
+            // directly assign .Size on the drawable. AutoSizeAxes makes that throw — must remain unset.
+            var icon = new BmsRulesetIcon();
+
+            Assert.That(icon.AutoSizeAxes, Is.EqualTo(Axes.None),
+                "BmsRulesetIcon must not use AutoSizeAxes; consumers assign .Size directly.");
+
+            Assert.DoesNotThrow(() => icon.Size = new Vector2(14),
+                "Setting Size on BmsRulesetIcon must not throw — PanelBeatmapSet.SpreadDisplay relies on it.");
+
+            Assert.That(icon.Size, Is.EqualTo(new Vector2(14)));
+        }
+
+        [Test]
+        public void TestMainMenuStillExposesButtonsField()
+        {
+            FieldInfo? buttonsField = walkHierarchy(typeof(MainMenu), "Buttons");
+
+            Assert.That(buttonsField, Is.Not.Null, "MainMenu.Buttons field has been renamed/removed; injector reflection is broken.");
+            Assert.That(typeof(ButtonSystem).IsAssignableFrom(buttonsField!.FieldType), "MainMenu.Buttons type changed; injector reflection is broken.");
+        }
+
+        [Test]
+        public void TestButtonSystemStillExposesPlayListAndButtonArea()
+        {
+            FieldInfo? buttonsPlay = typeof(ButtonSystem).GetField("buttonsPlay", instance_non_public);
+            FieldInfo? buttonArea = typeof(ButtonSystem).GetField("buttonArea", instance_non_public);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(buttonsPlay, Is.Not.Null, "ButtonSystem.buttonsPlay missing — injector cannot insert the BMS button.");
+                Assert.That(buttonArea, Is.Not.Null, "ButtonSystem.buttonArea missing — injector cannot show the new button.");
+
+                Assert.That(buttonsPlay!.FieldType.IsGenericType, Is.True);
+                Assert.That(buttonsPlay.FieldType.GetGenericTypeDefinition(), Is.EqualTo(typeof(List<>)));
+                Assert.That(buttonsPlay.FieldType.GetGenericArguments()[0], Is.EqualTo(typeof(MainMenuButton)));
+
+                Assert.That(buttonArea!.FieldType, Is.EqualTo(typeof(ButtonArea)));
+            });
+        }
+
+        [Test]
+        public void TestButtonAreaFlowIsAccessible()
+        {
+            FieldInfo? flow = typeof(ButtonArea).GetField("Flow", BindingFlags.Instance | BindingFlags.Public);
+
+            Assert.That(flow, Is.Not.Null, "ButtonArea.Flow has been removed; injector cannot attach the new button to the visible row.");
+        }
+
+        [Test]
+        public void TestOsuGamePerformFromScreenIsPublic()
+        {
+            MethodInfo? performFromScreen = typeof(OsuGame).GetMethod("PerformFromScreen", BindingFlags.Instance | BindingFlags.Public);
+
+            Assert.That(performFromScreen, Is.Not.Null, "OsuGame.PerformFromScreen has been moved/renamed; injector click handler is broken.");
+        }
+
+        [Test]
+        public void TestClickTargetIsBmsSoloSongSelect()
+        {
+            // BMS song select intentionally derives from osu.Game's SoloSongSelect now: the goal is to reuse
+            // every official song-select sub-component (title wedge / details area / filter control / carousel)
+            // verbatim, with BMS-specific behaviour layered in via OnStart override + Ruleset.Value pinning.
+            // Earlier history briefly bypassed this by pushing a fully BMS-owned OsuScreen, but the resulting
+            // UI drifted out of parity with osu's own. Lock the inheritance chain explicitly here.
+            IScreen target = BmsMainMenuButtonInjector.CreateBmsSongSelectScreen();
+
+            Assert.That(target, Is.Not.Null, "Injector factory must produce a screen.");
+            Assert.That(target, Is.InstanceOf<BmsSoloSongSelect>(),
+                "Main-menu BMS button must push BmsSoloSongSelect so it inherits the official SongSelect UI tree.");
+            Assert.That(target, Is.InstanceOf<SoloSongSelect>(),
+                "BmsSoloSongSelect must extend SoloSongSelect — that's how it reuses standard mod overlay / footer / wedges.");
+            Assert.That(target, Is.InstanceOf<Screens.Select.SongSelect>(),
+                "BmsSoloSongSelect must extend SongSelect — that's how the official carousel + filter pipeline is reused.");
+        }
+
+        private static FieldInfo? walkHierarchy(Type? type, string name)
+        {
+            for (Type? t = type; t != null; t = t.BaseType)
+            {
+                FieldInfo? field = t.GetField(name, instance_non_public);
+                if (field != null)
+                    return field;
+            }
+
+            return null;
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS.Tests/BmsOsuLibrarySynchronizerTest.cs
+++ b/osu.Game.Rulesets.BMS.Tests/BmsOsuLibrarySynchronizerTest.cs
@@ -1,0 +1,149 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ExternalLibraries;
+using osu.Game.Models;
+using osu.Game.Rulesets.BMS.Beatmaps;
+
+namespace osu.Game.Rulesets.BMS.Tests
+{
+    [TestFixture]
+    public class BmsOsuLibrarySynchronizerTest
+    {
+        private const string content_root = @"E:\bms\song-folder";
+
+        [Test]
+        public void TestComputeRelativeChartFilename_uses_subdirectory()
+        {
+            string chartPath = Path.Combine(content_root, "charts", "chart.bme");
+            Assert.That(BMSOsuLibrarySynchronizer.ComputeRelativeChartFilename(chartPath, content_root), Is.EqualTo("charts/chart.bme"));
+        }
+
+        [Test]
+        public void TestSetMatches_false_when_file_entry_is_bare_filename_only()
+        {
+            var ruleset = new RulesetInfo { ShortName = "bms", Name = "BMS" };
+            Guid beatmapId = Guid.NewGuid();
+            string chartPath = Path.Combine(content_root, "charts", "chart.bme");
+            var sourceMap = new Dictionary<Guid, BMSSourceReference>
+            {
+                [beatmapId] = new BMSSourceReference
+                {
+                    BeatmapId = beatmapId,
+                    FolderPath = content_root,
+                    ChartPath = chartPath,
+                    Md5Hash = BmsPathKeys.ComputeChartPathKey(chartPath),
+                },
+            };
+
+            var targetSet = buildVirtualSet(ruleset, beatmapId, chartPath);
+            var existingSet = buildSyncedSet(ruleset, beatmapId, chartPath, relativeFilename: "chart.bme");
+
+            Assert.That(BMSOsuLibrarySynchronizer.SetMatchesForTesting(existingSet, targetSet, sourceMap), Is.False);
+        }
+
+        [Test]
+        public void TestSetMatches_true_when_file_mapping_matches_relative_path()
+        {
+            var ruleset = new RulesetInfo { ShortName = "bms", Name = "BMS" };
+            Guid beatmapId = Guid.NewGuid();
+            string chartPath = Path.Combine(content_root, "charts", "chart.bme");
+            var sourceMap = new Dictionary<Guid, BMSSourceReference>
+            {
+                [beatmapId] = new BMSSourceReference
+                {
+                    BeatmapId = beatmapId,
+                    FolderPath = content_root,
+                    ChartPath = chartPath,
+                    Md5Hash = BmsPathKeys.ComputeChartPathKey(chartPath),
+                },
+            };
+
+            var targetSet = buildVirtualSet(ruleset, beatmapId, chartPath);
+            var existingSet = buildSyncedSet(ruleset, beatmapId, chartPath, relativeFilename: "charts/chart.bme");
+
+            Assert.That(BMSOsuLibrarySynchronizer.SetMatchesForTesting(existingSet, targetSet, sourceMap), Is.True);
+        }
+
+        [Test]
+        public void TestSetMatches_false_when_hash_is_legacy_prefix()
+        {
+            var ruleset = new RulesetInfo { ShortName = "bms", Name = "BMS" };
+            Guid beatmapId = Guid.NewGuid();
+            string chartPath = Path.Combine(content_root, "chart.bms");
+            var sourceMap = new Dictionary<Guid, BMSSourceReference>
+            {
+                [beatmapId] = new BMSSourceReference
+                {
+                    BeatmapId = beatmapId,
+                    FolderPath = content_root,
+                    ChartPath = chartPath,
+                    Md5Hash = BmsPathKeys.ComputeChartPathKey(chartPath),
+                },
+            };
+
+            var targetSet = buildVirtualSet(ruleset, beatmapId, chartPath);
+            var existingSet = buildSyncedSet(ruleset, beatmapId, chartPath, relativeFilename: "chart.bms");
+            string legacyEncoded = Convert.ToBase64String(Encoding.UTF8.GetBytes(Path.GetFullPath(content_root)));
+            existingSet.Hash = BMSExternalPath.LEGACY_HASH_PREFIX + legacyEncoded;
+
+            Assert.That(BMSOsuLibrarySynchronizer.SetMatchesForTesting(existingSet, targetSet, sourceMap), Is.False);
+        }
+
+        private static BeatmapSetInfo buildVirtualSet(RulesetInfo ruleset, Guid beatmapId, string chartPath)
+        {
+            string realmHash = BmsPathKeys.ComputeRealmFileHash(chartPath);
+            string pathKey = BmsPathKeys.ComputeChartPathKey(chartPath);
+
+            var set = new BeatmapSetInfo
+            {
+                ID = Guid.NewGuid(),
+                Hash = content_root,
+            };
+
+            set.Beatmaps.Add(new BeatmapInfo(ruleset, new BeatmapDifficulty(), new BeatmapMetadata())
+            {
+                ID = beatmapId,
+                Hash = realmHash,
+                MD5Hash = pathKey,
+                DifficultyName = "Normal",
+                BeatmapSet = set,
+            });
+
+            return set;
+        }
+
+        private static BeatmapSetInfo buildSyncedSet(RulesetInfo ruleset, Guid beatmapId, string chartPath, string relativeFilename)
+        {
+            string realmHash = BmsPathKeys.ComputeRealmFileHash(chartPath);
+            string pathKey = BmsPathKeys.ComputeChartPathKey(chartPath);
+
+            var set = new BeatmapSetInfo
+            {
+                ID = Guid.NewGuid(),
+                Hash = ExternalBeatmapPathEncoding.Encode(content_root),
+                ExternalContentRoot = content_root,
+                HostingKind = BeatmapSetHostingKind.External,
+            };
+
+            set.Files.Add(new RealmNamedFileUsage(new RealmFile { Hash = realmHash }, relativeFilename));
+
+            set.Beatmaps.Add(new BeatmapInfo(ruleset, new BeatmapDifficulty(), new BeatmapMetadata())
+            {
+                ID = beatmapId,
+                Hash = realmHash,
+                MD5Hash = pathKey,
+                DifficultyName = "Normal",
+                BeatmapSet = set,
+            });
+
+            return set;
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS.Tests/BmsPathKeysTest.cs
+++ b/osu.Game.Rulesets.BMS.Tests/BmsPathKeysTest.cs
@@ -1,0 +1,29 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Rulesets.BMS.Beatmaps;
+
+namespace osu.Game.Rulesets.BMS.Tests
+{
+    [TestFixture]
+    public class BmsPathKeysTest
+    {
+        [Test]
+        public void TestPathKeyIsStableForSamePath()
+        {
+            const string path = @"E:\Music\test\chart.bms";
+            string first = BmsPathKeys.ComputeChartPathKey(path);
+            string second = BmsPathKeys.ComputeChartPathKey(path);
+            Assert.That(first, Is.EqualTo(second));
+            Assert.That(first, Has.Length.EqualTo(64));
+        }
+
+        [Test]
+        public void TestRealmFileHashMatchesPathKey()
+        {
+            const string path = @"E:\Music\test\chart.bms";
+            Assert.That(BmsPathKeys.ComputeRealmFileHash(path), Is.EqualTo(BmsPathKeys.ComputeChartPathKey(path)));
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS.Tests/Raja/BmsRajaSqlQueryTest.cs
+++ b/osu.Game.Rulesets.BMS.Tests/Raja/BmsRajaSqlQueryTest.cs
@@ -1,0 +1,88 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.IO;
+using Microsoft.Data.Sqlite;
+using NUnit.Framework;
+using osu.Game.Rulesets.BMS.Beatmaps;
+using osu.Game.Rulesets.BMS.Beatmaps.Persistence;
+using osu.Game.Rulesets.BMS.UI.BmsSongSelect.Filtering;
+
+namespace osu.Game.Rulesets.BMS.Tests.Raja
+{
+    [TestFixture]
+    public class BmsRajaSqlQueryTest
+    {
+        [Test]
+        public void TestClearTypePeakDensityAndPlaycountFilters()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bms-raja-sql-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                string filterPath = Path.Combine(tempDir, BmsStoragePaths.FILTER_DATABASE_FILE);
+                string indexPath = Path.Combine(tempDir, BmsStoragePaths.INDEX_DATABASE_FILE);
+
+                var chart = new BMSChartCache
+                {
+                    FolderPath = @"E:\bms\sample",
+                    FileName = "test.bms",
+                    Title = "Test",
+                    KeyCount = 7,
+                    PlayLevel = 10,
+                    TotalNotes = 100,
+                    Duration = 120000,
+                };
+
+                var indexRepository = new BmsLibraryIndexRepository(indexPath);
+                indexRepository.UpsertSong(new BMSSongCache { FolderPath = chart.FolderPath, Title = "Song" });
+                indexRepository.UpsertChart(chart, Guid.NewGuid(), BmsPathKeys.ComputeChartPathKey(chart.FullPath));
+
+                var manager = new BMSBeatmapManager(tempDir);
+                manager.LoadCache();
+
+                using (var connection = new SqliteConnection($"Data Source={filterPath}"))
+                {
+                    connection.Open();
+                    using var cmd = connection.CreateCommand();
+                    cmd.CommandText = @"
+CREATE TABLE song (md5 TEXT, sha256 TEXT PRIMARY KEY, title TEXT, subtitle TEXT, genre TEXT, artist TEXT, subartist TEXT, path TEXT, folder TEXT, parent TEXT, level INTEGER, difficulty INTEGER, mode INTEGER, notes INTEGER, favorite INTEGER, maxbpm INTEGER, minbpm INTEGER, length INTEGER, date INTEGER, adddate INTEGER);
+CREATE TABLE score (sha256 TEXT PRIMARY KEY, mode INTEGER, clear INTEGER, playcount INTEGER, clearcount INTEGER, epg INTEGER, lpg INTEGER, egr INTEGER, lgr INTEGER, egd INTEGER, lgd INTEGER, ebd INTEGER, lbd INTEGER, epr INTEGER, lpr INTEGER, ems INTEGER, lms INTEGER, notes INTEGER, combo INTEGER, minbp INTEGER, avgjudge INTEGER, date INTEGER);
+CREATE TABLE scorelog (sha256 TEXT, mode INTEGER, clear INTEGER, playcount INTEGER, clearcount INTEGER, epg INTEGER, lpg INTEGER, egr INTEGER, lgr INTEGER, notes INTEGER, combo INTEGER, minbp INTEGER, date INTEGER);
+CREATE TABLE information (sha256 TEXT PRIMARY KEY, n INTEGER, ln INTEGER, s INTEGER, ls INTEGER, total REAL, density REAL, peakdensity REAL, enddensity REAL, mainbpm REAL);";
+                    cmd.ExecuteNonQuery();
+
+                    string key = BmsPathKeys.ComputeChartPathKey(chart.FullPath);
+                    cmd.CommandText = @"
+INSERT INTO song (md5, sha256, title, subtitle, genre, artist, subartist, path, folder, parent, level, difficulty, mode, notes, favorite, maxbpm, minbpm, length, date, adddate)
+VALUES ($md5, $sha, 'Test', '', '', '', '', 't.bms', $folder, 'p', 10, 2, 7, 100, 0, 140, 130, 120000, 0, 0);
+INSERT INTO score (sha256, mode, clear, playcount, clearcount, epg, lpg, egr, lgr, egd, lgd, ebd, lbd, epr, lpr, ems, lms, notes, combo, minbp, avgjudge, date)
+VALUES ($sha, 7, 5, 1, 1, 90, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 100, 100, 0, 2147483647, 0);
+INSERT INTO information (sha256, n, ln, s, ls, total, density, peakdensity, enddensity, mainbpm)
+VALUES ($sha, 90, 10, 0, 0, 100, 12, 18, 10, 140);";
+                    cmd.Parameters.AddWithValue("$md5", key[..32]);
+                    cmd.Parameters.AddWithValue("$sha", key);
+                    cmd.Parameters.AddWithValue("$folder", chart.FolderPath);
+                    cmd.ExecuteNonQuery();
+                }
+
+                var query = new BmsSqlSongQuery(filterPath, manager);
+
+                Assert.That(query.Execute("score.clear >= 5"), Has.Count.EqualTo(1));
+                Assert.That(query.Execute("peakdensity >= 15 AND peakdensity < 20"), Has.Count.EqualTo(1));
+                Assert.That(query.Execute("density >= 10 AND density < 15"), Has.Count.EqualTo(1));
+                Assert.That(query.Execute("playcount = 0"), Is.Empty);
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, true); }
+                catch
+                {
+                    /* ignore */
+                }
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS.Tests/SongSelect/BmsAnalyticsEzConverterTest.cs
+++ b/osu.Game.Rulesets.BMS.Tests/SongSelect/BmsAnalyticsEzConverterTest.cs
@@ -1,0 +1,44 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Rulesets.BMS.UI.BmsSongSelect.Analytics;
+using osu.Game.Rulesets.BMS.UI.SongSelect;
+
+namespace osu.Game.Rulesets.BMS.Tests.SongSelect
+{
+    [TestFixture]
+    public class BmsAnalyticsEzConverterTest
+    {
+        [Test]
+        public void ToEzAnalysisResult_maps_pp_kps_and_xxy_sr()
+        {
+            var record = new BmsAnalyticsRecord
+            {
+                PathKey = "abc",
+                Pp = 123.4,
+                XxySr = 5.6,
+                AvgKps = 7.8,
+                MaxKps = 9.0,
+                ColumnCountsJson = "{\"1\":10,\"2\":5}",
+            };
+
+            Assert.That(BmsAnalyticsEzConverter.ToEzAnalysisResult(record), Is.Not.Null);
+
+            var result = BmsAnalyticsEzConverter.ToEzAnalysisResult(record)!.Value;
+            Assert.That(result.Pp, Is.EqualTo(123.4));
+            Assert.That(result.AverageKps, Is.EqualTo(7.8));
+            Assert.That(result.MaxKps, Is.EqualTo(9.0));
+            Assert.That(result.ManiaSummary?.XxySr, Is.EqualTo(5.6));
+            Assert.That(result.ManiaSummary?.ColumnCounts[1], Is.EqualTo(10));
+            Assert.That(result.ManiaSummary?.ColumnCounts[2], Is.EqualTo(5));
+        }
+
+        [Test]
+        public void ToEzAnalysisResult_returns_null_for_empty_row()
+        {
+            var record = new BmsAnalyticsRecord { PathKey = "empty" };
+            Assert.That(BmsAnalyticsEzConverter.ToEzAnalysisResult(record), Is.Null);
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS.Tests/TestReflectionHelpers.cs
+++ b/osu.Game.Rulesets.BMS.Tests/TestReflectionHelpers.cs
@@ -1,0 +1,56 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.Serialization;
+using osu.Framework.Audio.Sample;
+using osu.Game.Rulesets.BMS.Audio;
+using osu.Game.Rulesets.BMS.Beatmaps;
+
+namespace osu.Game.Rulesets.BMS.Tests
+{
+    internal static class TestReflectionHelpers
+    {
+        public static BmsKeysoundManager CreateUninitialisedBmsKeysoundManager()
+        {
+#pragma warning disable SYSLIB0050
+            var manager = (BmsKeysoundManager)FormatterServices.GetUninitializedObject(typeof(BmsKeysoundManager));
+#pragma warning restore SYSLIB0050
+
+            SetField(manager, "keysoundCache", new Dictionary<string, ISample>());
+            SetField(manager, "keysoundPlayTimes", new Dictionary<string, double>());
+            SetField(manager, "backgroundEvents", new List<BmsBackgroundSoundEvent>());
+            SetField(manager, "sampleVolume", 1d);
+            SetField(manager, "currentOffset", 0d);
+            SetField(manager, "gameplayTime", 0d);
+            SetField(manager, "nextBackgroundIndex", 0);
+            SetField(manager, "lastBackgroundUpdateTime", double.MinValue);
+            SetField(manager, "loggedMissingBackgroundEvents", false);
+            SetField(manager, "loggedFirstBackgroundUpdate", false);
+
+            return manager;
+        }
+
+        public static void SetField<T>(object target, string fieldName, T value)
+        {
+            FieldInfo? field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+
+            if (field == null)
+                throw new MissingFieldException(target.GetType().FullName, fieldName);
+
+            field.SetValue(target, value);
+        }
+
+        public static T GetField<T>(object target, string fieldName)
+        {
+            FieldInfo? field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+
+            if (field == null)
+                throw new MissingFieldException(target.GetType().FullName, fieldName);
+
+            return (T)field.GetValue(target)!;
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS.Tests/osu.Game.Rulesets.BMS.Tests.csproj
+++ b/osu.Game.Rulesets.BMS.Tests/osu.Game.Rulesets.BMS.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\osu.TestProject.props"/>
+  <ItemGroup Label="Package References">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0"/>
+    <PackageReference Include="NUnit" Version="4.5.1"/>
+    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0"/>
+  </ItemGroup>
+  <PropertyGroup Label="Project">
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup Label="Project References">
+    <ProjectReference Include="..\osu.Game.Rulesets.BMS\osu.Game.Rulesets.BMS.csproj"/>
+    <ProjectReference Include="..\osu.Game.Tests\osu.Game.Tests.csproj"/>
+  </ItemGroup>
+</Project>

--- a/osu.Game.Rulesets.BMS/Audio/BmsBackgroundMusicLoader.cs
+++ b/osu.Game.Rulesets.BMS/Audio/BmsBackgroundMusicLoader.cs
@@ -1,0 +1,130 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Audio;
+using osu.Framework.Audio.Track;
+using osu.Framework.IO.Stores;
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+
+namespace osu.Game.Rulesets.BMS.Audio
+{
+    /// <summary>
+    /// Loads background music/atmosphere from BMS files.
+    /// In BMS format, all sounds except note keysounds contribute to the "background" audio.
+    ///
+    /// Implementation note: we mount the BMS folder as its own <see cref="ITrackStore"/> via
+    /// <see cref="NativeStorage"/>+<see cref="StorageBackedResourceStore"/>+<see cref="AudioManager.GetTrackStore"/>.
+    /// Calling <c>audioManager.Tracks.Get(absolutePath)</c> directly would route through the global game-data
+    /// <see cref="NativeStorage"/>, which rejects external paths with <see cref="ArgumentException"/>
+    /// ("traverses outside of …"). The mounted store is the only way to read external BMS audio without
+    /// modifying osu.Game.
+    /// </summary>
+    public static class BmsBackgroundMusicLoader
+    {
+        /// <summary>
+        /// Try to load a background music track from a BMS file.
+        /// Looks for common BGM channels like #01 or uses first available WAV.
+        /// </summary>
+        public static Track? TryLoadBgmTrack(AudioManager audioManager, string bmsFilePath)
+        {
+            if (!File.Exists(bmsFilePath))
+                return null;
+
+            try
+            {
+                string folderPath = Path.GetDirectoryName(bmsFilePath) ?? string.Empty;
+                if (string.IsNullOrEmpty(folderPath) || !Directory.Exists(folderPath))
+                    return null;
+
+                var wavDefinitions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+                // Parse BMS file to extract WAV definitions
+                using (var reader = new StreamReader(bmsFilePath))
+                {
+                    string? line;
+
+                    while ((line = reader.ReadLine()) != null)
+                    {
+                        if (string.IsNullOrWhiteSpace(line) || !line.StartsWith("#WAV", StringComparison.OrdinalIgnoreCase))
+                            continue;
+
+                        // Parse #WAVxx filename format
+                        int spaceIdx = line.IndexOf(' ');
+
+                        if (spaceIdx > 4)
+                        {
+                            string index = line.Substring(4, spaceIdx - 4);
+                            string filename = line.Substring(spaceIdx + 1).Trim();
+                            wavDefinitions[index] = filename;
+                        }
+                    }
+                }
+
+                // Try to find BGM file (typically #01 or #00)
+                string? bgmFile = null;
+
+                if (wavDefinitions.TryGetValue("01", out string? f01))
+                    bgmFile = f01;
+                else if (wavDefinitions.TryGetValue("00", out string? f00))
+                    bgmFile = f00;
+                else if (wavDefinitions.Count > 0)
+                    bgmFile = wavDefinitions.First().Value;
+
+                if (string.IsNullOrEmpty(bgmFile))
+                    return null;
+
+                // Resolve a folder-relative reference. We may need to swap extensions or fall back to a probe.
+                string? relative = probeRelative(folderPath, bgmFile);
+
+                if (relative == null)
+                {
+                    Logger.Log($"[BMS] Background music file not found near: {bgmFile}", LoggingTarget.Runtime, LogLevel.Debug);
+                    return null;
+                }
+
+                var storage = new NativeStorage(folderPath);
+                var resourceStore = new StorageBackedResourceStore(storage);
+                var trackStore = audioManager.GetTrackStore(resourceStore);
+
+                var track = trackStore.Get(relative);
+                Logger.Log($"[BMS] Loaded background music: {relative}", LoggingTarget.Runtime, LogLevel.Debug);
+                return track;
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"[BMS] Failed to load background music: {ex.Message}", LoggingTarget.Runtime, LogLevel.Important);
+                return null;
+            }
+        }
+
+        private static readonly string[] track_extensions = { ".ogg", ".wav", ".mp3", ".flac" };
+
+        private static string? probeRelative(string folderPath, string filename)
+        {
+            string normalised = filename.Replace('\\', '/');
+
+            string direct = Path.Combine(folderPath, normalised.Replace('/', Path.DirectorySeparatorChar));
+
+            if (File.Exists(direct))
+                return normalised;
+
+            string directory = Path.GetDirectoryName(normalised) ?? string.Empty;
+            string baseName = Path.GetFileNameWithoutExtension(normalised);
+
+            if (string.IsNullOrEmpty(baseName))
+                return null;
+
+            foreach (string ext in track_extensions)
+            {
+                string candidateRelative = string.IsNullOrEmpty(directory) ? baseName + ext : directory + "/" + baseName + ext;
+                string candidateFull = Path.Combine(folderPath, candidateRelative.Replace('/', Path.DirectorySeparatorChar));
+
+                if (File.Exists(candidateFull))
+                    return candidateRelative;
+            }
+
+            return null;
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/Audio/BmsKeysoundManager.cs
+++ b/osu.Game.Rulesets.BMS/Audio/BmsKeysoundManager.cs
@@ -1,0 +1,354 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
+using osu.Framework.IO.Stores;
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using osu.Game.Audio;
+using osu.Game.Rulesets.BMS.Beatmaps;
+using osu.Game.Rulesets.BMS.Objects;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Legacy;
+
+namespace osu.Game.Rulesets.BMS.Audio
+{
+    /// <summary>
+    /// Manages keysound playback for BMS beatmaps.
+    /// BMS uses keysounds as the primary audio source with optional BGM.
+    /// </summary>
+    public class BmsKeysoundManager
+    {
+        private const string bms_log_prefix = "[BMS]";
+        private const int max_background_triggers_per_update = 32;
+        private const double stale_background_event_threshold = 250;
+
+        private readonly AudioManager audioManager;
+        private readonly ISampleStore? sampleStore;
+        private readonly string bmsFolder;
+        private readonly Dictionary<string, ISample> keysoundCache = new Dictionary<string, ISample>();
+        private readonly Dictionary<string, double> keysoundPlayTimes = new Dictionary<string, double>(); // filename -> scheduled play time
+        private double currentOffset;
+        private double gameplayTime;
+        private double sampleVolume = 1;
+        private List<BmsBackgroundSoundEvent> backgroundEvents = new List<BmsBackgroundSoundEvent>();
+        private int nextBackgroundIndex;
+        private double lastBackgroundUpdateTime = double.MinValue;
+        private bool loggedMissingBackgroundEvents;
+        private bool loggedFirstBackgroundUpdate;
+        public bool IsDisposed { get; private set; }
+
+        public BmsKeysoundManager(AudioManager audioManager, string bmsFolder)
+        {
+            this.audioManager = audioManager;
+            this.bmsFolder = bmsFolder;
+
+            // Create a sample store for the BMS folder
+            var storage = new NativeStorage(bmsFolder);
+            var resourceStore = new StorageBackedResourceStore(storage);
+            sampleStore = audioManager.GetSampleStore(resourceStore);
+
+            Logger.Log($"{bms_log_prefix} Keysound manager created - AudioManager: {true}, Folder: {bmsFolder}", LoggingTarget.Runtime, LogLevel.Important);
+            Logger.Log($"{bms_log_prefix} Created SampleStore for BMS folder: {sampleStore != null}", LoggingTarget.Runtime, LogLevel.Important);
+        }
+
+        /// <summary>
+        /// Preload all keysounds from the beatmap's hit objects.
+        /// </summary>
+        public void PreloadKeysounds(IEnumerable<HitObject> hitObjects)
+        {
+            if (IsDisposed)
+                return;
+
+            var keysoundFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var hitObject in hitObjects)
+            {
+                IEnumerable<HitSampleInfo> samples = hitObject.Samples;
+
+                if (hitObject is IBmsKeysoundProvider provider && provider.KeysoundSamples.Count > 0)
+                    samples = provider.KeysoundSamples;
+                else if (hitObject.AuxiliarySamples.Count > 0)
+                    samples = hitObject.AuxiliarySamples;
+
+                foreach (var sample in samples)
+                {
+                    if (sample is ConvertHitObjectParser.FileHitSampleInfo fileSample)
+                    {
+                        keysoundFiles.Add(fileSample.Filename);
+                    }
+                }
+            }
+
+            Logger.Log($"{bms_log_prefix} Preloading {keysoundFiles.Count} keysounds", LoggingTarget.Runtime, LogLevel.Debug);
+
+            foreach (string filename in keysoundFiles)
+            {
+                try
+                {
+                    LoadKeysound(filename);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Log($"{bms_log_prefix} Failed to preload keysound {filename}: {ex.Message}", LoggingTarget.Runtime, LogLevel.Debug);
+                }
+            }
+        }
+
+        public void SetBackgroundSoundEvents(IReadOnlyList<BmsBackgroundSoundEvent> events)
+        {
+            if (IsDisposed)
+                return;
+
+            backgroundEvents = events
+                               .OrderBy(e => e.Time)
+                               .ToList();
+            nextBackgroundIndex = 0;
+            lastBackgroundUpdateTime = double.MinValue;
+            loggedMissingBackgroundEvents = false;
+            loggedFirstBackgroundUpdate = false;
+
+            Logger.Log($"{bms_log_prefix} Background sound events set: {backgroundEvents.Count}", LoggingTarget.Runtime, LogLevel.Debug);
+        }
+
+        /// <summary>
+        /// Load a keysound file into cache.
+        /// </summary>
+        public ISample? LoadKeysound(string filename)
+        {
+            if (IsDisposed)
+                return null;
+
+            if (string.IsNullOrEmpty(filename))
+                return null;
+
+            // Normalize filename - use lowercase for cache key to handle case-insensitive filesystems
+            string cacheKey = filename.ToLowerInvariant();
+
+            if (keysoundCache.TryGetValue(cacheKey, out var cached))
+                return cached;
+
+            // Try to load the sample - sampleStore will handle file extensions automatically
+            string? foundFilename = null;
+
+            // Try the filename as-is first
+            if (File.Exists(Path.Combine(bmsFolder, filename)))
+            {
+                foundFilename = filename;
+            }
+            else
+            {
+                // Get base name without extension and try different extensions
+                string baseName = Path.GetFileNameWithoutExtension(filename);
+                string[] extensions = new[] { "", ".wav", ".ogg", ".mp3", ".flac" };
+
+                foreach (string ext in extensions)
+                {
+                    // Try different case variations
+                    string[] testNames = new[] { baseName + ext, baseName.ToLowerInvariant() + ext, baseName.ToUpperInvariant() + ext };
+
+                    foreach (string testName in testNames)
+                    {
+                        if (File.Exists(Path.Combine(bmsFolder, testName)))
+                        {
+                            foundFilename = testName;
+                            break;
+                        }
+                    }
+
+                    if (foundFilename != null)
+                        break;
+                }
+            }
+
+            if (foundFilename == null)
+            {
+                // Only log first few failures to avoid spam
+                if (keysoundCache.Count < 100)
+                    Logger.Log($"[BMS] ❌ Not found: {filename}", LoggingTarget.Runtime, LogLevel.Debug);
+                return null;
+            }
+
+            try
+            {
+                if (sampleStore == null)
+                    return null;
+
+                var sample = sampleStore.Get(foundFilename);
+                keysoundCache[cacheKey] = sample;
+
+                // Log first few successful loads with more detail
+                if (keysoundCache.Count <= 5)
+                {
+                    Logger.Log($"{bms_log_prefix} ✓ Loaded #{keysoundCache.Count}: {filename} -> {foundFilename}", LoggingTarget.Runtime, LogLevel.Important);
+                    Logger.Log($"{bms_log_prefix}    Sample info: {sample != null}, Has volume: {sample?.Volume != null}, Volume value: {sample?.Volume?.Value ?? -1:F2}", LoggingTarget.Runtime,
+                        LogLevel.Important);
+                }
+                else if (keysoundCache.Count == 10)
+                {
+                    Logger.Log($"{bms_log_prefix} ✓ Loaded 10 samples, suppressing further load logs...", LoggingTarget.Runtime, LogLevel.Debug);
+                }
+
+                return sample;
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"{bms_log_prefix} ❌ Load exception: {filename}: {ex.Message}", LoggingTarget.Runtime, LogLevel.Debug);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Trigger a keysound to play immediately with offset applied.
+        /// </summary>
+        public void TriggerKeysound(string filename)
+        {
+            if (IsDisposed)
+                return;
+
+            if (string.IsNullOrEmpty(filename))
+                return;
+
+            var sample = LoadKeysound(filename);
+
+            if (sample != null)
+            {
+                try
+                {
+                    var channel = sample.Play();
+
+                    if (channel != null)
+                        channel.Volume.Value = sampleVolume;
+
+                    // Log detailed playback info for first few triggers
+                    if (nextBackgroundIndex < 5 || gameplayTime < 10000)
+                    {
+                        Logger.Log($"{bms_log_prefix} ▶ Playing: {filename} at {gameplayTime:F0}ms - Channel: {channel != null}, Volume: {sample.Volume?.Value ?? -1}", LoggingTarget.Runtime,
+                            LogLevel.Important);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.Log($"[BMS] Failed to play keysound {filename}: {ex.Message}", LoggingTarget.Runtime, LogLevel.Error);
+                }
+            }
+            else
+            {
+                Logger.Log($"{bms_log_prefix} ⚠ Keysound not loaded: {filename}", LoggingTarget.Runtime, LogLevel.Debug);
+            }
+        }
+
+        /// <summary>
+        /// Update the current gameplay time. Call this every frame from the Player.
+        /// </summary>
+        public void Update(double currentGameplayTime)
+        {
+            if (IsDisposed)
+                return;
+
+            gameplayTime = currentGameplayTime;
+
+            if (backgroundEvents.Count == 0)
+            {
+                // Only log this once
+                if (!loggedMissingBackgroundEvents)
+                {
+                    Logger.Log($"{bms_log_prefix} Update called but no background events loaded", LoggingTarget.Runtime, LogLevel.Debug);
+                    loggedMissingBackgroundEvents = true;
+                }
+
+                return;
+            }
+
+            // Log first update with background events
+            if (!loggedFirstBackgroundUpdate)
+            {
+                Logger.Log($"{bms_log_prefix} First Update with {backgroundEvents.Count} background events, currentTime={currentGameplayTime:F1}ms", LoggingTarget.Runtime, LogLevel.Debug);
+                loggedFirstBackgroundUpdate = true;
+            }
+
+            if (currentGameplayTime < lastBackgroundUpdateTime)
+            {
+                nextBackgroundIndex = backgroundEvents.FindIndex(e => e.Time + currentOffset >= currentGameplayTime);
+                if (nextBackgroundIndex < 0)
+                    nextBackgroundIndex = backgroundEvents.Count;
+            }
+
+            int eventsTriggered = 0;
+            int discardedEvents = 0;
+
+            while (nextBackgroundIndex < backgroundEvents.Count)
+            {
+                var evt = backgroundEvents[nextBackgroundIndex];
+                double scheduledTime = evt.Time + currentOffset;
+
+                if (currentGameplayTime < scheduledTime)
+                    break;
+
+                if (currentGameplayTime - scheduledTime > stale_background_event_threshold)
+                {
+                    discardedEvents++;
+                    nextBackgroundIndex++;
+                    continue;
+                }
+
+                TriggerKeysound(evt.Filename);
+                eventsTriggered++;
+                nextBackgroundIndex++;
+
+                if (eventsTriggered >= max_background_triggers_per_update)
+                    break;
+            }
+
+            if (eventsTriggered > 0)
+                Logger.Log($"{bms_log_prefix} Triggered {eventsTriggered} background sound events at time={currentGameplayTime:F1}ms", LoggingTarget.Runtime, LogLevel.Debug);
+            if (discardedEvents > 0)
+                Logger.Log($"{bms_log_prefix} Discarded {discardedEvents} stale background events at time={currentGameplayTime:F1}ms", LoggingTarget.Runtime, LogLevel.Debug);
+            if (eventsTriggered >= max_background_triggers_per_update && nextBackgroundIndex < backgroundEvents.Count)
+                Logger.Log($"{bms_log_prefix} Background trigger cap reached ({max_background_triggers_per_update}) at time={currentGameplayTime:F1}ms", LoggingTarget.Runtime, LogLevel.Debug);
+
+            lastBackgroundUpdateTime = currentGameplayTime;
+        }
+
+        /// <summary>
+        /// Set the offset to apply to all keysound timings.
+        /// BMS offset works inversely: positive offset delays the audio playback.
+        /// </summary>
+        public void SetOffset(double offsetMs)
+        {
+            if (IsDisposed)
+                return;
+
+            currentOffset = offsetMs;
+        }
+
+        public void SetVolume(double volume)
+        {
+            if (IsDisposed)
+                return;
+
+            sampleVolume = Math.Clamp(volume, 0, 1);
+        }
+
+        /// <summary>
+        /// Dispose all cached keysounds.
+        /// </summary>
+        public void Dispose()
+        {
+            if (IsDisposed)
+                return;
+
+            IsDisposed = true;
+
+            foreach (var sample in keysoundCache.Values)
+            {
+                (sample as IDisposable)?.Dispose();
+            }
+
+            keysoundCache.Clear();
+            keysoundPlayTimes.Clear();
+            backgroundEvents.Clear();
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/BMSAction.cs
+++ b/osu.Game.Rulesets.BMS/BMSAction.cs
@@ -1,0 +1,31 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.BMS
+{
+    /// <summary>
+    /// Actions available for BMS gameplay input.
+    /// </summary>
+    public enum BMSAction
+    {
+        // Main keys (supports up to 14 keys for Double Play)
+        Key1,
+        Key2,
+        Key3,
+        Key4,
+        Key5,
+        Key6,
+        Key7,
+        Key8,
+        Key9,
+        Key10,
+        Key11,
+        Key12,
+        Key13,
+        Key14,
+
+        // Scratch lanes
+        Scratch1,
+        Scratch2,
+    }
+}

--- a/osu.Game.Rulesets.BMS/BMSDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.BMS/BMSDifficultyCalculator.cs
@@ -1,0 +1,51 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.BMS.Objects;
+using osu.Game.Rulesets.Difficulty;
+using osu.Game.Rulesets.Difficulty.Preprocessing;
+using osu.Game.Rulesets.Difficulty.Skills;
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Rulesets.BMS
+{
+    public class BMSDifficultyCalculator : DifficultyCalculator
+    {
+        public BMSDifficultyCalculator(IRulesetInfo ruleset, IWorkingBeatmap beatmap)
+            : base(ruleset, beatmap)
+        {
+        }
+
+        protected override DifficultyAttributes CreateDifficultyAttributes(IBeatmap beatmap, Mod[] mods, Skill[] skills, double clockRate)
+        {
+            // Simple difficulty calculation based on note density
+            int noteCount = beatmap.HitObjects.Count;
+            double length = beatmap.HitObjects.LastOrDefault()?.StartTime ?? 0;
+            double density = length > 0 ? noteCount / (length / 1000.0) : 0;
+
+            return new DifficultyAttributes
+            {
+                StarRating = density * 0.5, // Very simplified
+                MaxCombo = noteCount,
+            };
+        }
+
+        protected override IEnumerable<DifficultyHitObject> CreateDifficultyHitObjects(IBeatmap beatmap, double clockRate)
+        {
+            var hitObjects = beatmap.HitObjects.OfType<BMSHitObject>().ToList();
+
+            for (int i = 1; i < hitObjects.Count; i++)
+            {
+                yield return new DifficultyHitObject(hitObjects[i], hitObjects[i - 1], clockRate, new List<DifficultyHitObject>(), i - 1);
+            }
+        }
+
+        protected override Skill[] CreateSkills(IBeatmap beatmap, Mod[] mods, double clockRate)
+        {
+            return Array.Empty<Skill>();
+        }
+
+        protected override Mod[] DifficultyAdjustmentMods => Array.Empty<Mod>();
+    }
+}

--- a/osu.Game.Rulesets.BMS/BMSInputManager.cs
+++ b/osu.Game.Rulesets.BMS/BMSInputManager.cs
@@ -1,0 +1,16 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Input.Bindings;
+using osu.Game.Rulesets.UI;
+
+namespace osu.Game.Rulesets.BMS
+{
+    public partial class BMSInputManager : RulesetInputManager<BMSAction>
+    {
+        public BMSInputManager(RulesetInfo ruleset, int variant, SimultaneousBindingMode unique)
+            : base(ruleset, variant, unique)
+        {
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/BMSRuleset.cs
+++ b/osu.Game.Rulesets.BMS/BMSRuleset.cs
@@ -1,0 +1,534 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Audio.Track;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Localisation;
+using osu.Framework.Logging;
+using osu.Game.Beatmaps;
+using osu.Game.Configuration;
+using osu.Game.EzOsuGame.Analysis;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Extensions;
+using osu.Game.Graphics;
+using osu.Game.IO;
+using osu.Game.Localisation;
+using osu.Game.Overlays.Settings;
+using osu.Game.Rulesets.BMS.Beatmaps;
+using osu.Game.Rulesets.BMS.Configuration;
+using osu.Game.Rulesets.BMS.Mods;
+using osu.Game.Rulesets.BMS.Objects;
+using osu.Game.Rulesets.BMS.Scoring;
+using osu.Game.Rulesets.BMS.UI;
+using osu.Game.Rulesets.BMS.UI.MenuEntry;
+using osu.Game.Rulesets.Configuration;
+using osu.Game.Rulesets.Difficulty;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Filter;
+using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Mania.Beatmaps;
+using osu.Game.Rulesets.Mania.Difficulty;
+using osu.Game.Rulesets.Mania.Edit;
+using osu.Game.Rulesets.Mania.EzMania.Helper;
+using osu.Game.Rulesets.Mania.Mods;
+using osu.Game.Rulesets.Mania.Objects;
+using osu.Game.Rulesets.Mania.Replays;
+using osu.Game.Rulesets.Mania.Scoring;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Replays.Types;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Scoring.Legacy;
+using osu.Game.Rulesets.UI;
+using osu.Game.Scoring;
+using osu.Game.Screens.Ranking.Statistics;
+using osu.Game.Skinning;
+
+namespace osu.Game.Rulesets.BMS
+{
+    public class BMSRuleset : Ruleset
+    {
+        static BMSRuleset()
+        {
+            BMSBeatmapDecoder.Register();
+        }
+
+        public override string Description => "BMS - Be-Music Source";
+
+        public override string ShortName => "bms";
+
+        public override string PlayingVerb => "Playing BMS";
+
+        public override DrawableRuleset CreateDrawableRulesetWith(IBeatmap beatmap, IReadOnlyList<Mod>? mods = null)
+        {
+            var maniaDrawableRuleset = new ManiaRuleset().CreateDrawableRulesetWith(ManiaConvertedWorkingBeatmap.ConvertToManiaBeatmap(beatmap), mods);
+
+            attachBmsRuntimeComponents(maniaDrawableRuleset, beatmap);
+
+            return maniaDrawableRuleset;
+        }
+
+        private static void attachBmsRuntimeComponents(DrawableRuleset drawableRuleset, IBeatmap beatmap)
+        {
+            // Always register the AudioManager for non-Drawable BMS helpers (e.g. BMSExternalSampleSkin).
+            drawableRuleset.Overlays.Add(new BmsRuntimeAudioRegistrar());
+
+            // Only attach the BGM driver when this beatmap is actually backed by an external BMS folder
+            // and we can resolve some background sound events.
+            if (!BMSExternalPath.TryGetContentRoot(beatmap.BeatmapInfo.BeatmapSet, out string folder))
+                return;
+
+            var bgmEvents = tryLoadBackgroundSoundEvents(beatmap, folder);
+
+            if (bgmEvents.Count == 0)
+                return;
+
+            drawableRuleset.Overlays.Add(new BmsBackgroundSoundDriver(folder, bgmEvents));
+        }
+
+        private static IReadOnlyList<BmsBackgroundSoundEvent> tryLoadBackgroundSoundEvents(IBeatmap beatmap, string folder)
+        {
+            if (beatmap is BMSBeatmap directBmsBeatmap && directBmsBeatmap.BackgroundSoundEvents.Count > 0)
+                return directBmsBeatmap.BackgroundSoundEvents;
+
+            // The standard play path runs the chart through the mania converter, which strips top-level
+            // BMS metadata. As a last-resort fallback, locate the original .bms file in the folder and
+            // re-decode it just to fish out the BGM event list.
+            try
+            {
+                if (!Directory.Exists(folder))
+                    return Array.Empty<BmsBackgroundSoundEvent>();
+
+                string? chartFile = Directory.EnumerateFiles(folder)
+                                             .FirstOrDefault(path =>
+                                             {
+                                                 string ext = Path.GetExtension(path);
+                                                 return string.Equals(ext, ".bms", StringComparison.OrdinalIgnoreCase)
+                                                        || string.Equals(ext, ".bme", StringComparison.OrdinalIgnoreCase)
+                                                        || string.Equals(ext, ".bml", StringComparison.OrdinalIgnoreCase)
+                                                        || string.Equals(ext, ".pms", StringComparison.OrdinalIgnoreCase);
+                                             });
+
+                if (chartFile == null)
+                    return Array.Empty<BmsBackgroundSoundEvent>();
+
+                using var stream = File.OpenRead(chartFile);
+                using var reader = new LineBufferedReader(stream);
+                var decoder = new BMSBeatmapDecoder();
+
+                if (decoder.Decode(reader) is BMSBeatmap decoded)
+                    return decoded.BackgroundSoundEvents;
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"[BMS] Failed to load background sound events from '{folder}': {ex.Message}", LoggingTarget.Runtime, LogLevel.Debug);
+            }
+
+            return Array.Empty<BmsBackgroundSoundEvent>();
+        }
+
+        public override ScoreProcessor CreateScoreProcessor() => new BMSScoreProcessor();
+
+        public override HealthProcessor CreateHealthProcessor(double drainStartTime) => new BMSNoFailHealthProcessor(drainStartTime);
+
+        public override IBeatmapConverter CreateBeatmapConverter(IBeatmap beatmap) => new BMSBeatmapConverter(beatmap, this);
+        public override PerformanceCalculator CreatePerformanceCalculator() => new ManiaPerformanceCalculator();
+
+        public override HitObjectComposer CreateHitObjectComposer() => new ManiaHitObjectComposer(this);
+
+        public override IBeatmapVerifier CreateBeatmapVerifier() => new ManiaBeatmapVerifier();
+
+        public override IEzAnalysisProvider CreateEzAnalysisProvider() => new EzBms.BmsEzAnalysisProvider();
+
+        public override ISkin? CreateSkinTransformer(ISkin skin, IBeatmap beatmap)
+        {
+            // WorkingBeatmap.Skin may already wrap LegacyBeatmapSkin with BMSExternalSampleSkin (song select preview).
+            // Unwrap so Mania skin transformers see LegacyBeatmapSkin once; then apply a single external wrapper.
+            ISkin chain = skin is BMSExternalSampleSkin ext ? ext.Inner : skin;
+
+            var inner = createInnerSkinTransformer(chain, beatmap) ?? chain;
+
+            if (!BMSExternalPath.TryGetContentRoot(beatmap.BeatmapInfo.BeatmapSet, out string folder))
+                return ReferenceEquals(inner, skin) ? null : inner;
+
+            return new BMSExternalSampleSkin(inner, folder, () => BmsRuntimeAudioContext.Audio);
+        }
+
+        private ISkin? createInnerSkinTransformer(ISkin skin, IBeatmap beatmap)
+        {
+            var maniaRuleset = new ManiaRuleset();
+
+            try
+            {
+                return maniaRuleset.CreateSkinTransformer(skin, beatmap) ?? base.CreateSkinTransformer(skin, beatmap);
+            }
+            catch (InvalidCastException) when (beatmap is not ManiaBeatmap)
+            {
+                // Some mania transformers assume ManiaBeatmap; provide an adapted beatmap for BMS.
+                var adaptedBeatmap = createManiaSkinBeatmap(beatmap);
+
+                try
+                {
+                    return maniaRuleset.CreateSkinTransformer(skin, adaptedBeatmap) ?? base.CreateSkinTransformer(skin, beatmap);
+                }
+                catch
+                {
+                    // Transformer-specific assumptions may still fail (e.g. custom skin configs).
+                    return base.CreateSkinTransformer(skin, beatmap);
+                }
+            }
+            catch
+            {
+                // Never let skin transformer failures crash BMS gameplay startup.
+                return base.CreateSkinTransformer(skin, beatmap);
+            }
+        }
+
+        public override DifficultyCalculator CreateDifficultyCalculator(IWorkingBeatmap beatmap) =>
+            new ManiaDifficultyCalculator(new ManiaRuleset().RulesetInfo, new ManiaDifficultyWorkingBeatmapAdapter(beatmap));
+
+        public override IConvertibleReplayFrame CreateConvertibleReplayFrame() => new ManiaReplayFrame();
+
+        public override IRulesetConfigManager CreateConfig(SettingsStore? settings) => new BMSRulesetConfigManager(settings, RulesetInfo);
+
+        public override RulesetSettingsSubsection CreateSettings() => new BMSSettingsSubsection(this);
+
+        public override IEnumerable<Mod> GetModsFor(ModType type)
+        {
+            switch (type)
+            {
+                case ModType.DifficultyReduction:
+                    return new Mod[]
+                    {
+                        new ManiaModEasy(),
+                        new ManiaModNoFail(),
+                        new ManiaModHalfTime(),
+                    };
+
+                case ModType.DifficultyIncrease:
+                    return new Mod[]
+                    {
+                        new ManiaModHardRock(),
+                        new ManiaModSuddenDeath(),
+                        new ManiaModPerfect(),
+                        new ManiaModDoubleTime(),
+                        new ManiaModNightcore(),
+                        new ManiaModHidden(),
+                        new ManiaModFadeIn(),
+                        new ManiaModFlashlight(),
+                    };
+
+                case ModType.Automation:
+                    return new Mod[]
+                    {
+                        new ManiaModAutoplay(),
+                    };
+
+                case ModType.Conversion:
+                    return new Mod[]
+                    {
+                        new BMSModRandom(),
+                        new BMSModMirror(),
+                        new BMSModScratchLaneRight(),
+                    };
+
+                case ModType.Fun:
+                    return Array.Empty<Mod>();
+
+                default:
+                    return Array.Empty<Mod>();
+            }
+        }
+
+        public override IEnumerable<KeyBinding> GetDefaultKeyBindings(int variant = 0)
+        {
+            int totalColumns = Math.Clamp(variant <= 0 ? 8 : variant, 1, 16);
+
+            var maniaRuleset = new ManiaRuleset();
+            var maniaBindings = maniaRuleset.GetDefaultKeyBindings((int)PlayfieldType.Single + totalColumns);
+
+            foreach (var binding in maniaBindings)
+            {
+                if (binding.Action is not ManiaAction maniaAction)
+                    continue;
+                if (binding.KeyCombination.Equals(InputKey.None))
+                    continue;
+
+                int index = (int)maniaAction;
+                BMSAction mapped = index switch
+                {
+                    <= 13 => (BMSAction)((int)BMSAction.Key1 + index),
+                    14 => BMSAction.Scratch1,
+                    15 => BMSAction.Scratch2,
+                    _ => BMSAction.Scratch2
+                };
+
+                yield return new KeyBinding(binding.KeyCombination, mapped);
+            }
+        }
+
+        public override LocalisableString VariantDescription => "Keys";
+
+        public override IEnumerable<int> AvailableVariants => Enumerable.Range(1, 18);
+
+        public override int GetVariantForBeatmap(IBeatmapInfo beatmapInfo, IReadOnlyList<Mod>? mods = null) => (int)getDisplayKeyCount(beatmapInfo, mods);
+
+        public override LocalisableString GetVariantName(int variant) => variant switch
+        {
+            8 => @"SP",
+            9 => @"PMS",
+            10 => @"10K2S",
+            14 => @"DP",
+            _ => $"{variant}K",
+        };
+
+        public override IEnumerable<HitResult> GetValidHitResults()
+        {
+            return HitModeHelper.GetHitModeValidHitResults();
+        }
+
+        public override LocalisableString GetDisplayNameForHitResult(HitResult result)
+        {
+            // 获取对应 HitMode 的显示名称
+            return result.GetHitModeDisplayName();
+        }
+
+        public override StatisticItem[] CreateStatisticsForScore(ScoreInfo score, IBeatmap playableBeatmap) => new[]
+        {
+            new StatisticItem("Performance Breakdown", () => new PerformanceBreakdownChart(score, playableBeatmap)
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y
+            }),
+            // new StatisticItem("Space Graph", () => new EzScoreGraphMania(score, playableBeatmap)
+            // {
+            //     RelativeSizeAxes = Axes.X,
+            //     Height = 200
+            // }, true),
+            new StatisticItem("Timing Distribution", () => new HitEventTimingDistributionGraph(score.HitEvents)
+            {
+                RelativeSizeAxes = Axes.X,
+                Height = 120
+            }, true),
+            // new StatisticItem("Every Column Timing Graphs", () => new EzScoreEveryColumnTimingGraphs(score)
+            // {
+            //     RelativeSizeAxes = Axes.X,
+            //     Height = 250,
+            // }, true),
+            // new StatisticItem("HitResult Count", () => new EzManiaScoreHitResultCountGraph(score)
+            // {
+            //     RelativeSizeAxes = Axes.X
+            // }, true),
+            new StatisticItem("Statistics", () => new SimpleStatisticTable(2, new SimpleStatisticItem[]
+            {
+                new AverageHitError(score.HitEvents),
+                new UnstableRate(score.HitEvents)
+            }), true)
+        };
+
+        /// <seealso cref="ManiaHitWindows"/>
+        public override BeatmapDifficulty GetAdjustedDisplayDifficulty(IBeatmapInfo beatmapInfo, IReadOnlyCollection<Mod> mods)
+        {
+            BeatmapDifficulty adjustedDifficulty = base.GetAdjustedDisplayDifficulty(beatmapInfo, mods);
+
+            // notably, in mania, hit windows are designed to be independent of track playback rate (see `ManiaHitWindows.SpeedMultiplier`).
+            // *however*, to not make matters *too* simple, mania Hard Rock and Easy differ from all other rulesets
+            // in that they apply multipliers *to hit window durations directly* rather than to the Overall Difficulty attribute itself.
+            // because the duration of hit window durations as a function of OD is not a linear function,
+            // this means that multiplying the OD is *not* the same thing as multiplying the hit window duration.
+            // in fact, the second operation is *much* harsher and will produce values much farther outside of normal operating range
+            // (even negative in the case of Easy).
+            // stable handles this wrong on song select and just assumes that it can handle mania EZ / HR the same way as all other rulesets.
+
+            double perfectHitWindow = IBeatmapDifficultyInfo.DifficultyRange(adjustedDifficulty.OverallDifficulty, ManiaHitWindows.PERFECT_WINDOW_RANGE);
+
+            if (mods.Any(m => m is ManiaModHardRock))
+                perfectHitWindow /= ManiaModHardRock.HIT_WINDOW_DIFFICULTY_MULTIPLIER;
+            else if (mods.Any(m => m is ManiaModEasy))
+                perfectHitWindow /= ManiaModEasy.HIT_WINDOW_DIFFICULTY_MULTIPLIER;
+
+            adjustedDifficulty.OverallDifficulty = (float)IBeatmapDifficultyInfo.InverseDifficultyRange(perfectHitWindow, ManiaHitWindows.PERFECT_WINDOW_RANGE);
+            adjustedDifficulty.CircleSize = getDisplayKeyCount(beatmapInfo, mods);
+
+            return adjustedDifficulty;
+        }
+
+        /// <summary>
+        /// BMS charts store key count in <see cref="BeatmapDifficulty.CircleSize"/> during indexing.
+        /// Mania conversion heuristics ignore that and collapse to 4–7K for non-mania sources.
+        /// </summary>
+        private const string bms_ruleset_short_name = "bms";
+
+        private static float getDisplayKeyCount(IBeatmapInfo beatmapInfo, IReadOnlyCollection<Mod>? mods = null)
+        {
+            if (string.Equals(beatmapInfo.Ruleset.ShortName, bms_ruleset_short_name, StringComparison.OrdinalIgnoreCase))
+                return Math.Max(1, (int)Math.Round(beatmapInfo.Difficulty.CircleSize));
+
+            return ManiaBeatmapConverter.GetColumnCount(LegacyBeatmapConversionDifficultyInfo.FromBeatmapInfo(beatmapInfo), mods);
+        }
+
+        public override IEnumerable<RulesetBeatmapAttribute> GetBeatmapAttributesForDisplay(IBeatmapInfo beatmapInfo, IReadOnlyCollection<Mod> mods)
+        {
+            // 清理残留
+            ManiaHitWindows.ClearModOverride();
+
+            // a special touch-up of key count is required to the original difficulty, since key conversion mods are not `IApplicableToDifficulty`
+            var originalDifficulty = new BeatmapDifficulty(beatmapInfo.Difficulty)
+            {
+                CircleSize = getDisplayKeyCount(beatmapInfo)
+            };
+            var adjustedDifficulty = GetAdjustedDisplayDifficulty(beatmapInfo, mods);
+
+            // 单独接口追踪Mod中的变化
+            var range = mods.OfType<IManiaHitRangeProvider>().FirstOrDefault()?.GetDisplayHitRange(beatmapInfo);
+
+            if (range != null)
+                ManiaHitWindows.SetModOverride(range.Value);
+
+            var colours = new OsuColour();
+
+            yield return new RulesetBeatmapAttribute(SongSelectStrings.KeyCount, @"KC", originalDifficulty.CircleSize, adjustedDifficulty.CircleSize, 18)
+            {
+                Description = "Affects the number of key columns on the playfield."
+            };
+
+            var hitWindows = new ManiaHitWindows();
+            hitWindows.SetDifficulty(adjustedDifficulty.OverallDifficulty);
+            hitWindows.IsConvert = !beatmapInfo.Ruleset.Equals(RulesetInfo);
+            hitWindows.ClassicModActive = mods.Any(m => m is ManiaModClassic);
+            hitWindows.BPM = beatmapInfo.BPM;
+
+            // 获取当前HitMode
+            var currentHitMode = GlobalConfigStore.EzConfig.Get<EzEnumHitMode>(Ez2Setting.ManiaHitMode);
+            bool isBMSMode = HitModeHelper.IsBMSHitMode(currentHitMode);
+
+            yield return new RulesetBeatmapAttribute(SongSelectStrings.Accuracy, @"OD", originalDifficulty.OverallDifficulty, adjustedDifficulty.OverallDifficulty, 10)
+            {
+                Description = "Affects timing requirements for notes.",
+                AdditionalMetrics = hitWindows.GetAllAvailableWindows()
+                                              .Reverse()
+                                              .Select(window =>
+                                              {
+                                                  LocalisableString windowText;
+
+                                                  if (isBMSMode)
+                                                  {
+                                                      // BMS模式：根据数值是否相等选择显示格式
+                                                      double earlyWindow = hitWindows.WindowFor(window.result, true);
+                                                      double lateWindow = hitWindows.WindowFor(window.result, false);
+
+                                                      if (Math.Abs(earlyWindow - lateWindow) > 0.01)
+                                                          windowText = $@"-{earlyWindow:0.##}/+{lateWindow:0.##} ms";
+                                                      else
+                                                          windowText = $@"±{earlyWindow:0.##} ms";
+                                                  }
+                                                  else
+                                                  {
+                                                      // 非BMS模式：显示对称格式
+                                                      double d = hitWindows.WindowFor(window.result);
+                                                      windowText = $@"±{d:0.##} ms";
+                                                  }
+
+                                                  return new RulesetBeatmapAttribute.AdditionalMetric(
+                                                      $"{window.result.GetHitModeDisplayName().ToString().ToUpperInvariant()} hit window",
+                                                      windowText,
+                                                      colours.ForHitResult(window.result)
+                                                  );
+                                              }).ToArray()
+            };
+
+            yield return new RulesetBeatmapAttribute(SongSelectStrings.HPDrain, @"HP", originalDifficulty.DrainRate, adjustedDifficulty.DrainRate, 10)
+            {
+                Description = "Affects the harshness of health drain and the health penalties for missing."
+            };
+        }
+
+        public override IRulesetFilterCriteria CreateRulesetFilterCriteria() => new BmsFilterCriteria();
+
+        public override Drawable CreateIcon() => new BmsRulesetIcon();
+
+        public override string RulesetAPIVersionSupported => CURRENT_RULESET_API_VERSION;
+
+        private static ManiaBeatmap createManiaSkinBeatmap(IBeatmap beatmap)
+        {
+            int totalColumns = Math.Max(1, getManiaSkinTotalColumns(beatmap));
+            var maniaBeatmap = new ManiaBeatmap(new StageDefinition(totalColumns))
+            {
+                BeatmapInfo = beatmap.BeatmapInfo,
+                ControlPointInfo = beatmap.ControlPointInfo,
+            };
+
+            foreach (BMSHitObject obj in beatmap.HitObjects.OfType<BMSHitObject>())
+            {
+                ManiaHitObject converted = obj switch
+                {
+                    BMSHoldNote hold => new HoldNote
+                    {
+                        StartTime = hold.StartTime,
+                        Duration = hold.Duration,
+                        Column = hold.Column
+                    },
+                    _ => new Note
+                    {
+                        StartTime = obj.StartTime,
+                        Column = obj.Column
+                    }
+                };
+
+                maniaBeatmap.HitObjects.Add(converted);
+            }
+
+            return maniaBeatmap;
+        }
+
+        private static int getManiaSkinTotalColumns(IBeatmap beatmap)
+        {
+            int fromLayout = BMSStageLayout.FromBeatmap(beatmap).TotalColumns;
+            int fromBeatmap = beatmap is BMSBeatmap bmsBeatmap ? bmsBeatmap.TotalColumns : 0;
+            int fromDifficulty = (int)Math.Round(beatmap.Difficulty.CircleSize);
+            int fromHitObjects = beatmap.HitObjects.OfType<BMSHitObject>().Select(h => h.Column + 1).DefaultIfEmpty(0).Max();
+            return Math.Max(Math.Max(fromLayout, fromBeatmap), Math.Max(fromDifficulty, fromHitObjects));
+        }
+    }
+
+    internal class BMSNativeRuleset : BMSRuleset
+    {
+        public override DrawableRuleset CreateDrawableRulesetWith(IBeatmap beatmap, IReadOnlyList<Mod>? mods = null) => new DrawableBMSRuleset(this, beatmap, mods);
+    }
+
+    internal class ManiaDifficultyWorkingBeatmapAdapter : WorkingBeatmap
+    {
+        private readonly IWorkingBeatmap source;
+        private readonly ManiaBeatmap maniaBeatmap;
+
+        public ManiaDifficultyWorkingBeatmapAdapter(IWorkingBeatmap source)
+            : base((BeatmapInfo)source.BeatmapInfo, null)
+        {
+            this.source = source;
+            maniaBeatmap = ManiaConvertedWorkingBeatmap.ConvertToManiaBeatmap(resolveSourceBeatmap(source));
+        }
+
+        private static IBeatmap resolveSourceBeatmap(IWorkingBeatmap source)
+        {
+            IBeatmap? sourceBeatmap = source.Beatmap;
+
+            if (sourceBeatmap is BMSBeatmap || (sourceBeatmap?.HitObjects.OfType<BMSHitObject>().Any() ?? false))
+                return sourceBeatmap;
+
+            return sourceBeatmap ?? new BMSBeatmap();
+        }
+
+        protected override IBeatmap GetBeatmap() => maniaBeatmap;
+
+        public override IBeatmap GetPlayableBeatmap(IRulesetInfo ruleset, IReadOnlyList<Mod> mods, CancellationToken token) => maniaBeatmap;
+
+        public override Texture? GetBackground() => source.GetBackground();
+
+        protected override Track GetBeatmapTrack() => source.Track;
+
+        protected override ISkin GetSkin() => source.Skin;
+
+        public override Stream? GetStream(string storagePath) => source.GetStream(storagePath);
+    }
+}

--- a/osu.Game.Rulesets.BMS/BMSStageLayout.cs
+++ b/osu.Game.Rulesets.BMS/BMSStageLayout.cs
@@ -1,0 +1,76 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.BMS.Objects;
+using osu.Game.Rulesets.Mania;
+
+namespace osu.Game.Rulesets.BMS
+{
+    /// <summary>
+    /// Derived lane metadata for one playable BMS beatmap (column count, scratch indices, input mapping).
+    /// </summary>
+    public sealed class BMSStageLayout
+    {
+        /// <summary>
+        /// Total columns (mania lanes), derived from highest used column index + 1.
+        /// </summary>
+        public int TotalColumns { get; }
+
+        /// <summary>
+        /// Scratch lane column indices, sorted ascending (left → right on screen).
+        /// </summary>
+        public IReadOnlyList<int> ScratchColumnIndices { get; }
+
+        public BMSStageLayout(int totalColumns, IReadOnlyList<int> scratchColumnIndices)
+        {
+            TotalColumns = Math.Max(0, totalColumns);
+            ScratchColumnIndices = scratchColumnIndices;
+        }
+
+        public static BMSStageLayout FromBeatmap(IBeatmap beatmap)
+        {
+            var bmsObjects = beatmap.HitObjects.OfType<BMSHitObject>().ToList();
+            int totalColumns = bmsObjects.Count == 0
+                ? 1
+                : bmsObjects.Max(h => h.Column) + 1;
+
+            var scratches = bmsObjects
+                            .Where(h => h.IsScratch)
+                            .Select(h => h.Column)
+                            .Distinct()
+                            .OrderBy(c => c)
+                            .ToList();
+
+            return new BMSStageLayout(totalColumns, scratches);
+        }
+
+        /// <summary>
+        /// Map BMS lane directly to a mania-like contiguous input sequence.
+        /// </summary>
+        /// <remarks>
+        /// This keeps scratch lanes in the same ordinal flow as normal keys (column 0 -> key1, column 1 -> key2, ...),
+        /// preventing off-by-one key requests when reusing mania visuals / key counters.
+        /// </remarks>
+        public BMSAction ActionFor(BMSHitObject hitObject)
+        {
+            int clamped = Math.Clamp(hitObject.Column, 0, 15);
+            if (clamped <= 13)
+                return (BMSAction)((int)BMSAction.Key1 + clamped);
+
+            return clamped == 14 ? BMSAction.Scratch1 : BMSAction.Scratch2;
+        }
+
+        /// <summary>
+        /// Value for hidden <see cref="Mania.UI.Column.Action"/> when reusing mania skins on BMS.
+        /// Matches <see cref="Mania.UI.ManiaPlayfield"/>: left-to-right lanes use consecutive <see cref="ManiaAction"/> starting at <see cref="ManiaAction.Key1"/> (clamp at <see cref="ManiaAction.Key20"/>).
+        /// Scratch side does not remap the enum — lane <paramref name="columnIndex"/> maps to the same ordinal <see cref="ManiaAction"/> as in mania; scratch lanes set <see cref="Mania.UI.Column.IsSpecial"/> on the hidden skin <see cref="Mania.UI.Column"/> (see playfield column ctor) for width / tint behaviour.
+        /// </summary>
+        public static ManiaAction ManiaSkinActionForColumn(int columnIndex)
+        {
+            const int max = (int)ManiaAction.Key20;
+            int clamped = Math.Clamp(columnIndex, 0, max);
+            return (ManiaAction)clamped;
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/Beatmaps/BMSBeatmap.cs
+++ b/osu.Game.Rulesets.BMS/Beatmaps/BMSBeatmap.cs
@@ -1,0 +1,33 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps;
+
+namespace osu.Game.Rulesets.BMS.Beatmaps
+{
+    /// <summary>
+    /// BMS-specific beatmap container.
+    /// </summary>
+    public class BMSBeatmap : Beatmap
+    {
+        /// <summary>
+        /// Total number of columns in this beatmap.
+        /// </summary>
+        public int TotalColumns { get; set; } = 8;
+
+        /// <summary>
+        /// Whether this beatmap includes a scratch lane.
+        /// </summary>
+        public bool HasScratch => TotalColumns == 6 || TotalColumns == 8 || TotalColumns == 12 || TotalColumns == 16;
+
+        /// <summary>
+        /// Whether this is a Double Play beatmap (14K).
+        /// </summary>
+        public bool IsDoublePlay => TotalColumns > 9;
+
+        /// <summary>
+        /// Background sound events (non-note audio).
+        /// </summary>
+        public List<BmsBackgroundSoundEvent> BackgroundSoundEvents { get; } = new List<BmsBackgroundSoundEvent>();
+    }
+}

--- a/osu.Game.Rulesets.BMS/Beatmaps/BMSBeatmapCache.cs
+++ b/osu.Game.Rulesets.BMS/Beatmaps/BMSBeatmapCache.cs
@@ -1,0 +1,292 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+// Legacy JSON load remains for one-time migration from bms_cache.
+
+namespace osu.Game.Rulesets.BMS.Beatmaps
+{
+    /// <summary>
+    /// Represents cached metadata for a BMS song folder (may contain multiple charts).
+    /// </summary>
+    [Serializable]
+    public class BMSSongCache
+    {
+        /// <summary>
+        /// The absolute path to the song folder.
+        /// </summary>
+        public string FolderPath { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Title of the song (from first chart parsed).
+        /// </summary>
+        public string Title { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Artist of the song.
+        /// </summary>
+        public string Artist { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Genre of the song.
+        /// </summary>
+        public string Genre { get; set; } = string.Empty;
+
+        /// <summary>
+        /// List of charts (difficulties) in this song folder.
+        /// </summary>
+        public List<BMSChartCache> Charts { get; set; } = new List<BMSChartCache>();
+
+        /// <summary>
+        /// Last modified time of the folder (for detecting changes).
+        /// </summary>
+        public DateTime LastModified { get; set; }
+
+        /// <summary>
+        /// Path to the banner image (relative to folder).
+        /// </summary>
+        public string? BannerPath { get; set; }
+
+        /// <summary>
+        /// Path to the stage file (relative to folder).
+        /// </summary>
+        public string? StageFilePath { get; set; }
+    }
+
+    /// <summary>
+    /// Represents cached metadata for a single BMS chart file.
+    /// </summary>
+    [Serializable]
+    public class BMSChartCache
+    {
+        /// <summary>
+        /// The filename of the BMS file (relative to song folder).
+        /// </summary>
+        public string FileName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Full absolute path to the BMS file.
+        /// </summary>
+        [JsonIgnore]
+        public string FullPath => Path.Combine(FolderPath, FileName);
+
+        /// <summary>
+        /// Parent folder path.
+        /// </summary>
+        public string FolderPath { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Chart-specific title (may differ from song title).
+        /// </summary>
+        public string Title { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Chart-specific subtitle.
+        /// </summary>
+        public string SubTitle { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Chart-specific artist.
+        /// </summary>
+        public string Artist { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Chart-specific subartist.
+        /// </summary>
+        public string SubArtist { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Genre.
+        /// </summary>
+        public string Genre { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Play level (difficulty number).
+        /// </summary>
+        public int PlayLevel { get; set; }
+
+        /// <summary>
+        /// Difficulty rank (JUDGE timing).
+        /// </summary>
+        public int Rank { get; set; } = 2;
+
+        /// <summary>
+        /// Total gauge (health).
+        /// </summary>
+        public double Total { get; set; } = 100;
+
+        /// <summary>
+        /// Initial BPM.
+        /// </summary>
+        public double Bpm { get; set; } = 130;
+
+        /// <summary>
+        /// Minimum BPM (for display).
+        /// </summary>
+        public double MinBpm { get; set; }
+
+        /// <summary>
+        /// Maximum BPM (for display).
+        /// </summary>
+        public double MaxBpm { get; set; }
+
+        /// <summary>
+        /// Number of keys (5, 7, 9, 10, 14, etc.).
+        /// </summary>
+        public int KeyCount { get; set; } = 7;
+
+        /// <summary>
+        /// Preferred backing audio file resolved from the chart.
+        /// </summary>
+        public string? AudioFile { get; set; }
+
+        /// <summary>
+        /// Preview start time in milliseconds.
+        /// </summary>
+        public int PreviewTime { get; set; } = -1;
+
+        /// <summary>
+        /// Optional preview audio file from #PREVIEW.
+        /// </summary>
+        public string? PreviewFile { get; set; }
+
+        /// <summary>
+        /// Whether this chart has scratch lane.
+        /// </summary>
+        public bool HasScratch { get; set; }
+
+        /// <summary>
+        /// Whether this chart has long notes.
+        /// </summary>
+        public bool HasLongNotes { get; set; }
+
+        /// <summary>
+        /// Whether this chart contains STOP sequence events.
+        /// </summary>
+        public bool HasStopSequence { get; set; }
+
+        /// <summary>
+        /// Whether this chart contains scroll speed changes.
+        /// </summary>
+        public bool HasScrollChanges { get; set; }
+
+        /// <summary>
+        /// Whether this chart references BGA/layer channels.
+        /// </summary>
+        public bool HasBgaLayer { get; set; }
+
+        /// <summary>
+        /// Parsed LNTYPE value if available.
+        /// </summary>
+        public int LnType { get; set; } = 1;
+
+        /// <summary>
+        /// Total note count.
+        /// </summary>
+        public int TotalNotes { get; set; }
+
+        /// <summary>
+        /// Long-note object count (channels 51–59 / 61–69) for mania conversion heuristics.
+        /// </summary>
+        public int LongNoteCount { get; set; }
+
+        /// <summary>
+        /// Duration of the chart in milliseconds.
+        /// </summary>
+        public double Duration { get; set; }
+
+        /// <summary>
+        /// List of keysound file paths used in this chart (relative to folder).
+        /// </summary>
+        public List<string> KeysoundFiles { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Path-derived chart key (legacy field name retained for compatibility).
+        /// </summary>
+        public string Md5Hash { get; set; } = string.Empty;
+
+        /// <summary>
+        /// File size for quick change detection.
+        /// </summary>
+        public long FileSize { get; set; }
+
+        /// <summary>
+        /// Last write time of the file.
+        /// </summary>
+        public DateTime LastModified { get; set; }
+    }
+
+    /// <summary>
+    /// The root cache structure that holds all scanned BMS songs.
+    /// </summary>
+    [Serializable]
+    public class BMSLibraryCache
+    {
+        /// <summary>
+        /// Version of the cache format (for migration).
+        /// </summary>
+        public int Version { get; set; } = 2;
+
+        /// <summary>
+        /// The root path that was scanned.
+        /// </summary>
+        public string RootPath { get; set; } = string.Empty;
+
+        /// <summary>
+        /// All configured root paths that were scanned.
+        /// </summary>
+        public List<string> RootPaths { get; set; } = new List<string>();
+
+        /// <summary>
+        /// When the cache was last updated.
+        /// </summary>
+        public DateTime LastScanTime { get; set; }
+
+        /// <summary>
+        /// All songs in the library.
+        /// </summary>
+        public List<BMSSongCache> Songs { get; set; } = new List<BMSSongCache>();
+
+        /// <summary>
+        /// Total number of charts.
+        /// </summary>
+        [JsonIgnore]
+        public int TotalCharts
+        {
+            get
+            {
+                int count = 0;
+                foreach (var song in Songs)
+                    count += song.Charts.Count;
+                return count;
+            }
+        }
+
+        internal static readonly JsonSerializerOptions JSON_OPTIONS = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
+
+        /// <summary>
+        /// Load legacy JSON cache (migration only).
+        /// </summary>
+        internal static BMSLibraryCache? Load(string filePath)
+        {
+            if (!File.Exists(filePath))
+                return null;
+
+            try
+            {
+                string json = File.ReadAllText(filePath);
+                return JsonSerializer.Deserialize<BMSLibraryCache>(json, JSON_OPTIONS);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/Beatmaps/BMSBeatmapConverter.cs
+++ b/osu.Game.Rulesets.BMS/Beatmaps/BMSBeatmapConverter.cs
@@ -1,0 +1,74 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.BMS.Objects;
+using osu.Game.Rulesets.Objects;
+
+namespace osu.Game.Rulesets.BMS.Beatmaps
+{
+    /// <summary>
+    /// Converts beatmaps for BMS ruleset.
+    /// </summary>
+    public class BMSBeatmapConverter : BeatmapConverter<BMSHitObject>
+    {
+        public int TargetColumns { get; set; } = 8; // Default 7K + scratch
+
+        public BMSBeatmapConverter(IBeatmap beatmap, Ruleset ruleset)
+            : base(beatmap, ruleset)
+        {
+            // Determine columns from beatmap
+            if (beatmap.HitObjects.OfType<BMSHitObject>().Any())
+            {
+                TargetColumns = beatmap.HitObjects.OfType<BMSHitObject>().Max(h => h.Column) + 1;
+            }
+        }
+
+        public override bool CanConvert() => true;
+
+        protected override Beatmap<BMSHitObject> CreateBeatmap()
+        {
+            var beatmap = new Beatmap<BMSHitObject>();
+
+            return beatmap;
+        }
+
+        protected override Beatmap<BMSHitObject> ConvertBeatmap(IBeatmap original, CancellationToken cancellationToken)
+        {
+            var converted = base.ConvertBeatmap(original, cancellationToken);
+            converted.HitObjects = converted.HitObjects.Select(cloneBmsHitObject).ToList();
+            return converted;
+        }
+
+        protected override IEnumerable<BMSHitObject> ConvertHitObject(HitObject original, IBeatmap beatmap, CancellationToken cancellationToken)
+        {
+            if (original is BMSHitObject bmsObject)
+                yield return cloneBmsHitObject(bmsObject);
+        }
+
+        private static BMSHitObject cloneBmsHitObject(BMSHitObject source)
+        {
+            BMSHitObject clone = source switch
+            {
+                BMSHoldNote hold => new BMSHoldNote
+                {
+                    Duration = hold.Duration
+                },
+                BMSHoldNoteHead => new BMSHoldNoteHead(),
+                BMSHoldNoteTail => new BMSHoldNoteTail(),
+                BMSHoldNoteBody body => new BMSHoldNoteBody
+                {
+                    Duration = body.Duration
+                },
+                BMSNote => new BMSNote(),
+                _ => throw new ArgumentOutOfRangeException(nameof(source), source.GetType(), @"Unsupported BMS hitobject type"),
+            };
+
+            clone.StartTime = source.StartTime;
+            clone.Column = source.Column;
+            clone.IsScratch = source.IsScratch;
+            clone.Samples = source.Samples.ToList();
+            return clone;
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/Beatmaps/BMSBeatmapDecoder.cs
+++ b/osu.Game.Rulesets.BMS/Beatmaps/BMSBeatmapDecoder.cs
@@ -1,0 +1,720 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Globalization;
+using System.Text.RegularExpressions;
+using osu.Framework.Logging;
+using osu.Game.Audio;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Beatmaps.Formats;
+using osu.Game.IO;
+using osu.Game.Rulesets.BMS.Objects;
+using osu.Game.Rulesets.BMS.UI.BmsSongSelect.Analytics;
+using osu.Game.Rulesets.Objects.Legacy;
+
+namespace osu.Game.Rulesets.BMS.Beatmaps
+{
+    /// <summary>
+    /// Decoder for BMS/BME/BML/PMS file formats.
+    /// </summary>
+    /// <remarks>
+    /// Scratch channels map to mania columns via a single global scheme (e.g. 16/56 → lane 0); keep converter, decoder and
+    /// <see cref="UI.BMSColumn"/> input bindings aligned when changing mapping. Mirror and DP are handled outside the decoder.
+    /// </remarks>
+    public class BMSBeatmapDecoder : Decoder<Beatmap>
+    {
+        private const string bms_log_prefix = "[BMS]";
+
+        protected override Beatmap CreateTemplateObject() => new BMSBeatmap();
+
+        // BMS channel definitions
+        private const int channel_bgm = 1;
+        private const int channel_measure_length = 2;
+        private const int channel_bpm_change = 3;
+        private const int channel_bga_base = 4;
+        private const int channel_bga_poor = 6;
+        private const int channel_bga_layer = 7;
+        private const int channel_extended_bpm = 8;
+        private const int channel_stop = 9;
+
+        // 1P visible notes: 11-19 (1-7 keys + scratch)
+        // 1P long notes: 51-59
+        // 1P invisible notes: 31-39
+        // 2P visible notes: 21-29
+        // 2P long notes: 61-69
+
+        private readonly Dictionary<string, string> wavDefinitions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, string> bmpDefinitions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, double> bpmDefinitions = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, double> stopDefinitions = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+
+        private readonly Dictionary<int, double> measureLengths = new Dictionary<int, double>();
+        private readonly List<BMSEvent> events = new List<BMSEvent>();
+        private readonly HashSet<string> lnObjectKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        private double initialBpm = 130;
+        private int totalKeys = 7;
+
+        /// <summary>1 = LN channel (51+), 2 = charge/note-based LN (+ optional LNOBJ), 3 = hell charge — generation matches 2 when LNOBJ set.</summary>
+        private int lnType = 1;
+
+        private int eventSequence;
+
+        /// <summary>Chart references #SCROLL (not measure channel).</summary>
+        private bool chartHasScrollDirective;
+
+        // Metadata
+        private string title = string.Empty;
+        private string subtitle = string.Empty;
+        private string artist = string.Empty;
+        private string subartist = string.Empty;
+        private string genre = string.Empty;
+        private string stageFile = string.Empty;
+        private string banner = string.Empty;
+        private int playLevel;
+        private int difficulty;
+        private int rank = 2; // Judge rank (0=very hard, 1=hard, 2=normal, 3=easy)
+        private double total = 100;
+
+        public static void Register()
+        {
+            // Register for various BMS file magic strings
+            AddDecoder<Beatmap>("*----------------------", _ => new BMSBeatmapDecoder());
+            AddDecoder<Beatmap>("#PLAYER", _ => new BMSBeatmapDecoder());
+            AddDecoder<Beatmap>("#GENRE", _ => new BMSBeatmapDecoder());
+            AddDecoder<Beatmap>("#TITLE", _ => new BMSBeatmapDecoder());
+            AddDecoder<Beatmap>("#ARTIST", _ => new BMSBeatmapDecoder());
+            AddDecoder<Beatmap>("#BPM", _ => new BMSBeatmapDecoder());
+            AddDecoder<Beatmap>("#PLAYLEVEL", _ => new BMSBeatmapDecoder());
+        }
+
+        protected override void ParseStreamInto(LineBufferedReader stream, bool isPrimaryStream, Beatmap beatmap)
+        {
+            // Reset state
+            wavDefinitions.Clear();
+            bmpDefinitions.Clear();
+            bpmDefinitions.Clear();
+            stopDefinitions.Clear();
+            measureLengths.Clear();
+            events.Clear();
+            lnObjectKeys.Clear();
+            eventSequence = 0;
+            chartHasScrollDirective = false;
+            lnType = 1;
+
+            string? line;
+            var scanCancellation = BmsAnalyticsScanContext.ActiveCancellation;
+
+            while ((line = stream.ReadLine()) != null)
+            {
+                if (scanCancellation.IsCancellationRequested)
+                    throw new OperationCanceledException(scanCancellation);
+
+                line = line.Trim();
+
+                if (string.IsNullOrEmpty(line) || line.StartsWith('*'))
+                    continue;
+
+                if (line.StartsWith('#'))
+                    parseLine(line);
+            }
+
+            // Build the beatmap
+            buildBeatmap(beatmap);
+        }
+
+        private void parseLine(string line)
+        {
+            if (line.StartsWith("#SCROLL", StringComparison.OrdinalIgnoreCase)
+                && !Regex.IsMatch(line, @"^#\d{3}\d{2}:"))
+            {
+                chartHasScrollDirective = true;
+            }
+
+            // Match header commands like #TITLE, #ARTIST, #WAV01/#WAVAA, etc.
+            // BMS uses base36 (0-9, A-Z) indices, but many headers have no index.
+            if (line.StartsWith('#'))
+            {
+                int spaceIndex = line.IndexOfAny(new[] { ' ', '\t' }, 1);
+
+                if (spaceIndex > 1)
+                {
+                    string header = line.Substring(1, spaceIndex - 1).Trim();
+                    string value = line.Substring(spaceIndex + 1).Trim();
+
+                    string upperHeader = header.ToUpperInvariant();
+                    string command = upperHeader;
+                    string index = string.Empty;
+
+                    if (upperHeader.StartsWith("WAV", StringComparison.Ordinal) && upperHeader.Length > 3)
+                    {
+                        command = "WAV";
+                        index = upperHeader.Substring(3);
+                    }
+                    else if (upperHeader.StartsWith("BMP", StringComparison.Ordinal) && upperHeader.Length > 3)
+                    {
+                        command = "BMP";
+                        index = upperHeader.Substring(3);
+                    }
+                    else if (upperHeader.StartsWith("STOP", StringComparison.Ordinal) && upperHeader.Length > 4)
+                    {
+                        command = "STOP";
+                        index = upperHeader.Substring(4);
+                    }
+                    else if (upperHeader.StartsWith("BPM", StringComparison.Ordinal) && upperHeader.Length > 3)
+                    {
+                        command = "BPM";
+                        index = upperHeader.Substring(3);
+                    }
+
+                    parseHeader(command, index, value);
+                    return;
+                }
+            }
+
+            // Match channel data like #00111:01020304
+            var channelMatch = Regex.Match(line, @"^#(\d{3})(\d{2}):(.+)$");
+
+            if (channelMatch.Success)
+            {
+                int measure = int.Parse(channelMatch.Groups[1].Value, CultureInfo.InvariantCulture);
+                int channel = int.Parse(channelMatch.Groups[2].Value, CultureInfo.InvariantCulture);
+                string data = channelMatch.Groups[3].Value;
+
+                parseChannelData(measure, channel, data);
+            }
+        }
+
+        private void parseHeader(string command, string index, string value)
+        {
+            switch (command)
+            {
+                case "TITLE":
+                    title = value;
+                    break;
+
+                case "SUBTITLE":
+                    subtitle = value;
+                    break;
+
+                case "ARTIST":
+                    artist = value;
+                    break;
+
+                case "SUBARTIST":
+                    subartist = value;
+                    break;
+
+                case "GENRE":
+                    genre = value;
+                    break;
+
+                case "BPM":
+                    if (string.IsNullOrEmpty(index))
+                    {
+                        // Initial BPM
+                        if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out double bpm))
+                            initialBpm = bpm;
+                    }
+                    else
+                    {
+                        // Extended BPM definition
+                        if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out double bpm))
+                            bpmDefinitions[index] = bpm;
+                    }
+
+                    break;
+
+                case "WAV":
+                    if (!string.IsNullOrEmpty(index))
+                        wavDefinitions[index] = value;
+                    break;
+
+                case "BMP":
+                    if (!string.IsNullOrEmpty(index))
+                        bmpDefinitions[index] = value;
+                    break;
+
+                case "STOP":
+                    if (!string.IsNullOrEmpty(index) && double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out double stopValue))
+                        stopDefinitions[index] = stopValue;
+                    break;
+
+                case "STAGEFILE":
+                    stageFile = value;
+                    break;
+
+                case "BANNER":
+                    banner = value;
+                    break;
+
+                case "PLAYLEVEL":
+                    int.TryParse(value, out playLevel);
+                    break;
+
+                case "DIFFICULTY":
+                    int.TryParse(value, out difficulty);
+                    break;
+
+                case "RANK":
+                    int.TryParse(value, out rank);
+                    break;
+
+                case "TOTAL":
+                    double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out total);
+                    break;
+
+                case "LNTYPE":
+                    int.TryParse(value, out lnType);
+                    break;
+
+                case "LNOBJ":
+                    foreach (string part in value.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries))
+                    {
+                        string p = part.Trim();
+                        if (p.Length >= 2)
+                            lnObjectKeys.Add(p[..2]);
+                    }
+
+                    break;
+
+                case "PLAYER":
+                    // 1=SP, 2=DP, 3=double play
+                    break;
+            }
+        }
+
+        private void parseChannelData(int measure, int channel, string data)
+        {
+            // Measure length change
+            if (channel == channel_measure_length)
+            {
+                if (double.TryParse(data, NumberStyles.Float, CultureInfo.InvariantCulture, out double length))
+                    measureLengths[measure] = length;
+                return;
+            }
+
+            // Parse the object data (every 2 characters = 1 object)
+            int objectCount = data.Length / 2;
+
+            for (int i = 0; i < objectCount; i++)
+            {
+                string objKey = data.Substring(i * 2, 2);
+
+                if (objKey == "00")
+                    continue;
+
+                double position = (double)i / objectCount;
+
+                events.Add(new BMSEvent
+                {
+                    Sequence = eventSequence++,
+                    Measure = measure,
+                    Channel = channel,
+                    Position = position,
+                    Value = objKey
+                });
+            }
+        }
+
+        private void buildBeatmap(Beatmap beatmap)
+        {
+            // Log for debugging
+            Logger.Log($"[BMS] Loaded {wavDefinitions.Count} WAV definitions, {bmpDefinitions.Count} BMP definitions", LoggingTarget.Runtime, LogLevel.Debug);
+
+            // Set metadata
+            beatmap.BeatmapInfo.Metadata.Title = title;
+            beatmap.BeatmapInfo.Metadata.TitleUnicode = title;
+            beatmap.BeatmapInfo.Metadata.Artist = artist;
+            beatmap.BeatmapInfo.Metadata.ArtistUnicode = artist;
+            beatmap.BeatmapInfo.Metadata.Author.Username = "Ez2Lazer BMSDecoder";
+            beatmap.BeatmapInfo.Metadata.Source = "BMS Import";
+            beatmap.BeatmapInfo.Ruleset = new BMSRuleset().RulesetInfo;
+            beatmap.BeatmapInfo.DifficultyName = getDifficultyName();
+
+            if (!string.IsNullOrEmpty(stageFile))
+                beatmap.BeatmapInfo.Metadata.BackgroundFile = stageFile;
+
+            // Calculate chart timeline once and re-use for all generated objects/events.
+            var timeline = buildTimeline();
+            var timingPoints = createTimingPointsFromTimeline(timeline);
+            foreach (var tp in timingPoints)
+                beatmap.ControlPointInfo.Add(tp.Time, tp.ControlPoint);
+
+            // Create hit objects
+            var hitObjects = createHitObjects(timeline.EventTimes);
+            beatmap.HitObjects.AddRange(hitObjects);
+            beatmap.BeatmapInfo.Metadata.Tags = buildFeatureTags(hitObjects);
+
+            // Store background (non-note) sound events
+            if (beatmap is BMSBeatmap bmsBeatmap)
+            {
+                bmsBeatmap.TotalColumns = totalKeys;
+                var backgroundEvents = createBackgroundSoundEvents(timeline.EventTimes);
+                bmsBeatmap.BackgroundSoundEvents.AddRange(backgroundEvents);
+
+                if (backgroundEvents.Count > 0)
+                {
+                    beatmap.BeatmapInfo.Metadata.AudioFile = backgroundEvents[0].Filename;
+                    beatmap.BeatmapInfo.Metadata.PreviewTime = (int)Math.Max(0, backgroundEvents[0].Time);
+                }
+                else if (wavDefinitions.Count > 0)
+                {
+                    beatmap.BeatmapInfo.Metadata.AudioFile = wavDefinitions.OrderBy(kvp => kvp.Key).Select(kvp => kvp.Value).First();
+                }
+
+                Logger.Log($"[BMS] Background sound events: {backgroundEvents.Count}", LoggingTarget.Runtime, LogLevel.Debug);
+            }
+
+            // Set difficulty
+            beatmap.Difficulty.CircleSize = totalKeys;
+            beatmap.Difficulty.OverallDifficulty = mapRankToOD(rank);
+            beatmap.Difficulty.DrainRate = 7;
+        }
+
+        private string buildFeatureTags(List<BMSHitObject> notes)
+        {
+            var tags = new List<string> { "bms" };
+
+            if (!string.IsNullOrWhiteSpace(genre))
+                tags.Add(genre.Trim());
+
+            if (notes.Exists(static n => n is BMSHoldNote))
+                tags.Add("ln");
+
+            if (events.Exists(e => e.Channel == channel_stop && isNonEmptyObjectValue(e.Value)))
+                tags.Add("stop");
+
+            if (chartHasScrollDirective)
+                tags.Add("scroll");
+
+            if (events.Exists(static e => e.Channel is channel_bga_base or channel_bga_poor or channel_bga_layer))
+                tags.Add("bga");
+
+            return string.Join(' ', tags);
+        }
+
+        private static bool isNonEmptyObjectValue(string valueKey) => valueKey.Length >= 2 && valueKey != "00";
+
+        private string getDifficultyName()
+        {
+            string name = difficulty switch
+            {
+                1 => "Beginner",
+                2 => "Normal",
+                3 => "Hyper",
+                4 => "Another",
+                5 => "Insane",
+                _ => $"Level {playLevel}"
+            };
+
+            if (!string.IsNullOrEmpty(subtitle))
+                name = $"{subtitle} [{name}]";
+
+            return name;
+        }
+
+        private float mapRankToOD(int bmsRank)
+        {
+            // BMS RANK: 0=very hard, 1=hard, 2=normal, 3=easy
+            // Map to OD: higher OD = tighter windows
+            return bmsRank switch
+            {
+                0 => 9f,
+                1 => 8f,
+                2 => 7f,
+                3 => 5f,
+                _ => 7f
+            };
+        }
+
+        private TimelineData buildTimeline()
+        {
+            var timingPoints = new List<TimingPointData>
+            {
+                new TimingPointData
+                {
+                    Time = 0,
+                    ControlPoint = new TimingControlPoint { BeatLength = 60000 / initialBpm }
+                }
+            };
+
+            var sortedEvents = events
+                               .OrderBy(e => e.Measure)
+                               .ThenBy(e => e.Position)
+                               .ThenBy(e => e.Sequence)
+                               .ToList();
+
+            var eventTimes = new Dictionary<BMSEvent, double>();
+
+            double currentTime = 0;
+            double currentBpm = initialBpm;
+            int currentMeasure = 0;
+            double currentPositionInMeasure = 0;
+
+            foreach (var evt in sortedEvents.OrderBy(e => e.Measure).ThenBy(e => e.Position).ThenBy(e => e.Sequence))
+            {
+                double targetPositionInMeasure = Math.Clamp(evt.Position, 0, 1);
+                advanceTimeline(ref currentTime, ref currentMeasure, ref currentPositionInMeasure, evt.Measure, targetPositionInMeasure, currentBpm);
+                eventTimes[evt] = currentTime;
+
+                if (tryGetBpmChange(evt, out double bpm) && bpm > 0)
+                {
+                    currentBpm = bpm;
+                    timingPoints.Add(new TimingPointData
+                    {
+                        Time = currentTime,
+                        ControlPoint = new TimingControlPoint { BeatLength = 60000 / bpm }
+                    });
+                }
+
+                if (evt.Channel == channel_stop && stopDefinitions.TryGetValue(evt.Value, out double stopValue) && stopValue > 0)
+                {
+                    // In BMS, STOP units are based on 1/192 measure (== 1/48 beat at 4/4).
+                    currentTime += stopValue * (60000 / currentBpm) / 48.0;
+                }
+            }
+
+            return new TimelineData
+            {
+                TimingPoints = timingPoints.OrderBy(t => t.Time).ToList(),
+                EventTimes = eventTimes
+            };
+        }
+
+        private List<TimingPointData> createTimingPointsFromTimeline(TimelineData timeline) => timeline.TimingPoints;
+
+        private void advanceTimeline(ref double currentTime, ref int currentMeasure, ref double currentPositionInMeasure, int targetMeasure, double targetPositionInMeasure, double bpm)
+        {
+            if (targetMeasure < currentMeasure || targetMeasure == currentMeasure && targetPositionInMeasure < currentPositionInMeasure)
+                return;
+
+            while (currentMeasure < targetMeasure)
+            {
+                double remainingPortion = 1 - currentPositionInMeasure;
+                currentTime += beatLengthForMeasure(currentMeasure, bpm) * remainingPortion;
+                currentMeasure++;
+                currentPositionInMeasure = 0;
+            }
+
+            if (targetPositionInMeasure > currentPositionInMeasure)
+                currentTime += beatLengthForMeasure(currentMeasure, bpm) * (targetPositionInMeasure - currentPositionInMeasure);
+
+            currentPositionInMeasure = targetPositionInMeasure;
+        }
+
+        private bool tryGetBpmChange(BMSEvent evt, out double bpm)
+        {
+            bpm = 0;
+
+            if (evt.Channel == channel_bpm_change)
+            {
+                bpm = Convert.ToInt32(evt.Value, 16);
+                return bpm > 0;
+            }
+
+            if (evt.Channel == channel_extended_bpm && bpmDefinitions.TryGetValue(evt.Value, out bpm))
+                return bpm > 0;
+
+            return false;
+        }
+
+        private double beatLengthForMeasure(int measure, double bpm)
+        {
+            double measureLength = measureLengths.GetValueOrDefault(measure, 1.0);
+            double beatsPerMeasure = 4.0 * measureLength;
+            double msPerBeat = 60000 / bpm;
+            return beatsPerMeasure * msPerBeat;
+        }
+
+        private List<BMSHitObject> createHitObjects(Dictionary<BMSEvent, double> eventTimes)
+        {
+            var result = new List<BMSHitObject>();
+            var activeHolds = new Dictionary<int, BMSEvent>(); // For LN processing
+
+            var noteEvents = events
+                             .Where(e => isNoteChannel(e.Channel))
+                             .OrderBy(e => e.Measure)
+                             .ThenBy(e => e.Position)
+                             .ToList();
+
+            Logger.Log($"{bms_log_prefix} Found {noteEvents.Count} note events", LoggingTarget.Runtime, LogLevel.Debug);
+
+            bool longNotesFromVisibleWithLnObj = lnObjectKeys.Count > 0 && (lnType == 2 || lnType == 3);
+
+            foreach (var evt in noteEvents)
+            {
+                int column = getColumn(evt.Channel);
+                bool isScratch = BmsLaneMapping.IsScratchChannel(evt.Channel);
+                bool isLongNote = isLongNoteChannel(evt.Channel)
+                                  || longNotesFromVisibleWithLnObj && isVisiblePlayerNoteChannel(evt.Channel) && lnObjectKeys.Contains(evt.Value);
+                double time = eventTimes[evt];
+
+                // Get keysound sample
+                var samples = new List<HitSampleInfo>();
+
+                if (wavDefinitions.TryGetValue(evt.Value, out string? wavFile))
+                {
+                    samples.Add(new ConvertHitObjectParser.FileHitSampleInfo(wavFile, 100));
+                }
+
+                if (isLongNote)
+                {
+                    // LN processing: pair start and end
+                    if (activeHolds.TryGetValue(column, out var startEvent))
+                    {
+                        double startTime = eventTimes[startEvent];
+
+                        result.Add(new BMSHoldNote
+                        {
+                            Column = column,
+                            StartTime = startTime,
+                            Duration = time - startTime,
+                            IsScratch = isScratch,
+                            Samples = samples,
+                        });
+
+                        activeHolds.Remove(column);
+                    }
+                    else
+                    {
+                        activeHolds[column] = evt;
+                    }
+                }
+                else
+                {
+                    result.Add(new BMSNote
+                    {
+                        Column = column,
+                        StartTime = time,
+                        IsScratch = isScratch,
+                        Samples = samples,
+                    });
+                }
+            }
+
+            compactColumns(result);
+
+            // Update total keys based on used columns
+            if (result.Count > 0)
+            {
+                totalKeys = result.Max(h => h.Column) + 1;
+
+                // Log first note's samples for debugging
+                var firstNote = result.First();
+                string sampleInfo = firstNote.Samples.Count > 0
+                    ? string.Join(", ", firstNote.Samples.Select(s => s is ConvertHitObjectParser.FileHitSampleInfo fs ? fs.Filename : s.Name))
+                    : "(no samples)";
+                Logger.Log($"[BMS] Created {result.Count} hit objects, first note samples: {sampleInfo}", LoggingTarget.Runtime, LogLevel.Debug);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Compress sparse decoder columns to contiguous lanes (0..N-1).
+        /// Prevents panel inflation when channel mapping leaves gaps (e.g. 10+2 charts).
+        /// </summary>
+        private static void compactColumns(List<BMSHitObject> hitObjects)
+        {
+            if (hitObjects.Count == 0)
+                return;
+
+            int[] used = hitObjects.Select(h => h.Column)
+                                   .Distinct()
+                                   .OrderBy(c => c)
+                                   .ToArray();
+
+            var remap = new Dictionary<int, int>(used.Length);
+
+            for (int i = 0; i < used.Length; i++)
+                remap[used[i]] = i;
+
+            foreach (var hitObject in hitObjects)
+                hitObject.Column = remap[hitObject.Column];
+        }
+
+        private List<BmsBackgroundSoundEvent> createBackgroundSoundEvents(Dictionary<BMSEvent, double> eventTimes)
+        {
+            var result = new List<BmsBackgroundSoundEvent>();
+
+            var backgroundEvents = events
+                                   .Where(e => isBackgroundSoundChannel(e.Channel))
+                                   .OrderBy(e => e.Measure)
+                                   .ThenBy(e => e.Position)
+                                   .ToList();
+
+            foreach (var evt in backgroundEvents)
+            {
+                if (!wavDefinitions.TryGetValue(evt.Value, out string? wavFile))
+                    continue;
+
+                double time = eventTimes[evt];
+                result.Add(new BmsBackgroundSoundEvent(time, wavFile));
+            }
+
+            return result;
+        }
+
+        private bool isNoteChannel(int channel)
+        {
+            // 1P visible: 11-19, 1P LN: 51-59
+            // 2P visible: 21-29, 2P LN: 61-69
+            return channel >= 11 && channel <= 19 ||
+                   channel >= 21 && channel <= 29 ||
+                   channel >= 51 && channel <= 59 ||
+                   channel >= 61 && channel <= 69;
+        }
+
+        private bool isBackgroundSoundChannel(int channel)
+        {
+            if (isNoteChannel(channel))
+                return false;
+
+            if (channel == channel_measure_length ||
+                channel == channel_bpm_change ||
+                channel == channel_extended_bpm ||
+                channel == channel_stop)
+                return false;
+
+            if (channel == channel_bga_base ||
+                channel == channel_bga_poor ||
+                channel == channel_bga_layer)
+                return false;
+
+            return true;
+        }
+
+        private bool isLongNoteChannel(int channel)
+        {
+            return channel >= 51 && channel <= 59 ||
+                   channel >= 61 && channel <= 69;
+        }
+
+        private static bool isVisiblePlayerNoteChannel(int channel) => channel is >= 11 and <= 19 or >= 21 and <= 29;
+
+        private int getColumn(int channel) => BmsLaneMapping.ChannelToColumn(channel);
+
+        private class BMSEvent
+        {
+            public int Sequence { get; set; }
+            public int Measure { get; set; }
+            public int Channel { get; set; }
+            public double Position { get; set; }
+            public string Value { get; set; } = string.Empty;
+        }
+
+        private class TimelineData
+        {
+            public List<TimingPointData> TimingPoints { get; set; } = new List<TimingPointData>();
+            public Dictionary<BMSEvent, double> EventTimes { get; set; } = new Dictionary<BMSEvent, double>();
+        }
+
+        private class TimingPointData
+        {
+            public double Time { get; set; }
+            public TimingControlPoint ControlPoint { get; set; } = new TimingControlPoint();
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/Beatmaps/BMSBeatmapManager.cs
+++ b/osu.Game.Rulesets.BMS/Beatmaps/BMSBeatmapManager.cs
@@ -1,0 +1,968 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
+using osu.Framework.Bindables;
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.BMS.Beatmaps.Persistence;
+
+namespace osu.Game.Rulesets.BMS.Beatmaps
+{
+    /// <summary>
+    ///     Manages BMS library scanning, SQLite indexing, and loading.
+    /// </summary>
+    public class BMSBeatmapManager
+    {
+        private static readonly object shared_manager_lock = new object();
+        private static BMSBeatmapManager? sharedManager;
+        private static string? sharedStorageDirectory;
+
+        public Bindable<string> RootPath { get; } = new Bindable<string>(string.Empty);
+
+        public IReadOnlyList<string> RootPaths => rootPaths;
+
+        public BindableDouble ScanProgress { get; } = new BindableDouble();
+
+        public Bindable<string> StatusMessage { get; } = new Bindable<string>(string.Empty);
+
+        public BindableBool IsScanning { get; } = new BindableBool();
+
+        public BMSLibraryCache? LibraryCache { get; private set; }
+
+        public long LastScanRevision { get; private set; }
+
+        public long LastSynchronizedScanRevision { get; private set; }
+
+        public int LastSynchronizedRealmFileMappingVersion { get; private set; }
+
+        /// <summary>
+        /// Tracks whether Realm still needs a catalog pass. Revision equality alone is insufficient
+        /// (both zero on a fresh index) and would skip the first sync, leaving the carousel on stale IDs.
+        /// </summary>
+        private bool realmSyncRequired;
+
+        public bool NeedsRealmSynchronization => realmSyncRequired
+                                                 || LastScanRevision != LastSynchronizedScanRevision
+                                                 || LastSynchronizedRealmFileMappingVersion != BmsRealmSyncConstants.FILE_MAPPING_SCHEMA_VERSION;
+
+        public bool HasIndexedCharts => LibraryCache?.TotalCharts > 0;
+
+        private static readonly string[] bms_extensions = { ".bms", ".bme", ".bml", ".pms" };
+
+        private readonly string storageDirectory;
+        private readonly BmsLibraryIndexRepository indexRepository;
+        private readonly List<string> rootPaths = new List<string>();
+        private readonly Dictionary<Guid, BMSSourceReference> beatmapSourceMap = new Dictionary<Guid, BMSSourceReference>();
+        private readonly object sourceMapLock = new object();
+
+        private CancellationTokenSource? scanCts;
+
+        public static BMSBeatmapManager GetShared(Storage storage)
+        {
+            string directory = BmsStoragePaths.EnsureInitialized(storage);
+
+            lock (shared_manager_lock)
+            {
+                if (sharedManager == null || !string.Equals(sharedStorageDirectory, directory, StringComparison.Ordinal))
+                {
+                    sharedManager = new BMSBeatmapManager(directory);
+                    sharedManager.LoadCache();
+                    sharedStorageDirectory = directory;
+                }
+
+                return sharedManager;
+            }
+        }
+
+        public BMSBeatmapManager(string storageDirectory)
+        {
+            this.storageDirectory = storageDirectory;
+            Directory.CreateDirectory(storageDirectory);
+            indexRepository = new BmsLibraryIndexRepository(Path.Combine(storageDirectory, BmsStoragePaths.INDEX_DATABASE_FILE));
+        }
+
+        public void LoadCache()
+        {
+            try
+            {
+                LibraryCache = indexRepository.LoadLibraryCache();
+                LastScanRevision = indexRepository.ScanRevision;
+                LastSynchronizedRealmFileMappingVersion = indexRepository.RealmFileMappingVersion;
+                rebuildSourceMapFromIndex();
+
+                if (LibraryCache.RootPaths.Count > 0)
+                    SetRootPaths(LibraryCache.RootPaths);
+                else if (!string.IsNullOrEmpty(LibraryCache.RootPath))
+                    SetRootPaths(new[] { LibraryCache.RootPath });
+
+                StatusMessage.Value = $"已加载 {LibraryCache.Songs.Count} 首歌曲, {LibraryCache.TotalCharts} 张谱面";
+
+                if (LibraryCache.TotalCharts > 0)
+                    realmSyncRequired = true;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "[BMS] Failed to load library index");
+                LibraryCache = new BMSLibraryCache();
+            }
+        }
+
+        public void SetRootPaths(IEnumerable<string> paths)
+        {
+            rootPaths.Clear();
+            rootPaths.AddRange(normaliseRootPaths(paths));
+            RootPath.Value = rootPaths.FirstOrDefault() ?? string.Empty;
+        }
+
+        public void MarkRealmSynchronized()
+        {
+            LastSynchronizedScanRevision = LastScanRevision;
+            LastSynchronizedRealmFileMappingVersion = BmsRealmSyncConstants.FILE_MAPPING_SCHEMA_VERSION;
+            indexRepository.WriteRealmFileMappingVersion(BmsRealmSyncConstants.FILE_MAPPING_SCHEMA_VERSION);
+            realmSyncRequired = false;
+        }
+
+        public void RequireRealmSynchronization() => realmSyncRequired = true;
+
+        public void CancelScan() => scanCts?.Cancel();
+
+        public Task ScanLibraryAsync(string rootPath, CancellationToken cancellationToken = default) => ScanLibraryAsync(new[] { rootPath }, cancellationToken);
+
+        public async Task ScanLibraryAsync(IEnumerable<string> scanPaths, CancellationToken cancellationToken = default)
+        {
+            if (IsScanning.Value)
+            {
+                CancelScan();
+                await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+            }
+
+            scanCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var token = scanCts.Token;
+
+            IsScanning.Value = true;
+            ScanProgress.Value = 0;
+            StatusMessage.Value = "正在扫描文件夹...";
+
+            try
+            {
+                List<string> configuredPaths = normaliseRootPaths(scanPaths);
+                List<string> existingPaths = configuredPaths.Where(Directory.Exists).ToList();
+
+                if (existingPaths.Count == 0)
+                {
+                    StatusMessage.Value = "错误: 没有可用的路径";
+                    return;
+                }
+
+                var bmsFiles = enumerateBmsFiles(existingPaths).ToList();
+
+                if (bmsFiles.Count == 0)
+                {
+                    StatusMessage.Value = "未找到 BMS 文件";
+                    return;
+                }
+
+                StatusMessage.Value = $"找到 {bmsFiles.Count} 个 BMS 文件，正在解析...";
+
+                var folderGroups = bmsFiles
+                                   .GroupBy(f => Path.GetDirectoryName(f) ?? string.Empty)
+                                   .ToList();
+
+                var snapshots = indexRepository.GetChartSnapshots();
+                var seenChartPaths = new ConcurrentBag<string>();
+                int processedFolders = 0;
+                int totalFolders = folderGroups.Count;
+                object progressLock = new object();
+
+                await Task.Run(() =>
+                {
+                    Parallel.ForEach(
+                        folderGroups,
+                        new ParallelOptions
+                        {
+                            MaxDegreeOfParallelism = Math.Clamp(Environment.ProcessorCount, 2, 8),
+                            CancellationToken = token,
+                        },
+                        group =>
+                        {
+                            token.ThrowIfCancellationRequested();
+
+                            string folderPath = group.Key;
+                            var songCache = scanSongFolder(folderPath, group.ToList(), snapshots, token);
+
+                            if (songCache == null || songCache.Charts.Count == 0)
+                                return;
+
+                            indexRepository.UpsertSong(songCache);
+
+                            foreach (BMSChartCache chart in songCache.Charts)
+                            {
+                                string chartPath = chart.FullPath;
+                                seenChartPaths.Add(chartPath);
+
+                                string pathKey = BmsPathKeys.ComputeChartPathKey(chartPath);
+                                chart.Md5Hash = pathKey;
+                                Guid beatmapId = createDeterministicGuid($"bms:chart:{chartPath}");
+
+                                indexRepository.UpsertChart(chart, beatmapId, pathKey);
+
+                                lock (sourceMapLock)
+                                {
+                                    beatmapSourceMap[beatmapId] = new BMSSourceReference
+                                    {
+                                        BeatmapId = beatmapId,
+                                        FolderPath = chart.FolderPath,
+                                        ChartPath = chartPath,
+                                        Md5Hash = pathKey,
+                                    };
+                                }
+                            }
+
+                            int done = Interlocked.Increment(ref processedFolders);
+
+                            lock (progressLock)
+                            {
+                                ScanProgress.Value = (double)done / totalFolders;
+                                StatusMessage.Value = $"正在解析... {done}/{totalFolders} 文件夹";
+                            }
+                        });
+                }, token).ConfigureAwait(false);
+
+                indexRepository.DeleteChartsNotIn(seenChartPaths.Distinct(StringComparer.OrdinalIgnoreCase).ToList());
+                LastScanRevision = indexRepository.MarkScanComplete(existingPaths);
+                LibraryCache = indexRepository.LoadLibraryCache();
+                SetRootPaths(existingPaths);
+                rebuildSourceMapFromIndex();
+                realmSyncRequired = true;
+
+                StatusMessage.Value = $"扫描完成: {LibraryCache.Songs.Count} 首歌曲, {LibraryCache.TotalCharts} 张谱面";
+            }
+            catch (OperationCanceledException)
+            {
+                StatusMessage.Value = "扫描已取消";
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "BMS library scan failed");
+                StatusMessage.Value = $"扫描错误: {ex.Message}";
+            }
+            finally
+            {
+                IsScanning.Value = false;
+                ScanProgress.Value = 1;
+            }
+        }
+
+        public BMSChartCache? GetChartByHash(string pathKey)
+        {
+            if (indexRepository.TryGetSourceReferenceByPathKey(pathKey, out BMSSourceReference reference)
+                && indexRepository.TryLoadChart(reference.ChartPath, out BMSChartCache chart))
+                return chart;
+
+            if (LibraryCache == null)
+                return null;
+
+            foreach (var song in LibraryCache.Songs)
+            {
+                foreach (var cached in song.Charts)
+                {
+                    if (cached.Md5Hash.Equals(pathKey, StringComparison.OrdinalIgnoreCase))
+                        return cached;
+                }
+            }
+
+            return null;
+        }
+
+        public IEnumerable<BMSSongCache> GetAllSongs() => LibraryCache?.Songs ?? Enumerable.Empty<BMSSongCache>();
+
+        public IEnumerable<BMSChartCache> GetAllCharts()
+        {
+            if (LibraryCache == null)
+                yield break;
+
+            foreach (var song in LibraryCache.Songs)
+            {
+                foreach (var chart in song.Charts)
+                    yield return chart;
+            }
+        }
+
+        public IReadOnlyList<BeatmapSetInfo> BuildVirtualBeatmapCatalog(RulesetInfo bmsRulesetInfo)
+        {
+            List<BeatmapSetInfo> result = new List<BeatmapSetInfo>();
+
+            if (LibraryCache == null)
+                return result;
+
+            foreach (BMSSongCache song in LibraryCache.Songs)
+            {
+                if (song.Charts.Count == 0)
+                    continue;
+
+                var beatmapSet = new BeatmapSetInfo
+                {
+                    ID = createDeterministicGuid($"bms:set:{song.FolderPath}"),
+                    DateAdded = song.LastModified,
+                    Hash = song.FolderPath,
+                };
+
+                foreach (BMSChartCache chart in song.Charts.OrderBy(c => c.PlayLevel).ThenBy(c => c.FileName, StringComparer.OrdinalIgnoreCase))
+                {
+                    string chartPath = chart.FullPath;
+                    string pathKey = string.IsNullOrEmpty(chart.Md5Hash)
+                        ? BmsPathKeys.ComputeChartPathKey(chartPath)
+                        : chart.Md5Hash;
+                    string realmHash = BmsPathKeys.ComputeRealmFileHash(chartPath);
+
+                    var metadata = new BeatmapMetadata
+                    {
+                        Title = string.IsNullOrWhiteSpace(chart.Title) ? song.Title : chart.Title,
+                        TitleUnicode = string.IsNullOrWhiteSpace(chart.Title) ? song.Title : chart.Title,
+                        Artist = string.IsNullOrWhiteSpace(chart.Artist) ? song.Artist : chart.Artist,
+                        ArtistUnicode = string.IsNullOrWhiteSpace(chart.Artist) ? song.Artist : chart.Artist,
+                        Source = "BMS",
+                        Tags = buildTags(chart),
+                        AudioFile = string.Empty,
+                        BackgroundFile = song.StageFilePath ?? string.Empty,
+                        PreviewTime = chart.PreviewTime,
+                    };
+
+                    var beatmapInfo = new BeatmapInfo(bmsRulesetInfo, new BeatmapDifficulty(), metadata)
+                    {
+                        ID = createDeterministicGuid($"bms:chart:{chartPath}"),
+                        DifficultyName = formatDifficultyName(chart),
+                        BPM = chart.Bpm,
+                        Length = chart.Duration,
+                        Hash = realmHash,
+                        MD5Hash = pathKey,
+                        TotalObjectCount = chart.TotalNotes,
+                        EndTimeObjectCount = chart.LongNoteCount,
+                        BeatmapSet = beatmapSet,
+                        Difficulty =
+                        {
+                            CircleSize = chart.KeyCount,
+                            OverallDifficulty = mapRankToOD(chart.Rank),
+                            DrainRate = 7
+                        }
+                    };
+
+                    beatmapSet.Beatmaps.Add(beatmapInfo);
+                }
+
+                result.Add(beatmapSet);
+            }
+
+            return result;
+        }
+
+        public bool TryGetSourceReference(Guid beatmapId, out BMSSourceReference sourceReference)
+        {
+            if (tryGetSourceReferenceCore(beatmapId, out sourceReference))
+                return true;
+
+            if (indexRepository.TryGetSourceReference(beatmapId, out sourceReference))
+            {
+                cacheSourceReference(sourceReference);
+                return true;
+            }
+
+            sourceReference = default;
+            return false;
+        }
+
+        public bool TryGetSourceReferenceByHash(string pathKey, out BMSSourceReference sourceReference)
+        {
+            if (tryGetSourceReferenceByHashCore(pathKey, out sourceReference))
+                return true;
+
+            if (indexRepository.TryGetSourceReferenceByPathKey(pathKey, out sourceReference))
+            {
+                cacheSourceReference(sourceReference);
+                return true;
+            }
+
+            sourceReference = default;
+            return false;
+        }
+
+        public Dictionary<Guid, BMSSourceReference> GetCurrentSourceMap()
+        {
+            lock (sourceMapLock)
+                return new Dictionary<Guid, BMSSourceReference>(beatmapSourceMap);
+        }
+
+        private void rebuildSourceMapFromIndex()
+        {
+            var map = new Dictionary<Guid, BMSSourceReference>();
+
+            if (LibraryCache == null)
+            {
+                replaceSourceMap(map);
+                return;
+            }
+
+            foreach (var song in LibraryCache.Songs)
+            {
+                foreach (var chart in song.Charts)
+                {
+                    string chartPath = chart.FullPath;
+                    string pathKey = string.IsNullOrEmpty(chart.Md5Hash)
+                        ? BmsPathKeys.ComputeChartPathKey(chartPath)
+                        : chart.Md5Hash;
+                    Guid beatmapId = createDeterministicGuid($"bms:chart:{chartPath}");
+
+                    map[beatmapId] = new BMSSourceReference
+                    {
+                        BeatmapId = beatmapId,
+                        FolderPath = chart.FolderPath,
+                        ChartPath = chartPath,
+                        Md5Hash = pathKey,
+                    };
+                }
+            }
+
+            replaceSourceMap(map);
+        }
+
+        private void cacheSourceReference(BMSSourceReference reference)
+        {
+            if (reference.BeatmapId == Guid.Empty)
+                return;
+
+            lock (sourceMapLock)
+                beatmapSourceMap[reference.BeatmapId] = reference;
+        }
+
+        private void replaceSourceMap(Dictionary<Guid, BMSSourceReference> newMap)
+        {
+            lock (sourceMapLock)
+            {
+                beatmapSourceMap.Clear();
+
+                foreach ((Guid key, BMSSourceReference value) in newMap)
+                    beatmapSourceMap[key] = value;
+            }
+        }
+
+        private bool tryGetSourceReferenceCore(Guid beatmapId, out BMSSourceReference sourceReference)
+        {
+            lock (sourceMapLock)
+                return beatmapSourceMap.TryGetValue(beatmapId, out sourceReference);
+        }
+
+        private bool tryGetSourceReferenceByHashCore(string pathKey, out BMSSourceReference sourceReference)
+        {
+            lock (sourceMapLock)
+            {
+                foreach (BMSSourceReference reference in beatmapSourceMap.Values)
+                {
+                    if (string.Equals(reference.Md5Hash, pathKey, StringComparison.OrdinalIgnoreCase))
+                    {
+                        sourceReference = reference;
+                        return true;
+                    }
+                }
+            }
+
+            sourceReference = default;
+            return false;
+        }
+
+        private static IEnumerable<string> enumerateBmsFiles(IEnumerable<string> rootPaths)
+        {
+            var extensions = new HashSet<string>(bms_extensions, StringComparer.OrdinalIgnoreCase);
+
+            foreach (string rootPath in rootPaths)
+            {
+                IEnumerable<string> files;
+
+                try
+                {
+                    files = Directory.EnumerateFiles(rootPath, "*.*", SearchOption.AllDirectories);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Log($"[BMS] Failed to enumerate '{rootPath}': {ex.Message}", LoggingTarget.Runtime, LogLevel.Debug);
+                    continue;
+                }
+
+                foreach (string file in files)
+                {
+                    if (extensions.Contains(Path.GetExtension(file)))
+                        yield return file;
+                }
+            }
+        }
+
+        private BMSSongCache? scanSongFolder(
+            string folderPath,
+            List<string> bmsFiles,
+            Dictionary<string, BmsLibraryIndexRepository.ChartFileSnapshot> snapshots,
+            CancellationToken token)
+        {
+            var songCache = new BMSSongCache
+            {
+                FolderPath = folderPath,
+                LastModified = Directory.GetLastWriteTime(folderPath)
+            };
+
+            bool firstChart = true;
+
+            foreach (string bmsFile in bmsFiles)
+            {
+                token.ThrowIfCancellationRequested();
+
+                try
+                {
+                    var chartCache = parseOrLoadChart(bmsFile, snapshots, token);
+
+                    if (chartCache == null)
+                        continue;
+
+                    songCache.Charts.Add(chartCache);
+
+                    if (firstChart)
+                    {
+                        songCache.Title = chartCache.Title;
+                        songCache.Artist = chartCache.Artist;
+                        songCache.Genre = chartCache.Genre;
+                        firstChart = false;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.Log($"Failed to parse BMS file: {bmsFile} - {ex.Message}", LoggingTarget.Runtime, LogLevel.Debug);
+                }
+            }
+
+            songCache.BannerPath = findImageFile(folderPath, "banner", "bn");
+            songCache.StageFilePath = findImageFile(folderPath, "stagefile", "stage", "bg");
+
+            return songCache;
+        }
+
+        private BMSChartCache? parseOrLoadChart(string filePath, Dictionary<string, BmsLibraryIndexRepository.ChartFileSnapshot> snapshots, CancellationToken token)
+        {
+            var fileInfo = new FileInfo(filePath);
+
+            if (!fileInfo.Exists)
+                return null;
+
+            long ticks = fileInfo.LastWriteTimeUtc.Ticks;
+
+            if (snapshots.TryGetValue(filePath, out var snapshot)
+                && snapshot.FileSize == fileInfo.Length
+                && snapshot.LastModifiedTicks == ticks
+                && indexRepository.TryLoadChart(filePath, out BMSChartCache? cached))
+                return cached;
+
+            return parseBmsFileForCache(filePath, token);
+        }
+
+        private static string formatDifficultyName(BMSChartCache chart)
+        {
+            string label = !string.IsNullOrWhiteSpace(chart.SubTitle)
+                ? chart.SubTitle.Trim()
+                : Path.GetFileNameWithoutExtension(chart.FileName);
+
+            return chart.PlayLevel > 0
+                ? $"★{chart.PlayLevel} {label}".TrimEnd()
+                : label;
+        }
+
+        private static float mapRankToOD(int bmsRank) => bmsRank switch
+        {
+            0 => 9f,
+            1 => 8f,
+            2 => 7f,
+            3 => 5f,
+            _ => 7f
+        };
+
+        private static string? sanitiseAudioReference(string? raw, string? baseFolder)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+                return null;
+
+            string trimmed = raw.Trim();
+            trimmed = trimmed.Replace('\\', '/');
+
+            if (!Path.IsPathRooted(trimmed))
+                return trimmed;
+
+            if (!string.IsNullOrWhiteSpace(baseFolder))
+            {
+                try
+                {
+                    string fullBase = Path.GetFullPath(baseFolder);
+                    string fullPath = Path.GetFullPath(trimmed);
+                    string relative = Path.GetRelativePath(fullBase, fullPath);
+
+                    if (!relative.StartsWith("..", StringComparison.Ordinal) && !Path.IsPathRooted(relative))
+                        return relative.Replace('\\', '/');
+                }
+                catch
+                {
+                    // Fall back to file name below.
+                }
+            }
+
+            return Path.GetFileName(trimmed);
+        }
+
+        private static string buildTags(BMSChartCache chart)
+        {
+            List<string> tags = new List<string> { "bms", $"key{Math.Max(1, chart.KeyCount)}" };
+
+            if (chart.HasScratch) tags.Add("scratch");
+            if (chart.HasLongNotes) tags.Add("ln");
+            if (chart.HasStopSequence) tags.Add("stop");
+            if (chart.HasScrollChanges) tags.Add("scroll");
+            if (chart.HasBgaLayer) tags.Add("bga");
+
+            return string.Join(' ', tags);
+        }
+
+        private static Guid createDeterministicGuid(string input)
+        {
+            byte[] bytes = MD5.HashData(Encoding.UTF8.GetBytes(input));
+            return new Guid(bytes);
+        }
+
+        private static bool isNoteChannel(string channel)
+        {
+            if (channel.Length != 2) return false;
+
+            char first = channel[0];
+            char second = channel[1];
+
+            if (first == '1' && second >= '1' && second <= '9') return true;
+            if (first == '2' && second >= '1' && second <= '9') return true;
+            if (first == '5' && second >= '1' && second <= '9') return true;
+            if (first == '6' && second >= '1' && second <= '9') return true;
+
+            return false;
+        }
+
+        private static bool isScratchChannel(string channel) => channel == "16" || channel == "26" || channel == "56" || channel == "66";
+
+        private static bool isLongNoteChannel(string channel)
+        {
+            if (channel.Length != 2) return false;
+
+            return channel[0] == '5' || channel[0] == '6';
+        }
+
+        private static List<string> normaliseRootPaths(IEnumerable<string> paths)
+        {
+            HashSet<string> seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            List<string> result = new List<string>();
+
+            foreach (string path in paths)
+            {
+                string trimmed = path?.Trim() ?? string.Empty;
+
+                if (string.IsNullOrEmpty(trimmed) || !seen.Add(trimmed))
+                    continue;
+
+                result.Add(trimmed);
+            }
+
+            return result;
+        }
+
+        private static bool isBackgroundSoundChannel(string channel)
+        {
+            if (isNoteChannel(channel))
+                return false;
+
+            return channel is not "02" and not "03" and not "04" and not "06" and not "07" and not "08" and not "09";
+        }
+
+        private static int countNotes(string data)
+        {
+            int count = 0;
+
+            for (int i = 0; i + 1 < data.Length; i += 2)
+            {
+                if (data.Substring(i, 2) != "00")
+                    count++;
+            }
+
+            return count;
+        }
+
+        private static (string Key, double Position)? findFirstObjectKey(string data)
+        {
+            int objectCount = data.Length / 2;
+
+            if (objectCount <= 0)
+                return null;
+
+            for (int i = 0; i + 1 < data.Length; i += 2)
+            {
+                string key = data.Substring(i, 2);
+
+                if (key == "00")
+                    continue;
+
+                return (key, (double)i / 2 / objectCount);
+            }
+
+            return null;
+        }
+
+        private static int determineKeyCount(HashSet<string> noteChannels)
+        {
+            bool hasPlayerTwo = noteChannels.Any(c => c[0] is '2' or '6');
+
+            if (hasPlayerTwo)
+            {
+                int playerOneKeys = noteChannels.Count(c => c[0] is '1' or '5' && c[1] is not '6' and not '7');
+                int playerTwoKeys = noteChannels.Count(c => c[0] is '2' or '6' && c[1] is not '6' and not '7');
+                return playerOneKeys + playerTwoKeys;
+            }
+
+            if (noteChannels.Contains("11") && noteChannels.Contains("12") && noteChannels.Contains("13") && noteChannels.Contains("14") && noteChannels.Contains("15")
+                && noteChannels.Contains("18") && noteChannels.Contains("19"))
+                return 7;
+
+            return noteChannels.Count(c => c[0] is '1' or '5' && c[1] is not '6' and not '7');
+        }
+
+        private static string[] readBmsLines(string filePath)
+        {
+            try
+            {
+                Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+                var shiftJis = Encoding.GetEncoding(932);
+                return File.ReadAllLines(filePath, shiftJis);
+            }
+            catch
+            {
+                try
+                {
+                    return File.ReadAllLines(filePath, Encoding.UTF8);
+                }
+                catch
+                {
+                    return File.ReadAllLines(filePath);
+                }
+            }
+        }
+
+        private static string? findImageFile(string folderPath, params string[] patterns)
+        {
+            string[] imageExtensions = { ".png", ".jpg", ".jpeg", ".bmp" };
+
+            foreach (string pattern in patterns)
+            {
+                foreach (string ext in imageExtensions)
+                {
+                    string[] files = Directory.GetFiles(folderPath, $"*{pattern}*{ext}", SearchOption.TopDirectoryOnly);
+                    if (files.Length > 0)
+                        return Path.GetFileName(files[0]);
+                }
+            }
+
+            return null;
+        }
+
+        private BMSChartCache? parseBmsFileForCache(string filePath, CancellationToken token)
+        {
+            var fileInfo = new FileInfo(filePath);
+
+            if (!fileInfo.Exists)
+                return null;
+
+            var cache = new BMSChartCache
+            {
+                FileName = fileInfo.Name,
+                FolderPath = fileInfo.DirectoryName ?? string.Empty,
+                FileSize = fileInfo.Length,
+                LastModified = fileInfo.LastWriteTime,
+                Md5Hash = BmsPathKeys.ComputeChartPathKey(filePath),
+            };
+
+            string[] lines = readBmsLines(filePath);
+            var keysoundFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var wavDefinitions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var noteChannels = new HashSet<string>();
+            var bpmValues = new List<double>();
+            bool hasLongNotes = false;
+            bool hasScratch = false;
+            bool hasStopSequence = false;
+            bool hasScrollChanges = false;
+            bool hasBgaLayer = false;
+            int noteCount = 0;
+            int longNoteCount = 0;
+            int maxMeasure = 0;
+            string? previewAudioFile = null;
+            string? explicitPreviewFile = null;
+            int previewMeasure = int.MaxValue;
+            double previewPosition = double.MaxValue;
+            double baseBpm = 130;
+
+            foreach (string line in lines)
+            {
+                token.ThrowIfCancellationRequested();
+
+                if (!line.StartsWith('#')) continue;
+
+                string upperLine = line.ToUpperInvariant();
+
+                if (upperLine.StartsWith("#TITLE ", StringComparison.Ordinal))
+                    cache.Title = line.Substring(7).Trim();
+                else if (upperLine.StartsWith("#SUBTITLE ", StringComparison.Ordinal))
+                    cache.SubTitle = line.Substring(10).Trim();
+                else if (upperLine.StartsWith("#ARTIST ", StringComparison.Ordinal))
+                    cache.Artist = line.Substring(8).Trim();
+                else if (upperLine.StartsWith("#SUBARTIST ", StringComparison.Ordinal))
+                    cache.SubArtist = line.Substring(11).Trim();
+                else if (upperLine.StartsWith("#GENRE ", StringComparison.Ordinal))
+                    cache.Genre = line.Substring(7).Trim();
+                else if (upperLine.StartsWith("#PLAYLEVEL ", StringComparison.Ordinal))
+                {
+                    if (int.TryParse(line.Substring(11).Trim(), out int level))
+                        cache.PlayLevel = level;
+                }
+                else if (upperLine.StartsWith("#RANK ", StringComparison.Ordinal))
+                {
+                    if (int.TryParse(line.Substring(6).Trim(), out int rank))
+                        cache.Rank = rank;
+                }
+                else if (upperLine.StartsWith("#TOTAL ", StringComparison.Ordinal))
+                {
+                    if (double.TryParse(line.Substring(7).Trim(), out double total))
+                        cache.Total = total;
+                }
+                else if (upperLine.StartsWith("#BPM ", StringComparison.Ordinal) && !upperLine.StartsWith("#BPM0", StringComparison.Ordinal))
+                {
+                    if (double.TryParse(line.Substring(5).Trim(), out double bpm))
+                    {
+                        baseBpm = bpm;
+                        bpmValues.Add(bpm);
+                    }
+                }
+                else if (upperLine.StartsWith("#BPM", StringComparison.Ordinal))
+                {
+                    int spaceIdx = line.IndexOf(' ');
+
+                    if (spaceIdx > 4 && double.TryParse(line.Substring(spaceIdx + 1).Trim(), out double bpmVal))
+                    {
+                        string key = line.Substring(4, spaceIdx - 4);
+                        bpmValues.Add(bpmVal);
+                    }
+                }
+                else if (upperLine.StartsWith("#WAV", StringComparison.Ordinal))
+                {
+                    int spaceIdx = line.IndexOf(' ');
+
+                    if (spaceIdx > 4)
+                    {
+                        string key = line.Substring(4, spaceIdx - 4).Trim();
+                        string soundFile = line.Substring(spaceIdx + 1).Trim();
+
+                        if (!string.IsNullOrEmpty(soundFile))
+                        {
+                            keysoundFiles.Add(soundFile);
+
+                            if (!string.IsNullOrEmpty(key))
+                                wavDefinitions[key] = soundFile;
+                        }
+                    }
+                }
+                else if (upperLine.StartsWith("#LNTYPE ", StringComparison.Ordinal) || upperLine.StartsWith("#LNOBJ ", StringComparison.Ordinal))
+                {
+                    hasLongNotes = true;
+
+                    if (upperLine.StartsWith("#LNTYPE ", StringComparison.Ordinal)
+                        && int.TryParse(line.Substring(8).Trim(), out int lnType))
+                        cache.LnType = lnType;
+                }
+                else if (upperLine.StartsWith("#PREVIEW ", StringComparison.Ordinal))
+                    explicitPreviewFile = line.Substring(9).Trim();
+                else if (upperLine.StartsWith("#SCROLL", StringComparison.Ordinal))
+                    hasScrollChanges = true;
+                else if (line.Length > 6 && line[6] == ':')
+                {
+                    if (int.TryParse(line.AsSpan(1, 3), out int measureNum) && measureNum > maxMeasure)
+                        maxMeasure = measureNum;
+
+                    string channelStr = line.Substring(4, 2);
+
+                    if (isNoteChannel(channelStr))
+                    {
+                        noteChannels.Add(channelStr);
+                        string data = line.Substring(7);
+                        int notesInChannel = countNotes(data);
+                        noteCount += notesInChannel;
+
+                        if (isScratchChannel(channelStr))
+                            hasScratch = true;
+
+                        if (isLongNoteChannel(channelStr))
+                        {
+                            hasLongNotes = true;
+                            longNoteCount += notesInChannel;
+                        }
+                    }
+                    else if (isBackgroundSoundChannel(channelStr))
+                    {
+                        var firstObject = findFirstObjectKey(line.Substring(7));
+
+                        if (firstObject.HasValue
+                            && wavDefinitions.TryGetValue(firstObject.Value.Key, out string? audioFile)
+                            && (measureNum < previewMeasure || measureNum == previewMeasure && firstObject.Value.Position < previewPosition))
+                        {
+                            previewMeasure = measureNum;
+                            previewPosition = firstObject.Value.Position;
+                            previewAudioFile = audioFile;
+                        }
+                    }
+
+                    if (channelStr == "09")
+                        hasStopSequence = true;
+                    else if (channelStr is "04" or "06" or "07")
+                        hasBgaLayer = true;
+                }
+            }
+
+            cache.Bpm = baseBpm;
+            cache.MinBpm = bpmValues.Count > 0 ? bpmValues.Min() : baseBpm;
+            cache.MaxBpm = bpmValues.Count > 0 ? bpmValues.Max() : baseBpm;
+            cache.TotalNotes = noteCount;
+            cache.LongNoteCount = longNoteCount;
+            cache.HasScratch = hasScratch;
+            cache.HasLongNotes = hasLongNotes;
+            cache.HasStopSequence = hasStopSequence;
+            cache.HasScrollChanges = hasScrollChanges;
+            cache.HasBgaLayer = hasBgaLayer;
+            cache.KeysoundFiles = keysoundFiles.ToList();
+            cache.AudioFile = sanitiseAudioReference(previewAudioFile, cache.FolderPath);
+            cache.PreviewFile = sanitiseAudioReference(explicitPreviewFile, cache.FolderPath);
+
+            if (baseBpm > 0 && maxMeasure > 0)
+                cache.Duration = (maxMeasure + 1) * 4.0 * 60000.0 / baseBpm;
+
+            if (baseBpm > 0 && previewMeasure != int.MaxValue)
+                cache.PreviewTime = (int)Math.Max(0, (previewMeasure * 4 + previewPosition * 4) * 60000.0 / baseBpm);
+
+            cache.KeyCount = Math.Max(1, determineKeyCount(noteChannels));
+            return cache;
+        }
+    }
+
+    public struct BMSSourceReference
+    {
+        public Guid BeatmapId { get; set; }
+        public string FolderPath { get; set; }
+        public string ChartPath { get; set; }
+        public string Md5Hash { get; set; }
+    }
+}

--- a/osu.Game.Rulesets.BMS/Beatmaps/BMSExternalPath.cs
+++ b/osu.Game.Rulesets.BMS/Beatmaps/BMSExternalPath.cs
@@ -1,0 +1,109 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Text;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ExternalLibraries;
+
+namespace osu.Game.Rulesets.BMS.Beatmaps
+{
+    /// <summary>
+    /// BMS-specific helpers for resolving external chart paths. New imports use <see cref="ExternalBeatmapPathEncoding"/>.
+    /// </summary>
+    public static class BMSExternalPath
+    {
+        /// <summary>
+        /// Legacy hash prefix written by older BMS library sync before unified external hosting.
+        /// </summary>
+        public const string LEGACY_HASH_PREFIX = "bms-ext:set:";
+
+        private static readonly string[] chart_extensions = { ".bms", ".bme", ".bml", ".pms" };
+
+        public static string Encode(string? folderPath) => ExternalBeatmapPathEncoding.Encode(folderPath ?? string.Empty);
+
+        /// <summary>
+        /// Resolves the on-disk folder for an externally hosted BMS set.
+        /// </summary>
+        public static bool TryGetContentRoot(BeatmapSetInfo? beatmapSet, out string folderPath)
+        {
+            folderPath = beatmapSet?.GetEffectiveExternalContentRoot() ?? string.Empty;
+
+            if (!string.IsNullOrEmpty(folderPath) && Directory.Exists(folderPath))
+                return true;
+
+            return TryDecode(beatmapSet?.Hash, out folderPath);
+        }
+
+        public static bool TryDecode(string? hash, out string folderPath)
+        {
+            if (ExternalBeatmapPathEncoding.TryDecode(hash, out folderPath))
+                return Directory.Exists(folderPath);
+
+            if (!TryDecodeLegacyHash(hash, out folderPath))
+                return false;
+
+            return Directory.Exists(folderPath);
+        }
+
+        public static bool TryDecodeRaw(string? hash, out string folderPath)
+        {
+            if (ExternalBeatmapPathEncoding.TryDecode(hash, out folderPath))
+                return true;
+
+            return TryDecodeLegacyHash(hash, out folderPath);
+        }
+
+        internal static bool TryDecodeLegacyHash(string? hash, out string folderPath)
+        {
+            folderPath = string.Empty;
+
+            if (string.IsNullOrEmpty(hash) || !hash.StartsWith(LEGACY_HASH_PREFIX, StringComparison.Ordinal))
+                return false;
+
+            string encoded = hash.Substring(LEGACY_HASH_PREFIX.Length);
+
+            if (string.IsNullOrEmpty(encoded))
+                return false;
+
+            try
+            {
+                byte[] bytes = Convert.FromBase64String(encoded);
+                string decoded = Encoding.UTF8.GetString(bytes);
+
+                if (string.IsNullOrWhiteSpace(decoded))
+                    return false;
+
+                folderPath = Path.GetFullPath(decoded);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public static bool TryResolveExternalChartPath(BeatmapSetInfo? beatmapSet, string? beatmapPath, IEnumerable<string> setFilenames, out string chartPath)
+        {
+            chartPath = string.Empty;
+
+            if (!TryGetContentRoot(beatmapSet, out string folderPath))
+                return false;
+
+            string? chartFilename = beatmapPath;
+
+            if (string.IsNullOrEmpty(chartFilename))
+                chartFilename = setFilenames.FirstOrDefault(name => chart_extensions.Any(ext => name.EndsWith(ext, StringComparison.OrdinalIgnoreCase)));
+
+            if (string.IsNullOrEmpty(chartFilename))
+                return false;
+
+            string candidate = Path.Combine(folderPath, chartFilename);
+
+            if (!File.Exists(candidate))
+                return false;
+
+            chartPath = candidate;
+            return true;
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/Beatmaps/BMSExternalSampleSkin.cs
+++ b/osu.Game.Rulesets.BMS/Beatmaps/BMSExternalSampleSkin.cs
@@ -1,0 +1,191 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.IO.Stores;
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using osu.Game.Audio;
+using osu.Game.Skinning;
+
+namespace osu.Game.Rulesets.BMS.Beatmaps
+{
+    /// <summary>
+    /// Wraps another <see cref="ISkin"/> (typically the Mania transformer or the legacy beatmap skin)
+    /// and falls back to loading samples from the BMS chart folder on disk when the inner skin can't
+    /// resolve a lookup.
+    ///
+    /// This is the seam that lets a standard <see cref="osu.Game.Beatmaps.WorkingBeatmap"/> still hear
+    /// keysounds for an external BMS chart at gameplay time, without copying the keysound files into
+    /// Realm or replacing the working beatmap type.
+    /// </summary>
+    public sealed class BMSExternalSampleSkin : ISkin
+    {
+        private static readonly string[] sample_extensions = { string.Empty, ".wav", ".ogg", ".mp3", ".flac" };
+        private static readonly object load_log_gate = new object();
+        private static int loadLogCount;
+
+        private readonly string bmsFolder;
+        private readonly Func<AudioManager?> audioProvider;
+        private readonly Dictionary<string, ISample?> resolvedSamples = new Dictionary<string, ISample?>(StringComparer.OrdinalIgnoreCase);
+        private ISampleStore? folderSampleStore;
+        private bool storeInitialised;
+
+        public BMSExternalSampleSkin(ISkin inner, string? bmsFolder, Func<AudioManager?> audioProvider)
+        {
+            Inner = inner ?? throw new ArgumentNullException(nameof(inner));
+            this.bmsFolder = bmsFolder ?? string.Empty;
+            this.audioProvider = audioProvider ?? throw new ArgumentNullException(nameof(audioProvider));
+        }
+
+        /// <summary>Routed legacy / Mania skin without folder fallback.</summary>
+        public ISkin Inner { get; }
+
+        private ISampleStore? ensureStore()
+        {
+            if (storeInitialised)
+                return folderSampleStore;
+
+            var audioManager = audioProvider();
+
+            if (audioManager == null || !Directory.Exists(bmsFolder))
+                return null;
+
+            try
+            {
+                var storage = new NativeStorage(bmsFolder);
+                var resourceStore = new StorageBackedResourceStore(storage);
+                folderSampleStore = audioManager.GetSampleStore(resourceStore);
+                storeInitialised = true;
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"[BMS] Failed to create external sample store for '{bmsFolder}': {ex.Message}", LoggingTarget.Runtime, LogLevel.Debug);
+                folderSampleStore = null;
+                storeInitialised = true;
+            }
+
+            return folderSampleStore;
+        }
+
+        public Drawable? GetDrawableComponent(ISkinComponentLookup lookup) => Inner.GetDrawableComponent(lookup);
+
+        public Texture? GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT) => Inner.GetTexture(componentName, wrapModeS, wrapModeT);
+
+        public IBindable<TValue>? GetConfig<TLookup, TValue>(TLookup lookup)
+            where TLookup : notnull
+            where TValue : notnull => Inner.GetConfig<TLookup, TValue>(lookup);
+
+        public ISample? GetSample(ISampleInfo sampleInfo)
+        {
+            var fromInner = Inner.GetSample(sampleInfo);
+
+            if (fromInner != null)
+                return fromInner;
+
+            var store = ensureStore();
+
+            if (store == null)
+                return null;
+
+            foreach (string lookupName in sampleInfo.LookupNames)
+            {
+                if (string.IsNullOrWhiteSpace(lookupName))
+                    continue;
+
+                var sample = tryResolve(lookupName, store);
+
+                if (sample != null)
+                    return sample;
+            }
+
+            return null;
+        }
+
+        private ISample? tryResolve(string lookupName, ISampleStore store)
+        {
+            if (resolvedSamples.TryGetValue(lookupName, out var cached))
+                return cached;
+
+            string? foundFilename = probeFilename(lookupName);
+
+            if (foundFilename == null)
+            {
+                resolvedSamples[lookupName] = null;
+                return null;
+            }
+
+            try
+            {
+                var sample = store.Get(foundFilename);
+                resolvedSamples[lookupName] = sample;
+
+                lock (load_log_gate)
+                {
+                    if (loadLogCount < 5)
+                    {
+                        loadLogCount++;
+                        Logger.Log($"[BMS] External sample resolved: {lookupName} -> {foundFilename}", LoggingTarget.Runtime, LogLevel.Debug);
+                    }
+                }
+
+                return sample;
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"[BMS] External sample load failed for '{lookupName}': {ex.Message}", LoggingTarget.Runtime, LogLevel.Debug);
+                resolvedSamples[lookupName] = null;
+                return null;
+            }
+        }
+
+        private string? probeFilename(string lookupName)
+        {
+            string normalised = lookupName.Replace('\\', '/');
+
+            string direct = Path.Combine(bmsFolder, normalised.Replace('/', Path.DirectorySeparatorChar));
+
+            if (File.Exists(direct))
+                return normalised;
+
+            string directory = Path.GetDirectoryName(normalised) ?? string.Empty;
+            string baseName = Path.GetFileNameWithoutExtension(normalised);
+
+            if (string.IsNullOrEmpty(baseName))
+                return null;
+
+            string[] caseVariants = buildCaseVariants(baseName);
+
+            foreach (string ext in sample_extensions)
+            {
+                foreach (string variant in caseVariants)
+                {
+                    string candidateRelative = string.IsNullOrEmpty(directory)
+                        ? variant + ext
+                        : directory + "/" + variant + ext;
+
+                    string candidateFull = Path.Combine(bmsFolder, candidateRelative.Replace('/', Path.DirectorySeparatorChar));
+
+                    if (File.Exists(candidateFull))
+                        return candidateRelative;
+                }
+            }
+
+            return null;
+        }
+
+        private static string[] buildCaseVariants(string baseName)
+        {
+            string lower = baseName.ToLowerInvariant();
+            string upper = baseName.ToUpperInvariant();
+
+            return new[] { baseName, lower, upper }
+                   .Distinct(StringComparer.Ordinal)
+                   .ToArray();
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/Beatmaps/BMSOsuLibrarySynchronizer.cs
+++ b/osu.Game.Rulesets.BMS/Beatmaps/BMSOsuLibrarySynchronizer.cs
@@ -1,0 +1,308 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ExternalLibraries;
+using osu.Game.Database;
+using osu.Game.Models;
+using Realms;
+
+namespace osu.Game.Rulesets.BMS.Beatmaps
+{
+    public static class BMSOsuLibrarySynchronizer
+    {
+        public static void Synchronize(BMSBeatmapManager manager, Storage storage, RealmAccess realm, RulesetInfo bmsRulesetInfo)
+        {
+            if (manager.LibraryCache == null)
+                return;
+
+            if (!manager.NeedsRealmSynchronization)
+                return;
+
+            IReadOnlyList<BeatmapSetInfo> virtualSets = manager.BuildVirtualBeatmapCatalog(bmsRulesetInfo);
+
+            if (virtualSets.Count == 0)
+            {
+                Logger.Log("[BMS] Library index has no charts; skipping Realm sync to avoid clearing the carousel.", LoggingTarget.Database);
+                return;
+            }
+
+            Dictionary<Guid, BMSSourceReference> sourceMap = manager.GetCurrentSourceMap();
+
+            var realmFileStore = new RealmFileStore(realm, storage);
+            int importedSets = 0;
+            int importedBeatmaps = 0;
+            int removedSets = 0;
+            int skippedSets = 0;
+
+            realm.Write(r =>
+            {
+                RulesetInfo? managedRuleset = r.All<RulesetInfo>().FirstOrDefault(info => info.ShortName == bmsRulesetInfo.ShortName);
+
+                if (managedRuleset == null)
+                    throw new InvalidOperationException("BMS ruleset is not available in realm.");
+
+                // Realm cannot translate HostingKind enum or custom helpers; query persisted HostingKindInt + hash prefixes only.
+                const int external_hosting_kind = (int)BeatmapSetHostingKind.External;
+
+                List<BeatmapSetInfo> candidateSets = r.All<BeatmapSetInfo>()
+                                                      .Where(set => set.HostingKindInt == external_hosting_kind
+                                                                    || set.Hash.StartsWith(BMSExternalPath.LEGACY_HASH_PREFIX)
+                                                                    || set.Hash.StartsWith(ExternalBeatmapPathEncoding.HASH_PREFIX))
+                                                      .ToList();
+
+                Dictionary<Guid, BeatmapSetInfo> existingSets = candidateSets
+                                                                .Where(set => isManagedExternalBmsSet(set, bmsRulesetInfo.ShortName))
+                                                                .ToDictionary(set => set.ID);
+                HashSet<Guid> targetSetIds = virtualSets.Select(set => set.ID).ToHashSet();
+
+                foreach ((Guid setId, BeatmapSetInfo oldSet) in existingSets)
+                {
+                    if (!targetSetIds.Contains(setId))
+                    {
+                        removeSet(r, oldSet);
+                        removedSets++;
+                    }
+                }
+
+                foreach (BeatmapSetInfo virtualSet in virtualSets)
+                {
+                    if (existingSets.TryGetValue(virtualSet.ID, out BeatmapSetInfo? existingSet)
+                        && setMatches(existingSet, virtualSet, sourceMap))
+                    {
+                        Logger.Log($"[BMS] Skipping unchanged external set {virtualSet.ID} (setMatches).", LoggingTarget.Database, LogLevel.Debug);
+                        skippedSets++;
+                        continue;
+                    }
+
+                    if (existingSet != null)
+                    {
+                        removeSet(r, existingSet);
+                        removedSets++;
+                    }
+
+                    string contentRoot = virtualSet.Hash;
+
+                    var newSet = new BeatmapSetInfo
+                    {
+                        ID = virtualSet.ID,
+                        DateAdded = virtualSet.DateAdded,
+                        Hash = ExternalBeatmapPathEncoding.Encode(contentRoot),
+                        ExternalContentRoot = Path.GetFullPath(contentRoot),
+                        HostingKind = BeatmapSetHostingKind.External,
+                        Status = BeatmapOnlineStatus.LocallyModified,
+                    };
+
+                    foreach (BeatmapInfo virtualBeatmap in virtualSet.Beatmaps)
+                    {
+                        if (!sourceMap.TryGetValue(virtualBeatmap.ID, out BMSSourceReference sourceRef))
+                            continue;
+
+                        if (!File.Exists(sourceRef.ChartPath))
+                            continue;
+
+                        string relativeChartPath = registerExternalChartFile(realmFileStore, r, newSet, sourceRef.ChartPath, contentRoot);
+
+                        if (string.IsNullOrEmpty(relativeChartPath))
+                            continue;
+
+                        RealmNamedFileUsage? chartFileUsage = newSet.GetFile(relativeChartPath);
+
+                        if (chartFileUsage is null)
+                            continue;
+
+                        var beatmap = new BeatmapInfo(managedRuleset, virtualBeatmap.Difficulty.Clone(), virtualBeatmap.Metadata.DeepClone())
+                        {
+                            ID = virtualBeatmap.ID,
+                            DifficultyName = virtualBeatmap.DifficultyName,
+                            Hash = chartFileUsage.File.Hash,
+                            MD5Hash = virtualBeatmap.MD5Hash,
+                            Status = BeatmapOnlineStatus.LocallyModified,
+                            BeatmapSet = newSet,
+                        };
+
+                        applyVirtualBeatmapToRealm(beatmap, virtualBeatmap);
+
+                        newSet.Beatmaps.Add(beatmap);
+                        importedBeatmaps++;
+                    }
+
+                    if (newSet.Beatmaps.Count > 0)
+                    {
+                        r.Add(newSet, update: true);
+                        importedSets++;
+                    }
+                }
+            });
+
+            manager.MarkRealmSynchronized();
+
+            Logger.Log($"[BMS] External library sync finished: imported {importedSets} sets/{importedBeatmaps} beatmaps, removed {removedSets} sets, skipped {skippedSets} unchanged sets.");
+        }
+
+        private static void applyVirtualBeatmapToRealm(BeatmapInfo beatmap, BeatmapInfo virtualBeatmap)
+        {
+            beatmap.BPM = virtualBeatmap.BPM;
+            beatmap.Length = virtualBeatmap.Length;
+            beatmap.TotalObjectCount = virtualBeatmap.TotalObjectCount;
+            beatmap.EndTimeObjectCount = virtualBeatmap.EndTimeObjectCount;
+
+            beatmap.Difficulty.CircleSize = virtualBeatmap.Difficulty.CircleSize;
+            beatmap.Difficulty.OverallDifficulty = virtualBeatmap.Difficulty.OverallDifficulty;
+            beatmap.Difficulty.DrainRate = virtualBeatmap.Difficulty.DrainRate;
+            beatmap.Difficulty.ApproachRate = virtualBeatmap.Difficulty.ApproachRate;
+
+            beatmap.Metadata.Title = virtualBeatmap.Metadata.Title;
+            beatmap.Metadata.TitleUnicode = virtualBeatmap.Metadata.TitleUnicode;
+            beatmap.Metadata.Artist = virtualBeatmap.Metadata.Artist;
+            beatmap.Metadata.ArtistUnicode = virtualBeatmap.Metadata.ArtistUnicode;
+            beatmap.Metadata.Source = virtualBeatmap.Metadata.Source;
+            beatmap.Metadata.Tags = virtualBeatmap.Metadata.Tags;
+            beatmap.Metadata.AudioFile = virtualBeatmap.Metadata.AudioFile;
+            beatmap.Metadata.BackgroundFile = virtualBeatmap.Metadata.BackgroundFile;
+            beatmap.Metadata.PreviewTime = virtualBeatmap.Metadata.PreviewTime;
+        }
+
+        private static bool isManagedExternalBmsSet(BeatmapSetInfo set, string bmsShortName)
+        {
+            if (!set.IsExternallyHosted)
+                return BMSExternalPath.TryDecodeLegacyHash(set.Hash, out _);
+
+            return set.Beatmaps.Any(b => string.Equals(b.Ruleset.ShortName, bmsShortName, StringComparison.Ordinal));
+        }
+
+        /// <summary>
+        /// Exposed for unit tests validating Realm skip/re-import decisions.
+        /// </summary>
+        public static bool SetMatchesForTesting(BeatmapSetInfo existingSet, BeatmapSetInfo targetSet, IReadOnlyDictionary<Guid, BMSSourceReference> sourceMap)
+            => setMatches(existingSet, targetSet, sourceMap);
+
+        /// <summary>
+        /// Computes the <see cref="RealmNamedFileUsage.Filename"/> stored for an external chart (relative to the song folder).
+        /// </summary>
+        public static string ComputeRelativeChartFilename(string chartPath, string contentRoot)
+        {
+            string relativeFilename = Path.GetRelativePath(contentRoot, chartPath);
+
+            if (relativeFilename.StartsWith("..", StringComparison.Ordinal))
+                relativeFilename = Path.GetFileName(chartPath);
+
+            return relativeFilename.Replace('\\', '/');
+        }
+
+        private static bool setMatches(BeatmapSetInfo existingSet, BeatmapSetInfo targetSet, IReadOnlyDictionary<Guid, BMSSourceReference> sourceMap)
+        {
+            string contentRoot = targetSet.Hash;
+
+            if (!existingSet.IsExternallyHosted)
+                return false;
+
+            if (string.IsNullOrWhiteSpace(existingSet.ExternalContentRoot))
+                return false;
+
+            if (!existingSet.Hash.StartsWith(ExternalBeatmapPathEncoding.HASH_PREFIX, StringComparison.Ordinal))
+                return false;
+
+            if (!string.Equals(existingSet.Hash, ExternalBeatmapPathEncoding.Encode(contentRoot), StringComparison.Ordinal))
+                return false;
+
+            if (existingSet.Beatmaps.Count != targetSet.Beatmaps.Count)
+                return false;
+
+            Dictionary<Guid, BeatmapInfo> existingBeatmaps = existingSet.Beatmaps.ToDictionary(beatmap => beatmap.ID);
+
+            foreach (BeatmapInfo targetBeatmap in targetSet.Beatmaps)
+            {
+                if (!existingBeatmaps.TryGetValue(targetBeatmap.ID, out BeatmapInfo? existingBeatmap))
+                    return false;
+
+                if (!sourceMap.TryGetValue(targetBeatmap.ID, out BMSSourceReference sourceRef))
+                    return false;
+
+                string expectedRelative = ComputeRelativeChartFilename(sourceRef.ChartPath, contentRoot);
+
+                if (string.IsNullOrEmpty(expectedRelative))
+                    return false;
+
+                if (!string.Equals(existingBeatmap.Path, expectedRelative, StringComparison.OrdinalIgnoreCase))
+                    return false;
+
+                if (existingSet.GetFile(expectedRelative) == null)
+                    return false;
+
+                if (!string.Equals(existingBeatmap.Hash, targetBeatmap.Hash, StringComparison.OrdinalIgnoreCase))
+                    return false;
+
+                if (!string.Equals(existingBeatmap.MD5Hash, targetBeatmap.MD5Hash, StringComparison.OrdinalIgnoreCase))
+                    return false;
+
+                if (!string.Equals(existingBeatmap.DifficultyName, targetBeatmap.DifficultyName, StringComparison.Ordinal))
+                    return false;
+
+                if (Path.IsPathRooted(existingBeatmap.Metadata.AudioFile))
+                    return false;
+
+                if (!string.Equals(existingBeatmap.Metadata.AudioFile, targetBeatmap.Metadata.AudioFile, StringComparison.OrdinalIgnoreCase))
+                    return false;
+
+                if (!string.Equals(existingBeatmap.Metadata.BackgroundFile, targetBeatmap.Metadata.BackgroundFile, StringComparison.OrdinalIgnoreCase))
+                    return false;
+
+                if (!string.Equals(existingBeatmap.Metadata.Tags, targetBeatmap.Metadata.Tags, StringComparison.Ordinal))
+                    return false;
+
+                if (!difficultyMatches(existingBeatmap, targetBeatmap))
+                    return false;
+
+                if (!floatEquals(existingBeatmap.BPM, targetBeatmap.BPM))
+                    return false;
+
+                if (!floatEquals(existingBeatmap.Length, targetBeatmap.Length))
+                    return false;
+
+                if (existingBeatmap.TotalObjectCount != targetBeatmap.TotalObjectCount)
+                    return false;
+
+                if (existingBeatmap.EndTimeObjectCount != targetBeatmap.EndTimeObjectCount)
+                    return false;
+            }
+
+            return true;
+        }
+
+        private static bool difficultyMatches(BeatmapInfo existing, BeatmapInfo target) => floatEquals(existing.Difficulty.CircleSize, target.Difficulty.CircleSize)
+                                                                                           && floatEquals(existing.Difficulty.OverallDifficulty, target.Difficulty.OverallDifficulty)
+                                                                                           && floatEquals(existing.Difficulty.DrainRate, target.Difficulty.DrainRate);
+
+        private static bool floatEquals(double a, double b) => Math.Abs(a - b) < 0.01;
+
+        private static string registerExternalChartFile(RealmFileStore realmFileStore, Realm realm, BeatmapSetInfo set, string chartPath, string contentRoot)
+        {
+            string relativeFilename = ComputeRelativeChartFilename(chartPath, contentRoot);
+
+            if (string.IsNullOrEmpty(relativeFilename))
+                return string.Empty;
+
+            if (set.GetFile(relativeFilename) != null)
+                return relativeFilename;
+
+            string syntheticHash = BmsPathKeys.ComputeRealmFileHash(chartPath);
+            RealmFile file = realmFileStore.RegisterExternalHash(syntheticHash, realm);
+            set.Files.Add(new RealmNamedFileUsage(file, relativeFilename));
+            return relativeFilename;
+        }
+
+        private static void removeSet(Realm realm, BeatmapSetInfo set)
+        {
+            foreach (BeatmapInfo beatmap in set.Beatmaps.ToList())
+            {
+                realm.Remove(beatmap.Metadata);
+                realm.Remove(beatmap);
+            }
+
+            realm.Remove(set);
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/Beatmaps/BMSSkin.cs
+++ b/osu.Game.Rulesets.BMS/Beatmaps/BMSSkin.cs
@@ -1,0 +1,159 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.IO.Stores;
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using osu.Game.Audio;
+using osu.Game.Skinning;
+
+namespace osu.Game.Rulesets.BMS.Beatmaps
+{
+    /// <summary>
+    /// A skin that provides keysound samples from a BMS folder on disk.
+    ///
+    /// Implementation note: this class MUST NOT call AudioManager.Samples or AudioManager.Tracks directly.
+    /// osu-framework's NativeStorage wraps the global game data folder and rejects any absolute path that
+    /// "traverses outside of" that root with ArgumentException, which silently breaks both song-select preview
+    /// and in-game keysound playback for external BMS folders.
+    ///
+    /// Instead we mount the BMS folder as its own ISampleStore via NativeStorage + StorageBackedResourceStore
+    /// + AudioManager.GetSampleStore, and look up samples by paths relative to that mount.
+    /// </summary>
+    public class BMSSkin : ISkin
+    {
+        private static readonly string[] sample_extensions = { ".wav", ".ogg", ".mp3", ".flac" };
+
+        private readonly string folderPath;
+        private readonly AudioManager audioManager;
+        private readonly Dictionary<string, ISample?> resolvedSamples = new Dictionary<string, ISample?>(StringComparer.OrdinalIgnoreCase);
+        private ISampleStore? folderSampleStore;
+        private bool storeInitialised;
+
+        public BMSSkin(string folderPath, AudioManager audioManager)
+        {
+            this.folderPath = folderPath ?? string.Empty;
+            this.audioManager = audioManager;
+        }
+
+        public Drawable? GetDrawableComponent(ISkinComponentLookup lookup) => null;
+
+        public Texture? GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT) => null;
+
+        public ISample? GetSample(ISampleInfo sampleInfo)
+        {
+            ISampleStore? store = ensureStore();
+
+            if (store == null)
+                return null;
+
+            foreach (string lookupName in sampleInfo.LookupNames)
+            {
+                if (string.IsNullOrWhiteSpace(lookupName))
+                    continue;
+
+                ISample? sample = tryResolve(lookupName, store);
+
+                if (sample != null)
+                    return sample;
+            }
+
+            return null;
+        }
+
+        public IBindable<TValue>? GetConfig<TLookup, TValue>(TLookup lookup)
+            where TLookup : notnull
+            where TValue : notnull
+        {
+            return null;
+        }
+
+        private ISampleStore? ensureStore()
+        {
+            if (storeInitialised)
+                return folderSampleStore;
+
+            if (audioManager == null || !Directory.Exists(folderPath))
+            {
+                storeInitialised = true;
+                return null;
+            }
+
+            try
+            {
+                var storage = new NativeStorage(folderPath);
+                var resourceStore = new StorageBackedResourceStore(storage);
+                folderSampleStore = audioManager.GetSampleStore(resourceStore);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"[BMS] BMSSkin failed to mount sample store for '{folderPath}': {ex.Message}", LoggingTarget.Runtime, LogLevel.Important);
+                folderSampleStore = null;
+            }
+            finally
+            {
+                storeInitialised = true;
+            }
+
+            return folderSampleStore;
+        }
+
+        private ISample? tryResolve(string lookupName, ISampleStore store)
+        {
+            if (resolvedSamples.TryGetValue(lookupName, out ISample? cached))
+                return cached;
+
+            string? probedRelative = probeRelativePath(lookupName);
+
+            if (probedRelative == null)
+            {
+                resolvedSamples[lookupName] = null;
+                return null;
+            }
+
+            try
+            {
+                ISample? sample = store.Get(probedRelative);
+                resolvedSamples[lookupName] = sample;
+                return sample;
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"[BMS] BMSSkin sample load failed for '{lookupName}': {ex.Message}", LoggingTarget.Runtime, LogLevel.Debug);
+                resolvedSamples[lookupName] = null;
+                return null;
+            }
+        }
+
+        private string? probeRelativePath(string lookupName)
+        {
+            string normalised = lookupName.Replace('\\', '/');
+            string direct = Path.Combine(folderPath, normalised.Replace('/', Path.DirectorySeparatorChar));
+
+            if (File.Exists(direct))
+                return normalised;
+
+            string directory = Path.GetDirectoryName(normalised) ?? string.Empty;
+            string baseName = Path.GetFileNameWithoutExtension(normalised);
+
+            if (string.IsNullOrEmpty(baseName))
+                return null;
+
+            foreach (string ext in sample_extensions)
+            {
+                string candidateRelative = string.IsNullOrEmpty(directory) ? baseName + ext : directory + "/" + baseName + ext;
+                string candidateFull = Path.Combine(folderPath, candidateRelative.Replace('/', Path.DirectorySeparatorChar));
+
+                if (File.Exists(candidateFull))
+                    return candidateRelative;
+            }
+
+            return null;
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/Beatmaps/BMSWorkingBeatmap.cs
+++ b/osu.Game.Rulesets.BMS/Beatmaps/BMSWorkingBeatmap.cs
@@ -1,0 +1,325 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Security.Cryptography;
+using System.Text;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Track;
+using osu.Framework.Graphics.Rendering;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.IO.Stores;
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using osu.Game.Beatmaps;
+using osu.Game.IO;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Skinning;
+using osu.Game.Storyboards;
+using FileInfo = System.IO.FileInfo;
+
+namespace osu.Game.Rulesets.BMS.Beatmaps
+{
+    /// <summary>
+    /// A WorkingBeatmap that loads directly from BMS files on disk,
+    /// without importing into the osu! database.
+    /// </summary>
+    public class BMSWorkingBeatmap : WorkingBeatmap
+    {
+        private readonly string bmsFilePath;
+        private readonly AudioManager audioManager;
+        private readonly BMSChartCache? chartCache;
+
+        /// <summary>
+        /// Per-instance texture store rooted at <see cref="FolderPath"/>. Each chart owns its own cache so
+        /// folders that share a filename (e.g. every chart having a "bg.png") never collide on the global
+        /// <c>TextureStore</c>'s key-by-filename cache.
+        /// </summary>
+        private readonly LargeTextureStore? localBackgroundStore;
+
+        private BMSBeatmap? cachedBeatmap;
+
+        /// <summary>
+        /// Gets the folder path containing the BMS file.
+        /// </summary>
+        public string FolderPath { get; }
+
+        /// <summary>
+        /// Construct a working beatmap directly from a BMS file on disk.
+        /// </summary>
+        /// <param name="bmsFilePath">Absolute path to the .bms / .bme / .bml / .pms chart.</param>
+        /// <param name="audioManager">Audio manager (mandatory; required for keysound playback).</param>
+        /// <param name="renderer">Optional renderer; required to load backgrounds. Pass null if backgrounds aren't needed (e.g. in headless tests).</param>
+        /// <param name="chartCache">Optional pre-parsed cache of chart metadata.</param>
+        /// <param name="beatmapInfoOverride">
+        /// Optional <see cref="BeatmapInfo"/> to use instead of the one synthesised from <paramref name="bmsFilePath"/>.
+        /// Pass a detached copy of the realm-managed BeatmapInfo for the chart so downstream consumers
+        /// (FooterButtonOptions etc.) can look it up by <see cref="BeatmapInfo.ID"/>.
+        /// </param>
+        public BMSWorkingBeatmap(
+            string bmsFilePath,
+            AudioManager audioManager,
+            IRenderer? renderer = null,
+            BMSChartCache? chartCache = null,
+            BeatmapInfo? beatmapInfoOverride = null)
+            : base(beatmapInfoOverride ?? createBeatmapInfo(bmsFilePath, chartCache), audioManager)
+        {
+            this.bmsFilePath = bmsFilePath;
+            FolderPath = Path.GetDirectoryName(bmsFilePath) ?? string.Empty;
+            this.audioManager = audioManager;
+            this.chartCache = chartCache;
+
+            if (renderer != null && Directory.Exists(FolderPath))
+            {
+                // Build a per-chart store rather than calling textures.AddTextureSource on the shared
+                // global TextureStore. The global cache keys by filename only, so multiple BMS folders
+                // each containing "bg.png" would all return the first cached texture → all charts ended
+                // up showing the same background.
+                var storage = new NativeStorage(FolderPath);
+                var loader = new TextureLoaderStore(new StorageBackedResourceStore(storage));
+                localBackgroundStore = new LargeTextureStore(renderer, loader);
+            }
+        }
+
+        /// <summary>
+        /// Create a BeatmapInfo from BMS file path (minimal info for display).
+        /// Full parsing happens in GetBeatmap().
+        /// </summary>
+        private static BeatmapInfo createBeatmapInfo(string bmsFilePath, BMSChartCache? chartCache)
+        {
+            var fileInfo = new FileInfo(bmsFilePath);
+
+            string? title = chartCache?.Title;
+            if (string.IsNullOrWhiteSpace(title))
+                title = fileInfo.Name;
+
+            string? artist = chartCache?.Artist;
+            if (string.IsNullOrWhiteSpace(artist))
+                artist = "BMS";
+
+            string? difficultyName = chartCache?.SubTitle;
+            if (string.IsNullOrWhiteSpace(difficultyName))
+                difficultyName = Path.GetFileNameWithoutExtension(bmsFilePath);
+
+            var beatmapInfo = new BeatmapInfo(new BMSRuleset().RulesetInfo)
+            {
+                ID = createDeterministicBeatmapId(bmsFilePath),
+                Metadata = new BeatmapMetadata
+                {
+                    Title = title,
+                    Artist = artist,
+                    Source = "BMS Import",
+                    AudioFile = sanitiseAudioReference(chartCache?.PreviewFile ?? chartCache?.AudioFile, chartCache?.FolderPath ?? fileInfo.DirectoryName) ?? string.Empty,
+                },
+                DifficultyName = difficultyName,
+                Difficulty = new BeatmapDifficulty
+                {
+                    CircleSize = chartCache?.KeyCount ?? 7,
+                },
+                BPM = chartCache?.Bpm ?? 0,
+                Length = chartCache?.Duration ?? 0,
+                MD5Hash = chartCache?.Md5Hash ?? string.Empty,
+                Hash = chartCache?.Md5Hash ?? string.Empty,
+                TotalObjectCount = chartCache?.TotalNotes ?? -1,
+                EndTimeObjectCount = chartCache?.TotalNotes ?? -1,
+                BeatmapSet = new BeatmapSetInfo
+                {
+                    OnlineID = -1,
+                },
+            };
+
+            if (chartCache != null)
+            {
+                beatmapInfo.Metadata.PreviewTime = chartCache.PreviewTime;
+                beatmapInfo.Metadata.BackgroundFile = string.Empty;
+            }
+
+            return beatmapInfo;
+        }
+
+        private static Guid createDeterministicBeatmapId(string chartPath)
+        {
+            byte[] bytes = MD5.HashData(Encoding.UTF8.GetBytes($"bms:chart:{chartPath}"));
+            return new Guid(bytes);
+        }
+
+        private static string? sanitiseAudioReference(string? raw, string? baseFolder)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+                return null;
+
+            string trimmed = raw.Trim();
+            trimmed = trimmed.Replace('\\', '/');
+
+            if (!Path.IsPathRooted(trimmed))
+                return trimmed;
+
+            if (!string.IsNullOrWhiteSpace(baseFolder))
+            {
+                try
+                {
+                    string fullBase = Path.GetFullPath(baseFolder);
+                    string fullPath = Path.GetFullPath(trimmed);
+                    string relative = Path.GetRelativePath(fullBase, fullPath);
+
+                    if (!relative.StartsWith("..", StringComparison.Ordinal) && !Path.IsPathRooted(relative))
+                        return relative.Replace('\\', '/');
+                }
+                catch
+                {
+                    // Fall back to file name below.
+                }
+            }
+
+            return Path.GetFileName(trimmed);
+        }
+
+        protected override IBeatmap GetBeatmap()
+        {
+            if (cachedBeatmap != null)
+                return cachedBeatmap;
+
+            try
+            {
+                using var stream = File.OpenRead(bmsFilePath);
+                using var reader = new LineBufferedReader(stream);
+                var decoder = new BMSBeatmapDecoder();
+                var result = decoder.Decode(reader);
+
+                if (result is BMSBeatmap bmsBeatmap)
+                {
+                    cachedBeatmap = bmsBeatmap;
+                    // Update BeatmapInfo with parsed metadata
+                    BeatmapInfo.Ruleset = cachedBeatmap.BeatmapInfo.Ruleset;
+                    BeatmapInfo.Metadata.Title = cachedBeatmap.BeatmapInfo.Metadata.Title;
+                    BeatmapInfo.Metadata.Artist = cachedBeatmap.BeatmapInfo.Metadata.Artist;
+                    BeatmapInfo.Metadata.Source = "BMS Import";
+                    BeatmapInfo.Metadata.AudioFile = sanitiseAudioReference(cachedBeatmap.BeatmapInfo.Metadata.AudioFile, FolderPath) ?? string.Empty;
+                    BeatmapInfo.Metadata.BackgroundFile = cachedBeatmap.BeatmapInfo.Metadata.BackgroundFile;
+                    BeatmapInfo.Metadata.PreviewTime = cachedBeatmap.BeatmapInfo.Metadata.PreviewTime;
+                    BeatmapInfo.DifficultyName = cachedBeatmap.BeatmapInfo.DifficultyName;
+                    BeatmapInfo.Difficulty = cachedBeatmap.BeatmapInfo.Difficulty.Clone();
+                    BeatmapInfo.BPM = cachedBeatmap.BeatmapInfo.BPM;
+                }
+                else
+                {
+                    cachedBeatmap = new BMSBeatmap();
+                }
+
+                return cachedBeatmap;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, $"Failed to parse BMS file: {bmsFilePath}");
+                return new BMSBeatmap();
+            }
+        }
+
+        public override Texture? GetBackground()
+        {
+            if (localBackgroundStore == null)
+                return null;
+
+            // GetBackground() may run before GetBeatmap() has populated Metadata.BackgroundFile from the parsed
+            // chart, so eagerly trigger one chart parse to learn the actual filename.
+            string backgroundFile = BeatmapInfo.Metadata.BackgroundFile;
+
+            if (string.IsNullOrEmpty(backgroundFile))
+            {
+                _ = GetBeatmap();
+                backgroundFile = BeatmapInfo.Metadata.BackgroundFile;
+            }
+
+            if (string.IsNullOrEmpty(backgroundFile))
+                return null;
+
+            var texture = localBackgroundStore.Get(backgroundFile);
+
+            if (texture == null)
+            {
+                Logger.Log($"BMS background not found: {backgroundFile}", LoggingTarget.Runtime, LogLevel.Debug);
+                return null;
+            }
+
+            return texture;
+        }
+
+        protected override Track GetBeatmapTrack()
+        {
+            // BMS doesn't have a main track - keysounds ARE the track
+            // We need to create a virtual track of the appropriate length
+            var beatmap = GetBeatmap();
+            double length = 0;
+
+            if (beatmap.HitObjects.Count > 0)
+            {
+                var lastObject = beatmap.HitObjects.MaxBy(h => h.GetEndTime());
+                if (lastObject != null)
+                    length = lastObject.GetEndTime() + 2000; // Add 2 seconds padding
+            }
+
+            return audioManager.Tracks.GetVirtual(Math.Max(length, 60000));
+        }
+
+        protected override Storyboard GetStoryboard()
+        {
+            var storyboard = base.GetStoryboard();
+
+            if (GetBeatmap() is not BMSBeatmap beatmap || beatmap.BackgroundSoundEvents.Count == 0)
+                return storyboard;
+
+            BmsStoryboardPreviewAugment.Augment(storyboard, beatmap.BackgroundSoundEvents);
+            return storyboard;
+        }
+
+        protected override ISkin GetSkin()
+        {
+            // Return a skin that can load keysounds from the BMS folder
+            return new BMSSkin(FolderPath, audioManager);
+        }
+
+        public override Stream? GetStream(string storagePath)
+        {
+            // Try to load from the BMS folder
+            string fullPath = Path.Combine(FolderPath, storagePath);
+            if (File.Exists(fullPath))
+                return File.OpenRead(fullPath);
+
+            return null;
+        }
+
+        internal static string? ResolveAudioPath(string folderPath, string? relativePath)
+        {
+            if (!string.IsNullOrWhiteSpace(relativePath))
+            {
+                string normalisedRelativePath = relativePath.Replace('/', Path.DirectorySeparatorChar);
+                string directPath = Path.Combine(folderPath, normalisedRelativePath);
+
+                if (File.Exists(directPath))
+                    return directPath;
+
+                string directory = Path.GetDirectoryName(normalisedRelativePath) ?? string.Empty;
+                string baseName = Path.GetFileNameWithoutExtension(normalisedRelativePath);
+
+                foreach (string extension in new[] { ".wav", ".ogg", ".mp3", ".flac" })
+                {
+                    string candidate = Path.Combine(folderPath, directory, baseName + extension);
+
+                    if (File.Exists(candidate))
+                        return candidate;
+                }
+            }
+
+            foreach (string extension in new[] { "*.ogg", "*.mp3", "*.wav", "*.flac" })
+            {
+                string? fallback = Directory.GetFiles(folderPath, extension, SearchOption.TopDirectoryOnly)
+                                            .OrderBy(static path => path, StringComparer.OrdinalIgnoreCase)
+                                            .FirstOrDefault();
+
+                if (fallback != null)
+                    return fallback;
+            }
+
+            return null;
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/Beatmaps/BmsBackgroundSoundEvent.cs
+++ b/osu.Game.Rulesets.BMS/Beatmaps/BmsBackgroundSoundEvent.cs
@@ -1,0 +1,21 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.BMS.Beatmaps
+{
+    /// <summary>
+    /// Represents a background (non-note) sound event in BMS.
+    /// </summary>
+    public class BmsBackgroundSoundEvent
+    {
+        public BmsBackgroundSoundEvent(double time, string filename)
+        {
+            Time = time;
+            Filename = filename;
+        }
+
+        public double Time { get; }
+
+        public string Filename { get; }
+    }
+}

--- a/osu.Game.Rulesets.BMS/Beatmaps/BmsChartFileParser.cs
+++ b/osu.Game.Rulesets.BMS/Beatmaps/BmsChartFileParser.cs
@@ -1,0 +1,36 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.IO;
+
+namespace osu.Game.Rulesets.BMS.Beatmaps
+{
+    /// <summary>
+    /// Parses a BMS chart file from disk without constructing <see cref="BMSWorkingBeatmap"/> (no audio/skin/track IO).
+    /// </summary>
+    public static class BmsChartFileParser
+    {
+        public static BMSBeatmap? TryParse(string chartPath, CancellationToken cancellationToken = default)
+        {
+            if (!File.Exists(chartPath))
+                return null;
+
+            try
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                using var stream = File.OpenRead(chartPath);
+                using var reader = new LineBufferedReader(stream);
+                return new BMSBeatmapDecoder().Decode(reader) as BMSBeatmap;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/Beatmaps/BmsLibraryImportPipeline.cs
+++ b/osu.Game.Rulesets.BMS/Beatmaps/BmsLibraryImportPipeline.cs
@@ -1,0 +1,76 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Platform;
+using osu.Game.Database;
+
+namespace osu.Game.Rulesets.BMS.Beatmaps
+{
+    /// <summary>
+    /// Two-phase BMS library import: SQLite index scan, then Realm catalog sync (off UI thread).
+    /// </summary>
+    public static class BmsLibraryImportPipeline
+    {
+        /// <summary>Progress fraction reserved for the disk scan / SQLite index phase.</summary>
+        public const double SCAN_PROGRESS_PORTION = 0.85;
+
+        public readonly struct ImportProgress
+        {
+            public ImportProgress(double progress, string statusMessage)
+            {
+                Progress = progress;
+                StatusMessage = statusMessage;
+            }
+
+            public double Progress { get; }
+            public string StatusMessage { get; }
+        }
+
+        public readonly struct ImportResult
+        {
+            public ImportResult(int songCount, int chartCount)
+            {
+                SongCount = songCount;
+                ChartCount = chartCount;
+            }
+
+            public int SongCount { get; }
+            public int ChartCount { get; }
+        }
+
+        /// <summary>
+        /// Run scan then Realm sync. Safe to call from a background thread.
+        /// </summary>
+        public static async Task<ImportResult> RunAsync(
+            BMSBeatmapManager manager,
+            Storage storage,
+            RealmAccess realm,
+            RulesetInfo bmsRulesetInfo,
+            IReadOnlyList<string> paths,
+            Action<ImportProgress>? reportProgress = null,
+            CancellationToken cancellationToken = default)
+        {
+            reportProgress?.Invoke(new ImportProgress(0, "正在索引 BMS 曲库..."));
+
+            await manager.ScanLibraryAsync(paths, cancellationToken).ConfigureAwait(false);
+
+            reportProgress?.Invoke(new ImportProgress(SCAN_PROGRESS_PORTION, "正在写入 osu 曲库..."));
+
+            await Task.Run(
+                () => BMSOsuLibrarySynchronizer.Synchronize(manager, storage, realm, bmsRulesetInfo),
+                cancellationToken).ConfigureAwait(false);
+
+            int songs = manager.LibraryCache?.Songs.Count ?? 0;
+            int charts = manager.LibraryCache?.TotalCharts ?? 0;
+
+            reportProgress?.Invoke(new ImportProgress(1, $"完成: {songs} 首歌曲, {charts} 张谱面"));
+
+            return new ImportResult(songs, charts);
+        }
+
+        /// <summary>
+        /// Maps scan progress (0–1) into the first phase of combined import progress.
+        /// </summary>
+        public static double MapScanProgress(double scanProgress) => scanProgress * SCAN_PROGRESS_PORTION;
+    }
+}

--- a/osu.Game.Rulesets.BMS/Beatmaps/BmsPathKeys.cs
+++ b/osu.Game.Rulesets.BMS/Beatmaps/BmsPathKeys.cs
@@ -1,0 +1,34 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Security.Cryptography;
+using System.Text;
+
+namespace osu.Game.Rulesets.BMS.Beatmaps
+{
+    /// <summary>
+    /// Path-derived identifiers for BMS charts (no content hashing).
+    /// </summary>
+    public static class BmsPathKeys
+    {
+        public static string ComputeChartPathKey(string chartPath)
+        {
+            string normalised = normalisePath(chartPath);
+            return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(normalised))).ToLowerInvariant();
+        }
+
+        public static string ComputeRealmFileHash(string chartPath) => ComputeChartPathKey(chartPath);
+
+        private static string normalisePath(string chartPath)
+        {
+            try
+            {
+                return Path.GetFullPath(chartPath).Replace('\\', '/').ToLowerInvariant();
+            }
+            catch
+            {
+                return chartPath.Replace('\\', '/').ToLowerInvariant();
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/Beatmaps/BmsRealmSyncConstants.cs
+++ b/osu.Game.Rulesets.BMS/Beatmaps/BmsRealmSyncConstants.cs
@@ -1,0 +1,19 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.BMS.Beatmaps
+{
+    /// <summary>
+    /// Versioning for how BMS charts are registered in Realm <see cref="osu.Game.Models.RealmNamedFileUsage"/> rows.
+    /// Bump when <c>Files.Filename</c> rules change so the next sync re-imports external sets.
+    /// </summary>
+    public static class BmsRealmSyncConstants
+    {
+        /// <summary>
+        /// v1: chart files use paths relative to <see cref="osu.Game.Beatmaps.BeatmapSetInfo.ExternalContentRoot"/> (not bare file names).
+        /// </summary>
+        public const int FILE_MAPPING_SCHEMA_VERSION = 1;
+
+        public const string REALM_FILE_MAPPING_META_KEY = "realm_file_mapping_version";
+    }
+}

--- a/osu.Game.Rulesets.BMS/Beatmaps/BmsRuntimeAudioContext.cs
+++ b/osu.Game.Rulesets.BMS/Beatmaps/BmsRuntimeAudioContext.cs
@@ -1,0 +1,31 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Audio;
+
+namespace osu.Game.Rulesets.BMS.Beatmaps
+{
+    /// <summary>
+    /// Provides BMS-only access to the runtime <see cref="AudioManager"/>.
+    ///
+    /// The plain <see cref="Ruleset"/> extension points (CreateSkinTransformer, CreateBeatmapConverter, ...)
+    /// are not Drawable and therefore cannot use [BackgroundDependencyLoader] to obtain the
+    /// <see cref="AudioManager"/>. We use a small Drawable registrar that the BMS DrawableRuleset attaches
+    /// during gameplay setup; it writes the live <see cref="AudioManager"/> into this context, so other
+    /// non-Drawable BMS components (like <see cref="BMSExternalSampleSkin"/>) can lazily read it.
+    ///
+    /// All access is best-effort: components must tolerate <see cref="Audio"/> being null and fall back
+    /// gracefully when no DI host has registered yet.
+    /// </summary>
+    public static class BmsRuntimeAudioContext
+    {
+        public static AudioManager? Audio { get; private set; }
+
+        internal static void Register(AudioManager audioManager)
+        {
+            // Last writer wins; under normal flow there is a single AudioManager per game host instance.
+            if (audioManager != null)
+                Audio = audioManager;
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/Beatmaps/BmsStoragePaths.cs
+++ b/osu.Game.Rulesets.BMS/Beatmaps/BmsStoragePaths.cs
@@ -1,0 +1,112 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using osu.Game.Rulesets.BMS.Beatmaps.Persistence;
+
+namespace osu.Game.Rulesets.BMS.Beatmaps
+{
+    /// <summary>
+    /// Canonical on-disk layout for BMS ruleset data under the osu storage root.
+    /// </summary>
+    public static class BmsStoragePaths
+    {
+        public const string STORAGE_ROOT = "EzBMS";
+        public const string INDEX_DATABASE_FILE = "index.sqlite";
+        public const string LAMP_DATABASE_FILE = "lamps.sqlite";
+        public const string FILTER_DATABASE_FILE = "filter.sqlite";
+        public const string ANALYTICS_DATABASE_FILE = "analytics.sqlite";
+
+        public static string GetStorageRootPath(Storage storage) => storage.GetFullPath(STORAGE_ROOT);
+
+        public static string GetIndexDatabasePath(Storage storage) => Path.Combine(GetStorageRootPath(storage), INDEX_DATABASE_FILE);
+
+        public static string GetLampDatabasePath(Storage storage) => Path.Combine(GetStorageRootPath(storage), LAMP_DATABASE_FILE);
+
+        public static string GetFilterDatabasePath(Storage storage) => Path.Combine(GetStorageRootPath(storage), FILTER_DATABASE_FILE);
+
+        public static string GetAnalyticsDatabasePath(Storage storage) => Path.Combine(GetStorageRootPath(storage), ANALYTICS_DATABASE_FILE);
+
+        /// <summary>
+        /// Ensures <see cref="STORAGE_ROOT"/> exists and migrates legacy <c>bms_cache</c> / <c>bms</c> data when needed.
+        /// </summary>
+        public static string EnsureInitialized(Storage storage)
+        {
+            string root = GetStorageRootPath(storage);
+            Directory.CreateDirectory(root);
+
+            BmsLibraryMigration.MigrateIfNeeded(storage, root);
+            return root;
+        }
+    }
+
+    internal static class BmsLibraryMigration
+    {
+        private const string legacy_cache_directory = "bms_cache";
+        private const string legacy_bms_directory = "bms";
+        private const string legacy_library_cache = "bms_library_cache.json";
+
+        public static void MigrateIfNeeded(Storage storage, string ezbmsRoot)
+        {
+            string indexPath = Path.Combine(ezbmsRoot, BmsStoragePaths.INDEX_DATABASE_FILE);
+            bool indexExists = File.Exists(indexPath);
+
+            if (!indexExists)
+                tryImportLegacyJson(storage, ezbmsRoot, indexPath);
+
+            migrateLampDatabase(storage, ezbmsRoot);
+        }
+
+        private static void tryImportLegacyJson(Storage storage, string ezbmsRoot, string indexPath)
+        {
+            foreach (string legacyDir in new[] { legacy_cache_directory, legacy_bms_directory })
+            {
+                string legacyRoot = storage.GetFullPath(legacyDir);
+                string jsonPath = Path.Combine(legacyRoot, legacy_library_cache);
+
+                if (!File.Exists(jsonPath))
+                    continue;
+
+                var cache = BMSLibraryCache.Load(jsonPath);
+
+                if (cache == null)
+                    continue;
+
+                var repository = new BmsLibraryIndexRepository(indexPath);
+                repository.ImportFromLibraryCache(cache);
+                Logger.Log($"[BMS] Migrated library cache from '{legacyDir}' into EzBMS index.", LoggingTarget.Database);
+                break;
+            }
+        }
+
+        private static void migrateLampDatabase(Storage storage, string ezbmsRoot)
+        {
+            string target = Path.Combine(ezbmsRoot, BmsStoragePaths.LAMP_DATABASE_FILE);
+
+            if (File.Exists(target))
+                return;
+
+            foreach (string legacyDir in new[] { legacy_cache_directory, legacy_bms_directory, BmsStoragePaths.STORAGE_ROOT })
+            {
+                string candidate = Path.Combine(storage.GetFullPath(legacyDir), BmsStoragePaths.LAMP_DATABASE_FILE);
+
+                if (!File.Exists(candidate) || string.Equals(Path.GetFullPath(candidate), Path.GetFullPath(target), StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                try
+                {
+                    Directory.CreateDirectory(ezbmsRoot);
+                    File.Move(candidate, target);
+                    Logger.Log($"[BMS] Moved lamp database from '{legacyDir}' to EzBMS.", LoggingTarget.Database);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Log($"[BMS] Lamp database migration failed: {ex.Message}", LoggingTarget.Database, LogLevel.Important);
+                }
+
+                return;
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/Beatmaps/BmsStoryboardPreviewAugment.cs
+++ b/osu.Game.Rulesets.BMS/Beatmaps/BmsStoryboardPreviewAugment.cs
@@ -1,0 +1,54 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.IO;
+using osu.Game.Storyboards;
+
+namespace osu.Game.Rulesets.BMS.Beatmaps
+{
+    /// <summary>
+    /// Merges BMS non-note BGM events into a <see cref="Storyboard"/> so the standard
+    /// osu! preview / storyboard sample scheduling can see them.
+    ///
+    /// Called only from inside the BMS ruleset assembly (e.g. <see cref="BMSWorkingBeatmap.GetStoryboard"/>).
+    /// </summary>
+    public static class BmsStoryboardPreviewAugment
+    {
+        public const string SAMPLE_LAYER_NAME = "BMSBackgroundSamples";
+
+        /// <summary>
+        /// Re-decode a BMS chart file from disk and augment <paramref name="storyboard"/> with its BGM events.
+        /// Useful for callers that hold a chart path but no parsed <see cref="BMSBeatmap"/> instance.
+        /// </summary>
+        public static void Augment(Storyboard storyboard, string chartFilePath)
+        {
+            if (!File.Exists(chartFilePath))
+                return;
+
+            using var stream = File.OpenRead(chartFilePath);
+            using var reader = new LineBufferedReader(stream);
+            var decoder = new BMSBeatmapDecoder();
+
+            if (decoder.Decode(reader) is not BMSBeatmap bms || bms.BackgroundSoundEvents.Count == 0)
+                return;
+
+            Augment(storyboard, bms.BackgroundSoundEvents);
+        }
+
+        /// <summary>
+        /// Augment <paramref name="storyboard"/> with the supplied background sound events.
+        /// </summary>
+        public static void Augment(Storyboard storyboard, IEnumerable<BmsBackgroundSoundEvent> backgroundSoundEvents)
+        {
+            var sampleLayer = storyboard.GetLayer(SAMPLE_LAYER_NAME);
+
+            foreach (var e in backgroundSoundEvents)
+            {
+                if (string.IsNullOrEmpty(e.Filename))
+                    continue;
+
+                sampleLayer.Add(new StoryboardSampleInfo(StoryboardElementSource.Beatmap, e.Filename.Replace('\\', '/'), e.Time, 100));
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/Beatmaps/ManiaConvertedWorkingBeatmap.cs
+++ b/osu.Game.Rulesets.BMS/Beatmaps/ManiaConvertedWorkingBeatmap.cs
@@ -1,0 +1,182 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Audio;
+using osu.Framework.Audio.Track;
+using osu.Framework.Graphics.Textures;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.BMS.Audio;
+using osu.Game.Rulesets.BMS.Objects;
+using osu.Game.Rulesets.Mania.Beatmaps;
+using osu.Game.Rulesets.Mania.Objects;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Skinning;
+
+namespace osu.Game.Rulesets.BMS.Beatmaps
+{
+    /// <summary>
+    /// Wraps a BMS chart as a pre-converted Mania beatmap, so gameplay uses full mania pipelines.
+    /// </summary>
+    public class ManiaConvertedWorkingBeatmap : WorkingBeatmap
+    {
+        /// <summary>
+        /// Gameplay, previews, and Ez analysis may call <see cref="GetPlayableBeatmap"/> concurrently on the same
+        /// instance; in-place ApplyDefaults mutates shared lists → lock for thread safety.
+        /// </summary>
+        private readonly object playableMutationLock = new object();
+
+        private readonly ManiaBeatmap maniaBeatmap;
+        private readonly AudioManager audioManager;
+        private readonly double beatmapLength;
+
+        /// <param name="source">Parsed BMS working beatmap.</param>
+        /// <param name="audioManager">Used only for a virtual timeline track (no sample IO when <paramref name="preloadKeysounds"/> is false).</param>
+        /// <param name="preloadKeysounds">
+        /// When <see langword="false"/>, skips keysound sample IO (for offline analytics scans).
+        /// Gameplay and previews should keep the default <see langword="true"/>.
+        /// </param>
+        public ManiaConvertedWorkingBeatmap(BMSWorkingBeatmap source, AudioManager audioManager, bool preloadKeysounds = true)
+            : base(source.BeatmapInfo, audioManager)
+        {
+            SourceBeatmap = source;
+            this.audioManager = audioManager;
+
+            maniaBeatmap = ConvertToManiaBeatmap(source.Beatmap);
+
+            if (preloadKeysounds)
+            {
+                KeysoundManager = new BmsKeysoundManager(audioManager, SourceBeatmap.FolderPath);
+                KeysoundManager.PreloadKeysounds(maniaBeatmap.HitObjects);
+
+                if (source.Beatmap is BMSBeatmap bmsBeatmap)
+                    KeysoundManager.SetBackgroundSoundEvents(bmsBeatmap.BackgroundSoundEvents);
+            }
+
+            if (maniaBeatmap.HitObjects.Count > 0)
+                beatmapLength = maniaBeatmap.HitObjects.Max(h => h.GetEndTime()) + 2000;
+        }
+
+        public static ManiaBeatmap ConvertToManiaBeatmap(IBeatmap bmsBeatmap)
+        {
+            var usedColumns = bmsBeatmap.HitObjects
+                                        .OfType<BMSHitObject>()
+                                        .Select(h => h.Column)
+                                        .Distinct()
+                                        .OrderBy(c => c)
+                                        .ToList();
+
+            var columnRemap = new Dictionary<int, int>();
+            for (int i = 0; i < usedColumns.Count; i++)
+                columnRemap[usedColumns[i]] = i;
+
+            int columnCount = usedColumns.Count > 0 ? usedColumns.Count : 1;
+
+            var maniaBeatmap = new ManiaBeatmap(new StageDefinition(columnCount))
+            {
+                BeatmapInfo = bmsBeatmap.BeatmapInfo,
+                Difficulty = new BeatmapDifficulty(bmsBeatmap.Difficulty)
+                {
+                    CircleSize = columnCount
+                },
+                ControlPointInfo = bmsBeatmap.ControlPointInfo
+            };
+
+            foreach (var hitObject in bmsBeatmap.HitObjects.OfType<BMSHitObject>())
+            {
+                int column = columnRemap.GetValueOrDefault(hitObject.Column, 0);
+
+                ManiaHitObject maniaHitObject = hitObject switch
+                {
+                    BMSHoldNote holdNote => new HoldNote
+                    {
+                        Column = column,
+                        StartTime = holdNote.StartTime,
+                        Duration = holdNote.Duration,
+                        Samples = holdNote.Samples.ToList(),
+                    },
+                    _ => new Note
+                    {
+                        Column = column,
+                        StartTime = hitObject.StartTime,
+                        Samples = hitObject.Samples.ToList(),
+                    }
+                };
+
+                maniaHitObject.ApplyDefaults(maniaBeatmap.ControlPointInfo, maniaBeatmap.Difficulty);
+                maniaBeatmap.HitObjects.Add(maniaHitObject);
+            }
+
+            return maniaBeatmap;
+        }
+
+        protected override IBeatmap GetBeatmap()
+        {
+            lock (playableMutationLock)
+            {
+                return maniaBeatmap;
+            }
+        }
+
+        public override IBeatmap GetPlayableBeatmap(IRulesetInfo ruleset, IReadOnlyList<Mod> mods, CancellationToken token)
+        {
+            lock (playableMutationLock)
+            {
+                var rulesetInstance = ruleset.CreateInstance();
+
+                foreach (var mod in mods.OfType<IApplicableToDifficulty>())
+                {
+                    token.ThrowIfCancellationRequested();
+                    mod.ApplyToDifficulty(maniaBeatmap.Difficulty);
+                }
+
+                foreach (var mod in mods.OfType<IApplicableAfterBeatmapConversion>())
+                {
+                    token.ThrowIfCancellationRequested();
+                    mod.ApplyToBeatmap(maniaBeatmap);
+                }
+
+                var processor = rulesetInstance.CreateBeatmapProcessor(maniaBeatmap);
+
+                if (processor != null)
+                {
+                    foreach (var mod in mods.OfType<IApplicableToBeatmapProcessor>())
+                        mod.ApplyToBeatmapProcessor(processor);
+
+                    processor.PreProcess();
+                }
+
+                foreach (var obj in maniaBeatmap.HitObjects)
+                {
+                    token.ThrowIfCancellationRequested();
+                    obj.ApplyDefaults(maniaBeatmap.ControlPointInfo, maniaBeatmap.Difficulty, token);
+                }
+
+                processor?.PostProcess();
+
+                foreach (var mod in mods.OfType<IApplicableToHitObject>())
+                {
+                    foreach (var obj in maniaBeatmap.HitObjects)
+                    {
+                        token.ThrowIfCancellationRequested();
+                        mod.ApplyToHitObject(obj);
+                    }
+                }
+
+                return maniaBeatmap;
+            }
+        }
+
+        public override Texture? GetBackground() => SourceBeatmap.GetBackground();
+
+        protected override Track GetBeatmapTrack() => audioManager.Tracks.GetVirtual(Math.Max(beatmapLength, 60000));
+
+        protected override ISkin GetSkin() => null!;
+
+        public override Stream? GetStream(string storagePath) => SourceBeatmap.GetStream(storagePath);
+
+        public BmsKeysoundManager? KeysoundManager { get; }
+
+        public BMSWorkingBeatmap SourceBeatmap { get; }
+    }
+}

--- a/osu.Game.Rulesets.BMS/Beatmaps/Persistence/BmsLibraryIndexRepository.cs
+++ b/osu.Game.Rulesets.BMS/Beatmaps/Persistence/BmsLibraryIndexRepository.cs
@@ -1,0 +1,669 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Data.Sqlite;
+
+namespace osu.Game.Rulesets.BMS.Beatmaps.Persistence
+{
+    public sealed class BmsLibraryIndexRepository
+    {
+        private const int schema_version = 1;
+
+        private const string table_meta = "meta";
+        private const string table_roots = "roots";
+        private const string table_songs = "songs";
+        private const string table_charts = "charts";
+
+        private readonly string databasePath;
+        private readonly object writeLock = new object();
+        private bool initialized;
+
+        public BmsLibraryIndexRepository(string databasePath)
+        {
+            this.databasePath = databasePath ?? throw new ArgumentNullException(nameof(databasePath));
+        }
+
+        public long ScanRevision => readLongMeta("scan_revision");
+
+        public int RealmFileMappingVersion => (int)readLongMeta(BmsRealmSyncConstants.REALM_FILE_MAPPING_META_KEY);
+
+        public void WriteRealmFileMappingVersion(int version)
+        {
+            lock (writeLock)
+            {
+                ensureInitialized();
+
+                using var connection = openConnection();
+                writeMeta(connection, BmsRealmSyncConstants.REALM_FILE_MAPPING_META_KEY, version.ToString(CultureInfo.InvariantCulture));
+            }
+        }
+
+        public DateTime LastScanTime
+        {
+            get
+            {
+                long ticks = readLongMeta("last_scan_ticks");
+                return ticks > 0 ? new DateTime(ticks, DateTimeKind.Utc) : DateTime.MinValue;
+            }
+        }
+
+        /// <summary>
+        /// Represents a snapshot of a chart file for change detection.
+        /// ChartPath is included for data integrity even though the dictionary key already contains the path.
+        /// </summary>
+        public record ChartFileSnapshot(string ChartPath, long FileSize, long LastModifiedTicks);
+
+        public Dictionary<string, ChartFileSnapshot> GetChartSnapshots()
+        {
+            ensureInitialized();
+            var result = new Dictionary<string, ChartFileSnapshot>(StringComparer.OrdinalIgnoreCase);
+
+            using var connection = openConnection();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT chart_path, file_size, last_modified_ticks FROM charts;";
+
+            using var reader = cmd.ExecuteReader();
+
+            while (reader.Read())
+            {
+                result[reader.GetString(0)] = new ChartFileSnapshot(
+                    reader.GetString(0),
+                    reader.GetInt64(1),
+                    reader.GetInt64(2));
+            }
+
+            return result;
+        }
+
+        public bool TryLoadChart(string chartPath, out BMSChartCache chart)
+        {
+            chart = null!;
+
+            ensureInitialized();
+
+            using var connection = openConnection();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT * FROM charts WHERE chart_path = $path LIMIT 1;";
+            cmd.Parameters.AddWithValue("$path", chartPath);
+
+            using var reader = cmd.ExecuteReader();
+
+            if (!reader.Read())
+                return false;
+
+            chart = readChart(reader);
+            return true;
+        }
+
+        public bool TryGetSourceReference(Guid beatmapId, out BMSSourceReference reference)
+        {
+            reference = default;
+            ensureInitialized();
+
+            using var connection = openConnection();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = @"
+SELECT beatmap_id, folder_path, chart_path, path_key
+FROM charts
+WHERE beatmap_id = $id
+LIMIT 1;";
+            cmd.Parameters.AddWithValue("$id", beatmapId.ToString());
+
+            using var reader = cmd.ExecuteReader();
+
+            if (!reader.Read())
+                return false;
+
+            reference = new BMSSourceReference
+            {
+                BeatmapId = beatmapId,
+                FolderPath = reader.GetString(1),
+                ChartPath = reader.GetString(2),
+                Md5Hash = reader.GetString(3),
+            };
+
+            return true;
+        }
+
+        public bool TryGetSourceReferenceByPathKey(string pathKey, out BMSSourceReference reference)
+        {
+            reference = default;
+            ensureInitialized();
+
+            using var connection = openConnection();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = @"
+SELECT beatmap_id, folder_path, chart_path, path_key
+FROM charts
+WHERE path_key = $key
+LIMIT 1;";
+            cmd.Parameters.AddWithValue("$key", pathKey);
+
+            using var reader = cmd.ExecuteReader();
+
+            if (!reader.Read())
+                return false;
+
+            reference = new BMSSourceReference
+            {
+                BeatmapId = Guid.Parse(reader.GetString(0)),
+                FolderPath = reader.GetString(1),
+                ChartPath = reader.GetString(2),
+                Md5Hash = reader.GetString(3),
+            };
+
+            return true;
+        }
+
+        public void ReplaceRoots(IEnumerable<string> rootPaths)
+        {
+            lock (writeLock)
+            {
+                ensureInitialized();
+
+                using var connection = openConnection();
+                using var transaction = connection.BeginTransaction();
+
+                using (var delete = connection.CreateCommand())
+                {
+                    delete.Transaction = transaction;
+                    // Intentionally clear all roots before replacing with new list
+                    delete.CommandText = $"DELETE FROM {table_roots};";
+                    delete.ExecuteNonQuery();
+                }
+
+                foreach (string path in rootPaths)
+                {
+                    using var insert = connection.CreateCommand();
+                    insert.Transaction = transaction;
+                    insert.CommandText = $"INSERT INTO {table_roots} (path) VALUES ($path);";
+                    insert.Parameters.AddWithValue("$path", path);
+                    insert.ExecuteNonQuery();
+                }
+
+                transaction.Commit();
+            }
+        }
+
+        public void UpsertSong(BMSSongCache song)
+        {
+            lock (writeLock)
+            {
+                ensureInitialized();
+
+                using var connection = openConnection();
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = $@"
+INSERT INTO {table_songs} (
+    folder_path, title, artist, genre, banner_path, stage_path, last_modified_ticks
+) VALUES (
+    $folder, $title, $artist, $genre, $banner, $stage, $modified
+)
+ON CONFLICT(folder_path) DO UPDATE SET
+    title = excluded.title,
+    artist = excluded.artist,
+    genre = excluded.genre,
+    banner_path = excluded.banner_path,
+    stage_path = excluded.stage_path,
+    last_modified_ticks = excluded.last_modified_ticks;";
+
+                cmd.Parameters.AddWithValue("$folder", song.FolderPath);
+                cmd.Parameters.AddWithValue("$title", song.Title ?? string.Empty);
+                cmd.Parameters.AddWithValue("$artist", song.Artist ?? string.Empty);
+                cmd.Parameters.AddWithValue("$genre", song.Genre ?? string.Empty);
+                cmd.Parameters.AddWithValue("$banner", (object?)song.BannerPath ?? DBNull.Value);
+                cmd.Parameters.AddWithValue("$stage", (object?)song.StageFilePath ?? DBNull.Value);
+                cmd.Parameters.AddWithValue("$modified", song.LastModified.ToUniversalTime().Ticks);
+                cmd.ExecuteNonQuery();
+            }
+        }
+
+        public void UpsertChart(BMSChartCache chart, Guid beatmapId, string pathKey)
+        {
+            lock (writeLock)
+            {
+                ensureInitialized();
+
+                using var connection = openConnection();
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = $@"
+INSERT INTO {table_charts} (
+    chart_path, folder_path, file_name, file_size, last_modified_ticks,
+    beatmap_id, path_key, title, sub_title, artist, sub_artist, genre,
+    play_level, rank, ln_type, key_count, total_notes,
+    bpm, min_bpm, max_bpm, duration, total_gauge,
+    preview_time, audio_file, preview_file,
+    has_scratch, has_ln, has_stop, has_scroll, has_bga,
+    keysound_files_json
+) VALUES (
+    $chartPath, $folder, $fileName, $size, $modified,
+    $beatmapId, $pathKey, $title, $subTitle, $artist, $subArtist, $genre,
+    $playLevel, $rank, $lnType, $keyCount, $totalNotes,
+    $bpm, $minBpm, $maxBpm, $duration, $totalGauge,
+    $previewTime, $audio, $preview,
+    $scratch, $ln, $stop, $scroll, $bga,
+    $keysounds
+)
+ON CONFLICT(chart_path) DO UPDATE SET
+    folder_path = excluded.folder_path,
+    file_name = excluded.file_name,
+    file_size = excluded.file_size,
+    last_modified_ticks = excluded.last_modified_ticks,
+    beatmap_id = excluded.beatmap_id,
+    path_key = excluded.path_key,
+    title = excluded.title,
+    sub_title = excluded.sub_title,
+    artist = excluded.artist,
+    sub_artist = excluded.sub_artist,
+    genre = excluded.genre,
+    play_level = excluded.play_level,
+    rank = excluded.rank,
+    ln_type = excluded.ln_type,
+    key_count = excluded.key_count,
+    total_notes = excluded.total_notes,
+    bpm = excluded.bpm,
+    min_bpm = excluded.min_bpm,
+    max_bpm = excluded.max_bpm,
+    duration = excluded.duration,
+    total_gauge = excluded.total_gauge,
+    preview_time = excluded.preview_time,
+    audio_file = excluded.audio_file,
+    preview_file = excluded.preview_file,
+    has_scratch = excluded.has_scratch,
+    has_ln = excluded.has_ln,
+    has_stop = excluded.has_stop,
+    has_scroll = excluded.has_scroll,
+    has_bga = excluded.has_bga,
+    keysound_files_json = excluded.keysound_files_json;";
+
+                string chartPath = chart.FullPath;
+                cmd.Parameters.AddWithValue("$chartPath", chartPath);
+                cmd.Parameters.AddWithValue("$folder", chart.FolderPath);
+                cmd.Parameters.AddWithValue("$fileName", chart.FileName);
+                cmd.Parameters.AddWithValue("$size", chart.FileSize);
+                cmd.Parameters.AddWithValue("$modified", chart.LastModified.ToUniversalTime().Ticks);
+                cmd.Parameters.AddWithValue("$beatmapId", beatmapId.ToString());
+                cmd.Parameters.AddWithValue("$pathKey", pathKey);
+                cmd.Parameters.AddWithValue("$title", chart.Title ?? string.Empty);
+                cmd.Parameters.AddWithValue("$subTitle", chart.SubTitle ?? string.Empty);
+                cmd.Parameters.AddWithValue("$artist", chart.Artist ?? string.Empty);
+                cmd.Parameters.AddWithValue("$subArtist", chart.SubArtist ?? string.Empty);
+                cmd.Parameters.AddWithValue("$genre", chart.Genre ?? string.Empty);
+                cmd.Parameters.AddWithValue("$playLevel", chart.PlayLevel);
+                cmd.Parameters.AddWithValue("$rank", chart.Rank);
+                cmd.Parameters.AddWithValue("$lnType", chart.LnType);
+                cmd.Parameters.AddWithValue("$keyCount", chart.KeyCount);
+                cmd.Parameters.AddWithValue("$totalNotes", chart.TotalNotes);
+                cmd.Parameters.AddWithValue("$bpm", chart.Bpm);
+                cmd.Parameters.AddWithValue("$minBpm", chart.MinBpm);
+                cmd.Parameters.AddWithValue("$maxBpm", chart.MaxBpm);
+                cmd.Parameters.AddWithValue("$duration", chart.Duration);
+                cmd.Parameters.AddWithValue("$totalGauge", chart.Total);
+                cmd.Parameters.AddWithValue("$previewTime", chart.PreviewTime);
+                cmd.Parameters.AddWithValue("$audio", (object?)chart.AudioFile ?? DBNull.Value);
+                cmd.Parameters.AddWithValue("$preview", (object?)chart.PreviewFile ?? DBNull.Value);
+                cmd.Parameters.AddWithValue("$scratch", chart.HasScratch ? 1 : 0);
+                cmd.Parameters.AddWithValue("$ln", chart.HasLongNotes ? 1 : 0);
+                cmd.Parameters.AddWithValue("$stop", chart.HasStopSequence ? 1 : 0);
+                cmd.Parameters.AddWithValue("$scroll", chart.HasScrollChanges ? 1 : 0);
+                cmd.Parameters.AddWithValue("$bga", chart.HasBgaLayer ? 1 : 0);
+                cmd.Parameters.AddWithValue("$keysounds", JsonSerializer.Serialize(chart.KeysoundFiles));
+                cmd.ExecuteNonQuery();
+            }
+        }
+
+        public int DeleteChartsNotIn(IReadOnlyCollection<string> chartPaths)
+        {
+            lock (writeLock)
+            {
+                ensureInitialized();
+
+                if (chartPaths.Count == 0)
+                {
+                    using var connection = openConnection();
+                    using var wipe = connection.CreateCommand();
+                    wipe.CommandText = $"DELETE FROM {table_charts};";
+                    return wipe.ExecuteNonQuery();
+                }
+
+                using var conn = openConnection();
+                using var transaction = conn.BeginTransaction();
+
+                var existing = new List<string>();
+
+                using (var select = conn.CreateCommand())
+                {
+                    select.Transaction = transaction;
+                    select.CommandText = "SELECT chart_path FROM charts;";
+
+                    using var reader = select.ExecuteReader();
+
+                    while (reader.Read())
+                        existing.Add(reader.GetString(0));
+                }
+
+                var keep = new HashSet<string>(chartPaths, StringComparer.OrdinalIgnoreCase);
+                int deleted = 0;
+
+                foreach (string path in existing)
+                {
+                    if (keep.Contains(path))
+                        continue;
+
+                    using var delete = conn.CreateCommand();
+                    delete.Transaction = transaction;
+                    delete.CommandText = "DELETE FROM charts WHERE chart_path = $path;";
+                    delete.Parameters.AddWithValue("$path", path);
+                    deleted += delete.ExecuteNonQuery();
+                }
+
+                pruneOrphanSongs(conn, transaction);
+                transaction.Commit();
+                return deleted;
+            }
+        }
+
+        public long MarkScanComplete(IEnumerable<string> rootPaths)
+        {
+            lock (writeLock)
+            {
+                ensureInitialized();
+                ReplaceRoots(rootPaths);
+
+                long revision = ScanRevision + 1;
+                DateTime now = DateTime.UtcNow;
+
+                using var connection = openConnection();
+                writeMeta(connection, "scan_revision", revision.ToString(CultureInfo.InvariantCulture));
+                writeMeta(connection, "last_scan_ticks", now.Ticks.ToString(CultureInfo.InvariantCulture));
+
+                return revision;
+            }
+        }
+
+        public BMSLibraryCache LoadLibraryCache()
+        {
+            ensureInitialized();
+
+            var cache = new BMSLibraryCache
+            {
+                Version = schema_version,
+                LastScanTime = LastScanTime.ToLocalTime(),
+            };
+
+            using var connection = openConnection();
+
+            using (var rootsCmd = connection.CreateCommand())
+            {
+                rootsCmd.CommandText = $"SELECT path FROM {table_roots} ORDER BY path;";
+                using var reader = rootsCmd.ExecuteReader();
+
+                while (reader.Read())
+                    cache.RootPaths.Add(reader.GetString(0));
+            }
+
+            cache.RootPath = cache.RootPaths.FirstOrDefault() ?? string.Empty;
+
+            var songsByFolder = new Dictionary<string, BMSSongCache>(StringComparer.OrdinalIgnoreCase);
+
+            using (var songsCmd = connection.CreateCommand())
+            {
+                songsCmd.CommandText = $"SELECT folder_path, title, artist, genre, banner_path, stage_path, last_modified_ticks FROM {table_songs};";
+                using var reader = songsCmd.ExecuteReader();
+
+                while (reader.Read())
+                {
+                    var song = new BMSSongCache
+                    {
+                        FolderPath = reader.GetString(0),
+                        Title = reader.GetString(1),
+                        Artist = reader.GetString(2),
+                        Genre = reader.GetString(3),
+                        BannerPath = reader.IsDBNull(4) ? null : reader.GetString(4),
+                        StageFilePath = reader.IsDBNull(5) ? null : reader.GetString(5),
+                        LastModified = new DateTime(reader.GetInt64(6), DateTimeKind.Utc).ToLocalTime(),
+                    };
+
+                    songsByFolder[song.FolderPath] = song;
+                    cache.Songs.Add(song);
+                }
+            }
+
+            using (var chartsCmd = connection.CreateCommand())
+            {
+                chartsCmd.CommandText = "SELECT * FROM charts ORDER BY folder_path, file_name;";
+                using var reader = chartsCmd.ExecuteReader();
+
+                while (reader.Read())
+                {
+                    var chart = readChart(reader);
+
+                    if (!songsByFolder.TryGetValue(chart.FolderPath, out var song))
+                    {
+                        song = new BMSSongCache
+                        {
+                            FolderPath = chart.FolderPath,
+                            Title = chart.Title,
+                            Artist = chart.Artist,
+                            Genre = chart.Genre,
+                            LastModified = chart.LastModified,
+                        };
+                        songsByFolder[song.FolderPath] = song;
+                        cache.Songs.Add(song);
+                    }
+
+                    chart.Md5Hash = reader.GetString(reader.GetOrdinal("path_key"));
+                    song.Charts.Add(chart);
+                }
+            }
+
+            return cache;
+        }
+
+        public void ImportFromLibraryCache(BMSLibraryCache cache)
+        {
+            lock (writeLock)
+            {
+                ensureInitialized();
+                ReplaceRoots(cache.RootPaths.Count > 0 ? cache.RootPaths : new[] { cache.RootPath });
+
+                foreach (var song in cache.Songs)
+                {
+                    UpsertSong(song);
+
+                    foreach (var chart in song.Charts)
+                    {
+                        string chartPath = chart.FullPath;
+                        string pathKey = string.IsNullOrEmpty(chart.Md5Hash)
+                            ? BmsPathKeys.ComputeChartPathKey(chartPath)
+                            : chart.Md5Hash;
+                        Guid beatmapId = createDeterministicGuid($"bms:chart:{chartPath}");
+                        UpsertChart(chart, beatmapId, pathKey);
+                    }
+                }
+
+                MarkScanComplete(cache.RootPaths.Count > 0 ? cache.RootPaths : new[] { cache.RootPath });
+            }
+        }
+
+        private static Guid createDeterministicGuid(string input)
+        {
+            byte[] bytes = MD5.HashData(Encoding.UTF8.GetBytes(input));
+            return new Guid(bytes);
+        }
+
+        private static BMSChartCache readChart(SqliteDataReader reader)
+        {
+            return new BMSChartCache
+            {
+                FolderPath = reader.GetString(reader.GetOrdinal("folder_path")),
+                FileName = reader.GetString(reader.GetOrdinal("file_name")),
+                FileSize = reader.GetInt64(reader.GetOrdinal("file_size")),
+                LastModified = new DateTime(reader.GetInt64(reader.GetOrdinal("last_modified_ticks")), DateTimeKind.Utc).ToLocalTime(),
+                Title = reader.GetString(reader.GetOrdinal("title")),
+                SubTitle = reader.GetString(reader.GetOrdinal("sub_title")),
+                Artist = reader.GetString(reader.GetOrdinal("artist")),
+                SubArtist = reader.GetString(reader.GetOrdinal("sub_artist")),
+                Genre = reader.GetString(reader.GetOrdinal("genre")),
+                PlayLevel = reader.GetInt32(reader.GetOrdinal("play_level")),
+                Rank = reader.GetInt32(reader.GetOrdinal("rank")),
+                LnType = reader.GetInt32(reader.GetOrdinal("ln_type")),
+                KeyCount = reader.GetInt32(reader.GetOrdinal("key_count")),
+                TotalNotes = reader.GetInt32(reader.GetOrdinal("total_notes")),
+                Bpm = reader.GetDouble(reader.GetOrdinal("bpm")),
+                MinBpm = reader.GetDouble(reader.GetOrdinal("min_bpm")),
+                MaxBpm = reader.GetDouble(reader.GetOrdinal("max_bpm")),
+                Duration = reader.GetDouble(reader.GetOrdinal("duration")),
+                Total = reader.GetDouble(reader.GetOrdinal("total_gauge")),
+                PreviewTime = reader.GetInt32(reader.GetOrdinal("preview_time")),
+                AudioFile = reader.IsDBNull(reader.GetOrdinal("audio_file")) ? null : reader.GetString(reader.GetOrdinal("audio_file")),
+                PreviewFile = reader.IsDBNull(reader.GetOrdinal("preview_file")) ? null : reader.GetString(reader.GetOrdinal("preview_file")),
+                HasScratch = reader.GetInt32(reader.GetOrdinal("has_scratch")) != 0,
+                HasLongNotes = reader.GetInt32(reader.GetOrdinal("has_ln")) != 0,
+                HasStopSequence = reader.GetInt32(reader.GetOrdinal("has_stop")) != 0,
+                HasScrollChanges = reader.GetInt32(reader.GetOrdinal("has_scroll")) != 0,
+                HasBgaLayer = reader.GetInt32(reader.GetOrdinal("has_bga")) != 0,
+                KeysoundFiles = JsonSerializer.Deserialize<List<string>>(reader.GetString(reader.GetOrdinal("keysound_files_json"))) ?? new List<string>(),
+                Md5Hash = reader.GetString(reader.GetOrdinal("path_key")),
+            };
+        }
+
+        private static void pruneOrphanSongs(SqliteConnection connection, SqliteTransaction transaction)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.Transaction = transaction;
+            cmd.CommandText = $@"
+DELETE FROM {table_songs}
+WHERE folder_path NOT IN (SELECT DISTINCT folder_path FROM {table_charts});";
+            cmd.ExecuteNonQuery();
+        }
+
+        private void ensureInitialized()
+        {
+            lock (writeLock)
+            {
+                if (initialized)
+                    return;
+
+                string? directory = Path.GetDirectoryName(databasePath);
+
+                if (!string.IsNullOrEmpty(directory))
+                    Directory.CreateDirectory(directory);
+
+                using var connection = openConnection();
+
+                using (var pragma = connection.CreateCommand())
+                {
+                    pragma.CommandText = @"
+PRAGMA journal_mode=WAL;
+PRAGMA synchronous=NORMAL;
+PRAGMA temp_store=MEMORY;";
+                    pragma.ExecuteNonQuery();
+                }
+
+                using (var cmd = connection.CreateCommand())
+                {
+                    cmd.CommandText = $@"
+CREATE TABLE IF NOT EXISTS {table_meta} (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS {table_roots} (
+    path TEXT PRIMARY KEY
+);
+
+CREATE TABLE IF NOT EXISTS {table_songs} (
+    folder_path TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    artist TEXT NOT NULL,
+    genre TEXT NOT NULL,
+    banner_path TEXT,
+    stage_path TEXT,
+    last_modified_ticks INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS {table_charts} (
+    chart_path TEXT PRIMARY KEY,
+    folder_path TEXT NOT NULL,
+    file_name TEXT NOT NULL,
+    file_size INTEGER NOT NULL,
+    last_modified_ticks INTEGER NOT NULL,
+    beatmap_id TEXT NOT NULL,
+    path_key TEXT NOT NULL,
+    title TEXT NOT NULL,
+    sub_title TEXT NOT NULL,
+    artist TEXT NOT NULL,
+    sub_artist TEXT NOT NULL,
+    genre TEXT NOT NULL,
+    play_level INTEGER NOT NULL,
+    rank INTEGER NOT NULL,
+    ln_type INTEGER NOT NULL,
+    key_count INTEGER NOT NULL,
+    total_notes INTEGER NOT NULL,
+    bpm REAL NOT NULL,
+    min_bpm REAL NOT NULL,
+    max_bpm REAL NOT NULL,
+    duration REAL NOT NULL,
+    total_gauge REAL NOT NULL,
+    preview_time INTEGER NOT NULL,
+    audio_file TEXT,
+    preview_file TEXT,
+    has_scratch INTEGER NOT NULL,
+    has_ln INTEGER NOT NULL,
+    has_stop INTEGER NOT NULL,
+    has_scroll INTEGER NOT NULL,
+    has_bga INTEGER NOT NULL,
+    keysound_files_json TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_charts_folder ON {table_charts}(folder_path);
+CREATE INDEX IF NOT EXISTS idx_charts_path_key ON {table_charts}(path_key);
+CREATE INDEX IF NOT EXISTS idx_charts_beatmap_id ON {table_charts}(beatmap_id);";
+                    cmd.ExecuteNonQuery();
+                }
+
+                writeMeta(connection, "schema_version", schema_version.ToString(CultureInfo.InvariantCulture));
+                initialized = true;
+            }
+        }
+
+        private long readLongMeta(string key)
+        {
+            ensureInitialized();
+
+            using var connection = openConnection();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = $"SELECT value FROM {table_meta} WHERE key = $key;";
+            cmd.Parameters.AddWithValue("$key", key);
+            object? result = cmd.ExecuteScalar();
+
+            if (result == null || result == DBNull.Value)
+                return 0;
+
+            return long.TryParse(result.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out long value) ? value : 0;
+        }
+
+        private static void writeMeta(SqliteConnection connection, string key, string value)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = $@"
+INSERT INTO {table_meta} (key, value) VALUES ($key, $value)
+ON CONFLICT(key) DO UPDATE SET value = excluded.value;";
+            cmd.Parameters.AddWithValue("$key", key);
+            cmd.Parameters.AddWithValue("$value", value);
+            cmd.ExecuteNonQuery();
+        }
+
+        private SqliteConnection openConnection()
+        {
+            var connection = new SqliteConnection($"Data Source={databasePath};Cache=Shared;Mode=ReadWriteCreate");
+            connection.Open();
+            return connection;
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/BmsFilterCriteria.cs
+++ b/osu.Game.Rulesets.BMS/BmsFilterCriteria.cs
@@ -1,0 +1,109 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.Formats;
+using osu.Game.Rulesets.Filter;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Screens.Select;
+using osu.Game.Screens.Select.Filter;
+
+namespace osu.Game.Rulesets.BMS
+{
+    /// <summary>
+    /// Song-select filter for BMS charts. Key count is read from <see cref="BeatmapDifficulty.CircleSize"/>
+    /// (indexed during library scan), not from <see cref="Mania.Beatmaps.ManiaBeatmapConverter"/> heuristics.
+    /// </summary>
+    public class BmsFilterCriteria : IRulesetFilterCriteria
+    {
+        private readonly HashSet<int> includedKeyCounts = Enumerable.Range(1, LegacyBeatmapDecoder.MAX_MANIA_KEY_COUNT).ToHashSet();
+        private FilterCriteria.OptionalRange<float> longNotePercentage;
+
+        public bool Matches(BeatmapInfo beatmapInfo, FilterCriteria criteria)
+        {
+            int keyCount = Math.Max(1, (int)Math.Round(beatmapInfo.Difficulty.CircleSize));
+            bool keyCountMatch = includedKeyCounts.Contains(keyCount);
+            bool longNotePercentageMatch = !longNotePercentage.HasFilter
+                                           || longNotePercentage.IsInRange(calculateLongNotePercentage(beatmapInfo));
+
+            return keyCountMatch && longNotePercentageMatch;
+        }
+
+        public bool TryParseCustomKeywordCriteria(string key, Operator op, string strValues)
+        {
+            switch (key)
+            {
+                case "key":
+                case "keys":
+                {
+                    var keyCounts = new HashSet<int>();
+
+                    foreach (string strValue in strValues.Split(','))
+                    {
+                        if (!int.TryParse(strValue, out int keyCount))
+                            return false;
+
+                        keyCounts.Add(keyCount);
+                    }
+
+                    int? singleKeyCount = keyCounts.Count == 1 ? keyCounts.Single() : null;
+
+                    switch (op)
+                    {
+                        case Operator.Equal:
+                            includedKeyCounts.IntersectWith(keyCounts);
+                            return true;
+
+                        case Operator.NotEqual:
+                            includedKeyCounts.ExceptWith(keyCounts);
+                            return true;
+
+                        case Operator.Less:
+                            if (singleKeyCount == null) return false;
+
+                            includedKeyCounts.RemoveWhere(k => k >= singleKeyCount.Value);
+                            return true;
+
+                        case Operator.LessOrEqual:
+                            if (singleKeyCount == null) return false;
+
+                            includedKeyCounts.RemoveWhere(k => k > singleKeyCount.Value);
+                            return true;
+
+                        case Operator.Greater:
+                            if (singleKeyCount == null) return false;
+
+                            includedKeyCounts.RemoveWhere(k => k <= singleKeyCount.Value);
+                            return true;
+
+                        case Operator.GreaterOrEqual:
+                            if (singleKeyCount == null) return false;
+
+                            includedKeyCounts.RemoveWhere(k => k < singleKeyCount.Value);
+                            return true;
+
+                        default:
+                            return false;
+                    }
+                }
+
+                case "ln":
+                case "lns":
+                    return FilterQueryParser.TryUpdateCriteriaRange(ref longNotePercentage, op, strValues);
+            }
+
+            return false;
+        }
+
+        public bool FilterMayChangeFromMods(FilterCriteria criteria, ValueChangedEvent<IReadOnlyList<Mod>> mods) => false;
+
+        private static float calculateLongNotePercentage(BeatmapInfo beatmapInfo)
+        {
+            int holdNotes = beatmapInfo.EndTimeObjectCount;
+            int totalNotes = Math.Max(1, beatmapInfo.TotalObjectCount);
+
+            return holdNotes / (float)totalNotes * 100;
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/BmsLaneMapping.cs
+++ b/osu.Game.Rulesets.BMS/BmsLaneMapping.cs
@@ -1,0 +1,46 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.BMS
+{
+    /// <summary>
+    /// Single source for BMS channel → gameplay column mapping (decoder, UI scratch width, input routing).
+    /// </summary>
+    public static class BmsLaneMapping
+    {
+        /// <summary>
+        /// Channel 16/56 = 1P scratch, 26/66 = 2P scratch.
+        /// </summary>
+        public static bool IsScratchChannel(int channel) => channel == 16 || channel == 26 || channel == 56 || channel == 66;
+
+        /// <summary>
+        /// Map BMS measure channel to mania-style column index (decoder scheme).
+        /// </summary>
+        /// <remarks>
+        /// 1P: 11=1, 12=2, … 15=5, 16→scratch column 0, 18=6, 19=7 (7 keys + scratch left).
+        /// 2P: similar with base columns 9–15 for second deck.
+        /// </remarks>
+        public static int ChannelToColumn(int channel) => channel switch
+        {
+            16 or 56 => 0,
+            11 or 51 => 1,
+            12 or 52 => 2,
+            13 or 53 => 3,
+            14 or 54 => 4,
+            15 or 55 => 5,
+            18 or 58 => 6,
+            19 or 59 => 7,
+
+            26 or 66 => 8,
+            21 or 61 => 9,
+            22 or 62 => 10,
+            23 or 63 => 11,
+            24 or 64 => 12,
+            25 or 65 => 13,
+            28 or 68 => 14,
+            29 or 69 => 15,
+
+            _ => 0,
+        };
+    }
+}

--- a/osu.Game.Rulesets.BMS/BmsLocalScoreQueries.cs
+++ b/osu.Game.Rulesets.BMS/BmsLocalScoreQueries.cs
@@ -1,0 +1,113 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+using osu.Game.Scoring;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.BMS
+{
+    /// <summary>
+    /// Local score lookups for BMS beatmaps indexed in Realm (MD5 + ruleset short name "bms").
+    /// </summary>
+    internal static class BmsLocalScoreQueries
+    {
+        private const string bms_ruleset_short_name = "bms";
+
+        public static ScoreInfo? GetBestLocalScore(RealmAccess realm, string beatmapMd5)
+        {
+            if (string.IsNullOrEmpty(beatmapMd5))
+                return null;
+
+            return realm.Run(r =>
+            {
+                var bmsRuleset = r.Find<RulesetInfo>(bms_ruleset_short_name);
+                if (bmsRuleset == null)
+                    return null;
+
+                BeatmapInfo? bm = r.All<BeatmapInfo>()
+                                   .FirstOrDefault(b => b.MD5Hash == beatmapMd5 && b.Ruleset == bmsRuleset);
+
+                ScoreInfo? best = bm?.Scores.Where(s => !s.DeletePending).OrderByDescending(s => s.TotalScore).FirstOrDefault();
+                return best?.Detach();
+            });
+        }
+
+        public static List<ScoreInfo> GetTopLocalScores(RealmAccess realm, string beatmapMd5, int take = 5)
+        {
+            if (string.IsNullOrEmpty(beatmapMd5))
+                return new List<ScoreInfo>();
+
+            return realm.Run(r =>
+            {
+                var bmsRuleset = r.Find<RulesetInfo>(bms_ruleset_short_name);
+                if (bmsRuleset == null)
+                    return new List<ScoreInfo>();
+
+                BeatmapInfo? bm = r.All<BeatmapInfo>()
+                                   .FirstOrDefault(b => b.MD5Hash == beatmapMd5 && b.Ruleset == bmsRuleset);
+                if (bm == null)
+                    return new List<ScoreInfo>();
+
+                // Realm does not support translating Take() on this collection query path.
+                // Materialise first, then apply ordering/Take in-memory.
+                return bm.Scores
+                         .AsEnumerable()
+                         .Where(s => !s.DeletePending)
+                         .OrderByDescending(s => s.TotalScore)
+                         .Take(take)
+                         .Select(s => s.Detach())
+                         .ToList();
+            });
+        }
+    }
+
+    /// <summary>
+    /// Clear lamp colours for BMS song select; maps osu <see cref="ScoreRank"/> to lamp hues (not BMS lamp tier names).
+    /// </summary>
+    internal static class BmsClearLampColour
+    {
+        public static Color4 ForBestScore(ScoreInfo? best)
+        {
+            if (best == null)
+                return no_play;
+
+            return ForRank(best.Rank);
+        }
+
+        public static Color4 ForRank(ScoreRank rank)
+        {
+            switch (rank)
+            {
+                case ScoreRank.F:
+                    return new Color4(0.92f, 0.22f, 0.22f, 1f);
+
+                case ScoreRank.D:
+                    return new Color4(0.55f, 0.38f, 0.28f, 1f);
+
+                case ScoreRank.C:
+                    return new Color4(0.28f, 0.48f, 0.92f, 1f);
+
+                case ScoreRank.B:
+                    return new Color4(0.32f, 0.78f, 0.42f, 1f);
+
+                case ScoreRank.A:
+                    return new Color4(0.95f, 0.86f, 0.22f, 1f);
+
+                case ScoreRank.S:
+                case ScoreRank.SH:
+                    return new Color4(1f, 0.62f, 0.12f, 1f);
+
+                case ScoreRank.X:
+                case ScoreRank.XH:
+                    return new Color4(0.22f, 0.92f, 0.92f, 1f);
+
+                default:
+                    return new Color4(0.5f, 0.5f, 0.5f, 1f);
+            }
+        }
+
+        private static readonly Color4 no_play = new Color4(0.25f, 0.25f, 0.25f, 1f);
+    }
+}

--- a/osu.Game.Rulesets.BMS/Configuration/BMSGameplayRoute.cs
+++ b/osu.Game.Rulesets.BMS/Configuration/BMSGameplayRoute.cs
@@ -1,0 +1,21 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.BMS.Configuration
+{
+    /// <summary>
+    /// Routing strategy used when entering BMS gameplay.
+    /// </summary>
+    public enum BMSGameplayRoute
+    {
+        /// <summary>
+        /// Convert the BMS beatmap to a Mania beatmap and run on the Mania ruleset pipeline.
+        /// </summary>
+        ManiaCompatibility,
+
+        /// <summary>
+        /// Run on the native BMS ruleset pipeline (experimental).
+        /// </summary>
+        BmsNative,
+    }
+}

--- a/osu.Game.Rulesets.BMS/Configuration/BMSRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.BMS/Configuration/BMSRulesetConfigManager.cs
@@ -1,0 +1,95 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Text.Json;
+using osu.Game.Configuration;
+using osu.Game.Rulesets.Configuration;
+
+namespace osu.Game.Rulesets.BMS.Configuration
+{
+    public class BMSRulesetConfigManager : RulesetConfigManager<BMSRulesetSetting>
+    {
+        public BMSRulesetConfigManager(SettingsStore? settings, RulesetInfo ruleset, int? variant = null)
+            : base(settings, ruleset, variant)
+        {
+        }
+
+        protected override void InitialiseDefaults()
+        {
+            base.InitialiseDefaults();
+
+            SetDefault(BMSRulesetSetting.BmsRootPath, string.Empty);
+            SetDefault(BMSRulesetSetting.BmsLibraryPaths, "[]");
+            SetDefault(BMSRulesetSetting.ScrollSpeed, 25.0, 1.0, 40.0, 1.0);
+            SetDefault(BMSRulesetSetting.AutoPreloadKeysounds, true);
+            SetDefault(BMSRulesetSetting.KeysoundVolume, 1.0, 0.0, 1.0, 0.01);
+            SetDefault(BMSRulesetSetting.DpStageSpacing, 0.0, 0.0, 200.0, 1.0);
+            SetDefault(BMSRulesetSetting.GameplayRoute, BMSGameplayRoute.ManiaCompatibility);
+        }
+
+        public static IReadOnlyList<string> ParseLibraryPaths(string? rawPaths, string? legacyRootPath = null)
+        {
+            List<string> paths = new List<string>();
+
+            if (!string.IsNullOrWhiteSpace(rawPaths))
+            {
+                string trimmed = rawPaths.Trim();
+
+                try
+                {
+                    if (trimmed.StartsWith('['))
+                    {
+                        List<string>? deserialised = JsonSerializer.Deserialize<List<string>>(trimmed);
+
+                        if (deserialised != null)
+                            paths.AddRange(deserialised);
+                    }
+                    else
+                    {
+                        paths.Add(trimmed);
+                    }
+                }
+                catch (JsonException)
+                {
+                    paths.Add(trimmed);
+                }
+            }
+
+            if (paths.Count == 0 && !string.IsNullOrWhiteSpace(legacyRootPath))
+                paths.Add(legacyRootPath);
+
+            return normalisePaths(paths);
+        }
+
+        public static string SerialiseLibraryPaths(IEnumerable<string> paths) => JsonSerializer.Serialize(normalisePaths(paths));
+
+        private static List<string> normalisePaths(IEnumerable<string> paths)
+        {
+            HashSet<string> seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            List<string> result = new List<string>();
+
+            foreach (string path in paths)
+            {
+                string trimmed = path.Trim();
+
+                if (string.IsNullOrEmpty(trimmed) || !seen.Add(trimmed))
+                    continue;
+
+                result.Add(trimmed);
+            }
+
+            return result;
+        }
+    }
+
+    public enum BMSRulesetSetting
+    {
+        BmsRootPath,
+        BmsLibraryPaths,
+        ScrollSpeed,
+        AutoPreloadKeysounds,
+        KeysoundVolume,
+        DpStageSpacing,
+        GameplayRoute,
+    }
+}

--- a/osu.Game.Rulesets.BMS/Database/BmsLegacyExternalBeatmapEzMigration.cs
+++ b/osu.Game.Rulesets.BMS/Database/BmsLegacyExternalBeatmapEzMigration.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ExternalLibraries;
+using osu.Game.Database;
+using osu.Game.Rulesets.BMS.Beatmaps;
+using Realms;
+
+namespace osu.Game.Rulesets.BMS.Database
+{
+    /// <summary>
+    /// Rewrites legacy <c>bms-ext:set:</c> set hashes to the shared <see cref="ExternalBeatmapPathEncoding"/> format.
+    /// </summary>
+    public sealed class BmsLegacyExternalBeatmapEzMigration : IEzRealmMigrationContributor
+    {
+        public IReadOnlyList<int> TargetEzVersions { get; } = new[] { 7 };
+
+        public void Apply(Migration migration, int targetEzVersion)
+        {
+            foreach (var set in migration.NewRealm.All<BeatmapSetInfo>())
+            {
+                if (!set.Beatmaps.Any(b => string.Equals(b.Ruleset.ShortName, "bms", StringComparison.Ordinal)))
+                    continue;
+
+                if (!BMSExternalPath.TryDecodeLegacyHash(set.Hash, out string folderPath))
+                    continue;
+
+                set.HostingKind = BeatmapSetHostingKind.External;
+                set.ExternalContentRoot = Path.GetFullPath(folderPath);
+                set.Hash = ExternalBeatmapPathEncoding.Encode(folderPath);
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/Difficulty/BMSDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.BMS/Difficulty/BMSDifficultyCalculator.cs
@@ -1,0 +1,34 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Difficulty;
+using osu.Game.Rulesets.Difficulty.Preprocessing;
+using osu.Game.Rulesets.Difficulty.Skills;
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Rulesets.BMS.Difficulty
+{
+    public class BMSDifficultyCalculator : DifficultyCalculator
+    {
+        public BMSDifficultyCalculator(IRulesetInfo ruleset, IWorkingBeatmap beatmap)
+            : base(ruleset, beatmap)
+        {
+        }
+
+        protected override DifficultyAttributes CreateDifficultyAttributes(IBeatmap beatmap, Mod[] mods, Skill[] skills, double clockRate)
+        {
+            return new DifficultyAttributes(mods, 0);
+        }
+
+        protected override IEnumerable<DifficultyHitObject> CreateDifficultyHitObjects(IBeatmap beatmap, double clockRate)
+        {
+            return Enumerable.Empty<DifficultyHitObject>();
+        }
+
+        protected override Skill[] CreateSkills(IBeatmap beatmap, Mod[] mods, double clockRate)
+        {
+            return Array.Empty<Skill>();
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/EzBms/BmsEzAnalysisProvider.cs
+++ b/osu.Game.Rulesets.BMS/EzBms/BmsEzAnalysisProvider.cs
@@ -1,0 +1,59 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps;
+using osu.Game.EzOsuGame.Analysis;
+using osu.Game.Rulesets.BMS.Beatmaps;
+using osu.Game.Rulesets.BMS.Objects;
+using osu.Game.Rulesets.Mania.Beatmaps;
+using osu.Game.Rulesets.Mania.EzMania.Analysis;
+
+namespace osu.Game.Rulesets.BMS.EzBms
+{
+    /// <summary>
+    /// Routes BMS beatmaps through mania conversion before delegating to <see cref="EzManiaAnalysisProvider"/>.
+    /// </summary>
+    public sealed class BmsEzAnalysisProvider : IEzAnalysisProvider, IEzXxyStarRatingSupport
+    {
+        private readonly EzManiaAnalysisProvider inner = new EzManiaAnalysisProvider();
+        public int XxyStarRatingVersion => inner.XxyStarRatingVersion;
+
+        public bool SupportsXxyStarRating(IBeatmap beatmap)
+        {
+            if (beatmap is BMSBeatmap || beatmap.HitObjects.Any(h => h is BMSHitObject))
+                return true;
+
+            return inner.SupportsXxyStarRating(beatmap);
+        }
+
+        public bool TryCompute(in EzAnalysisRequest request, CancellationToken cancellationToken, out IEzAnalysis analysis)
+        {
+            if (tryGetManiaBeatmap(request.Beatmap, out ManiaBeatmap? maniaBeatmap) && maniaBeatmap != null)
+            {
+                var maniaRequest = new EzAnalysisRequest(maniaBeatmap, request.ClockRate, request.RequestedScopes);
+                return inner.TryCompute(maniaRequest, cancellationToken, out analysis);
+            }
+
+            return inner.TryCompute(request, cancellationToken, out analysis);
+        }
+
+        private static bool tryGetManiaBeatmap(IBeatmap beatmap, out ManiaBeatmap? maniaBeatmap)
+        {
+            maniaBeatmap = null;
+
+            if (beatmap is ManiaBeatmap existing)
+            {
+                maniaBeatmap = existing;
+                return true;
+            }
+
+            if (beatmap is BMSBeatmap || beatmap.HitObjects.Any(h => h is BMSHitObject))
+            {
+                maniaBeatmap = ManiaConvertedWorkingBeatmap.ConvertToManiaBeatmap(beatmap);
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/GlobalUsings.cs
+++ b/osu.Game.Rulesets.BMS/GlobalUsings.cs
@@ -1,0 +1,9 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+global using System;
+global using System.Collections.Generic;
+global using System.IO;
+global using System.Linq;
+global using System.Threading;
+global using System.Threading.Tasks;

--- a/osu.Game.Rulesets.BMS/Mods/BMSMods.cs
+++ b/osu.Game.Rulesets.BMS/Mods/BMSMods.cs
@@ -1,0 +1,258 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+using osu.Framework.Utils;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.BMS.Objects;
+using osu.Game.Rulesets.Mania.Beatmaps;
+using osu.Game.Rulesets.Mania.Objects;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects;
+
+namespace osu.Game.Rulesets.BMS.Mods
+{
+    public class BMSModEasy : ModEasy
+    {
+        public override LocalisableString Description => "Wider hit windows for a more lenient experience.";
+    }
+
+    public class BMSModNoFail : ModNoFail
+    {
+        public override LocalisableString Description => "You can't fail, no matter what.";
+    }
+
+    public class BMSModHardRock : ModHardRock
+    {
+        public override LocalisableString Description => "Tighter hit windows for a more challenging experience.";
+    }
+
+    public class BMSModSuddenDeath : ModSuddenDeath
+    {
+        public override LocalisableString Description => "Miss and fail.";
+    }
+
+    public class BMSModAutoplay : ModAutoplay
+    {
+        public override LocalisableString Description => "Watch a perfect automated play through the song.";
+    }
+
+    public class BMSModRandom : ModRandom, IApplicableAfterBeatmapConversion
+    {
+        public override LocalisableString Description => "Randomize the lane positions of notes.";
+
+        public void ApplyToBeatmap(IBeatmap beatmap)
+        {
+            Seed.Value ??= RNG.Next();
+
+            var rng = new Random((int)Seed.Value);
+
+            foreach (int[] group in BMSStageModHelper.GetRegularLaneGroups(beatmap))
+            {
+                int[] shuffledColumns = group.OrderBy(_ => rng.Next()).ToArray();
+
+                foreach (var hitObject in beatmap.HitObjects)
+                    randomiseColumn(hitObject, group, shuffledColumns);
+            }
+        }
+
+        private static void randomiseColumn(HitObject hitObject, int[] group, int[] shuffledColumns)
+        {
+            if (BMSStageModHelper.HasColumn(hitObject))
+            {
+                int columnIndex = Array.IndexOf(group, BMSStageModHelper.GetColumn(hitObject));
+
+                if (columnIndex >= 0)
+                    BMSStageModHelper.SetColumn(hitObject, shuffledColumns[columnIndex]);
+            }
+
+            foreach (var nested in hitObject.NestedHitObjects)
+                randomiseColumn(nested, group, shuffledColumns);
+        }
+    }
+
+    /// <summary>
+    /// Horizontal mirror for BMS. Lane groups are split at scratch columns so non-scratch lanes can mirror without moving scratch.
+    /// </summary>
+    public class BMSModMirror : ModMirror, IApplicableAfterBeatmapConversion
+    {
+        public override LocalisableString Description => "Flip the playfield horizontally.";
+
+        public void ApplyToBeatmap(IBeatmap beatmap)
+        {
+            foreach (int[] group in BMSStageModHelper.GetRegularLaneGroups(beatmap))
+            {
+                foreach (var hitObject in beatmap.HitObjects)
+                    mirrorColumn(hitObject, group);
+            }
+        }
+
+        private static void mirrorColumn(HitObject hitObject, int[] group)
+        {
+            if (BMSStageModHelper.HasColumn(hitObject))
+            {
+                int columnIndex = Array.IndexOf(group, BMSStageModHelper.GetColumn(hitObject));
+
+                if (columnIndex >= 0)
+                    BMSStageModHelper.SetColumn(hitObject, group[group.Length - 1 - columnIndex]);
+            }
+
+            foreach (var nested in hitObject.NestedHitObjects)
+                mirrorColumn(nested, group);
+        }
+    }
+
+    /// <summary>
+    /// Move 1P scratch from the default left column (0) to the right (7) without mirroring key lanes.
+    /// Applies only to native <see cref="BMSHitObject"/> maps: 8 columns, single scratch at column 0.
+    /// </summary>
+    public class BMSModScratchLaneRight : Mod, IApplicableAfterBeatmapConversion
+    {
+        public override string Name => "Scratch right";
+        public override string Acronym => "SR";
+        public override ModType Type => ModType.Conversion;
+
+        public override LocalisableString Description => "Places the scratch lane on the right (7K + 1S). Key order is unchanged; only the scratch column moves.";
+
+        public void ApplyToBeatmap(IBeatmap beatmap)
+        {
+            var topLevel = beatmap.HitObjects.OfType<BMSHitObject>().ToList();
+            if (topLevel.Count == 0)
+                return;
+
+            int totalColumns = topLevel.Max(h => h.Column) + 1;
+            var scratchCols = topLevel.Where(h => h.IsScratch).Select(h => h.Column).Distinct().ToList();
+
+            if (totalColumns != 8 || scratchCols.Count != 1 || scratchCols[0] != 0)
+                return;
+
+            foreach (var ho in beatmap.HitObjects)
+                remapScratchRightRecursive(ho);
+        }
+
+        private static void remapScratchRightRecursive(HitObject hitObject)
+        {
+            if (hitObject is BMSHitObject bms)
+            {
+                if (bms.IsScratch)
+                    bms.Column = 7;
+                else if (bms.Column >= 1 && bms.Column <= 7)
+                    bms.Column = bms.Column - 1;
+            }
+
+            foreach (var nested in hitObject.NestedHitObjects)
+                remapScratchRightRecursive(nested);
+        }
+    }
+
+    /// <summary>
+    /// Splits columns into contiguous segments separated by scratch lanes for mirror/random.
+    /// Supports native <see cref="BMSHitObject"/> and mania-converted <see cref="BmsManiaNote"/> charts.
+    /// </summary>
+    internal static class BMSStageModHelper
+    {
+        public static IEnumerable<int[]> GetRegularLaneGroups(IBeatmap beatmap)
+        {
+            var scratchColumns = collectScratchColumns(beatmap);
+
+            int totalColumns = getTotalColumns(beatmap);
+
+            if (scratchColumns.Count == 0)
+            {
+                if (totalColumns > 0)
+                    yield return Enumerable.Range(0, totalColumns).ToArray();
+
+                yield break;
+            }
+
+            int start = 0;
+
+            foreach (int scratchColumn in scratchColumns)
+            {
+                if (scratchColumn > start)
+                    yield return Enumerable.Range(start, scratchColumn - start).ToArray();
+
+                start = scratchColumn + 1;
+            }
+
+            if (start < totalColumns)
+                yield return Enumerable.Range(start, totalColumns - start).ToArray();
+        }
+
+        private static List<int> collectScratchColumns(IBeatmap beatmap)
+        {
+            var set = new HashSet<int>();
+
+            foreach (var ho in beatmap.HitObjects)
+                collectScratchColumnsRecursive(ho, set);
+
+            return set.OrderBy(c => c).ToList();
+        }
+
+        private static void collectScratchColumnsRecursive(HitObject hitObject, HashSet<int> set)
+        {
+            if (isScratchObject(hitObject))
+                set.Add(GetColumn(hitObject));
+
+            foreach (var nested in hitObject.NestedHitObjects)
+                collectScratchColumnsRecursive(nested, set);
+        }
+
+        private static int getTotalColumns(IBeatmap beatmap)
+        {
+            if (beatmap is ManiaBeatmap mb)
+                return mb.TotalColumns;
+
+            if (beatmap.HitObjects.Count == 0)
+                return 0;
+
+            int max = -1;
+
+            foreach (var ho in beatmap.HitObjects)
+                max = Math.Max(max, maxColumnRecursive(ho));
+
+            return max + 1;
+        }
+
+        private static int maxColumnRecursive(HitObject hitObject)
+        {
+            int m = HasColumn(hitObject) ? GetColumn(hitObject) : -1;
+
+            foreach (var nested in hitObject.NestedHitObjects)
+                m = Math.Max(m, maxColumnRecursive(nested));
+
+            return m;
+        }
+
+        private static bool isScratchObject(HitObject hitObject) => hitObject switch
+        {
+            BMSHitObject b => b.IsScratch,
+            BmsManiaNote n => n.IsScratch,
+            BmsManiaHoldNote h => h.IsScratch,
+            _ => false,
+        };
+
+        public static bool HasColumn(HitObject hitObject) => hitObject is ManiaHitObject or BMSHitObject;
+
+        public static int GetColumn(HitObject hitObject) => hitObject switch
+        {
+            ManiaHitObject m => m.Column,
+            BMSHitObject b => b.Column,
+            _ => 0,
+        };
+
+        public static void SetColumn(HitObject hitObject, int column)
+        {
+            switch (hitObject)
+            {
+                case ManiaHitObject m:
+                    m.Column = column;
+                    break;
+
+                case BMSHitObject b:
+                    b.Column = column;
+                    break;
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/Objects/BMSHitObject.cs
+++ b/osu.Game.Rulesets.BMS/Objects/BMSHitObject.cs
@@ -1,0 +1,39 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Game.Rulesets.Mania.Scoring;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.BMS.Objects
+{
+    /// <summary>
+    /// Base class for all BMS hit objects.
+    /// </summary>
+    public abstract class BMSHitObject : HitObject, IHasColumn
+    {
+        private HitObjectProperty<int> column;
+
+        public Bindable<int> ColumnBindable => column.Bindable;
+
+        /// <summary>
+        /// The column (lane) this hit object is in.
+        /// </summary>
+        public virtual int Column
+        {
+            get => column.Value;
+            set => column.Value = value;
+        }
+
+        /// <summary>
+        /// Whether this is a scratch lane note.
+        /// </summary>
+        public bool IsScratch { get; set; }
+
+        /// <inheritdoc />
+        /// <remarks>Borrows osu mania Ez hit-mode / window tables (<see cref="ManiaHitWindows"/>) via global <c>ManiaHitMode</c>; no bespoke BMS skin timing.</remarks>
+        protected override HitWindows CreateHitWindows() => new ManiaHitWindows();
+    }
+}

--- a/osu.Game.Rulesets.BMS/Objects/BMSHoldNote.cs
+++ b/osu.Game.Rulesets.BMS/Objects/BMSHoldNote.cs
@@ -1,0 +1,100 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.BMS.Objects
+{
+    /// <summary>
+    /// A long note (hold note) in BMS.
+    /// </summary>
+    public class BMSHoldNote : BMSHitObject, IHasDuration
+    {
+        public double EndTime
+        {
+            get => StartTime + Duration;
+            set => Duration = value - StartTime;
+        }
+
+        public double Duration { get; set; }
+
+        /// <summary>
+        /// The head of the hold note.
+        /// </summary>
+        public BMSHoldNoteHead? Head { get; private set; }
+
+        /// <summary>
+        /// The tail of the hold note.
+        /// </summary>
+        public BMSHoldNoteTail? Tail { get; private set; }
+
+        /// <summary>
+        /// The body of the hold note.
+        /// </summary>
+        public BMSHoldNoteBody? Body { get; private set; }
+
+        protected override void CreateNestedHitObjects(CancellationToken cancellationToken)
+        {
+            base.CreateNestedHitObjects(cancellationToken);
+
+            AddNested(Head = new BMSHoldNoteHead
+            {
+                StartTime = StartTime,
+                Column = Column,
+                Samples = Samples,
+            });
+
+            AddNested(Body = new BMSHoldNoteBody
+            {
+                StartTime = StartTime,
+                Column = Column,
+                Duration = Duration,
+            });
+
+            AddNested(Tail = new BMSHoldNoteTail
+            {
+                StartTime = EndTime,
+                Column = Column,
+            });
+        }
+
+        public override Judgement CreateJudgement() => new IgnoreJudgement();
+
+        protected override HitWindows CreateHitWindows() => HitWindows.Empty;
+    }
+
+    /// <summary>
+    /// The head of a BMS hold note.
+    /// </summary>
+    public class BMSHoldNoteHead : BMSNote
+    {
+    }
+
+    /// <summary>
+    /// The body of a BMS hold note.
+    /// </summary>
+    public class BMSHoldNoteBody : BMSHitObject, IHasDuration
+    {
+        public double EndTime
+        {
+            get => StartTime + Duration;
+            set => Duration = value - StartTime;
+        }
+
+        public double Duration { get; set; }
+
+        public override Judgement CreateJudgement() => new IgnoreJudgement();
+
+        protected override HitWindows CreateHitWindows() => HitWindows.Empty;
+    }
+
+    /// <summary>
+    /// The tail of a BMS hold note.
+    /// </summary>
+    public class BMSHoldNoteTail : BMSNote
+    {
+        public override Judgement CreateJudgement() => new Judgement();
+    }
+}

--- a/osu.Game.Rulesets.BMS/Objects/BMSNote.cs
+++ b/osu.Game.Rulesets.BMS/Objects/BMSNote.cs
@@ -1,0 +1,15 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Judgements;
+
+namespace osu.Game.Rulesets.BMS.Objects
+{
+    /// <summary>
+    /// A regular tap note in BMS.
+    /// </summary>
+    public class BMSNote : BMSHitObject
+    {
+        public override Judgement CreateJudgement() => new Judgement();
+    }
+}

--- a/osu.Game.Rulesets.BMS/Objects/BmsManiaHoldNote.cs
+++ b/osu.Game.Rulesets.BMS/Objects/BmsManiaHoldNote.cs
@@ -1,0 +1,22 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Audio;
+using osu.Game.Rulesets.Mania.Objects;
+
+namespace osu.Game.Rulesets.BMS.Objects
+{
+    /// <summary>
+    /// Mania hold note with BMS keysound samples attached.
+    /// </summary>
+    public class BmsManiaHoldNote : HoldNote, IBmsKeysoundProvider
+    {
+        public bool IsScratch { get; init; }
+
+        public List<HitSampleInfo> KeysoundSamples { get; init; } = new List<HitSampleInfo>();
+
+        IReadOnlyList<HitSampleInfo> IBmsKeysoundProvider.KeysoundSamples => KeysoundSamples;
+
+        public override IList<HitSampleInfo> AuxiliarySamples => KeysoundSamples;
+    }
+}

--- a/osu.Game.Rulesets.BMS/Objects/BmsManiaNote.cs
+++ b/osu.Game.Rulesets.BMS/Objects/BmsManiaNote.cs
@@ -1,0 +1,22 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Audio;
+using osu.Game.Rulesets.Mania.Objects;
+
+namespace osu.Game.Rulesets.BMS.Objects
+{
+    /// <summary>
+    /// Mania note with BMS keysound samples attached.
+    /// </summary>
+    public class BmsManiaNote : Note, IBmsKeysoundProvider
+    {
+        public bool IsScratch { get; init; }
+
+        public List<HitSampleInfo> KeysoundSamples { get; init; } = new List<HitSampleInfo>();
+
+        IReadOnlyList<HitSampleInfo> IBmsKeysoundProvider.KeysoundSamples => KeysoundSamples;
+
+        public override IList<HitSampleInfo> AuxiliarySamples => KeysoundSamples;
+    }
+}

--- a/osu.Game.Rulesets.BMS/Objects/Drawables/DrawableBMSHitObject.cs
+++ b/osu.Game.Rulesets.BMS/Objects/Drawables/DrawableBMSHitObject.cs
@@ -1,0 +1,71 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.UI.Scrolling;
+
+namespace osu.Game.Rulesets.BMS.Objects.Drawables
+{
+    public abstract partial class DrawableBMSHitObject : DrawableHitObject<BMSHitObject>
+    {
+        protected readonly IBindable<ScrollingDirection> Direction = new Bindable<ScrollingDirection>();
+
+        /// <summary>
+        /// When set, judgements are ignored while this returns false (note lock / judge precedence).
+        /// </summary>
+        public Func<DrawableHitObject, double, bool>? CheckHittable;
+
+        protected DrawableBMSHitObject(BMSHitObject? hitObject)
+            : base(hitObject!)
+        {
+            RelativeSizeAxes = Axes.X;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(IScrollingInfo scrollingInfo)
+        {
+            Direction.BindTo(scrollingInfo.Direction);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            Direction.BindValueChanged(OnDirectionChanged, true);
+        }
+
+        protected virtual void OnDirectionChanged(ValueChangedEvent<ScrollingDirection> e)
+        {
+            Anchor = Origin = e.NewValue == ScrollingDirection.Up ? Anchor.TopCentre : Anchor.BottomCentre;
+        }
+
+        protected override void UpdateHitStateTransforms(ArmedState state)
+        {
+            switch (state)
+            {
+                case ArmedState.Miss:
+                    this.FadeOut(150, Easing.In);
+                    break;
+
+                case ArmedState.Hit:
+                    this.FadeOut();
+                    break;
+            }
+        }
+
+        public virtual void MissForcefully() => ApplyMinResult();
+    }
+
+    public abstract partial class DrawableBMSHitObject<TObject> : DrawableBMSHitObject
+        where TObject : BMSHitObject
+    {
+        public new TObject HitObject => (TObject)base.HitObject;
+
+        protected DrawableBMSHitObject(TObject? hitObject)
+            : base(hitObject)
+        {
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/Objects/Drawables/DrawableBMSHoldNote.cs
+++ b/osu.Game.Rulesets.BMS/Objects/Drawables/DrawableBMSHoldNote.cs
@@ -1,0 +1,260 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
+using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Skinning;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.BMS.Objects.Drawables
+{
+    public partial class DrawableBMSHoldNote : DrawableBMSHitObject<BMSHoldNote>, IKeyBindingHandler<BMSAction>
+    {
+        private const float note_height = 20f;
+
+        [Resolved]
+        private BMSStageLayout stageLayout { get; set; } = null!;
+
+        private Container bodyContainer = null!;
+        private Drawable noteBody = null!;
+        private Drawable noteHead = null!;
+        private Drawable noteTail = null!;
+
+        private bool isHolding;
+        private DrawableBMSHoldNoteHead? head;
+        private DrawableBMSHoldNoteBody? body;
+        private DrawableBMSHoldNoteTail? tail;
+
+        public DrawableBMSHoldNote()
+            : this(null!)
+        {
+        }
+
+        public DrawableBMSHoldNote(BMSHoldNote? hitObject)
+            : base(hitObject)
+        {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            AddInternal(bodyContainer = new Container
+            {
+                RelativeSizeAxes = Axes.X,
+                Anchor = Anchor.BottomCentre,
+                Origin = Anchor.BottomCentre,
+                Children = new[]
+                {
+                    // Body (the hold bar)
+                    noteBody = new SkinnableDrawable(new ManiaSkinComponentLookup(ManiaSkinComponents.HoldNoteBody), _ => new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    })
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    },
+                    // Head
+                    noteHead = new SkinnableDrawable(new ManiaSkinComponentLookup(ManiaSkinComponents.HoldNoteHead), _ => new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    })
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Height = note_height,
+                        Anchor = Anchor.BottomCentre,
+                        Origin = Anchor.BottomCentre,
+                    },
+                    // Tail
+                    noteTail = new SkinnableDrawable(new ManiaSkinComponentLookup(ManiaSkinComponents.HoldNoteTail), _ => new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    })
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Height = note_height,
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.TopCentre,
+                    },
+                }
+            });
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            // Calculate visual height based on duration and scroll speed
+            // This is a simplified calculation
+            float height = (float)(HitObject.Duration * 0.5f); // Adjust multiplier based on scroll speed
+            Height = height;
+            bodyContainer.Height = height;
+        }
+
+        protected override void CheckForResult(bool userTriggered, double timeOffset)
+        {
+            if (tail == null)
+                return;
+
+            if (!tail.AllJudged && Time.Current >= HitObject.EndTime)
+                tail.TriggerUpdate(false);
+
+            if (!tail.AllJudged)
+                return;
+
+            ApplyResult(tail.IsHit ? HitResult.Great : HitResult.Miss);
+        }
+
+        protected override DrawableHitObject CreateNestedHitObject(HitObject hitObject)
+        {
+            switch (hitObject)
+            {
+                case BMSHoldNoteHead holdHead:
+                    return new DrawableBMSHoldNoteHead(holdHead);
+
+                case BMSHoldNoteTail holdTail:
+                    return new DrawableBMSHoldNoteTail(holdTail);
+
+                case BMSHoldNoteBody holdBody:
+                    return new DrawableBMSHoldNoteBody(holdBody);
+            }
+
+            return base.CreateNestedHitObject(hitObject);
+        }
+
+        protected override void AddNestedHitObject(DrawableHitObject hitObject)
+        {
+            base.AddNestedHitObject(hitObject);
+
+            switch (hitObject)
+            {
+                case DrawableBMSHoldNoteHead nestedHead:
+                    head = nestedHead;
+                    break;
+
+                case DrawableBMSHoldNoteBody nestedBody:
+                    body = nestedBody;
+                    break;
+
+                case DrawableBMSHoldNoteTail nestedTail:
+                    tail = nestedTail;
+                    break;
+            }
+        }
+
+        protected override void ClearNestedHitObjects()
+        {
+            base.ClearNestedHitObjects();
+            head = null;
+            body = null;
+            tail = null;
+        }
+
+        public bool OnPressed(KeyBindingPressEvent<BMSAction> e)
+        {
+            if (AllJudged)
+                return false;
+
+            if (e.Action == stageLayout.ActionFor(HitObject))
+            {
+                if (CheckHittable?.Invoke(this, Time.Current) == false)
+                    return false;
+
+                if (head == null || tail == null)
+                    return false;
+
+                // Do not begin holds deep into the tail miss-lenience window.
+                if (Time.Current > tail.HitObject.StartTime && !tail.HitObject.HitWindows.CanBeHit(Time.Current - tail.HitObject.StartTime))
+                    return false;
+
+                bool consumed = head.TriggerUpdate(true);
+                isHolding = head.IsHit;
+                return consumed;
+            }
+
+            return false;
+        }
+
+        public void OnReleased(KeyBindingReleaseEvent<BMSAction> e)
+        {
+            if (AllJudged)
+                return;
+
+            if (e.Action == stageLayout.ActionFor(HitObject))
+            {
+                if (!isHolding || tail == null)
+                    return;
+
+                tail.TriggerUpdate(false);
+                isHolding = false;
+            }
+        }
+
+        public override void MissForcefully()
+        {
+            isHolding = false;
+            head?.MissForcefully();
+            body?.MissForcefully();
+            tail?.MissForcefully();
+            base.MissForcefully();
+        }
+
+        protected override void UpdateHitStateTransforms(ArmedState state)
+        {
+            switch (state)
+            {
+                case ArmedState.Hit:
+                    this.FadeOut(100);
+                    break;
+
+                case ArmedState.Miss:
+                    this.FadeColour(Color4.Red, 100);
+                    this.FadeOut(100);
+                    break;
+            }
+        }
+    }
+
+    public partial class DrawableBMSHoldNoteHead : DrawableBMSNote
+    {
+        public DrawableBMSHoldNoteHead(BMSHoldNoteHead hitObject)
+            : base(hitObject)
+        {
+            Alpha = 0;
+        }
+
+        public bool TriggerUpdate(bool userTriggered) => UpdateResult(userTriggered);
+    }
+
+    public partial class DrawableBMSHoldNoteTail : DrawableBMSNote
+    {
+        public DrawableBMSHoldNoteTail(BMSHoldNoteTail hitObject)
+            : base(hitObject)
+        {
+            Alpha = 0;
+        }
+
+        public bool TriggerUpdate(bool userTriggered) => UpdateResult(userTriggered);
+    }
+
+    public partial class DrawableBMSHoldNoteBody : DrawableBMSHitObject<BMSHoldNoteBody>
+    {
+        public DrawableBMSHoldNoteBody(BMSHoldNoteBody hitObject)
+            : base(hitObject)
+        {
+            Alpha = 0;
+            RelativeSizeAxes = Axes.X;
+        }
+
+        protected override void CheckForResult(bool userTriggered, double timeOffset)
+        {
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/Objects/Drawables/DrawableBMSNote.cs
+++ b/osu.Game.Rulesets.BMS/Objects/Drawables/DrawableBMSNote.cs
@@ -1,0 +1,98 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
+using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Skinning;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.BMS.Objects.Drawables
+{
+    public partial class DrawableBMSNote : DrawableBMSHitObject<BMSNote>, IKeyBindingHandler<BMSAction>
+    {
+        private const float note_height = 20f;
+
+        [Resolved]
+        private BMSStageLayout stageLayout { get; set; } = null!;
+
+        private Drawable noteBody = null!;
+
+        public DrawableBMSNote()
+            : this(null!)
+        {
+        }
+
+        public DrawableBMSNote(BMSNote? hitObject)
+            : base(hitObject)
+        {
+            Height = note_height;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            noteBody = new SkinnableDrawable(new ManiaSkinComponentLookup(ManiaSkinComponents.Note), _ => new Box
+            {
+                RelativeSizeAxes = Axes.Both,
+            });
+            AddInternal(noteBody);
+        }
+
+        protected override void CheckForResult(bool userTriggered, double timeOffset)
+        {
+            if (!userTriggered)
+            {
+                if (!HitObject.HitWindows.CanBeHit(timeOffset))
+                {
+                    ApplyMinResult();
+                }
+
+                return;
+            }
+
+            var result = HitObject.HitWindows.ResultFor(timeOffset);
+            if (result == HitResult.None)
+                return;
+
+            ApplyResult(result);
+        }
+
+        public bool OnPressed(KeyBindingPressEvent<BMSAction> e)
+        {
+            if (e.Action == stageLayout.ActionFor(HitObject))
+            {
+                if (CheckHittable?.Invoke(this, Time.Current) == false)
+                    return false;
+
+                return UpdateResult(true);
+            }
+
+            return false;
+        }
+
+        public void OnReleased(KeyBindingReleaseEvent<BMSAction> e)
+        {
+        }
+
+        protected override void UpdateHitStateTransforms(ArmedState state)
+        {
+            switch (state)
+            {
+                case ArmedState.Hit:
+                    this.FadeOut(100);
+                    break;
+
+                case ArmedState.Miss:
+                    this.FadeColour(Color4.Red, 100);
+                    this.FadeOut(100);
+                    break;
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/Objects/IBmsKeysoundProvider.cs
+++ b/osu.Game.Rulesets.BMS/Objects/IBmsKeysoundProvider.cs
@@ -1,0 +1,15 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Audio;
+
+namespace osu.Game.Rulesets.BMS.Objects
+{
+    /// <summary>
+    /// Provides keysound samples for BMS objects.
+    /// </summary>
+    public interface IBmsKeysoundProvider
+    {
+        IReadOnlyList<HitSampleInfo> KeysoundSamples { get; }
+    }
+}

--- a/osu.Game.Rulesets.BMS/Replays/BMSReplays.cs
+++ b/osu.Game.Rulesets.BMS/Replays/BMSReplays.cs
@@ -1,0 +1,73 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Input.StateChanges;
+using osu.Game.Beatmaps;
+using osu.Game.Replays;
+using osu.Game.Rulesets.BMS.Objects;
+using osu.Game.Rulesets.Replays;
+
+namespace osu.Game.Rulesets.BMS.Replays
+{
+    public class BMSAutoGenerator : AutoGenerator<BMSReplayFrame>
+    {
+        private readonly BMSStageLayout stageLayout;
+
+        public BMSAutoGenerator(IBeatmap beatmap)
+            : base(beatmap)
+        {
+            stageLayout = BMSStageLayout.FromBeatmap(beatmap);
+        }
+
+        protected override void GenerateFrames()
+        {
+            if (Beatmap.HitObjects.Count == 0)
+                return;
+
+            var currentActions = new List<BMSAction>();
+
+            foreach (var hitObject in Beatmap.HitObjects.OfType<BMSHitObject>())
+            {
+                var action = stageLayout.ActionFor(hitObject);
+
+                // Press
+                currentActions.Add(action);
+                Frames.Add(new BMSReplayFrame(hitObject.StartTime, currentActions.ToList()));
+
+                // Release
+                double releaseTime = hitObject is BMSHoldNote holdNote
+                    ? holdNote.EndTime
+                    : hitObject.StartTime + 50;
+
+                currentActions.Remove(action);
+                Frames.Add(new BMSReplayFrame(releaseTime, currentActions.ToList()));
+            }
+        }
+    }
+
+    public class BMSReplayFrame : ReplayFrame
+    {
+        public List<BMSAction> Actions { get; }
+
+        public BMSReplayFrame(double time, List<BMSAction> actions)
+            : base(time)
+        {
+            Actions = actions;
+        }
+    }
+
+    public class BMSFramedReplayInputHandler : FramedReplayInputHandler<BMSReplayFrame>
+    {
+        public BMSFramedReplayInputHandler(Replay replay)
+            : base(replay)
+        {
+        }
+
+        protected override bool IsImportant(BMSReplayFrame frame) => frame.Actions.Any();
+
+        protected override void CollectReplayInputs(List<IInput> inputs)
+        {
+            inputs.Add(new ReplayState<BMSAction> { PressedActions = CurrentFrame?.Actions ?? new List<BMSAction>() });
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/Resources/Raja/folder/default.json
+++ b/osu.Game.Rulesets.BMS/Resources/Raja/folder/default.json
@@ -1,0 +1,1256 @@
+[
+  {
+    "name": "MY BEST",
+    "sql": "playcount > 0 ORDER BY playcount DESC LIMIT 10"
+  },
+  {
+    "name": "FAVORITE SONG",
+    "sql": "favorite & 1 != 0"
+  },
+  {
+    "name": "FAVORITE CHART",
+    "sql": "favorite & 2 != 0"
+  },
+  {
+    "name": "INVISIBLE SONG",
+    "sql": "favorite & 4 != 0",
+    "showall": true
+  },
+  {
+    "name": "INVISIBLE CHART",
+    "sql": "favorite & 8 != 0",
+    "showall": true
+  },
+  {
+    "name": "CLEAR TYPE",
+    "folder": [
+      {
+        "name": "FULL COMBO",
+        "sql": "score.clear >= 8"
+      },
+      {
+        "name": "EX HARD CLEAR",
+        "sql": "score.clear = 7"
+      },
+      {
+        "name": "HARD CLEAR",
+        "sql": "score.clear = 6"
+      },
+      {
+        "name": "CLEAR",
+        "sql": "score.clear = 5"
+      },
+      {
+        "name": "EASY CLEAR",
+        "sql": "score.clear = 4"
+      },
+      {
+        "name": "ASSIST CLEAR",
+        "sql": "score.clear IN (2,3)"
+      },
+      {
+        "name": "FAILED",
+        "sql": "score.clear = 1"
+      }
+    ]
+  },
+  {
+    "name": "SCORE RANK",
+    "folder": [
+      {
+        "name": "RANK AAA",
+        "sql": "(lpg * 2 + epg * 2 + lgr + egr) * 50 / score.notes >= 88.88"
+      },
+      {
+        "name": "RANK AA",
+        "sql": "(lpg * 2 + epg * 2 + lgr + egr) * 50 / score.notes >= 77.77 AND (lpg * 2 + epg * 2 + lgr + egr) * 50 / score.notes < 88.88"
+      },
+      {
+        "name": "RANK A",
+        "sql": "(lpg * 2 + epg * 2 + lgr + egr) * 50 / score.notes >= 66.66 AND (lpg * 2 + epg * 2 + lgr + egr) * 50 / score.notes < 77.77"
+      },
+      {
+        "name": "RANK B",
+        "sql": "(lpg * 2 + epg * 2 + lgr + egr) * 50 / score.notes >= 55.55 AND (lpg * 2 + epg * 2 + lgr + egr) * 50 / score.notes < 66.66"
+      },
+      {
+        "name": "RANK C",
+        "sql": "(lpg * 2 + epg * 2 + lgr + egr) * 50 / score.notes >= 44.44 AND (lpg * 2 + epg * 2 + lgr + egr) * 50 / score.notes < 55.55"
+      },
+      {
+        "name": "RANK D",
+        "sql": "(lpg * 2 + epg * 2 + lgr + egr) * 50 / score.notes >= 33.33 AND (lpg * 2 + epg * 2 + lgr + egr) * 50 / score.notes < 44.44"
+      },
+      {
+        "name": "RANK E",
+        "sql": "(lpg * 2 + epg * 2 + lgr + egr) * 50 / score.notes >= 22.22 AND (lpg * 2 + epg * 2 + lgr + egr) * 50 / score.notes < 33.33"
+      }
+    ]
+  },
+  {
+    "name": "DENSITY",
+    "folder": [
+      {
+        "name": "AVERAGE",
+        "folder": [
+          {
+            "name": "DENSITY 〜3",
+            "sql": "density < 3"
+          },
+          {
+            "name": "DENSITY 3〜5",
+            "sql": "density >= 3 AND density < 5"
+          },
+          {
+            "name": "DENSITY 5〜7",
+            "sql": "density >= 5 AND density < 7"
+          },
+          {
+            "name": "DENSITY 7〜9",
+            "sql": "density >= 7 AND density < 9"
+          },
+          {
+            "name": "DENSITY 9〜10",
+            "sql": "density >= 9 AND density < 10"
+          },
+          {
+            "name": "DENSITY 10〜11",
+            "sql": "density >= 10 AND density < 11"
+          },
+          {
+            "name": "DENSITY 11〜12",
+            "sql": "density >= 11 AND density < 12"
+          },
+          {
+            "name": "DENSITY 12〜13",
+            "sql": "density >= 12 AND density < 13"
+          },
+          {
+            "name": "DENSITY 13〜14",
+            "sql": "density >= 13 AND density < 14"
+          },
+          {
+            "name": "DENSITY 14〜15",
+            "sql": "density >= 14 AND density < 15"
+          },
+          {
+            "name": "DENSITY 15〜16",
+            "sql": "density >= 15 AND density < 16"
+          },
+          {
+            "name": "DENSITY 16〜17",
+            "sql": "density >= 16 AND density < 17"
+          },
+          {
+            "name": "DENSITY 17〜18",
+            "sql": "density >= 17 AND density < 18"
+          },
+          {
+            "name": "DENSITY 18〜19",
+            "sql": "density >= 18 AND density < 19"
+          },
+          {
+            "name": "DENSITY 19〜20",
+            "sql": "density >= 19 AND density < 20"
+          },
+          {
+            "name": "DENSITY 20〜21",
+            "sql": "density >= 20 AND density < 21"
+          },
+          {
+            "name": "DENSITY 21〜22",
+            "sql": "density >= 21 AND density < 22"
+          },
+          {
+            "name": "DENSITY 22〜23",
+            "sql": "density >= 22 AND density < 23"
+          },
+          {
+            "name": "DENSITY 23〜24",
+            "sql": "density >= 23 AND density < 24"
+          },
+          {
+            "name": "DENSITY 24〜25",
+            "sql": "density >= 24 AND density < 25"
+          },
+          {
+            "name": "DENSITY 25〜26",
+            "sql": "density >= 25 AND density < 26"
+          },
+          {
+            "name": "DENSITY 26〜27",
+            "sql": "density >= 26 AND density < 27"
+          },
+          {
+            "name": "DENSITY 27〜28",
+            "sql": "density >= 27 AND density < 28"
+          },
+          {
+            "name": "DENSITY 28〜29",
+            "sql": "density >= 28 AND density < 29"
+          },
+          {
+            "name": "DENSITY 29〜30",
+            "sql": "density >= 29 AND density < 30"
+          },
+          {
+            "name": "DENSITY 30〜31",
+            "sql": "density >= 30 AND density < 31"
+          },
+          {
+            "name": "DENSITY 31〜32",
+            "sql": "density >= 31 AND density < 32"
+          },
+          {
+            "name": "DENSITY 32〜33",
+            "sql": "density >= 32 AND density < 33"
+          },
+          {
+            "name": "DENSITY 33〜34",
+            "sql": "density >= 33 AND density < 34"
+          },
+          {
+            "name": "DENSITY 34〜35",
+            "sql": "density >= 34 AND density < 35"
+          },
+          {
+            "name": "DENSITY 35〜36",
+            "sql": "density >= 35 AND density < 36"
+          },
+          {
+            "name": "DENSITY 36〜37",
+            "sql": "density >= 36 AND density < 37"
+          },
+          {
+            "name": "DENSITY 37〜38",
+            "sql": "density >= 37 AND density < 38"
+          },
+          {
+            "name": "DENSITY 38〜39",
+            "sql": "density >= 38 AND density < 39"
+          },
+          {
+            "name": "DENSITY 39〜40",
+            "sql": "density >= 39 AND density < 40"
+          },
+          {
+            "name": "DENSITY 40〜41",
+            "sql": "density >= 40 AND density < 41"
+          },
+          {
+            "name": "DENSITY 41〜42",
+            "sql": "density >= 41 AND density < 42"
+          },
+          {
+            "name": "DENSITY 42〜43",
+            "sql": "density >= 42 AND density < 43"
+          },
+          {
+            "name": "DENSITY 43〜44",
+            "sql": "density >= 43 AND density < 44"
+          },
+          {
+            "name": "DENSITY 44〜45",
+            "sql": "density >= 44 AND density < 45"
+          },
+          {
+            "name": "DENSITY 45〜46",
+            "sql": "density >= 45 AND density < 46"
+          },
+          {
+            "name": "DENSITY 46〜47",
+            "sql": "density >= 46 AND density < 47"
+          },
+          {
+            "name": "DENSITY 47〜48",
+            "sql": "density >= 47 AND density < 48"
+          },
+          {
+            "name": "DENSITY 48〜49",
+            "sql": "density >= 48 AND density < 49"
+          },
+          {
+            "name": "DENSITY 49〜50",
+            "sql": "density >= 49 AND density < 50"
+          },
+          {
+            "name": "DENSITY 50〜",
+            "sql": "density >= 50"
+          }
+        ]
+      },
+      {
+        "name": "PEAK",
+        "folder": [
+          {
+            "name": "DENSITY 〜3",
+            "sql": "peakdensity < 3"
+          },
+          {
+            "name": "DENSITY 3〜5",
+            "sql": "peakdensity >= 3 AND peakdensity < 5"
+          },
+          {
+            "name": "DENSITY 5〜7",
+            "sql": "peakdensity >= 5 AND peakdensity < 7"
+          },
+          {
+            "name": "DENSITY 7〜9",
+            "sql": "peakdensity >= 7 AND peakdensity < 9"
+          },
+          {
+            "name": "DENSITY 9〜10",
+            "sql": "peakdensity >= 9 AND peakdensity < 10"
+          },
+          {
+            "name": "DENSITY 10〜11",
+            "sql": "peakdensity >= 10 AND peakdensity < 11"
+          },
+          {
+            "name": "DENSITY 11〜12",
+            "sql": "peakdensity >= 11 AND peakdensity < 12"
+          },
+          {
+            "name": "DENSITY 12〜13",
+            "sql": "peakdensity >= 12 AND peakdensity < 13"
+          },
+          {
+            "name": "DENSITY 13〜14",
+            "sql": "peakdensity >= 13 AND peakdensity < 14"
+          },
+          {
+            "name": "DENSITY 14〜15",
+            "sql": "peakdensity >= 14 AND peakdensity < 15"
+          },
+          {
+            "name": "DENSITY 15〜16",
+            "sql": "peakdensity >= 15 AND peakdensity < 16"
+          },
+          {
+            "name": "DENSITY 16〜17",
+            "sql": "peakdensity >= 16 AND peakdensity < 17"
+          },
+          {
+            "name": "DENSITY 17〜18",
+            "sql": "peakdensity >= 17 AND peakdensity < 18"
+          },
+          {
+            "name": "DENSITY 18〜19",
+            "sql": "peakdensity >= 18 AND peakdensity < 19"
+          },
+          {
+            "name": "DENSITY 19〜20",
+            "sql": "peakdensity >= 19 AND peakdensity < 20"
+          },
+          {
+            "name": "DENSITY 20〜21",
+            "sql": "peakdensity >= 20 AND peakdensity < 21"
+          },
+          {
+            "name": "DENSITY 21〜22",
+            "sql": "peakdensity >= 21 AND peakdensity < 22"
+          },
+          {
+            "name": "DENSITY 22〜23",
+            "sql": "peakdensity >= 22 AND peakdensity < 23"
+          },
+          {
+            "name": "DENSITY 23〜24",
+            "sql": "peakdensity >= 23 AND peakdensity < 24"
+          },
+          {
+            "name": "DENSITY 24〜25",
+            "sql": "peakdensity >= 24 AND peakdensity < 25"
+          },
+          {
+            "name": "DENSITY 25〜26",
+            "sql": "peakdensity >= 25 AND peakdensity < 26"
+          },
+          {
+            "name": "DENSITY 26〜27",
+            "sql": "peakdensity >= 26 AND peakdensity < 27"
+          },
+          {
+            "name": "DENSITY 27〜28",
+            "sql": "peakdensity >= 27 AND peakdensity < 28"
+          },
+          {
+            "name": "DENSITY 28〜29",
+            "sql": "peakdensity >= 28 AND peakdensity < 29"
+          },
+          {
+            "name": "DENSITY 29〜30",
+            "sql": "peakdensity >= 29 AND peakdensity < 30"
+          },
+          {
+            "name": "DENSITY 30〜31",
+            "sql": "peakdensity >= 30 AND peakdensity < 31"
+          },
+          {
+            "name": "DENSITY 31〜32",
+            "sql": "peakdensity >= 31 AND peakdensity < 32"
+          },
+          {
+            "name": "DENSITY 32〜33",
+            "sql": "peakdensity >= 32 AND peakdensity < 33"
+          },
+          {
+            "name": "DENSITY 33〜34",
+            "sql": "peakdensity >= 33 AND peakdensity < 34"
+          },
+          {
+            "name": "DENSITY 34〜35",
+            "sql": "peakdensity >= 34 AND peakdensity < 35"
+          },
+          {
+            "name": "DENSITY 35〜36",
+            "sql": "peakdensity >= 35 AND peakdensity < 36"
+          },
+          {
+            "name": "DENSITY 36〜37",
+            "sql": "peakdensity >= 36 AND peakdensity < 37"
+          },
+          {
+            "name": "DENSITY 37〜38",
+            "sql": "peakdensity >= 37 AND peakdensity < 38"
+          },
+          {
+            "name": "DENSITY 38〜39",
+            "sql": "peakdensity >= 38 AND peakdensity < 39"
+          },
+          {
+            "name": "DENSITY 39〜40",
+            "sql": "peakdensity >= 39 AND peakdensity < 40"
+          },
+          {
+            "name": "DENSITY 40〜41",
+            "sql": "peakdensity >= 40 AND peakdensity < 41"
+          },
+          {
+            "name": "DENSITY 41〜42",
+            "sql": "peakdensity >= 41 AND peakdensity < 42"
+          },
+          {
+            "name": "DENSITY 42〜43",
+            "sql": "peakdensity >= 42 AND peakdensity < 43"
+          },
+          {
+            "name": "DENSITY 43〜44",
+            "sql": "peakdensity >= 43 AND peakdensity < 44"
+          },
+          {
+            "name": "DENSITY 44〜45",
+            "sql": "peakdensity >= 44 AND peakdensity < 45"
+          },
+          {
+            "name": "DENSITY 45〜46",
+            "sql": "peakdensity >= 45 AND peakdensity < 46"
+          },
+          {
+            "name": "DENSITY 46〜47",
+            "sql": "peakdensity >= 46 AND peakdensity < 47"
+          },
+          {
+            "name": "DENSITY 47〜48",
+            "sql": "peakdensity >= 47 AND peakdensity < 48"
+          },
+          {
+            "name": "DENSITY 48〜49",
+            "sql": "peakdensity >= 48 AND peakdensity < 49"
+          },
+          {
+            "name": "DENSITY 49〜50",
+            "sql": "peakdensity >= 49 AND peakdensity < 50"
+          },
+          {
+            "name": "DENSITY 50〜",
+            "sql": "peakdensity >= 50"
+          }
+        ]
+      },
+      {
+        "name": "END",
+        "folder": [
+          {
+            "name": "DENSITY 〜3",
+            "sql": "enddensity < 3"
+          },
+          {
+            "name": "DENSITY 3〜5",
+            "sql": "enddensity >= 3 AND enddensity < 5"
+          },
+          {
+            "name": "DENSITY 5〜7",
+            "sql": "enddensity >= 5 AND enddensity < 7"
+          },
+          {
+            "name": "DENSITY 7〜9",
+            "sql": "enddensity >= 7 AND enddensity < 9"
+          },
+          {
+            "name": "DENSITY 9〜10",
+            "sql": "enddensity >= 9 AND enddensity < 10"
+          },
+          {
+            "name": "DENSITY 10〜11",
+            "sql": "enddensity >= 10 AND enddensity < 11"
+          },
+          {
+            "name": "DENSITY 11〜12",
+            "sql": "enddensity >= 11 AND enddensity < 12"
+          },
+          {
+            "name": "DENSITY 12〜13",
+            "sql": "enddensity >= 12 AND enddensity < 13"
+          },
+          {
+            "name": "DENSITY 13〜14",
+            "sql": "enddensity >= 13 AND enddensity < 14"
+          },
+          {
+            "name": "DENSITY 14〜15",
+            "sql": "enddensity >= 14 AND enddensity < 15"
+          },
+          {
+            "name": "DENSITY 15〜16",
+            "sql": "enddensity >= 15 AND enddensity < 16"
+          },
+          {
+            "name": "DENSITY 16〜17",
+            "sql": "enddensity >= 16 AND enddensity < 17"
+          },
+          {
+            "name": "DENSITY 17〜18",
+            "sql": "enddensity >= 17 AND enddensity < 18"
+          },
+          {
+            "name": "DENSITY 18〜19",
+            "sql": "enddensity >= 18 AND enddensity < 19"
+          },
+          {
+            "name": "DENSITY 19〜20",
+            "sql": "enddensity >= 19 AND enddensity < 20"
+          },
+          {
+            "name": "DENSITY 20〜21",
+            "sql": "enddensity >= 20 AND enddensity < 21"
+          },
+          {
+            "name": "DENSITY 21〜22",
+            "sql": "enddensity >= 21 AND enddensity < 22"
+          },
+          {
+            "name": "DENSITY 22〜23",
+            "sql": "enddensity >= 22 AND enddensity < 23"
+          },
+          {
+            "name": "DENSITY 23〜24",
+            "sql": "enddensity >= 23 AND enddensity < 24"
+          },
+          {
+            "name": "DENSITY 24〜25",
+            "sql": "enddensity >= 24 AND enddensity < 25"
+          },
+          {
+            "name": "DENSITY 25〜26",
+            "sql": "enddensity >= 25 AND enddensity < 26"
+          },
+          {
+            "name": "DENSITY 26〜27",
+            "sql": "enddensity >= 26 AND enddensity < 27"
+          },
+          {
+            "name": "DENSITY 27〜28",
+            "sql": "enddensity >= 27 AND enddensity < 28"
+          },
+          {
+            "name": "DENSITY 28〜29",
+            "sql": "enddensity >= 28 AND enddensity < 29"
+          },
+          {
+            "name": "DENSITY 29〜30",
+            "sql": "enddensity >= 29 AND enddensity < 30"
+          },
+          {
+            "name": "DENSITY 30〜31",
+            "sql": "enddensity >= 30 AND enddensity < 31"
+          },
+          {
+            "name": "DENSITY 31〜32",
+            "sql": "enddensity >= 31 AND enddensity < 32"
+          },
+          {
+            "name": "DENSITY 32〜33",
+            "sql": "enddensity >= 32 AND enddensity < 33"
+          },
+          {
+            "name": "DENSITY 33〜34",
+            "sql": "enddensity >= 33 AND enddensity < 34"
+          },
+          {
+            "name": "DENSITY 34〜35",
+            "sql": "enddensity >= 34 AND enddensity < 35"
+          },
+          {
+            "name": "DENSITY 35〜36",
+            "sql": "enddensity >= 35 AND enddensity < 36"
+          },
+          {
+            "name": "DENSITY 36〜37",
+            "sql": "enddensity >= 36 AND enddensity < 37"
+          },
+          {
+            "name": "DENSITY 37〜38",
+            "sql": "enddensity >= 37 AND enddensity < 38"
+          },
+          {
+            "name": "DENSITY 38〜39",
+            "sql": "enddensity >= 38 AND enddensity < 39"
+          },
+          {
+            "name": "DENSITY 39〜40",
+            "sql": "enddensity >= 39 AND enddensity < 40"
+          },
+          {
+            "name": "DENSITY 40〜41",
+            "sql": "enddensity >= 40 AND enddensity < 41"
+          },
+          {
+            "name": "DENSITY 41〜42",
+            "sql": "enddensity >= 41 AND enddensity < 42"
+          },
+          {
+            "name": "DENSITY 42〜43",
+            "sql": "enddensity >= 42 AND enddensity < 43"
+          },
+          {
+            "name": "DENSITY 43〜44",
+            "sql": "enddensity >= 43 AND enddensity < 44"
+          },
+          {
+            "name": "DENSITY 44〜45",
+            "sql": "enddensity >= 44 AND enddensity < 45"
+          },
+          {
+            "name": "DENSITY 45〜46",
+            "sql": "enddensity >= 45 AND enddensity < 46"
+          },
+          {
+            "name": "DENSITY 46〜47",
+            "sql": "enddensity >= 46 AND enddensity < 47"
+          },
+          {
+            "name": "DENSITY 47〜48",
+            "sql": "enddensity >= 47 AND enddensity < 48"
+          },
+          {
+            "name": "DENSITY 48〜49",
+            "sql": "enddensity >= 48 AND enddensity < 49"
+          },
+          {
+            "name": "DENSITY 49〜50",
+            "sql": "enddensity >= 49 AND enddensity < 50"
+          },
+          {
+            "name": "DENSITY 50〜",
+            "sql": "enddensity >= 50"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "FEATURE",
+    "folder": [
+      {
+        "name": "SCRATCH 10 - 20%",
+        "sql": "(n + ln) <= (s + ls) * 9 AND (n + ln) > (s + ls) * 4"
+      },
+      {
+        "name": "SCRATCH > 20%",
+        "sql": "(n + ln) <= (s + ls) * 4"
+      },
+      {
+        "name": "LONG NOTE 10 - 20%",
+        "sql": "(n + s) <= (ln + ls) * 9 AND (n + s) > (ln + ls) * 4"
+      },
+      {
+        "name": "LONG NOTE > 20%",
+        "sql": "(n + s) <= (ln + ls) * 4"
+      }
+    ]
+  },
+  {
+    "name": "LEVEL",
+    "folder": [
+      {
+        "name": "7KEYS",
+        "folder": [
+          {
+            "name": "LEVEL 〜0",
+            "sql": "(level <= 0 OR level IS NULL) AND song.mode = 7"
+          },
+          {
+            "name": "LEVEL 1",
+            "sql": "level = 1 AND song.mode = 7"
+          },
+          {
+            "name": "LEVEL 2",
+            "sql": "level = 2 AND song.mode = 7"
+          },
+          {
+            "name": "LEVEL 3",
+            "sql": "level = 3 AND song.mode = 7"
+          },
+          {
+            "name": "LEVEL 4",
+            "sql": "level = 4 AND song.mode = 7"
+          },
+          {
+            "name": "LEVEL 5",
+            "sql": "level = 5 AND song.mode = 7"
+          },
+          {
+            "name": "LEVEL 6",
+            "sql": "level = 6 AND song.mode = 7"
+          },
+          {
+            "name": "LEVEL 7",
+            "sql": "level = 7 AND song.mode = 7"
+          },
+          {
+            "name": "LEVEL 8",
+            "sql": "level = 8 AND song.mode = 7"
+          },
+          {
+            "name": "LEVEL 9",
+            "sql": "level = 9 AND song.mode = 7"
+          },
+          {
+            "name": "LEVEL 10",
+            "sql": "level = 10 AND song.mode = 7"
+          },
+          {
+            "name": "LEVEL 11",
+            "sql": "level = 11 AND song.mode = 7"
+          },
+          {
+            "name": "LEVEL 12",
+            "sql": "level = 12 AND song.mode = 7"
+          },
+          {
+            "name": "LEVEL 13〜",
+            "sql": "level >= 13 AND song.mode = 7"
+          }
+        ]
+      },
+      {
+        "name": "14KEYS",
+        "folder": [
+          {
+            "name": "LEVEL 〜0",
+            "sql": "(level <= 0 OR level IS NULL) AND song.mode = 14"
+          },
+          {
+            "name": "LEVEL 1",
+            "sql": "level = 1 AND song.mode = 14"
+          },
+          {
+            "name": "LEVEL 2",
+            "sql": "level = 2 AND song.mode = 14"
+          },
+          {
+            "name": "LEVEL 3",
+            "sql": "level = 3 AND song.mode = 14"
+          },
+          {
+            "name": "LEVEL 4",
+            "sql": "level = 4 AND song.mode = 14"
+          },
+          {
+            "name": "LEVEL 5",
+            "sql": "level = 5 AND song.mode = 14"
+          },
+          {
+            "name": "LEVEL 6",
+            "sql": "level = 6 AND song.mode = 14"
+          },
+          {
+            "name": "LEVEL 7",
+            "sql": "level = 7 AND song.mode = 14"
+          },
+          {
+            "name": "LEVEL 8",
+            "sql": "level = 8 AND song.mode = 14"
+          },
+          {
+            "name": "LEVEL 9",
+            "sql": "level = 9 AND song.mode = 14"
+          },
+          {
+            "name": "LEVEL 10",
+            "sql": "level = 10 AND song.mode = 14"
+          },
+          {
+            "name": "LEVEL 11",
+            "sql": "level = 11 AND song.mode = 14"
+          },
+          {
+            "name": "LEVEL 12",
+            "sql": "level = 12 AND song.mode = 14"
+          },
+          {
+            "name": "LEVEL 13〜",
+            "sql": "level >= 13 AND song.mode = 14"
+          }
+        ]
+      },
+      {
+        "name": "9KEYS",
+        "folder": [
+          {
+            "name": "LEVEL 〜0",
+            "sql": "(level <= 0 OR level IS NULL) AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 1",
+            "sql": "level = 1 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 2",
+            "sql": "level = 2 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 3",
+            "sql": "level = 3 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 4",
+            "sql": "level = 4 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 5",
+            "sql": "level = 5 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 6",
+            "sql": "level = 6 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 7",
+            "sql": "level = 7 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 8",
+            "sql": "level = 8 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 9",
+            "sql": "level = 9 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 10",
+            "sql": "level = 10 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 11",
+            "sql": "level = 11 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 12",
+            "sql": "level = 12 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 13",
+            "sql": "level = 13 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 14",
+            "sql": "level = 14 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 15",
+            "sql": "level = 15 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 16",
+            "sql": "level = 16 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 17",
+            "sql": "level = 17 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 18",
+            "sql": "level = 18 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 19",
+            "sql": "level = 19 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 20",
+            "sql": "level = 20 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 21",
+            "sql": "level = 21 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 22",
+            "sql": "level = 22 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 23",
+            "sql": "level = 23 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 24",
+            "sql": "level = 24 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 25",
+            "sql": "level = 25 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 26",
+            "sql": "level = 26 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 27",
+            "sql": "level = 27 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 28",
+            "sql": "level = 28 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 29",
+            "sql": "level = 29 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 30",
+            "sql": "level = 30 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 31",
+            "sql": "level = 31 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 32",
+            "sql": "level = 32 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 33",
+            "sql": "level = 33 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 34",
+            "sql": "level = 34 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 35",
+            "sql": "level = 35 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 36",
+            "sql": "level = 36 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 37",
+            "sql": "level = 37 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 38",
+            "sql": "level = 38 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 39",
+            "sql": "level = 39 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 40",
+            "sql": "level = 40 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 41",
+            "sql": "level = 41 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 42",
+            "sql": "level = 42 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 43",
+            "sql": "level = 43 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 44",
+            "sql": "level = 44 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 45",
+            "sql": "level = 45 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 46",
+            "sql": "level = 46 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 47",
+            "sql": "level = 47 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 48",
+            "sql": "level = 48 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 49",
+            "sql": "level = 49 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 50",
+            "sql": "level = 50 AND song.mode = 9"
+          },
+          {
+            "name": "LEVEL 51〜",
+            "sql": "level >= 51 AND song.mode = 9"
+          }
+        ]
+      },
+      {
+        "name": "5KEYS",
+        "folder": [
+          {
+            "name": "LEVEL 〜0",
+            "sql": "(level <= 0 OR level IS NULL) AND song.mode = 5"
+          },
+          {
+            "name": "LEVEL 1",
+            "sql": "level = 1 AND song.mode = 5"
+          },
+          {
+            "name": "LEVEL 2",
+            "sql": "level = 2 AND song.mode = 5"
+          },
+          {
+            "name": "LEVEL 3",
+            "sql": "level = 3 AND song.mode = 5"
+          },
+          {
+            "name": "LEVEL 4",
+            "sql": "level = 4 AND song.mode = 5"
+          },
+          {
+            "name": "LEVEL 5",
+            "sql": "level = 5 AND song.mode = 5"
+          },
+          {
+            "name": "LEVEL 6",
+            "sql": "level = 6 AND song.mode = 5"
+          },
+          {
+            "name": "LEVEL 7",
+            "sql": "level = 7 AND song.mode = 5"
+          },
+          {
+            "name": "LEVEL 8",
+            "sql": "level = 8 AND song.mode = 5"
+          },
+          {
+            "name": "LEVEL 9",
+            "sql": "level = 9 AND song.mode = 5"
+          },
+          {
+            "name": "LEVEL 10",
+            "sql": "level = 10 AND song.mode = 5"
+          },
+          {
+            "name": "LEVEL 11",
+            "sql": "level = 11 AND song.mode = 5"
+          },
+          {
+            "name": "LEVEL 12",
+            "sql": "level = 12 AND song.mode = 5"
+          },
+          {
+            "name": "LEVEL 13〜",
+            "sql": "level >= 13 AND song.mode = 5"
+          }
+        ]
+      },
+      {
+        "name": "10KEYS",
+        "folder": [
+          {
+            "name": "LEVEL 〜0",
+            "sql": "(level <= 0 OR level IS NULL) AND song.mode = 10"
+          },
+          {
+            "name": "LEVEL 1",
+            "sql": "level = 1 AND song.mode = 10"
+          },
+          {
+            "name": "LEVEL 2",
+            "sql": "level = 2 AND song.mode = 10"
+          },
+          {
+            "name": "LEVEL 3",
+            "sql": "level = 3 AND song.mode = 10"
+          },
+          {
+            "name": "LEVEL 4",
+            "sql": "level = 4 AND song.mode = 10"
+          },
+          {
+            "name": "LEVEL 5",
+            "sql": "level = 5 AND song.mode = 10"
+          },
+          {
+            "name": "LEVEL 6",
+            "sql": "level = 6 AND song.mode = 10"
+          },
+          {
+            "name": "LEVEL 7",
+            "sql": "level = 7 AND song.mode = 10"
+          },
+          {
+            "name": "LEVEL 8",
+            "sql": "level = 8 AND song.mode = 10"
+          },
+          {
+            "name": "LEVEL 9",
+            "sql": "level = 9 AND song.mode = 10"
+          },
+          {
+            "name": "LEVEL 10",
+            "sql": "level = 10 AND song.mode = 10"
+          },
+          {
+            "name": "LEVEL 11",
+            "sql": "level = 11 AND song.mode = 10"
+          },
+          {
+            "name": "LEVEL 12",
+            "sql": "level = 12 AND song.mode = 10"
+          },
+          {
+            "name": "LEVEL 13〜",
+            "sql": "level >= 13 AND song.mode = 10"
+          }
+        ]
+      },
+      {
+        "name": "24KEYS",
+        "folder": [
+          {
+            "name": "LEVEL 〜0",
+            "sql": "(level <= 0 OR level IS NULL) AND song.mode = 25"
+          },
+          {
+            "name": "LEVEL 1",
+            "sql": "level = 1 AND song.mode = 25"
+          },
+          {
+            "name": "LEVEL 2",
+            "sql": "level = 2 AND song.mode = 25"
+          },
+          {
+            "name": "LEVEL 3",
+            "sql": "level = 3 AND song.mode = 25"
+          },
+          {
+            "name": "LEVEL 4",
+            "sql": "level = 4 AND song.mode = 25"
+          },
+          {
+            "name": "LEVEL 5",
+            "sql": "level = 5 AND song.mode = 25"
+          },
+          {
+            "name": "LEVEL 6",
+            "sql": "level = 6 AND song.mode = 25"
+          },
+          {
+            "name": "LEVEL 7〜",
+            "sql": "level >= 7 AND song.mode = 25"
+          }
+        ]
+      },
+      {
+        "name": "48KEYS",
+        "folder": [
+          {
+            "name": "LEVEL 〜0",
+            "sql": "(level <= 0 OR level IS NULL) AND song.mode = 50"
+          },
+          {
+            "name": "LEVEL 1",
+            "sql": "level = 1 AND song.mode = 50"
+          },
+          {
+            "name": "LEVEL 2",
+            "sql": "level = 2 AND song.mode = 50"
+          },
+          {
+            "name": "LEVEL 3",
+            "sql": "level = 3 AND song.mode = 50"
+          },
+          {
+            "name": "LEVEL 4",
+            "sql": "level = 4 AND song.mode = 50"
+          },
+          {
+            "name": "LEVEL 5",
+            "sql": "level = 5 AND song.mode = 50"
+          },
+          {
+            "name": "LEVEL 6",
+            "sql": "level = 6 AND song.mode = 50"
+          },
+          {
+            "name": "LEVEL 7〜",
+            "sql": "level >= 7 AND song.mode = 50"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "NEW",
+    "folder": [
+      {
+        "name": "TODAY",
+        "sql": "strftime('%s', 'now') - adddate <= 86400"
+      },
+      {
+        "name": "2 DAYS AGO",
+        "sql": "strftime('%s', 'now') - adddate > 86400*1 AND strftime('%s', 'now') - adddate <= 86400*2"
+      },
+      {
+        "name": "3 DAYS AGO",
+        "sql": "strftime('%s', 'now') - adddate > 86400*2 AND strftime('%s', 'now') - adddate <= 86400*3"
+      },
+      {
+        "name": "4 DAYS AGO",
+        "sql": "strftime('%s', 'now') - adddate > 86400*3 AND strftime('%s', 'now') - adddate <= 86400*4"
+      },
+      {
+        "name": "5 DAYS AGO",
+        "sql": "strftime('%s', 'now') - adddate > 86400*4 AND strftime('%s', 'now') - adddate <= 86400*5"
+      },
+      {
+        "name": "6 DAYS AGO",
+        "sql": "strftime('%s', 'now') - adddate > 86400*5 AND strftime('%s', 'now') - adddate <= 86400*6"
+      },
+      {
+        "name": "7 DAYS AGO",
+        "sql": "strftime('%s', 'now') - adddate > 86400*6 AND strftime('%s', 'now') - adddate <= 86400*7"
+      },
+      {
+        "name": "THIS WEEK",
+        "sql": "strftime('%s', 'now') - adddate <= 86400*7"
+      }
+    ]
+  }
+]

--- a/osu.Game.Rulesets.BMS/Resources/Raja/random/default.json
+++ b/osu.Game.Rulesets.BMS/Resources/Raja/random/default.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "RANDOM SELECT"
+  },
+  {
+    "name": "NO PLAY RANDOM SELECT",
+    "filter": {
+      "playcount": 0
+    }
+  },
+  {
+    "name": "FAILED RANDOM SELECT",
+    "filter": {
+      "clear": 1
+    }
+  }
+]

--- a/osu.Game.Rulesets.BMS/Scoring/BMSNoFailHealthProcessor.cs
+++ b/osu.Game.Rulesets.BMS/Scoring/BMSNoFailHealthProcessor.cs
@@ -1,0 +1,40 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.BMS.Scoring
+{
+    /// <summary>
+    /// BMS health processor that never fails by default and has no passive drain.
+    /// Health changes only come from judgement results.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// End-user behaviour matches <see cref="osu.Game.Rulesets.Mods.ModNoFail"/> for failure:
+    /// <see cref="HealthProcessor.Health"/> can still decrease all the way to its minimum (0);
+    /// the HUD reflects that, but the run is never aborted for "empty gauge". Play continues
+    /// to the end of the chart and the score is settled as a normal completion (not a fail exit).
+    /// </para>
+    /// <para>
+    /// Layer 1: returning <c>false</c> from <see cref="CheckDefaultFailCondition"/> prevents
+    /// the default "health at or below minimum" path from calling
+    /// <see cref="HealthProcessor.TriggerFailure"/>.
+    /// </para>
+    /// <para>
+    /// Layer 2: <c>BmsPlayer.CheckModsAllowFailure</c> returns <c>false</c>, same idea as
+    /// <c>ModNoFail.PerformFail()</c>, so the <see cref="HealthProcessor.Failed"/> handler never
+    /// permits <see cref="HealthProcessor.HasFailed"/> even if a mod registers
+    /// <see cref="HealthProcessor.FailConditions"/>.
+    /// </para>
+    /// </remarks>
+    public partial class BMSNoFailHealthProcessor : HealthProcessor
+    {
+        public BMSNoFailHealthProcessor(double drainStartTime)
+        {
+        }
+
+        protected override bool CheckDefaultFailCondition(JudgementResult result) => false;
+    }
+}

--- a/osu.Game.Rulesets.BMS/Scoring/BMSScoreProcessor.cs
+++ b/osu.Game.Rulesets.BMS/Scoring/BMSScoreProcessor.cs
@@ -1,0 +1,58 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.BMS.Beatmaps;
+using osu.Game.Rulesets.BMS.Objects;
+using osu.Game.Rulesets.Mania.Objects;
+using osu.Game.Rulesets.Mania.Scoring;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.BMS.Scoring
+{
+    /// <summary>
+    /// Score processor for BMS ruleset.
+    /// Uses EX SCORE style scoring (PGREAT=2, GREAT=1, etc.)
+    /// </summary>
+    public partial class BMSScoreProcessor : ManiaScoreProcessor
+    {
+        public override void ApplyBeatmap(IBeatmap beatmap)
+        {
+            // BeatmapDifficultyCache uses decoded BMS charts from GetPlayableBeatmap(bms) while the difficulty calculator
+            // runs on a mania-converted adapter. Convert here so ManiaScoreProcessor autoplay sees ManiaHitObject instances.
+            base.ApplyBeatmap(convertForManiaJudging(beatmap));
+        }
+
+        private static IBeatmap convertForManiaJudging(IBeatmap beatmap)
+        {
+            if (beatmap.HitObjects.Count > 0 && beatmap.HitObjects.All(h => h is ManiaHitObject))
+                return beatmap;
+
+            if (beatmap is BMSBeatmap || beatmap.HitObjects.Any(h => h is BMSHitObject))
+                return ManiaConvertedWorkingBeatmap.ConvertToManiaBeatmap(beatmap);
+
+            return beatmap;
+        }
+
+        protected override double ComputeTotalScore(double comboProgress, double accuracyProgress, double bonusPortion)
+        {
+            // BMS-style EX SCORE calculation
+            return 1000000 * accuracyProgress;
+        }
+
+        public override int GetBaseScoreForResult(HitResult result)
+        {
+            switch (result)
+            {
+                case HitResult.Perfect:
+                    return 2;
+
+                case HitResult.Great:
+                    return 1;
+
+                default:
+                    return 0;
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/Scoring/Lamp/BeatorajaLampScheme.cs
+++ b/osu.Game.Rulesets.BMS/Scoring/Lamp/BeatorajaLampScheme.cs
@@ -1,0 +1,65 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.BMS.Scoring.Lamp
+{
+    /// <summary>
+    /// Default lamp scheme: mirrors beatoraja's <c>ClearType</c> rules.
+    /// <para>
+    /// Resolution order (highest tier wins):
+    /// </para>
+    /// <list type="number">
+    /// <item><description>NoPlay if there's no recorded play.</description></item>
+    /// <item><description>Failed if gameplay didn't clear the chart on a real gauge.</description></item>
+    /// <item><description>Max if the play used the strictest hit window and earned every PG.</description></item>
+    /// <item><description>Perfect if every judgement was PG (top-tier) regardless of window.</description></item>
+    /// <item><description>FullCombo if there were zero misses.</description></item>
+    /// <item><description>Otherwise the lamp tier follows the gauge that cleared:
+    /// LightAssist / Easy / Normal / Hard / ExHard, with assist gauges mapped to AssistEasy.</description></item>
+    /// </list>
+    /// <para>
+    /// To swap in a custom scheme (LR2-style, sliding scale, network ranking), implement
+    /// <see cref="IBmsLampScheme"/> directly or subclass this and override <see cref="ResolveLamp"/>.
+    /// </para>
+    /// </summary>
+    public class BeatorajaLampScheme : IBmsLampScheme
+    {
+        public virtual string DisplayName => "Beatoraja";
+
+        public virtual BmsClearLamp ResolveLamp(BmsLampContext context)
+        {
+            if (!context.HasPlayed)
+                return BmsClearLamp.NoPlay;
+
+            if (!context.Cleared)
+                return BmsClearLamp.Failed;
+
+            if (context.IsAllPerfect && context.UsedHighestJudgementWindow)
+                return BmsClearLamp.Max;
+
+            if (context.IsAllPerfect)
+                return BmsClearLamp.Perfect;
+
+            if (context.IsFullCombo)
+                return BmsClearLamp.FullCombo;
+
+            return context.Gauge switch
+            {
+                BmsGaugeType.Assist => BmsClearLamp.AssistEasy,
+                BmsGaugeType.LightAssistEasy => BmsClearLamp.LightAssistEasy,
+                BmsGaugeType.Easy => BmsClearLamp.Easy,
+                BmsGaugeType.Normal or BmsGaugeType.PNormal => BmsClearLamp.Normal,
+                BmsGaugeType.Hard or BmsGaugeType.PHard => BmsClearLamp.Hard,
+                BmsGaugeType.ExHard or BmsGaugeType.PExHard => BmsClearLamp.ExHard,
+                BmsGaugeType.FullCombo => BmsClearLamp.FullCombo,
+                _ => BmsClearLamp.Normal,
+            };
+        }
+
+        public virtual Color4 GetLampColour(BmsClearLamp lamp) => BmsLampPalette.GetDefaultColour(lamp);
+
+        public virtual Color4 GetLampTextColour(BmsClearLamp lamp) => BmsLampPalette.GetDefaultTextColour(lamp);
+    }
+}

--- a/osu.Game.Rulesets.BMS/Scoring/Lamp/BmsClearLamp.cs
+++ b/osu.Game.Rulesets.BMS/Scoring/Lamp/BmsClearLamp.cs
@@ -1,0 +1,54 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.BMS.Scoring.Lamp
+{
+    /// <summary>
+    /// BMS clear-lamp tier. Models the canonical beatoraja <c>ClearType</c> spectrum,
+    /// from "never played" up through "perfect / max", so existing BMS players see a
+    /// familiar progression and so we can layer extra tiers in the future without
+    /// breaking the ordering.
+    /// </summary>
+    /// <remarks>
+    /// The integer values mirror beatoraja's <c>ClearType</c> ids (see
+    /// <c>src/bms/player/beatoraja/ClearType.java</c>) on purpose. Keeping the IDs
+    /// aligned lets us import/export lamps from beatoraja-format score data verbatim
+    /// later on. Higher ordinal == better lamp; UI code can rely on that for sorting
+    /// and "best lamp so far" comparisons.
+    /// </remarks>
+    public enum BmsClearLamp
+    {
+        /// <summary>The chart has never been played by the local user.</summary>
+        NoPlay = 0,
+
+        /// <summary>The player failed the chart (health hit zero on a non-assist gauge).</summary>
+        Failed = 1,
+
+        /// <summary>Cleared on a heavy-assist gauge (e.g. AEASY) - not a "real" clear.</summary>
+        AssistEasy = 2,
+
+        /// <summary>Cleared on a lighter assist gauge.</summary>
+        LightAssistEasy = 3,
+
+        /// <summary>Cleared on the Easy gauge.</summary>
+        Easy = 4,
+
+        /// <summary>Cleared on the Groove / Normal gauge.</summary>
+        Normal = 5,
+
+        /// <summary>Cleared on the Hard gauge (no instant-death miss allowed past a threshold).</summary>
+        Hard = 6,
+
+        /// <summary>Cleared on the EX-Hard gauge (more punishing version of Hard).</summary>
+        ExHard = 7,
+
+        /// <summary>Full Combo - no miss across the whole chart.</summary>
+        FullCombo = 8,
+
+        /// <summary>Perfect - every judgement was at the highest tier (typically PG).</summary>
+        Perfect = 9,
+
+        /// <summary>Max - perfect score with the strictest possible judgement window.</summary>
+        Max = 10,
+    }
+}

--- a/osu.Game.Rulesets.BMS/Scoring/Lamp/BmsGaugeType.cs
+++ b/osu.Game.Rulesets.BMS/Scoring/Lamp/BmsGaugeType.cs
@@ -1,0 +1,46 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.BMS.Scoring.Lamp
+{
+    /// <summary>
+    /// The gameplay gauge a BMS score was played on. Maps to the gauge type used
+    /// by the lamp scheme to decide which lamp tier the score qualifies for.
+    /// </summary>
+    /// <remarks>
+    /// Ordering matches beatoraja's gauge slots (see <c>ClearType.gaugetype</c> entries),
+    /// so external lamp data referenced by gauge id keeps working without translation.
+    /// </remarks>
+    public enum BmsGaugeType
+    {
+        /// <summary>Light assist gauge (LIGHT ASSIST EASY).</summary>
+        LightAssistEasy = 0,
+
+        /// <summary>Easy gauge.</summary>
+        Easy = 1,
+
+        /// <summary>Groove / Normal gauge.</summary>
+        Normal = 2,
+
+        /// <summary>Hard gauge.</summary>
+        Hard = 3,
+
+        /// <summary>EX-Hard gauge.</summary>
+        ExHard = 4,
+
+        /// <summary>Hazard / Full Combo gauge.</summary>
+        FullCombo = 5,
+
+        /// <summary>Beatoraja-style "P" gauge (Normal variant).</summary>
+        PNormal = 6,
+
+        /// <summary>Beatoraja-style "P" gauge (Hard variant).</summary>
+        PHard = 7,
+
+        /// <summary>Beatoraja-style "P" gauge (EX-Hard variant).</summary>
+        PExHard = 8,
+
+        /// <summary>Assist gauge (full assist).</summary>
+        Assist = 9,
+    }
+}

--- a/osu.Game.Rulesets.BMS/Scoring/Lamp/BmsLampAccentColourProvider.cs
+++ b/osu.Game.Rulesets.BMS/Scoring/Lamp/BmsLampAccentColourProvider.cs
@@ -1,0 +1,44 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps;
+using osu.Game.Screens.Select;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.BMS.Scoring.Lamp
+{
+    /// <summary>
+    /// Bridges <see cref="BmsLampStore"/> into osu.Game's panel accent system: when
+    /// SongSelect renders a BMS panel it asks this provider for the accent colour,
+    /// and we return the lamp colour for that beatmap. Non-BMS panels return null
+    /// so they keep the default star-rating colour.
+    /// </summary>
+    /// <remarks>
+    /// This type is optional at the engine level: if a fork omits <see cref="osu.Game.Screens.Select.IPanelAccentColourProvider"/>
+    /// from panels or never caches a provider, behaviour degrades to vanilla star-rating accents only.
+    /// BMS gameplay does not reference this class.
+    /// </remarks>
+    public class BmsLampAccentColourProvider : IPanelAccentColourProvider
+    {
+        private const string bms_ruleset_short_name = "bms";
+
+        private readonly BmsLampStore lampStore;
+
+        public BmsLampAccentColourProvider(BmsLampStore lampStore)
+        {
+            this.lampStore = lampStore;
+        }
+
+        public Color4? GetAccentColourFor(BeatmapInfo? beatmap)
+        {
+            if (beatmap?.Ruleset == null)
+                return null;
+
+            if (!string.Equals(beatmap.Ruleset.ShortName, bms_ruleset_short_name, StringComparison.OrdinalIgnoreCase))
+                return null;
+
+            var lamp = lampStore.GetLamp(beatmap);
+            return lampStore.Scheme.GetLampColour(lamp);
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/Scoring/Lamp/BmsLampContext.cs
+++ b/osu.Game.Rulesets.BMS/Scoring/Lamp/BmsLampContext.cs
@@ -1,0 +1,62 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.BMS.Scoring.Lamp
+{
+    /// <summary>
+    /// All inputs a <see cref="IBmsLampScheme"/> needs to decide which lamp a play
+    /// earned. Designed as a flat readonly record so call sites can build it from
+    /// either a live <c>ScoreInfo</c> or from rebuilt beatoraja score rows without
+    /// taking a dependency on either type.
+    /// </summary>
+    /// <param name="HasPlayed">
+    /// Whether the local user has any play record on this chart at all. Used to
+    /// distinguish <see cref="BmsClearLamp.NoPlay"/> from <see cref="BmsClearLamp.Failed"/>.
+    /// </param>
+    /// <param name="Cleared">
+    /// Whether gameplay finished without the gauge falling to zero on a "real" gauge.
+    /// Assist gauges are reported separately via <paramref name="Gauge"/>.
+    /// </param>
+    /// <param name="Gauge">The gauge the player used during this attempt.</param>
+    /// <param name="MissCount">Number of POOR/MISS judgements. <c>0</c> qualifies for FullCombo.</param>
+    /// <param name="GreatCount">Number of mid-tier judgements (BMS GREAT / mania GREAT).</param>
+    /// <param name="GoodCount">Number of low-tier judgements (BMS GOOD / mania OK).</param>
+    /// <param name="BadCount">Number of BAD judgements that don't count as miss.</param>
+    /// <param name="PerfectGreatCount">Number of highest-tier hits (BMS PGREAT / mania PERFECT).</param>
+    /// <param name="TotalNotes">Total judged note count.</param>
+    /// <param name="UsedHighestJudgementWindow">
+    /// True if the played hit-window profile was the strictest available (used to
+    /// distinguish <see cref="BmsClearLamp.Perfect"/> from <see cref="BmsClearLamp.Max"/>).
+    /// </param>
+    public readonly record struct BmsLampContext(
+        bool HasPlayed,
+        bool Cleared,
+        BmsGaugeType Gauge,
+        int MissCount,
+        int GreatCount,
+        int GoodCount,
+        int BadCount,
+        int PerfectGreatCount,
+        int TotalNotes,
+        bool UsedHighestJudgementWindow)
+    {
+        /// <summary>Helper: chart had no input recorded (NoPlay).</summary>
+        public static BmsLampContext NoPlay() => new BmsLampContext(
+            HasPlayed: false,
+            Cleared: false,
+            Gauge: BmsGaugeType.Normal,
+            MissCount: 0,
+            GreatCount: 0,
+            GoodCount: 0,
+            BadCount: 0,
+            PerfectGreatCount: 0,
+            TotalNotes: 0,
+            UsedHighestJudgementWindow: false);
+
+        /// <summary>True if there were zero misses (FC candidate).</summary>
+        public bool IsFullCombo => MissCount == 0 && TotalNotes > 0;
+
+        /// <summary>True if every judged note was the top tier (Perfect candidate).</summary>
+        public bool IsAllPerfect => TotalNotes > 0 && PerfectGreatCount == TotalNotes;
+    }
+}

--- a/osu.Game.Rulesets.BMS/Scoring/Lamp/BmsLampPalette.cs
+++ b/osu.Game.Rulesets.BMS/Scoring/Lamp/BmsLampPalette.cs
@@ -1,0 +1,62 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Extensions.Color4Extensions;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.BMS.Scoring.Lamp
+{
+    /// <summary>
+    /// Centralised default colours for each <see cref="BmsClearLamp"/>.
+    /// Picked to match common BMS-community conventions (mirroring beatoraja /
+    /// LR2 score-table colours) so existing players read the carousel intuitively:
+    /// <list type="bullet">
+    /// <item><description>NoPlay: muted slate (chart untouched)</description></item>
+    /// <item><description>Failed: dim red</description></item>
+    /// <item><description>Assist/LightAssist: purple shades</description></item>
+    /// <item><description>Easy: green</description></item>
+    /// <item><description>Normal: cyan-blue</description></item>
+    /// <item><description>Hard: amber/gold</description></item>
+    /// <item><description>ExHard: bright yellow</description></item>
+    /// <item><description>FullCombo: cyan-white</description></item>
+    /// <item><description>Perfect: pale gold</description></item>
+    /// <item><description>Max: rainbow stand-in (solid white-gold)</description></item>
+    /// </list>
+    /// Schemes that want a different palette can either subclass this or just bypass
+    /// it entirely and define their own <see cref="IBmsLampScheme.GetLampColour"/>.
+    /// </summary>
+    public static class BmsLampPalette
+    {
+        public static Color4 GetDefaultColour(BmsClearLamp lamp) => lamp switch
+        {
+            BmsClearLamp.NoPlay => Color4Extensions.FromHex("3F4248"),
+            BmsClearLamp.Failed => Color4Extensions.FromHex("B73C3C"),
+            BmsClearLamp.AssistEasy => Color4Extensions.FromHex("9D55C7"),
+            BmsClearLamp.LightAssistEasy => Color4Extensions.FromHex("C58CE0"),
+            BmsClearLamp.Easy => Color4Extensions.FromHex("4CD063"),
+            BmsClearLamp.Normal => Color4Extensions.FromHex("3FA6FF"),
+            BmsClearLamp.Hard => Color4Extensions.FromHex("F0A040"),
+            BmsClearLamp.ExHard => Color4Extensions.FromHex("F0E040"),
+            BmsClearLamp.FullCombo => Color4Extensions.FromHex("4FE3C4"),
+            BmsClearLamp.Perfect => Color4Extensions.FromHex("F7E08C"),
+            BmsClearLamp.Max => Color4Extensions.FromHex("FFFFFF"),
+            _ => Color4Extensions.FromHex("3F4248"),
+        };
+
+        /// <summary>
+        /// Default foreground colour (text/icon) intended to read on top of
+        /// <see cref="GetDefaultColour"/>. Light lamps (Easy and below) take dark text;
+        /// brighter / wider-gamut lamps still read well against near-black.
+        /// </summary>
+        public static Color4 GetDefaultTextColour(BmsClearLamp lamp) => lamp switch
+        {
+            BmsClearLamp.NoPlay => Color4Extensions.FromHex("D0D0D0"),
+            BmsClearLamp.LightAssistEasy => Color4Extensions.FromHex("1A1A1A"),
+            BmsClearLamp.Easy => Color4Extensions.FromHex("0A2A0A"),
+            BmsClearLamp.ExHard => Color4Extensions.FromHex("1A1A1A"),
+            BmsClearLamp.Perfect => Color4Extensions.FromHex("1A1A1A"),
+            BmsClearLamp.Max => Color4Extensions.FromHex("1A1A1A"),
+            _ => Color4.White,
+        };
+    }
+}

--- a/osu.Game.Rulesets.BMS/Scoring/Lamp/BmsLampStore.cs
+++ b/osu.Game.Rulesets.BMS/Scoring/Lamp/BmsLampStore.cs
@@ -1,0 +1,222 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Concurrent;
+using osu.Framework.Logging;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.BMS.Scoring.Lamp.Persistence;
+
+namespace osu.Game.Rulesets.BMS.Scoring.Lamp
+{
+    /// <summary>
+    /// Process-wide lookup of "best lamp seen so far" per BMS beatmap.
+    /// Acts as a thin facade for the rest of the BMS UI: nothing else needs to know
+    /// where the lamp data came from (SQLite store, beatoraja import, network, …).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The in-memory dictionary is the hot path: <c>PanelBeatmap.Update</c> reads it
+    /// every frame for every visible row, so look-ups must stay O(1) and lock-free.
+    /// <see cref="ConcurrentDictionary{TKey,TValue}"/> gives us that.
+    /// </para>
+    /// <para>
+    /// Persistence is opt-in via <see cref="AttachRepository"/>: tests and headless flows
+    /// keep the store fully in-memory; song-select wires up <see cref="BmsLampSqliteRepository"/>
+    /// at startup. Writes are fire-and-forget on the thread pool so the gameplay/results
+    /// path never blocks on disk I/O — best-lamp arbitration happens synchronously in
+    /// <see cref="ReportPlay"/> first, then the resulting row is shipped to the repository.
+    /// </para>
+    /// </remarks>
+    public class BmsLampStore
+    {
+        private readonly ConcurrentDictionary<Guid, BmsLampRecord> bestByBeatmap = new ConcurrentDictionary<Guid, BmsLampRecord>();
+
+        private IBmsLampRepository? repository;
+
+        public BmsLampStore(IBmsLampScheme scheme)
+        {
+            Scheme = scheme;
+        }
+
+        /// <summary>
+        /// The lamp scheme currently in use. UI components that want lamp colours
+        /// should route through this property rather than holding their own reference.
+        /// </summary>
+        public IBmsLampScheme Scheme { get; }
+
+        /// <summary>
+        /// Wire up a persistence backend. Loads every persisted record into the
+        /// in-memory map synchronously so the carousel sees correct lamps on first paint.
+        /// </summary>
+        /// <remarks>
+        /// Safe to call multiple times — subsequent calls replace the backend and re-seed
+        /// the dictionary from the new source (which is what you want when the storage
+        /// directory is rebound, e.g. profile switching). Existing in-memory entries that
+        /// the new repository doesn't know about are dropped — the persistent store is
+        /// authoritative.
+        /// </remarks>
+        public void AttachRepository(IBmsLampRepository repository)
+        {
+            this.repository = repository;
+
+            try
+            {
+                var rows = repository.LoadAll();
+
+                bestByBeatmap.Clear();
+
+                foreach (var record in rows)
+                    bestByBeatmap[record.BeatmapId] = record;
+
+                Logger.Log($"[BMS] Lamp store attached: loaded {rows.Count} record(s).", LoggingTarget.Database, LogLevel.Debug);
+            }
+            catch (Exception ex)
+            {
+                // LoadAll is contracted not to throw, but defend in depth: a broken store
+                // should leave the carousel running on a clean in-memory slate, not crash.
+                Logger.Log($"[BMS] Lamp store attach failed: {ex.Message}", LoggingTarget.Database, LogLevel.Important);
+            }
+        }
+
+        /// <summary>
+        /// Look up the best lamp recorded for the given beatmap, or <see cref="BmsClearLamp.NoPlay"/>
+        /// if nothing has been recorded yet.
+        /// </summary>
+        public BmsClearLamp GetLamp(BeatmapInfo beatmap)
+        {
+            if (beatmap == null)
+                return BmsClearLamp.NoPlay;
+
+            return bestByBeatmap.TryGetValue(beatmap.ID, out var record) ? record.Lamp : BmsClearLamp.NoPlay;
+        }
+
+        /// <summary>
+        /// Record a finished play for <paramref name="beatmap"/>. The store keeps the
+        /// best (highest-ranked) lamp seen for the beatmap so far. When the new play sets
+        /// a new personal best the row is shipped to <see cref="AttachRepository"/>'s
+        /// backend asynchronously.
+        /// </summary>
+        public BmsClearLamp ReportPlay(BeatmapInfo beatmap, BmsLampContext context)
+        {
+            var lamp = Scheme.ResolveLamp(context);
+
+            if (beatmap == null)
+                return lamp;
+
+            var candidate = new BmsLampRecord(
+                BeatmapId: beatmap.ID,
+                Lamp: lamp,
+                MissCount: context.MissCount,
+                GreatCount: context.GreatCount,
+                GoodCount: context.GoodCount,
+                BadCount: context.BadCount,
+                PerfectGreatCount: context.PerfectGreatCount,
+                TotalNotes: context.TotalNotes,
+                UpdatedAtUnixMs: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+
+            // AddOrUpdate keeps the existing row when the new lamp is strictly worse.
+            // `wonBest` flips iff the candidate became the winning entry; the closure may run
+            // more than once under bucket contention but the flag is still safe because every
+            // execution agrees on the same outcome — the worst case is a duplicate persist,
+            // which the repo handles idempotently via UPSERT.
+            bool wonBest = false;
+
+            bestByBeatmap.AddOrUpdate(
+                beatmap.ID,
+                _ =>
+                {
+                    wonBest = true;
+                    return candidate;
+                },
+                (_, existing) =>
+                {
+                    if ((int)candidate.Lamp > (int)existing.Lamp)
+                    {
+                        wonBest = true;
+                        return candidate;
+                    }
+
+                    return existing;
+                });
+
+            // Only persist when the candidate actually won — avoids re-writing every play and
+            // trims SQLite WAL pressure during practice grinding.
+            if (wonBest)
+                persist(candidate);
+
+            return lamp;
+        }
+
+        /// <summary>
+        /// Direct seed — bypasses scheme resolution and forces the best lamp for a beatmap.
+        /// Intended for the beatoraja importer and tests that need to pin the carousel to a
+        /// specific lamp colour.
+        /// </summary>
+        public void SetLamp(BeatmapInfo beatmap, BmsClearLamp lamp)
+        {
+            if (beatmap == null)
+                return;
+
+            var record = new BmsLampRecord(
+                BeatmapId: beatmap.ID,
+                Lamp: lamp,
+                MissCount: 0,
+                GreatCount: 0,
+                GoodCount: 0,
+                BadCount: 0,
+                PerfectGreatCount: 0,
+                TotalNotes: 0,
+                UpdatedAtUnixMs: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+
+            bestByBeatmap[beatmap.ID] = record;
+            persist(record);
+        }
+
+        /// <summary>
+        /// Clear in-memory records. The persistent store is left intact so a refresh of the
+        /// carousel doesn't wipe history; pass <c>true</c> for <paramref name="alsoPersistent"/>
+        /// to also delete from disk (used by the future "reset lamps" admin action).
+        /// </summary>
+        public void Clear(bool alsoPersistent = false)
+        {
+            if (alsoPersistent && repository != null)
+            {
+                foreach (var id in bestByBeatmap.Keys)
+                {
+                    try
+                    {
+                        repository.Delete(id);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Log($"[BMS] Lamp store delete failed for {id}: {ex.Message}", LoggingTarget.Database, LogLevel.Important);
+                    }
+                }
+            }
+
+            bestByBeatmap.Clear();
+        }
+
+        private void persist(BmsLampRecord record)
+        {
+            var repo = repository;
+            if (repo == null)
+                return;
+
+            // Fire-and-forget on the thread pool. The repository is internally synchronous +
+            // self-locked; running on the pool keeps gameplay's PrepareScoreForResultsAsync
+            // free of any disk-bound wait. Exceptions inside the repo are already logged.
+            Task.Run(() =>
+            {
+                try
+                {
+                    repo.Upsert(record);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Log($"[BMS] Lamp store persist failed: {ex.Message}", LoggingTarget.Database, LogLevel.Important);
+                }
+            });
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/Scoring/Lamp/IBmsLampScheme.cs
+++ b/osu.Game.Rulesets.BMS/Scoring/Lamp/IBmsLampScheme.cs
@@ -1,0 +1,40 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.BMS.Scoring.Lamp
+{
+    /// <summary>
+    /// Plug-point for "which lamp did this play earn, and what colour is it?".
+    /// Implement this once per lamp ruleset (beatoraja-compatible, LR2-style, custom…)
+    /// and register it in DI. UI components only depend on this interface, so swapping
+    /// the lamp scheme is a one-line change in <see cref="BMSRuleset"/>.
+    /// </summary>
+    public interface IBmsLampScheme
+    {
+        /// <summary>
+        /// A short, human-readable name of the scheme (shown in settings / debug overlays).
+        /// </summary>
+        string DisplayName { get; }
+
+        /// <summary>
+        /// Resolve which lamp a single play earned, given the gameplay context.
+        /// Implementations should be deterministic and side-effect free.
+        /// </summary>
+        BmsClearLamp ResolveLamp(BmsLampContext context);
+
+        /// <summary>
+        /// Resolve the display colour for a lamp tier. Used by song-select panels and
+        /// any other "lamp at a glance" UI.
+        /// </summary>
+        Color4 GetLampColour(BmsClearLamp lamp);
+
+        /// <summary>
+        /// Resolve the text-foreground colour to draw on top of <see cref="GetLampColour"/>.
+        /// Useful when the lamp background is very dark/light and the default content
+        /// colour would be unreadable.
+        /// </summary>
+        Color4 GetLampTextColour(BmsClearLamp lamp);
+    }
+}

--- a/osu.Game.Rulesets.BMS/Scoring/Lamp/Persistence/BmsLampRecord.cs
+++ b/osu.Game.Rulesets.BMS/Scoring/Lamp/Persistence/BmsLampRecord.cs
@@ -1,0 +1,33 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.BMS.Scoring.Lamp.Persistence
+{
+    /// <summary>
+    /// Single row of the BMS lamp persistence table.
+    /// Carries the canonical lamp value plus auxiliary stat columns so future UI (history,
+    /// inline tooltips, "personal best" surfaces) can light up without another schema migration.
+    /// </summary>
+    /// <param name="BeatmapId">
+    /// <see cref="osu.Game.Beatmaps.BeatmapInfo"/>.<c>ID</c>. This is stable per Realm-managed
+    /// beatmap row, so any rescan that keeps the same beatmap entry preserves history.
+    /// </param>
+    /// <param name="Lamp">Best lamp seen so far on this beatmap.</param>
+    /// <param name="MissCount">Miss count of the play that produced <paramref name="Lamp"/>.</param>
+    /// <param name="GreatCount">Great count of the play that produced <paramref name="Lamp"/>.</param>
+    /// <param name="GoodCount">Good count of the play that produced <paramref name="Lamp"/>.</param>
+    /// <param name="BadCount">Bad count of the play that produced <paramref name="Lamp"/>.</param>
+    /// <param name="PerfectGreatCount">PGREAT count of the play that produced <paramref name="Lamp"/>.</param>
+    /// <param name="TotalNotes">Judged note count of the play that produced <paramref name="Lamp"/>.</param>
+    /// <param name="UpdatedAtUnixMs">UTC wall-clock at write, milliseconds since epoch.</param>
+    public readonly record struct BmsLampRecord(
+        Guid BeatmapId,
+        BmsClearLamp Lamp,
+        int MissCount,
+        int GreatCount,
+        int GoodCount,
+        int BadCount,
+        int PerfectGreatCount,
+        int TotalNotes,
+        long UpdatedAtUnixMs);
+}

--- a/osu.Game.Rulesets.BMS/Scoring/Lamp/Persistence/BmsLampSqliteRepository.cs
+++ b/osu.Game.Rulesets.BMS/Scoring/Lamp/Persistence/BmsLampSqliteRepository.cs
@@ -1,0 +1,315 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Globalization;
+using Microsoft.Data.Sqlite;
+using osu.Framework.Logging;
+
+namespace osu.Game.Rulesets.BMS.Scoring.Lamp.Persistence
+{
+    /// <summary>
+    /// SQLite-backed implementation of <see cref="IBmsLampRepository"/>.
+    /// Modelled after <c>osu.Game.EzOsuGame.Analysis.EzAnalysisPersistentStore</c>: every
+    /// operation opens a fresh <see cref="SqliteConnection"/> (with shared cache + connection
+    /// pooling) to avoid cross-thread reuse hazards, and the database is configured WAL +
+    /// synchronous=NORMAL on first creation for high write throughput / cheap reader churn.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Schema migration is intentional and self-contained — the file lives outside osu.Game's
+    /// Realm and is keyed only by <c>BeatmapInfo.ID</c>, so loss of this file at most degrades
+    /// to "no lamps" without breaking the main library. Versions are tracked in a tiny
+    /// <c>meta</c> table; bumping <see cref="schema_version"/> recreates the lamp table from
+    /// scratch (cheap — typical row count fits in low five digits even for a saturated library).
+    /// </para>
+    /// <para>
+    /// Threading: SQLite handles intra-process concurrency for us via shared cache + WAL, so
+    /// the only invariant this class enforces is "every command runs in a using block". Callers
+    /// may invoke <see cref="Upsert"/> from arbitrary threads; <see cref="LoadAll"/> is meant
+    /// for one synchronous call during store attach.
+    /// </para>
+    /// </remarks>
+    public sealed class BmsLampSqliteRepository : IBmsLampRepository
+    {
+        // Bump this when the lamp table layout changes in a way that LoadAll cannot tolerate.
+        // The migration policy is "drop and rebuild" — lamp history is regenerable from future
+        // replays / external imports, so a hard reset is safer than partial-row migration code.
+        private const int schema_version = 1;
+
+        private const string table_lamp = "bms_lamp";
+        private const string table_meta = "meta";
+
+        private const string col_beatmap_id = "beatmap_id";
+        private const string col_lamp = "lamp";
+        private const string col_miss = "miss";
+        private const string col_great = "great";
+        private const string col_good = "good";
+        private const string col_bad = "bad";
+        private const string col_pgreat = "pgreat";
+        private const string col_total = "total";
+        private const string col_updated_at = "updated_at";
+
+        private readonly string databasePath;
+        private bool initialized;
+        private bool disposed;
+
+        public BmsLampSqliteRepository(string databasePath)
+        {
+            this.databasePath = databasePath ?? throw new ArgumentNullException(nameof(databasePath));
+
+            // Defer all schema work to first use so construction itself cannot throw — keeps the
+            // attach call site at song-select free of try/catch noise. Init is idempotent.
+            try
+            {
+                ensureInitialized();
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"[BMS] Lamp store init failed: {ex.Message}", LoggingTarget.Database, LogLevel.Important);
+            }
+        }
+
+        public IReadOnlyCollection<BmsLampRecord> LoadAll()
+        {
+            if (disposed)
+                return Array.Empty<BmsLampRecord>();
+
+            var rows = new List<BmsLampRecord>();
+
+            try
+            {
+                ensureInitialized();
+
+                using var connection = openConnection();
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = $@"
+SELECT {col_beatmap_id}, {col_lamp}, {col_miss}, {col_great}, {col_good}, {col_bad}, {col_pgreat}, {col_total}, {col_updated_at}
+FROM {table_lamp};";
+
+                using var reader = cmd.ExecuteReader();
+
+                while (reader.Read())
+                {
+                    if (!Guid.TryParse(reader.GetString(0), out var id))
+                        continue;
+
+                    var lamp = (BmsClearLamp)reader.GetInt32(1);
+
+                    rows.Add(new BmsLampRecord(
+                        BeatmapId: id,
+                        Lamp: lamp,
+                        MissCount: reader.GetInt32(2),
+                        GreatCount: reader.GetInt32(3),
+                        GoodCount: reader.GetInt32(4),
+                        BadCount: reader.GetInt32(5),
+                        PerfectGreatCount: reader.GetInt32(6),
+                        TotalNotes: reader.GetInt32(7),
+                        UpdatedAtUnixMs: reader.GetInt64(8)));
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"[BMS] Lamp store LoadAll failed: {ex.Message}", LoggingTarget.Database, LogLevel.Important);
+            }
+
+            return rows;
+        }
+
+        public void Upsert(BmsLampRecord record)
+        {
+            if (disposed)
+                return;
+
+            try
+            {
+                ensureInitialized();
+
+                using var connection = openConnection();
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = $@"
+INSERT INTO {table_lamp} ({col_beatmap_id}, {col_lamp}, {col_miss}, {col_great}, {col_good}, {col_bad}, {col_pgreat}, {col_total}, {col_updated_at})
+VALUES ($id, $lamp, $miss, $great, $good, $bad, $pgreat, $total, $updated_at)
+ON CONFLICT({col_beatmap_id}) DO UPDATE SET
+    {col_lamp}        = excluded.{col_lamp},
+    {col_miss}        = excluded.{col_miss},
+    {col_great}       = excluded.{col_great},
+    {col_good}        = excluded.{col_good},
+    {col_bad}         = excluded.{col_bad},
+    {col_pgreat}      = excluded.{col_pgreat},
+    {col_total}       = excluded.{col_total},
+    {col_updated_at}  = excluded.{col_updated_at};";
+
+                cmd.Parameters.AddWithValue("$id", record.BeatmapId.ToString("D", CultureInfo.InvariantCulture));
+                cmd.Parameters.AddWithValue("$lamp", (int)record.Lamp);
+                cmd.Parameters.AddWithValue("$miss", record.MissCount);
+                cmd.Parameters.AddWithValue("$great", record.GreatCount);
+                cmd.Parameters.AddWithValue("$good", record.GoodCount);
+                cmd.Parameters.AddWithValue("$bad", record.BadCount);
+                cmd.Parameters.AddWithValue("$pgreat", record.PerfectGreatCount);
+                cmd.Parameters.AddWithValue("$total", record.TotalNotes);
+                cmd.Parameters.AddWithValue("$updated_at", record.UpdatedAtUnixMs);
+
+                cmd.ExecuteNonQuery();
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"[BMS] Lamp store Upsert failed for {record.BeatmapId}: {ex.Message}", LoggingTarget.Database, LogLevel.Important);
+            }
+        }
+
+        public void Delete(Guid beatmapId)
+        {
+            if (disposed)
+                return;
+
+            try
+            {
+                ensureInitialized();
+
+                using var connection = openConnection();
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = $"DELETE FROM {table_lamp} WHERE {col_beatmap_id} = $id;";
+                cmd.Parameters.AddWithValue("$id", beatmapId.ToString("D", CultureInfo.InvariantCulture));
+                cmd.ExecuteNonQuery();
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"[BMS] Lamp store Delete failed for {beatmapId}: {ex.Message}", LoggingTarget.Database, LogLevel.Important);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (disposed)
+                return;
+
+            disposed = true;
+
+            // Best effort — Microsoft.Data.Sqlite pools connections per database path. Clearing
+            // the pool ensures Windows lets the WAL/SHM sidecar files release their locks so the
+            // user can move/delete the storage directory while osu is alive (test scenarios,
+            // "reset library" flows).
+            try
+            {
+                SqliteConnection.ClearAllPools();
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"[BMS] Lamp store dispose ClearAllPools failed: {ex.Message}", LoggingTarget.Database, LogLevel.Debug);
+            }
+        }
+
+        private void ensureInitialized()
+        {
+            if (initialized)
+                return;
+
+            string? directory = Path.GetDirectoryName(databasePath);
+
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+                Directory.CreateDirectory(directory);
+
+            using var connection = openConnection();
+
+            using (var pragma = connection.CreateCommand())
+            {
+                // Performance configuration mirrors EzAnalysisPersistentStore:
+                //   - WAL gives concurrent reads during writes (no big locks on the carousel side).
+                //   - synchronous=NORMAL is the canonical "fast enough, durable enough" SQLite knob;
+                //     in WAL mode it's still crash-safe across normal process termination.
+                //   - temp_store=MEMORY avoids touching disk for transient sort/hash space.
+                pragma.CommandText = @"
+PRAGMA journal_mode=WAL;
+PRAGMA synchronous=NORMAL;
+PRAGMA temp_store=MEMORY;";
+                pragma.ExecuteNonQuery();
+            }
+
+            using (var cmd = connection.CreateCommand())
+            {
+                cmd.CommandText = $@"
+CREATE TABLE IF NOT EXISTS {table_meta} (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS {table_lamp} (
+    {col_beatmap_id}   TEXT PRIMARY KEY,
+    {col_lamp}         INTEGER NOT NULL,
+    {col_miss}         INTEGER NOT NULL DEFAULT 0,
+    {col_great}        INTEGER NOT NULL DEFAULT 0,
+    {col_good}         INTEGER NOT NULL DEFAULT 0,
+    {col_bad}          INTEGER NOT NULL DEFAULT 0,
+    {col_pgreat}       INTEGER NOT NULL DEFAULT 0,
+    {col_total}        INTEGER NOT NULL DEFAULT 0,
+    {col_updated_at}   INTEGER NOT NULL DEFAULT 0
+);";
+                cmd.ExecuteNonQuery();
+            }
+
+            int existingVersion = readSchemaVersion(connection);
+
+            if (existingVersion != 0 && existingVersion != schema_version)
+            {
+                // Drop-and-rebuild policy: lamp data is fully regenerable from gameplay + future
+                // beatoraja imports, so when the column set changes we prefer a clean table over
+                // half-migrated rows that confuse the carousel.
+                using var drop = connection.CreateCommand();
+                drop.CommandText = $@"
+DROP TABLE IF EXISTS {table_lamp};
+
+CREATE TABLE {table_lamp} (
+    {col_beatmap_id}   TEXT PRIMARY KEY,
+    {col_lamp}         INTEGER NOT NULL,
+    {col_miss}         INTEGER NOT NULL DEFAULT 0,
+    {col_great}        INTEGER NOT NULL DEFAULT 0,
+    {col_good}         INTEGER NOT NULL DEFAULT 0,
+    {col_bad}          INTEGER NOT NULL DEFAULT 0,
+    {col_pgreat}       INTEGER NOT NULL DEFAULT 0,
+    {col_total}        INTEGER NOT NULL DEFAULT 0,
+    {col_updated_at}   INTEGER NOT NULL DEFAULT 0
+);";
+                drop.ExecuteNonQuery();
+                Logger.Log($"[BMS] Lamp store schema migrated from v{existingVersion} to v{schema_version} (rebuilt).", LoggingTarget.Database, LogLevel.Important);
+            }
+
+            writeSchemaVersion(connection, schema_version);
+
+            initialized = true;
+        }
+
+        private SqliteConnection openConnection()
+        {
+            // Mode=ReadWriteCreate so a missing file is created in place; Cache=Shared lets multiple
+            // short-lived connections from different threads share the page cache (cheaper reads).
+            // Connection pooling is on by default in Microsoft.Data.Sqlite — the actual native
+            // handle is reused across these `using` blocks.
+            var connection = new SqliteConnection($"Data Source={databasePath};Cache=Shared;Mode=ReadWriteCreate");
+            connection.Open();
+            return connection;
+        }
+
+        private static int readSchemaVersion(SqliteConnection connection)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = $"SELECT value FROM {table_meta} WHERE key = 'schema_version';";
+            object? result = cmd.ExecuteScalar();
+
+            if (result is string s && int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out int v))
+                return v;
+
+            return 0;
+        }
+
+        private static void writeSchemaVersion(SqliteConnection connection, int version)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = $@"
+INSERT INTO {table_meta} (key, value)
+VALUES ('schema_version', $v)
+ON CONFLICT(key) DO UPDATE SET value = excluded.value;";
+            cmd.Parameters.AddWithValue("$v", version.ToString(CultureInfo.InvariantCulture));
+            cmd.ExecuteNonQuery();
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/Scoring/Lamp/Persistence/IBmsLampRepository.cs
+++ b/osu.Game.Rulesets.BMS/Scoring/Lamp/Persistence/IBmsLampRepository.cs
@@ -1,0 +1,40 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.BMS.Scoring.Lamp.Persistence
+{
+    /// <summary>
+    /// Storage adapter contract for the BMS lamp record set. Exists so the in-memory
+    /// <see cref="BmsLampStore"/> stays oblivious to whether records live in SQLite, JSON,
+    /// a remote service, or only in-process tests. All methods are expected to be safe to
+    /// call from the gameplay/UI threads — implementations push slow I/O to a worker as needed.
+    /// </summary>
+    public interface IBmsLampRepository : IDisposable
+    {
+        /// <summary>
+        /// Eagerly load every persisted record. Called once at attach time; the result is
+        /// folded into the in-memory dictionary and never re-queried during normal operation.
+        /// </summary>
+        /// <remarks>
+        /// Failures must not throw — implementations should log + return an empty collection
+        /// so a corrupted store never blocks song-select from opening.
+        /// </remarks>
+        IReadOnlyCollection<BmsLampRecord> LoadAll();
+
+        /// <summary>
+        /// Persist a single record, replacing any previous row for the same beatmap.
+        /// </summary>
+        /// <remarks>
+        /// "Best lamp" arbitration is the caller's job — by the time a record reaches this
+        /// method it is already the canonical row that should be written. This keeps the
+        /// repository deterministic and easy to test (write-what-you-get).
+        /// </remarks>
+        void Upsert(BmsLampRecord record);
+
+        /// <summary>
+        /// Optional delete; used by the future "clear lamp history" admin action. Implementations
+        /// that don't support it can no-op.
+        /// </summary>
+        void Delete(Guid beatmapId);
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BMSColumn.cs
+++ b/osu.Game.Rulesets.BMS/UI/BMSColumn.cs
@@ -1,0 +1,151 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Pooling;
+using osu.Framework.Platform;
+using osu.Game.Extensions;
+using osu.Game.Rulesets.BMS.Objects.Drawables;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Mania.UI;
+using osu.Game.Rulesets.Mania.UI.Components;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.UI.Scrolling;
+using osu.Game.Skinning;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.BMS.UI
+{
+    /// <summary>
+    /// A single column in the BMS playfield. Reuses mania skin components via a hidden <see cref="Mania.UI.Column"/>
+    /// (<see cref="skinDependencyColumn"/>): <see cref="Mania.UI.Column.Index"/> matches this lane,
+    /// <see cref="Mania.UI.Column.IsSpecial"/> mirrors BMS scratch, and <see cref="Mania.UI.Column.Action"/> follows <see cref="BMSStageLayout.ManiaSkinActionForColumn"/>.
+    /// </summary>
+    public partial class BMSColumn : ScrollingPlayfield
+    {
+        public readonly int ColumnIndex;
+
+        /// <summary>
+        /// Provides <c>Resolved</c> <see cref="Column"/> for <see cref="DefaultColumnBackground"/>, <see cref="DefaultHitTarget"/>, <see cref="DefaultKeyArea"/> and skin colour lookup.
+        /// </summary>
+        [Cached]
+        private readonly Column skinDependencyColumn;
+
+        private readonly SkinnableDrawable skinColumnBackground;
+        private readonly SkinnableDrawable skinHitTarget;
+        private readonly SkinnableDrawable skinKeyArea;
+        private readonly Container explosionContainer;
+        private readonly DrawablePool<PoolableHitExplosion> hitExplosionPool;
+        private readonly BMSOrderedHitPolicy hitPolicy;
+
+        public BMSColumn(int columnIndex, bool isScratch)
+        {
+            ColumnIndex = columnIndex;
+
+            hitPolicy = new BMSOrderedHitPolicy(HitObjectContainer);
+
+            RelativeSizeAxes = Axes.Y;
+            Anchor = Anchor.TopLeft;
+            Origin = Anchor.TopLeft;
+
+            skinDependencyColumn = new Column(columnIndex, isScratch)
+            {
+                Alpha = 0,
+                RelativeSizeAxes = Axes.Both,
+                Action = { Value = BMSStageLayout.ManiaSkinActionForColumn(columnIndex) }
+            };
+
+            InternalChildren = new Drawable[]
+            {
+                skinDependencyColumn,
+                skinColumnBackground = new SkinnableDrawable(new ManiaSkinComponentLookup(ManiaSkinComponents.ColumnBackground), _ => new DefaultColumnBackground())
+                {
+                    RelativeSizeAxes = Axes.Both,
+                },
+                new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Height = 20,
+                    Anchor = Anchor.BottomCentre,
+                    Origin = Anchor.BottomCentre,
+                    Child = skinHitTarget = new SkinnableDrawable(new ManiaSkinComponentLookup(ManiaSkinComponents.HitTarget), _ => new DefaultHitTarget())
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    }
+                },
+                skinKeyArea = new SkinnableDrawable(new ManiaSkinComponentLookup(ManiaSkinComponents.KeyArea), _ => new DefaultKeyArea())
+                {
+                    RelativeSizeAxes = Axes.Both,
+                },
+                HitObjectContainer,
+                explosionContainer = new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                },
+                hitExplosionPool = new DrawablePool<PoolableHitExplosion>(5),
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(GameHost host)
+        {
+            skinDependencyColumn.ApplyGameWideClock(host);
+            skinColumnBackground.ApplyGameWideClock(host);
+            skinHitTarget.ApplyGameWideClock(host);
+            skinKeyArea.ApplyGameWideClock(host);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            NewResult += onOrderedHitNewResult;
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            NewResult -= onOrderedHitNewResult;
+            base.Dispose(isDisposing);
+        }
+
+        private void onOrderedHitNewResult(DrawableHitObject judgedObject, JudgementResult result)
+        {
+            if (result.IsHit)
+                hitPolicy.HandleHit(judgedObject);
+
+            if (!result.IsHit || !judgedObject.DisplayResult || !DisplayJudgements.Value)
+                return;
+
+            explosionContainer.Add(hitExplosionPool.Get(e => e.Apply(result)));
+        }
+
+        protected override void OnNewDrawableHitObject(DrawableHitObject drawableHitObject)
+        {
+            base.OnNewDrawableHitObject(drawableHitObject);
+
+            if (drawableHitObject is DrawableBMSHitObject bms)
+            {
+                bms.AccentColour.BindTo(skinDependencyColumn.AccentColour);
+                bms.CheckHittable = hitPolicy.IsHittable;
+            }
+        }
+
+        public static Color4 GetColumnColour(int columnIndex)
+        {
+            return columnIndex switch
+            {
+                0 => new Color4(255, 0, 0, 255),
+                1 => new Color4(255, 255, 255, 255),
+                2 => new Color4(0, 150, 255, 255),
+                3 => new Color4(255, 255, 255, 255),
+                4 => new Color4(0, 150, 255, 255),
+                5 => new Color4(255, 255, 255, 255),
+                6 => new Color4(0, 150, 255, 255),
+                7 => new Color4(255, 255, 255, 255),
+                _ => new Color4(200, 200, 200, 255),
+            };
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BMSDirectorySelectScreen.cs
+++ b/osu.Game.Rulesets.BMS/UI/BMSDirectorySelectScreen.cs
@@ -1,0 +1,343 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
+using osu.Framework.Screens;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Dialog;
+using osu.Game.Rulesets.BMS.Configuration;
+using osu.Game.Screens;
+using osuTK;
+
+namespace osu.Game.Rulesets.BMS.UI
+{
+    /// <summary>
+    /// Screen for selecting BMS root directory.
+    /// </summary>
+    public partial class BMSDirectorySelectScreen : OsuScreen
+    {
+        private readonly Bindable<string> libraryPathsBindable;
+        private readonly Bindable<string> legacyRootPathBindable;
+        private readonly List<string> stagedPaths;
+        private readonly Action<IReadOnlyList<string>>? applyAction;
+        private OsuDirectorySelector directorySelector = null!;
+        private FillFlowContainer pathList = null!;
+
+        [Cached]
+        private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Purple);
+
+        [Resolved(canBeNull: true)]
+        private IDialogOverlay? dialogOverlay { get; set; }
+
+        public BMSDirectorySelectScreen(Bindable<string> libraryPathsBindable, Bindable<string> legacyRootPathBindable, Action<IReadOnlyList<string>>? applyAction = null)
+        {
+            this.libraryPathsBindable = libraryPathsBindable;
+            this.legacyRootPathBindable = legacyRootPathBindable;
+            this.applyAction = applyAction;
+            stagedPaths = BMSRulesetConfigManager.ParseLibraryPaths(libraryPathsBindable.Value, legacyRootPathBindable.Value).ToList();
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            string? initialPath = stagedPaths.LastOrDefault();
+
+            InternalChild = new Container
+            {
+                Masking = true,
+                CornerRadius = 10,
+                RelativeSizeAxes = Axes.Both,
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(0.7f, 0.8f),
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = colourProvider.Background4,
+                    },
+                    new GridContainer
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        RowDimensions = new[]
+                        {
+                            new Dimension(GridSizeMode.AutoSize),
+                            new Dimension(),
+                            new Dimension(GridSizeMode.AutoSize),
+                        },
+                        Content = new[]
+                        {
+                            new Drawable[]
+                            {
+                                new FillFlowContainer
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    Direction = FillDirection.Vertical,
+                                    Spacing = new Vector2(0, 6),
+                                    Margin = new MarginPadding(10),
+                                    Children = new Drawable[]
+                                    {
+                                        new TooltipTextFlowContainer
+                                        {
+                                            Text = "BMS 曲库设置向导",
+                                            TextAnchor = Anchor.TopCentre,
+                                            RelativeSizeAxes = Axes.X,
+                                            AutoSizeAxes = Axes.Y,
+                                            TooltipText = "BMS 曲库路径设置向导 - 用于配置 BMS 文件的扫描目录",
+                                        },
+                                        new TooltipTextFlowContainer
+                                        {
+                                            Text = "先添加任意数量的文件夹路径。应用会立即保存并重建扫描，确定只关闭当前向导。",
+                                            RelativeSizeAxes = Axes.X,
+                                            AutoSizeAxes = Axes.Y,
+                                            TooltipText = "在此处选择包含 BMS 文件的文件夹，然后点击'添加当前路径'按钮将其添加到曲库列表中。您可以添加多个文件夹，每个文件夹都会被扫描以查找 BMS 文件。",
+                                        }
+                                    }
+                                }
+                            },
+                            new Drawable[]
+                            {
+                                new GridContainer
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    RowDimensions = new[]
+                                    {
+                                        new Dimension(GridSizeMode.Absolute, 260),
+                                        new Dimension(),
+                                    },
+                                    Content = new[]
+                                    {
+                                        new Drawable[]
+                                        {
+                                            directorySelector = new OsuDirectorySelector(initialPath)
+                                            {
+                                                RelativeSizeAxes = Axes.Both,
+                                            }
+                                        },
+                                        new Drawable[]
+                                        {
+                                            new FillFlowContainer
+                                            {
+                                                RelativeSizeAxes = Axes.Both,
+                                                Direction = FillDirection.Vertical,
+                                                Spacing = new Vector2(0, 8),
+                                                Children = new Drawable[]
+                                                {
+                                                    new FillFlowContainer
+                                                    {
+                                                        RelativeSizeAxes = Axes.X,
+                                                        AutoSizeAxes = Axes.Y,
+                                                        Direction = FillDirection.Horizontal,
+                                                        Spacing = new Vector2(10, 0),
+                                                        Children = new Drawable[]
+                                                        {
+                                                            new RoundedButton
+                                                            {
+                                                                Width = 180,
+                                                                Text = "添加当前路径",
+                                                                Action = addSelectedPath,
+                                                            },
+                                                            new RoundedButton
+                                                            {
+                                                                Width = 140,
+                                                                Text = "清空列表",
+                                                                Action = () =>
+                                                                {
+                                                                    stagedPaths.Clear();
+                                                                    refreshPathList();
+                                                                },
+                                                            },
+                                                        },
+                                                    },
+                                                    new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: 16))
+                                                    {
+                                                        Text = "已添加的路径",
+                                                        RelativeSizeAxes = Axes.X,
+                                                        AutoSizeAxes = Axes.Y,
+                                                    },
+                                                    new OsuScrollContainer
+                                                    {
+                                                        RelativeSizeAxes = Axes.Both,
+                                                        Child = pathList = new FillFlowContainer
+                                                        {
+                                                            RelativeSizeAxes = Axes.X,
+                                                            AutoSizeAxes = Axes.Y,
+                                                            Direction = FillDirection.Vertical,
+                                                            Spacing = new Vector2(0, 2),
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            new Drawable[]
+                            {
+                                new FillFlowContainer
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    Direction = FillDirection.Horizontal,
+                                    Spacing = new Vector2(10),
+                                    Padding = new MarginPadding(10),
+                                    Children = new Drawable[]
+                                    {
+                                        new RoundedButton
+                                        {
+                                            Width = 200,
+                                            Text = "确定",
+                                            Action = this.Exit,
+                                        },
+                                        new RoundedButton
+                                        {
+                                            Width = 200,
+                                            Text = "应用",
+                                            Action = applyPaths,
+                                        },
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            refreshPathList();
+        }
+
+        private void addSelectedPath()
+        {
+            string? selectedPath = directorySelector.CurrentPath.Value?.FullName;
+
+            if (string.IsNullOrWhiteSpace(selectedPath) || !Directory.Exists(selectedPath))
+                return;
+
+            if (stagedPaths.Any(path => string.Equals(path, selectedPath, StringComparison.OrdinalIgnoreCase)))
+                return;
+
+            stagedPaths.Add(selectedPath);
+            refreshPathList();
+        }
+
+        private void applyPaths()
+        {
+            libraryPathsBindable.Value = BMSRulesetConfigManager.SerialiseLibraryPaths(stagedPaths);
+            legacyRootPathBindable.Value = stagedPaths.FirstOrDefault() ?? string.Empty;
+            applyAction?.Invoke(stagedPaths.ToArray());
+        }
+
+        private void refreshPathList()
+        {
+            pathList.Clear();
+
+            if (stagedPaths.Count == 0)
+            {
+                pathList.Add(new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: 14))
+                {
+                    Text = "暂未添加路径。",
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                });
+                return;
+            }
+
+            foreach (string path in stagedPaths)
+            {
+                pathList.Add(new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Height = 40,
+                    Masking = true,
+                    CornerRadius = 6,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = colourProvider.Background3,
+                        },
+                        new GridContainer
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Padding = new MarginPadding { Left = 10, Right = 6, Top = 6, Bottom = 6 },
+                            ColumnDimensions = new[]
+                            {
+                                new Dimension(),
+                                new Dimension(GridSizeMode.Absolute, 92),
+                            },
+                            Content = new[]
+                            {
+                                new Drawable[]
+                                {
+                                    new TruncatingSpriteText
+                                    {
+                                        RelativeSizeAxes = Axes.X,
+                                        Anchor = Anchor.CentreLeft,
+                                        Origin = Anchor.CentreLeft,
+                                        Text = path,
+                                        Font = OsuFont.Default.With(size: 16),
+                                    },
+                                    new RoundedButton
+                                    {
+                                        Width = 86,
+                                        Height = 24,
+                                        Anchor = Anchor.CentreRight,
+                                        Origin = Anchor.CentreRight,
+                                        Text = "移除",
+                                        Action = () => requestRemovePath(path),
+                                    },
+                                },
+                            },
+                        },
+                    },
+                });
+            }
+        }
+
+        private void requestRemovePath(string path)
+        {
+            dialogOverlay?.Push(new RemovePathDialog(path, () =>
+            {
+                stagedPaths.Remove(path);
+                refreshPathList();
+            }));
+        }
+
+        private partial class RemovePathDialog : DangerousActionDialog
+        {
+            public RemovePathDialog(string path, Action onConfirm)
+            {
+                HeaderText = "移除曲库路径";
+                BodyText = $"该操作将从列表移除以下路径：{Environment.NewLine}{path}";
+                DangerousAction = onConfirm;
+            }
+        }
+
+        public override void OnSuspending(ScreenTransitionEvent e)
+        {
+            base.OnSuspending(e);
+            this.FadeOut(250);
+        }
+
+        /// <summary>
+        /// A text flow container that shows a tooltip on hover.
+        /// </summary>
+        private partial class TooltipTextFlowContainer : OsuTextFlowContainer, IHasTooltip
+        {
+            public LocalisableString TooltipText { get; set; } = string.Empty;
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BMSOrderedHitPolicy.cs
+++ b/osu.Game.Rulesets.BMS/UI/BMSOrderedHitPolicy.cs
@@ -1,0 +1,68 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.Rulesets.BMS.Objects.Drawables;
+using osu.Game.Rulesets.Mania.EzMania.Helper;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.UI;
+
+namespace osu.Game.Rulesets.BMS.UI
+{
+    /// <summary>
+    /// BMS 内部使用的 note lock / 判定优先级策略。
+    /// 逻辑与 mania OrderedHitPolicy 一致，但不修改其他规则集代码。
+    /// </summary>
+    public class BMSOrderedHitPolicy
+    {
+        private readonly HitObjectContainer hitObjectContainer;
+        private readonly OrderedHitPolicyHelper helper;
+
+        public BMSOrderedHitPolicy(HitObjectContainer hitObjectContainer)
+        {
+            this.hitObjectContainer = hitObjectContainer;
+            helper = new OrderedHitPolicyHelper(hitObjectContainer);
+        }
+
+        public bool IsHittable(DrawableHitObject hitObject, double time)
+        {
+            if (GlobalConfigStore.EzConfig.Get<EzEnumJudgePrecedence>(Ez2Setting.JudgePrecedence) != EzEnumJudgePrecedence.Earliest)
+                return helper.IsHittableWithPrecedence(hitObject, time);
+
+            var nextObject = hitObjectContainer.AliveObjects.GetNext(hitObject);
+            return nextObject == null || time < nextObject.HitObject.StartTime;
+        }
+
+        public void HandleHit(DrawableHitObject hitObject)
+        {
+            foreach (var obj in enumerateHitObjectsUpTo(hitObject.HitObject.StartTime))
+            {
+                if (obj.Judged)
+                    continue;
+
+                (obj as DrawableBMSHitObject)?.MissForcefully();
+            }
+        }
+
+        private IEnumerable<DrawableHitObject> enumerateHitObjectsUpTo(double targetTime)
+        {
+            foreach (var obj in hitObjectContainer.AliveObjects)
+            {
+                if (obj.HitObject.GetEndTime() >= targetTime)
+                    yield break;
+
+                yield return obj;
+
+                foreach (var nestedObj in obj.NestedHitObjects)
+                {
+                    if (nestedObj.HitObject.GetEndTime() >= targetTime)
+                        break;
+
+                    yield return nestedObj;
+                }
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BMSPlayfield.cs
+++ b/osu.Game.Rulesets.BMS/UI/BMSPlayfield.cs
@@ -1,0 +1,128 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.BMS.Configuration;
+using osu.Game.Rulesets.BMS.Objects.Drawables;
+using osu.Game.Rulesets.Mania.Beatmaps;
+using osu.Game.Rulesets.Mania.UI;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.UI.Scrolling;
+
+namespace osu.Game.Rulesets.BMS.UI
+{
+    /// <summary>
+    /// BMS playfield layout. Double-play stage gap (<see cref="BMSRulesetSetting.DpStageSpacing"/>) is implemented here on the BMS side
+    /// (not mania <see cref="Mania.UI.Stage"/>) until/unless promoted upstream.
+    /// Scratch lane width uses <see cref="BMSStageLayout.ScratchColumnIndices"/> when present; otherwise a legacy heuristic by column count.
+    /// </summary>
+    [Cached]
+    public partial class BMSPlayfield : ScrollingPlayfield
+    {
+        public const float COLUMN_WIDTH = Column.COLUMN_WIDTH;
+        public const float SCRATCH_WIDTH = Column.SPECIAL_COLUMN_WIDTH;
+
+        /// <summary>
+        /// Required for <see cref="Mania.UI.Column"/> load (match key count for mania skin / config).
+        /// </summary>
+        [Cached]
+        public readonly StageDefinition StageDefinition;
+
+        private readonly int totalColumns;
+        private readonly Container<BMSColumn> columns;
+        private readonly BindableDouble dpStageSpacing = new BindableDouble();
+
+        public BMSPlayfield(BMSStageLayout layout)
+        {
+            var scratchSet = new HashSet<int>(layout.ScratchColumnIndices);
+            totalColumns = layout.TotalColumns;
+            StageDefinition = new StageDefinition(totalColumns);
+
+            RelativeSizeAxes = Axes.Y;
+            AutoSizeAxes = Axes.X;
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+
+            InternalChild = columns = new Container<BMSColumn>
+            {
+                RelativeSizeAxes = Axes.Y,
+                AutoSizeAxes = Axes.X,
+            };
+
+            for (int i = 0; i < totalColumns; i++)
+            {
+                bool isScratch = scratchSet.Count > 0
+                    ? scratchSet.Contains(i)
+                    : legacyScratchHeuristic(i, totalColumns);
+
+                float width = isScratch ? SCRATCH_WIDTH : COLUMN_WIDTH;
+
+                columns.Add(new BMSColumn(i, isScratch)
+                {
+                    Width = width,
+                    RelativeSizeAxes = Axes.Y,
+                });
+            }
+
+            updateColumnLayout();
+        }
+
+        /// <summary>
+        /// Fallback when beatmap does not mark scratch lanes (empty <see cref="BMSStageLayout.ScratchColumnIndices"/>).
+        /// </summary>
+        private static bool legacyScratchHeuristic(int columnIndex, int columnsTotal) => columnsTotal switch
+        {
+            6 or 8 => columnIndex == 0,
+            12 or 16 => columnIndex == 0 || columnIndex == columnsTotal / 2,
+            _ => false,
+        };
+
+        [BackgroundDependencyLoader]
+        private void load(BMSRulesetConfigManager config)
+        {
+            config.BindWith(BMSRulesetSetting.DpStageSpacing, dpStageSpacing);
+            dpStageSpacing.BindValueChanged(_ => updateColumnLayout(), true);
+        }
+
+        private void updateColumnLayout()
+        {
+            float x = 0;
+            int midpoint = totalColumns / 2;
+            bool isDpLayout = totalColumns is 10 or 14 or 16 or 18;
+
+            for (int i = 0; i < columns.Count; i++)
+            {
+                columns[i].X = x;
+                x += columns[i].Width;
+
+                if (isDpLayout && i == midpoint - 1)
+                    x += (float)dpStageSpacing.Value;
+            }
+        }
+
+        public override void Add(DrawableHitObject hitObject)
+        {
+            if (hitObject is DrawableBMSHitObject bmsHitObject)
+            {
+                columns[bmsHitObject.HitObject.Column].Add(hitObject);
+            }
+            else
+            {
+                base.Add(hitObject);
+            }
+        }
+
+        public override bool Remove(DrawableHitObject hitObject)
+        {
+            if (hitObject is DrawableBMSHitObject bmsHitObject)
+            {
+                return columns[bmsHitObject.HitObject.Column].Remove(hitObject);
+            }
+
+            return base.Remove(hitObject);
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BMSSettingsSubsection.cs
+++ b/osu.Game.Rulesets.BMS/UI/BMSSettingsSubsection.cs
@@ -1,0 +1,444 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Rendering;
+using osu.Framework.Localisation;
+using osu.Framework.Platform;
+using osu.Framework.Screens;
+using osu.Game.Collections;
+using osu.Game.Database;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Localisation;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Notifications;
+using osu.Game.Overlays.Settings;
+using osu.Game.Rulesets.BMS.Beatmaps;
+using osu.Game.Rulesets.BMS.Configuration;
+using osu.Game.Rulesets.BMS.UI.BmsSongSelect;
+using osu.Game.Rulesets.BMS.UI.BmsSongSelect.Analytics;
+using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Mania.Configuration;
+using osu.Game.Rulesets.Mania.UI;
+using osu.Game.Screens;
+using osu.Game.Screens.Menu;
+using BmsUiSongSelect = osu.Game.Rulesets.BMS.UI.SongSelect;
+using OsuSongSelect = osu.Game.Screens.Select.SongSelect;
+
+namespace osu.Game.Rulesets.BMS.UI
+{
+    public partial class BMSSettingsSubsection : RulesetSettingsSubsection
+    {
+        protected override LocalisableString Header => "BMS";
+
+        private BMSRulesetConfigManager bmsConfig = null!;
+        private Bindable<string> libraryPathsBindable = null!;
+        private Bindable<string> legacyRootPathBindable = null!;
+
+        // private OsuTextFlowContainer pathDisplay = null!;
+        private SettingsNote cacheStatusNote = null!;
+        private SettingsNote speedNote = null!;
+        private Bindable<double>? maniaScrollSpeed;
+        private Bindable<double>? maniaBaseSpeed;
+        private Bindable<double>? maniaTimePerSpeed;
+
+        [Resolved(canBeNull: true)]
+        private OsuGame? game { get; set; }
+
+        [Resolved(canBeNull: true)]
+        private IPerformFromScreenRunner? performFromScreen { get; set; }
+
+        [Resolved]
+        private INotificationOverlay? notificationOverlay { get; set; }
+
+        [Resolved]
+        private Storage storage { get; set; } = null!;
+
+        [Resolved]
+        private RealmAccess realm { get; set; } = null!;
+
+        [Resolved]
+        private AudioManager audioManager { get; set; } = null!;
+
+        [Resolved]
+        private IRenderer renderer { get; set; } = null!;
+
+        [Resolved]
+        private IRulesetConfigCache rulesetConfigCache { get; set; } = null!;
+
+        private BMSBeatmapManager? beatmapManager;
+
+        public BMSSettingsSubsection(Ruleset ruleset)
+            : base(ruleset)
+        {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            bmsConfig = (BMSRulesetConfigManager)Config;
+            libraryPathsBindable = bmsConfig.GetBindable<string>(BMSRulesetSetting.BmsLibraryPaths);
+            legacyRootPathBindable = bmsConfig.GetBindable<string>(BMSRulesetSetting.BmsRootPath);
+
+            beatmapManager = BMSBeatmapManager.GetShared(storage);
+            beatmapManager.SetRootPaths(getConfiguredPaths());
+            bindManiaScrollSettings();
+
+            Children = new Drawable[]
+            {
+                new SettingsButtonV2
+                {
+                    Text = "标准 BMS 选歌（Carousel）",
+                    Action = openStandardBmsSongSelect,
+                },
+                new SettingsButtonV2
+                {
+                    Text = "Raja 风格 BMS 选歌",
+                    Action = openRajaBmsSongSelect,
+                },
+                new SettingsButtonV2
+                {
+                    Text = "构建 BMS 分析库",
+                    Action = buildAnalyticsDatabase,
+                },
+                new SettingsButtonV2
+                {
+                    Text = "打开 BMS 曲库设置向导",
+                    Action = selectPath,
+                },
+                new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Padding = SettingsPanel.CONTENT_PADDING,
+                    Child = cacheStatusNote = new SettingsNote
+                    {
+                        RelativeSizeAxes = Axes.X,
+                    },
+                },
+                // new Container
+                // {
+                //     RelativeSizeAxes = Axes.X,
+                //     Height = 110,
+                //     Padding = new MarginPadding { Left = SettingsPanel.CONTENT_MARGINS, Right = SettingsPanel.CONTENT_MARGINS, Top = 6 },
+                //     Child = new OsuScrollContainer
+                //     {
+                //         RelativeSizeAxes = Axes.Both,
+                //         Child = pathDisplay = new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: 13))
+                //         {
+                //             RelativeSizeAxes = Axes.X,
+                //             AutoSizeAxes = Axes.Y,
+                //         }
+                //     }
+                // },
+                new SettingsItemV2(new FormSliderBar<double>
+                {
+                    Caption = RulesetSettingsStrings.ScrollSpeed,
+                    Current = maniaScrollSpeed ?? new BindableDouble(200),
+                    KeyboardStep = 1,
+                    LabelFormat = v =>
+                    {
+                        double baseSpeed = maniaBaseSpeed?.Value ?? 500;
+                        double timePerSpeed = maniaTimePerSpeed?.Value ?? 5;
+                        int computedTime = (int)DrawableManiaRuleset.ComputeScrollTime(v, baseSpeed, timePerSpeed);
+                        return RulesetSettingsStrings.ScrollSpeedTooltip(computedTime, v).ToString();
+                    }
+                }),
+                new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Padding = SettingsPanel.CONTENT_PADDING,
+                    Child = speedNote = new SettingsNote
+                    {
+                        RelativeSizeAxes = Axes.X,
+                    },
+                },
+                new SettingsItemV2(new FormCheckBox
+                {
+                    Caption = "自动预加载 Key-sound",
+                    Current = bmsConfig.GetBindable<bool>(BMSRulesetSetting.AutoPreloadKeysounds),
+                }),
+                new SettingsItemV2(new FormSliderBar<double>
+                {
+                    Caption = "Key-sound 音量",
+                    Current = bmsConfig.GetBindable<double>(BMSRulesetSetting.KeysoundVolume),
+                    KeyboardStep = 0.01f,
+                    LabelFormat = v => $"{v:P0}",
+                }),
+                new SettingsItemV2(new FormSliderBar<double>
+                {
+                    Caption = "DP-Stage 间距",
+                    HintText = "DP模式(10k+)，控制左右面板之间的间距。",
+                    Current = bmsConfig.GetBindable<double>(BMSRulesetSetting.DpStageSpacing),
+                    KeyboardStep = 1,
+                    LabelFormat = v => $"{v:0}",
+                }),
+                new SettingsItemV2(new FormEnumDropdown<BMSGameplayRoute>
+                {
+                    Caption = "Gameplay 路由",
+                    HintText = "ManiaCompatibility：复用 Mania 渲染与判定（推荐）。BmsNative：使用 BMS 原生流水线（实验性）。",
+                    Current = bmsConfig.GetBindable<BMSGameplayRoute>(BMSRulesetSetting.GameplayRoute),
+                }),
+            };
+        }
+
+        private void bindManiaScrollSettings()
+        {
+            var maniaConfig = rulesetConfigCache.GetConfigFor(new ManiaRuleset()) as ManiaRulesetConfigManager;
+
+            if (maniaConfig == null)
+                return;
+
+            maniaScrollSpeed = maniaConfig.GetBindable<double>(ManiaRulesetSetting.ScrollSpeed);
+            maniaBaseSpeed = maniaConfig.GetBindable<double>(ManiaRulesetSetting.ScrollBaseSpeed);
+            maniaTimePerSpeed = maniaConfig.GetBindable<double>(ManiaRulesetSetting.ScrollTimePerSpeed);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            libraryPathsBindable.BindValueChanged(_ => updatePathDisplay(), true);
+            legacyRootPathBindable.BindValueChanged(_ => updatePathDisplay());
+
+            speedNote.Current.Value = new SettingsNote.Data("BMS 复用 mania 设置及快捷键（含 LAlt 加速步进）。", SettingsNote.Type.Informational);
+
+            // Show initial cache status
+            if (beatmapManager?.LibraryCache != null)
+            {
+                cacheStatusNote.Current.Value = new SettingsNote.Data($"已缓存 {beatmapManager.LibraryCache.Songs.Count} 首歌曲, {beatmapManager.LibraryCache.TotalCharts} 张谱面",
+                    SettingsNote.Type.Informational);
+            }
+        }
+
+        private IReadOnlyList<string> getConfiguredPaths() => BMSRulesetConfigManager.ParseLibraryPaths(libraryPathsBindable.Value, legacyRootPathBindable.Value);
+
+        private void updatePathDisplay()
+        {
+            // IReadOnlyList<string> paths = getConfiguredPaths();
+            //
+            // if (paths.Count == 0)
+            //     pathDisplay.Text = "未设置路径";
+            // else
+            //     pathDisplay.Text = $"当前路径 ({paths.Count}):{Environment.NewLine}{string.Join(Environment.NewLine, paths.Select(path => $"- {path}"))}";
+        }
+
+        private void openStandardBmsSongSelect() => openSongSelectScreen(new BmsUiSongSelect.BmsSoloSongSelect());
+
+        private void openRajaBmsSongSelect() => openSongSelectScreen(new BmsBmsSongSelect());
+
+        private void openSongSelectScreen(IScreen screen)
+        {
+            var runner = performFromScreen ?? game;
+
+            if (runner == null)
+            {
+                notificationOverlay?.Post(new SimpleErrorNotification { Text = "无法打开 BMS 选歌界面（未找到屏幕导航器）。" });
+                return;
+            }
+
+            runner.PerformFromScreen(s => s.Push(screen), new[] { typeof(MainMenu), typeof(OsuSongSelect) });
+        }
+
+        private void buildAnalyticsDatabase()
+        {
+            if (beatmapManager == null)
+                return;
+
+            var analyticsRepository = new BmsAnalyticsSqliteRepository(BmsStoragePaths.GetAnalyticsDatabasePath(storage));
+
+            BmsUiSongSelect.BmsSongSelectAnalyticsOperations.RunAnalyticsBuild(
+                Scheduler,
+                beatmapManager,
+                analyticsRepository,
+                audioManager,
+                realm,
+                notificationOverlay);
+        }
+
+        private void selectPath()
+        {
+            var runner = performFromScreen ?? game;
+
+            if (runner == null)
+            {
+                notificationOverlay?.Post(new SimpleErrorNotification { Text = "无法打开向导（未找到屏幕导航器）。" });
+                return;
+            }
+
+            runner.PerformFromScreen(screen =>
+            {
+                screen.Push(new BMSDirectorySelectScreen(libraryPathsBindable, legacyRootPathBindable, applyPathsAndScan));
+            }, new[] { typeof(MainMenu), typeof(OsuSongSelect) });
+        }
+
+        private void applyPathsAndScan(IReadOnlyList<string> paths)
+        {
+            libraryPathsBindable.Value = BMSRulesetConfigManager.SerialiseLibraryPaths(paths);
+            legacyRootPathBindable.Value = paths.FirstOrDefault() ?? string.Empty;
+            startScan(paths);
+        }
+
+        private void startScan(IReadOnlyList<string>? configuredPaths = null)
+        {
+            if (beatmapManager == null) return;
+
+            IReadOnlyList<string> paths = configuredPaths ?? getConfiguredPaths();
+            beatmapManager.SetRootPaths(paths);
+
+            if (paths.Count == 0 || !paths.Any(Directory.Exists))
+            {
+                notificationOverlay?.Post(new SimpleErrorNotification
+                {
+                    Text = "请先在向导中添加至少一个有效的 BMS 文件夹路径"
+                });
+                return;
+            }
+
+            cacheStatusNote.Current.Value = new SettingsNote.Data("正在扫描...", SettingsNote.Type.Informational);
+
+            var notification = new ProgressNotification
+            {
+                Text = "正在扫描 BMS 歌曲库...",
+                CompletionText = "BMS 歌曲库扫描完成!",
+                State = ProgressNotificationState.Active,
+                Progress = 0 // 初始化进度为 0,显示进度条而不是转圈
+            };
+
+            notificationOverlay?.Post(notification);
+
+            void onScanProgress(ValueChangedEvent<double> e) => Schedule(() => notification.Progress = (float)BmsLibraryImportPipeline.MapScanProgress(e.NewValue));
+
+            void onScanStatus(ValueChangedEvent<string> e) => Schedule(() => notification.Text = e.NewValue);
+
+            beatmapManager.ScanProgress.BindValueChanged(onScanProgress, true);
+            beatmapManager.StatusMessage.BindValueChanged(onScanStatus, true);
+
+            Task.Run(async () =>
+            {
+                try
+                {
+                    var result = await BmsLibraryImportPipeline.RunAsync(
+                        beatmapManager,
+                        storage,
+                        realm,
+                        new BMSRuleset().RulesetInfo,
+                        paths,
+                        p => Schedule(() =>
+                        {
+                            notification.Progress = (float)p.Progress;
+                            notification.Text = p.StatusMessage;
+                        })).ConfigureAwait(false);
+
+                    Schedule(() =>
+                    {
+                        notification.Progress = 1f;
+                        notification.State = ProgressNotificationState.Completed;
+                        cacheStatusNote.Current.Value = new SettingsNote.Data(
+                            $"扫描完成! {result.SongCount} 首歌曲, {result.ChartCount} 张谱面",
+                            SettingsNote.Type.Informational);
+
+                        // 扫描完成后，为每个路径创建独立的收藏夹
+                        createCollectionsFromPaths(paths);
+                    });
+                }
+                catch (Exception ex)
+                {
+                    Schedule(() =>
+                    {
+                        notification.State = ProgressNotificationState.Cancelled;
+                        cacheStatusNote.Current.Value = new SettingsNote.Data($"扫描失败: {ex.Message}", SettingsNote.Type.Critical);
+                    });
+                }
+                finally
+                {
+                    Schedule(() =>
+                    {
+                        beatmapManager.ScanProgress.ValueChanged -= onScanProgress;
+                        beatmapManager.StatusMessage.ValueChanged -= onScanStatus;
+                    });
+                }
+            });
+        }
+
+        private void createCollectionsFromPaths(IReadOnlyList<string> paths)
+        {
+            if (paths.Count == 0 || beatmapManager?.LibraryCache == null)
+                return;
+
+            int createdCount = 0;
+            int totalCharts = 0;
+            // 用于跟踪已使用的收藏夹名称，避免重复
+            var usedCollectionNames = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (string path in paths)
+            {
+                if (!Directory.Exists(path))
+                    continue;
+
+                // 获取该路径下的所有谱面哈希值
+                var beatmapHashes = new List<string>();
+
+                // 从 LibraryCache 中查找属于该路径的谱面
+                foreach (var song in beatmapManager.LibraryCache.Songs)
+                {
+                    // 检查歌曲是否在该路径下
+                    if (song.FolderPath.StartsWith(path, StringComparison.OrdinalIgnoreCase))
+                    {
+                        foreach (var chart in song.Charts)
+                        {
+                            string md5Hash = BmsPathKeys.ComputeChartPathKey(chart.FullPath);
+                            beatmapHashes.Add(md5Hash);
+                        }
+                    }
+                }
+
+                if (beatmapHashes.Count == 0)
+                    continue;
+
+                // 使用路径的文件夹名称作为收藏夹名称
+                string collectionName = Path.GetFileName(path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+                if (string.IsNullOrEmpty(collectionName))
+                    collectionName = Path.GetFileName(path); // 尝试再次获取
+                if (string.IsNullOrEmpty(collectionName))
+                    collectionName = "BMS Collection"; // 最后的默认值
+
+                // 检查名称是否已使用，如果已使用则追加序号
+                if (usedCollectionNames.TryGetValue(collectionName, out int value))
+                {
+                    // 增加该名称的计数器
+                    usedCollectionNames[collectionName] = ++value;
+                    collectionName = $"{collectionName} ({value})";
+                }
+                else
+                {
+                    // 首次使用该名称，计数器设为0
+                    usedCollectionNames[collectionName] = 0;
+                }
+
+                // 创建收藏夹
+                realm.Write(r =>
+                {
+                    var collection = new BeatmapCollection(collectionName, beatmapHashes);
+                    r.Add(collection);
+                });
+
+                createdCount++;
+                totalCharts += beatmapHashes.Count;
+            }
+
+            if (createdCount > 0)
+            {
+                notificationOverlay?.Post(new SimpleNotification
+                {
+                    Text = $"已为 {createdCount} 个路径创建收藏夹，共收藏 {totalCharts} 张谱面"
+                });
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BmsBackgroundSoundDriver.cs
+++ b/osu.Game.Rulesets.BMS/UI/BmsBackgroundSoundDriver.cs
@@ -1,0 +1,78 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Graphics;
+using osu.Framework.Logging;
+using osu.Game.Rulesets.BMS.Audio;
+using osu.Game.Rulesets.BMS.Beatmaps;
+using osu.Game.Screens.Play;
+
+namespace osu.Game.Rulesets.BMS.UI
+{
+    /// <summary>
+    /// Drives <see cref="BmsKeysoundManager"/> background sound events from the gameplay clock.
+    ///
+    /// Used by the BMS DrawableRuleset on the standard play path, where <see cref="BmsPlayer"/>
+    /// itself isn't necessarily instantiated and therefore wouldn't otherwise dispatch BMS BGM
+    /// events. Hit object keysounds remain handled via the regular skin/sample pipeline (through
+    /// <see cref="BMSExternalSampleSkin"/>), this driver only covers the non-note BGM stream.
+    /// </summary>
+    internal partial class BmsBackgroundSoundDriver : Drawable
+    {
+        private readonly string bmsFolder;
+        private readonly IReadOnlyList<BmsBackgroundSoundEvent> events;
+
+        private BmsKeysoundManager? keysoundManager;
+        private IGameplayClock? gameplayClock;
+
+        public BmsBackgroundSoundDriver(string bmsFolder, IReadOnlyList<BmsBackgroundSoundEvent> events)
+        {
+            this.bmsFolder = bmsFolder;
+            this.events = events;
+            AlwaysPresent = true;
+        }
+
+        [BackgroundDependencyLoader(true)]
+        private void load(AudioManager audioManager, IGameplayClock? clock)
+        {
+            // Make audio available to other non-Drawable BMS helpers (e.g. external sample skin).
+            BmsRuntimeAudioContext.Register(audioManager);
+
+            gameplayClock = clock;
+
+            try
+            {
+                keysoundManager = new BmsKeysoundManager(audioManager, bmsFolder);
+                keysoundManager.SetBackgroundSoundEvents(events);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"[BMS] BGM driver failed to initialise: {ex.Message}", LoggingTarget.Runtime, LogLevel.Error);
+                keysoundManager = null;
+            }
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (keysoundManager == null || gameplayClock == null)
+                return;
+
+            if (keysoundManager.IsDisposed)
+                return;
+
+            keysoundManager.Update(gameplayClock.CurrentTime);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            keysoundManager?.Dispose();
+            keysoundManager = null;
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BmsPlayer.cs
+++ b/osu.Game.Rulesets.BMS/UI/BmsPlayer.cs
@@ -1,0 +1,318 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Bindables;
+using osu.Framework.Logging;
+using osu.Game.Audio;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.BMS.Audio;
+using osu.Game.Rulesets.BMS.Beatmaps;
+using osu.Game.Rulesets.BMS.Configuration;
+using osu.Game.Rulesets.BMS.Objects;
+using osu.Game.Rulesets.BMS.Scoring.Lamp;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects.Legacy;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
+using osu.Game.Screens.Play;
+
+namespace osu.Game.Rulesets.BMS.UI
+{
+    /// <summary>
+    /// Custom player for BMS beatmaps that handles keysound triggering.
+    /// Extends the standard Player to integrate BMS audio driving.
+    /// </summary>
+    public partial class BmsPlayer : SoloPlayer
+    {
+        private const string bms_log_prefix = "[BMS]";
+        private BmsKeysoundManager? keysoundManager;
+        private int updateCount;
+        private int triggerCount;
+        private Bindable<double>? bmsKeysoundVolume;
+        private bool isDisposed;
+
+        [Resolved]
+        private IRulesetConfigCache rulesetConfigCache { get; set; } = null!;
+
+        [Resolved]
+        private AudioManager audioManager { get; set; } = null!;
+
+        /// <summary>
+        /// Optional lamp store cached by <c>BmsSoloSongSelect</c>. When BMS gameplay is reached
+        /// through a different host (tests, replay viewer, etc.) no provider is registered and
+        /// the score is simply not surfaced to the carousel; gameplay itself is unaffected.
+        /// </summary>
+        [Resolved(canBeNull: true)]
+        private BmsLampStore? lampStore { get; set; }
+
+        public BmsPlayer()
+            : base(new PlayerConfiguration
+            {
+                AllowPause = false,
+            })
+        {
+        }
+
+        protected override bool PauseOnFocusLost => false;
+
+        /// <summary>
+        /// Same failure policy as always having <see cref="osu.Game.Rulesets.Mods.ModNoFail"/> active:
+        /// health may reach 0, but the session does not end in a fail state; the chart runs to completion
+        /// and the score is settled normally (equivalent to <c>ModNoFail.PerformFail()</c> returning
+        /// <c>false</c> from <c>Player</c>'s fail gate).
+        /// </summary>
+        /// <remarks>
+        /// Always returning <c>false</c> makes <c>Player.onFail()</c> reject failure so
+        /// <see cref="osu.Game.Rulesets.Scoring.HealthProcessor.TriggerFailure"/> cannot set
+        /// <c>HasFailed = true</c>. Mods that implement <see cref="osu.Game.Rulesets.Mods.IApplicableFailOverride"/>
+        /// (SuddenDeath, Perfect, …) therefore cannot terminate the run for BMS.
+        /// </remarks>
+        protected override bool CheckModsAllowFailure() => false;
+
+        /// <summary>
+        /// BMS gameplay runs through mania's DrawableRuleset under <see cref="BMSGameplayRoute.ManiaCompatibility"/>,
+        /// so <c>BMSPlayerLoader</c> switches <c>Ruleset.Value</c> to mania at gameplay start. <see cref="Player"/>
+        /// then propagates that into <c>Score.ScoreInfo.Ruleset</c>, which leaves the post-gameplay score attributed
+        /// to mania even though the underlying <see cref="osu.Game.Beatmaps.BeatmapInfo"/> belongs to BMS.
+        /// <para>
+        /// That mismatch breaks <c>ResultsScreen</c> + <c>StatisticsPanel</c>: they re-resolve a fresh
+        /// <c>BeatmapManagerWorkingBeatmap</c> from <c>BeatmapInfo</c> (which decodes the .bms file into a
+        /// <see cref="BMSBeatmap"/> with <see cref="BMSHitObject"/>s) and call
+        /// <c>GetPlayableBeatmap(score.Ruleset)</c>. With <c>score.Ruleset = mania</c> that resolves to
+        /// <see cref="osu.Game.Rulesets.Mania.Beatmaps.ManiaBeatmapConverter"/> whose <c>CanConvert()</c>
+        /// returns false for <see cref="BMSHitObject"/>, throwing <c>BeatmapInvalidForRulesetException</c>.
+        /// </para>
+        /// <para>
+        /// Re-attributing the score to BMS here keeps in-game HUD/skin/judgement under mania (gameplay path is
+        /// untouched), while results / statistics route through <see cref="BMSBeatmapConverter"/>
+        /// (<c>CanConvert() == true</c> for BMS hit objects). The argument is the cloned <c>scoreCopy</c> that
+        /// <c>Player.prepareAndImportScoreAsync</c> hands off to <c>ImportScore</c> and the results screen, so
+        /// gameplay's live <c>Score</c> is unaffected.
+        /// </para>
+        /// </summary>
+        protected override Task PrepareScoreForResultsAsync(Score score)
+        {
+            score.ScoreInfo.Ruleset = new BMSRuleset().RulesetInfo;
+
+            // Surface the play to the lamp store *before* the base implementation suspends on its async
+            // import work — this guarantees the carousel/song-select sees the new lamp by the time the
+            // player returns to it. Exceptions are caught so a broken lamp pipeline never blocks the
+            // results screen.
+            try
+            {
+                reportLampForScore(score);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"{bms_log_prefix} Lamp report failed: {ex.Message}", LoggingTarget.Runtime, LogLevel.Important);
+            }
+
+            return base.PrepareScoreForResultsAsync(score);
+        }
+
+        /// <summary>
+        /// Build a <see cref="BmsLampContext"/> from the finalized score + live <see cref="HealthProcessor"/>
+        /// and hand it to the cached <see cref="BmsLampStore"/>, which folds it into the per-beatmap
+        /// best-lamp record consumed by <c>BmsLampAccentColourProvider</c> in song-select.
+        /// </summary>
+        /// <remarks>
+        /// Cleared judgement: since BMS gameplay is force-NoFail (<see cref="CheckModsAllowFailure"/>),
+        /// the canonical osu <c>HasFailed</c> path never fires. We instead approximate beatoraja NORMAL-gauge
+        /// rule (game must end with the gauge above the empty mark) by checking
+        /// <see cref="HealthProcessor"/>.<c>Health</c> &gt; 0 at score-prep time.
+        /// </remarks>
+        private void reportLampForScore(Score score)
+        {
+            if (lampStore == null)
+                return;
+
+            BeatmapInfo? beatmapInfo = score.ScoreInfo.BeatmapInfo;
+            if (beatmapInfo == null)
+                return;
+
+            var stats = score.ScoreInfo.Statistics;
+            int get(HitResult r) => stats.GetValueOrDefault(r, 0);
+
+            int perfect = get(HitResult.Perfect);
+            int great = get(HitResult.Great);
+            int good = get(HitResult.Good) + get(HitResult.Ok);
+            int bad = get(HitResult.Meh) + get(HitResult.Poor);
+            int miss = get(HitResult.Miss);
+            int total = perfect + great + good + bad + miss;
+
+            // Beatoraja "cleared" check is gauge-end >= empty threshold. We approximate that with
+            // the live HealthProcessor's final value because BMS gauge accounting isn't wired through
+            // osu's HealthProcessor in detail yet — this still correctly distinguishes "kept the gauge
+            // alive" from "drained to zero", which is what controls Easy/Normal/Hard/FullCombo branching
+            // inside BeatorajaLampScheme.ResolveLamp.
+            bool cleared = HealthProcessor != null && HealthProcessor.Health.Value > 0;
+
+            var context = new BmsLampContext(
+                HasPlayed: true,
+                Cleared: cleared,
+                Gauge: BmsGaugeType.Normal,
+                MissCount: miss,
+                GreatCount: great,
+                GoodCount: good,
+                BadCount: bad,
+                PerfectGreatCount: perfect,
+                TotalNotes: total,
+                UsedHighestJudgementWindow: false);
+
+            var lamp = lampStore.ReportPlay(beatmapInfo, context);
+
+            Logger.Log(
+                $"{bms_log_prefix} Lamp reported for beatmap {beatmapInfo.ID}: {lamp} " +
+                $"(cleared={cleared}, pg={perfect}, gr={great}, gd={good}, bd={bad}, miss={miss}, total={total})",
+                LoggingTarget.Runtime, LogLevel.Debug);
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            if (Beatmap.Value is BMSWorkingBeatmap bmsWorkingBeatmap)
+            {
+                keysoundManager = new BmsKeysoundManager(audioManager, bmsWorkingBeatmap.FolderPath);
+
+                if (bmsWorkingBeatmap.Beatmap is BMSBeatmap bmsBeatmap)
+                {
+                    keysoundManager.PreloadKeysounds(bmsBeatmap.HitObjects);
+                    keysoundManager.SetBackgroundSoundEvents(bmsBeatmap.BackgroundSoundEvents);
+                }
+            }
+            else if (Beatmap.Value is ManiaConvertedWorkingBeatmap maniaConverted)
+            {
+                keysoundManager = maniaConverted.KeysoundManager;
+
+                // Analytics-only wrappers pass preloadKeysounds: false; fall back to runtime preload.
+                if (keysoundManager == null && maniaConverted.SourceBeatmap is BMSWorkingBeatmap bmsSource)
+                {
+                    keysoundManager = new BmsKeysoundManager(audioManager, bmsSource.FolderPath);
+
+                    if (bmsSource.Beatmap is BMSBeatmap bmsBeatmap)
+                    {
+                        keysoundManager.PreloadKeysounds(bmsBeatmap.HitObjects);
+                        keysoundManager.SetBackgroundSoundEvents(bmsBeatmap.BackgroundSoundEvents);
+                    }
+                }
+            }
+            else
+            {
+                Logger.Log($"{bms_log_prefix} Unexpected working beatmap type: {Beatmap.Value?.GetType().Name}", LoggingTarget.Runtime, LogLevel.Error);
+            }
+
+            if (rulesetConfigCache.GetConfigFor(new BMSRuleset()) is BMSRulesetConfigManager bmsConfig)
+            {
+                bmsKeysoundVolume = bmsConfig.GetBindable<double>(BMSRulesetSetting.KeysoundVolume);
+                bmsKeysoundVolume.BindValueChanged(onKeysoundVolumeChanged, true);
+            }
+        }
+
+        private void onKeysoundVolumeChanged(ValueChangedEvent<double> volume)
+        {
+            var manager = keysoundManager;
+            if (isDisposed || manager == null || manager.IsDisposed)
+                return;
+
+            manager.SetVolume(volume.NewValue);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            // Subscribe to hit events to trigger keysounds on player input
+            if (DrawableRuleset != null)
+            {
+                DrawableRuleset.NewResult += onNewResult;
+                Logger.Log($"{bms_log_prefix} Subscribed to hit events", LoggingTarget.Runtime, LogLevel.Debug);
+            }
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            var manager = keysoundManager;
+
+            if (isDisposed || manager == null || manager.IsDisposed)
+            {
+                if (++updateCount == 1)
+                    Logger.Log($"{bms_log_prefix} Update: keysoundManager is null", LoggingTarget.Runtime, LogLevel.Error);
+                return;
+            }
+
+            if (!IsLoaded)
+                return;
+
+            if (GameplayClockContainer == null)
+            {
+                if (updateCount++ < 3)
+                    Logger.Log($"{bms_log_prefix} GameplayClockContainer is null, skip keysound update.", LoggingTarget.Runtime, LogLevel.Debug);
+                return;
+            }
+
+            double currentTime = GameplayClockContainer.CurrentTime;
+
+            // Log first few updates
+            if (updateCount++ < 5)
+                Logger.Log($"{bms_log_prefix} Update #{updateCount}: chartClock={currentTime:F1}ms", LoggingTarget.Runtime, LogLevel.Debug);
+
+            // Only update after the game has started (after intro)
+            if (currentTime < 0)
+                return;
+
+            // Update keysound manager with current time - THIS PLAYS BACKGROUND SOUNDS
+            manager.Update(currentTime);
+        }
+
+        private void onNewResult(JudgementResult result)
+        {
+            var manager = keysoundManager;
+            if (isDisposed || manager == null || manager.IsDisposed)
+                return;
+
+            // Only trigger keysounds on successful hits (not miss)
+            if (!result.IsHit)
+                return;
+
+            // Get keysound samples
+            IEnumerable<HitSampleInfo> samples = result.HitObject.Samples;
+
+            if (result.HitObject is IBmsKeysoundProvider provider && provider.KeysoundSamples.Count > 0)
+                samples = provider.KeysoundSamples;
+            else if (result.HitObject.AuxiliarySamples.Count > 0)
+                samples = result.HitObject.AuxiliarySamples;
+
+            // Trigger the keysound
+            foreach (var sample in samples)
+            {
+                if (sample is ConvertHitObjectParser.FileHitSampleInfo fileSample)
+                {
+                    triggerCount++;
+                    if (triggerCount <= 10)
+                        Logger.Log($"{bms_log_prefix} Hit trigger #{triggerCount}: {fileSample.Filename} - {result.Type}", LoggingTarget.Runtime, LogLevel.Debug);
+                    manager.TriggerKeysound(fileSample.Filename);
+                    break;
+                }
+            }
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            isDisposed = true;
+
+            if (DrawableRuleset != null)
+                DrawableRuleset.NewResult -= onNewResult;
+
+            if (bmsKeysoundVolume != null)
+                bmsKeysoundVolume.ValueChanged -= onKeysoundVolumeChanged;
+
+            keysoundManager?.Dispose();
+            keysoundManager = null;
+            base.Dispose(isDisposing);
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BmsRuntimeAudioRegistrar.cs
+++ b/osu.Game.Rulesets.BMS/UI/BmsRuntimeAudioRegistrar.cs
@@ -1,0 +1,25 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.BMS.Beatmaps;
+
+namespace osu.Game.Rulesets.BMS.UI
+{
+    /// <summary>
+    /// Tiny invisible component whose only job is to grab the live <see cref="AudioManager"/> from
+    /// gameplay-side DI and stash it in <see cref="BmsRuntimeAudioContext"/> so that non-Drawable BMS
+    /// helpers (skin transformer, sample skin, ...) can resolve external keysound files without
+    /// needing osu.Game-side hooks.
+    /// </summary>
+    internal partial class BmsRuntimeAudioRegistrar : Drawable
+    {
+        [BackgroundDependencyLoader]
+        private void load(AudioManager audioManager)
+        {
+            BmsRuntimeAudioContext.Register(audioManager);
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Analytics/BmsAnalyticsManiaWorkingBeatmap.cs
+++ b/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Analytics/BmsAnalyticsManiaWorkingBeatmap.cs
@@ -1,0 +1,48 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Audio;
+using osu.Framework.Audio.Track;
+using osu.Framework.Graphics.Textures;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Mania.Beatmaps;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Skinning;
+using osu.Game.Storyboards;
+
+namespace osu.Game.Rulesets.BMS.UI.BmsSongSelect.Analytics
+{
+    /// <summary>
+    /// Minimal <see cref="WorkingBeatmap"/> for offline analytics: pre-built mania beatmap, no keysounds, no background IO.
+    /// </summary>
+    internal sealed class BmsAnalyticsManiaWorkingBeatmap : WorkingBeatmap
+    {
+        private readonly AudioManager audio;
+        private readonly ManiaBeatmap maniaBeatmap;
+        private readonly double length;
+
+        public BmsAnalyticsManiaWorkingBeatmap(BeatmapInfo beatmapInfo, ManiaBeatmap maniaBeatmap, AudioManager audioManager)
+            : base(beatmapInfo, audioManager)
+        {
+            audio = audioManager;
+            this.maniaBeatmap = maniaBeatmap;
+
+            if (maniaBeatmap.HitObjects.Count > 0)
+                length = maniaBeatmap.HitObjects[^1].StartTime + 2000;
+        }
+
+        protected override IBeatmap GetBeatmap() => maniaBeatmap;
+
+        public override IBeatmap GetPlayableBeatmap(IRulesetInfo ruleset, IReadOnlyList<Mod> mods, CancellationToken token) => maniaBeatmap;
+
+        public override Texture? GetBackground() => null;
+
+        protected override Track GetBeatmapTrack() => audio.Tracks.GetVirtual(Math.Max(length, 1000));
+
+        protected override ISkin GetSkin() => null!;
+
+        public override Stream? GetStream(string storagePath) => null;
+
+        protected override Storyboard GetStoryboard() => new Storyboard { BeatmapInfo = BeatmapInfo, Beatmap = maniaBeatmap };
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Analytics/BmsAnalyticsRealmWriteback.cs
+++ b/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Analytics/BmsAnalyticsRealmWriteback.cs
@@ -1,0 +1,53 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Security.Cryptography;
+using System.Text;
+using osu.Framework.Logging;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+using osu.Game.Rulesets.BMS.Beatmaps;
+
+namespace osu.Game.Rulesets.BMS.UI.BmsSongSelect.Analytics
+{
+    /// <summary>
+    /// Persists offline BMS analytics onto <see cref="BeatmapInfo"/> in Realm for standard song-select panels.
+    /// </summary>
+    public static class BmsAnalyticsRealmWriteback
+    {
+        public static void TryApply(RealmAccess realm, BMSChartCache chart, BmsChartAnalyticsResult result)
+        {
+            Guid beatmapId = GetDeterministicBeatmapId(chart.FullPath);
+
+            try
+            {
+                realm.Write(r =>
+                {
+                    var beatmap = r.Find<BeatmapInfo>(beatmapId);
+
+                    if (beatmap == null)
+                        return;
+
+                    if (result.StarRating is double star && star >= 0)
+                        beatmap.StarRating = star;
+
+                    if (result.XxySr is double xxy && xxy >= 0)
+                        beatmap.XxyStarRating = xxy;
+
+                    if (result.Pp is double pp && pp >= 0)
+                        beatmap.PerformancePoints = pp;
+                });
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"[BMS] Realm analytics writeback failed for {chart.FullPath}: {ex.Message}", LoggingTarget.Database, LogLevel.Debug);
+            }
+        }
+
+        internal static Guid GetDeterministicBeatmapId(string chartPath)
+        {
+            byte[] hash = MD5.HashData(Encoding.UTF8.GetBytes($"bms:chart:{chartPath}"));
+            return new Guid(hash);
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Analytics/BmsAnalyticsScanContext.cs
+++ b/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Analytics/BmsAnalyticsScanContext.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.BMS.UI.BmsSongSelect.Analytics
+{
+    /// <summary>
+    /// Process-wide gate for offline analytics: suppresses preview/decoding noise and forwards cancellation into the BMS decoder.
+    /// </summary>
+    internal static class BmsAnalyticsScanContext
+    {
+        public static bool IsRunning { get; private set; }
+
+        public static bool SuppressDecoderVerboseLogging { get; private set; }
+
+        public static CancellationToken ActiveCancellation { get; private set; }
+
+        public static IDisposable Enter(CancellationToken cancellationToken)
+        {
+            IsRunning = true;
+            SuppressDecoderVerboseLogging = true;
+            ActiveCancellation = cancellationToken;
+            return new Scope();
+        }
+
+        private sealed class Scope : IDisposable
+        {
+            public void Dispose()
+            {
+                IsRunning = false;
+                SuppressDecoderVerboseLogging = false;
+                ActiveCancellation = CancellationToken.None;
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Analytics/BmsAnalyticsScanService.cs
+++ b/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Analytics/BmsAnalyticsScanService.cs
@@ -1,0 +1,134 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Audio;
+using osu.Framework.Logging;
+using osu.Game.Database;
+using osu.Game.Rulesets.BMS.Beatmaps;
+
+namespace osu.Game.Rulesets.BMS.UI.BmsSongSelect.Analytics
+{
+    public sealed class BmsAnalyticsScanProgress
+    {
+        public double Progress { get; init; }
+        public string Status { get; init; } = string.Empty;
+    }
+
+    public static class BmsAnalyticsScanService
+    {
+        public static bool IsRunning => BmsAnalyticsScanContext.IsRunning;
+
+        public static Task RunAsync(
+            BMSBeatmapManager beatmapManager,
+            BmsAnalyticsSqliteRepository repository,
+            AudioManager audioManager,
+            IProgress<BmsAnalyticsScanProgress>? progress = null,
+            CancellationToken cancellationToken = default,
+            RealmAccess? realm = null)
+        {
+            var charts = beatmapManager.GetAllCharts().ToList();
+            if (charts.Count == 0)
+                return Task.CompletedTask;
+
+            return Task.Run(() => runOnBackgroundThread(charts, repository, audioManager, realm, progress, cancellationToken), cancellationToken);
+        }
+
+        private static void runOnBackgroundThread(
+            IReadOnlyList<BMSChartCache> charts,
+            BmsAnalyticsSqliteRepository repository,
+            AudioManager audioManager,
+            RealmAccess? realm,
+            IProgress<BmsAnalyticsScanProgress>? progress,
+            CancellationToken cancellationToken)
+        {
+            using var scope = BmsAnalyticsScanContext.Enter(cancellationToken);
+
+            int total = charts.Count;
+
+            report(progress, 0, total, "准备分析…");
+
+            try
+            {
+                for (int index = 0; index < total; index++)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    var chart = charts[index];
+                    int displayIndex = index + 1;
+
+                    report(progress, index, total, $"[{displayIndex}/{total}] 开始: {chart.Title}");
+
+                    string pathKey = string.IsNullOrEmpty(chart.Md5Hash)
+                        ? BmsPathKeys.ComputeChartPathKey(chart.FullPath)
+                        : chart.Md5Hash;
+
+                    try
+                    {
+                        using var heartbeat = startHeartbeat(progress, index, total, chart.Title, cancellationToken);
+                        var result = BmsChartAnalyticsProcessor.TryAnalyze(chart, audioManager, cancellationToken);
+
+                        if (result != null)
+                        {
+                            var analyticsResult = result.Value;
+
+                            repository.Upsert(new BmsAnalyticsRecord
+                            {
+                                PathKey = pathKey,
+                                Pp = analyticsResult.Pp,
+                                XxySr = analyticsResult.XxySr,
+                                AvgKps = analyticsResult.AvgKps,
+                                MaxKps = analyticsResult.MaxKps,
+                                StarRating = analyticsResult.StarRating,
+                                ColumnCountsJson = analyticsResult.ColumnCountsJson,
+                                KpsListJson = analyticsResult.KpsListJson,
+                            });
+
+                            if (realm != null)
+                                BmsAnalyticsRealmWriteback.TryApply(realm, chart, analyticsResult);
+                        }
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Log($"[BMS] Analytics scan failed for {chart.FullPath}: {ex.Message}", LoggingTarget.Runtime, LogLevel.Debug);
+                    }
+
+                    report(progress, displayIndex, total, $"[{displayIndex}/{total}] 完成: {chart.Title}");
+                }
+
+                report(progress, total, total, "分析完成");
+            }
+            catch (OperationCanceledException)
+            {
+                report(progress, 0, total, "分析已取消");
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// While a single chart is parsing (can take minutes), keep nudging the UI so the notification does not look frozen.
+        /// </summary>
+        private static IDisposable startHeartbeat(IProgress<BmsAnalyticsScanProgress>? progress, int completed, int total, string title, CancellationToken cancellationToken)
+        {
+            return new Timer(_ =>
+            {
+                if (cancellationToken.IsCancellationRequested)
+                    return;
+
+                report(progress, completed, total, $"[{completed + 1}/{total}] 解析中: {title}");
+            }, null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
+        }
+
+        private static void report(IProgress<BmsAnalyticsScanProgress>? progress, int completed, int total, string status)
+        {
+            progress?.Report(new BmsAnalyticsScanProgress
+            {
+                Progress = total > 0 ? (double)completed / total : 0,
+                Status = status,
+            });
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Analytics/BmsAnalyticsSqliteRepository.cs
+++ b/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Analytics/BmsAnalyticsSqliteRepository.cs
@@ -1,0 +1,187 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Microsoft.Data.Sqlite;
+
+namespace osu.Game.Rulesets.BMS.UI.BmsSongSelect.Analytics
+{
+    public sealed class BmsAnalyticsRecord
+    {
+        public string PathKey { get; init; } = string.Empty;
+        public double? Pp { get; init; }
+        public double? XxySr { get; init; }
+        public double? AvgKps { get; init; }
+        public double? MaxKps { get; init; }
+        public double? StarRating { get; init; }
+        public string? ColumnCountsJson { get; init; }
+        public string? KpsListJson { get; init; }
+    }
+
+    public sealed class BmsAnalyticsSqliteRepository
+    {
+        private const int schema_version = 2;
+        private readonly string databasePath;
+        private readonly object writeLock = new object();
+
+        public BmsAnalyticsSqliteRepository(string databasePath)
+        {
+            this.databasePath = databasePath;
+            ensureInitialized();
+        }
+
+        public void Upsert(BmsAnalyticsRecord record)
+        {
+            ensureInitialized();
+
+            lock (writeLock)
+            {
+                using var connection = openConnection();
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = @"
+INSERT INTO chart_analytics (
+    path_key, pp, xxy_sr, avg_kps, max_kps, star_rating, column_counts_json, kps_list_json, file_size, last_modified_ticks, scanned_at
+) VALUES (
+    $path_key, $pp, $xxy_sr, $avg_kps, $max_kps, $star_rating, $column_counts_json, $kps_list_json, $file_size, $last_modified_ticks, $scanned_at
+)
+ON CONFLICT(path_key) DO UPDATE SET
+    pp = excluded.pp,
+    xxy_sr = excluded.xxy_sr,
+    avg_kps = excluded.avg_kps,
+    max_kps = excluded.max_kps,
+    star_rating = excluded.star_rating,
+    column_counts_json = excluded.column_counts_json,
+    kps_list_json = excluded.kps_list_json,
+    file_size = excluded.file_size,
+    last_modified_ticks = excluded.last_modified_ticks,
+    scanned_at = excluded.scanned_at;";
+
+                cmd.Parameters.AddWithValue("$path_key", record.PathKey);
+                cmd.Parameters.AddWithValue("$pp", (object?)record.Pp ?? DBNull.Value);
+                cmd.Parameters.AddWithValue("$xxy_sr", (object?)record.XxySr ?? DBNull.Value);
+                cmd.Parameters.AddWithValue("$avg_kps", (object?)record.AvgKps ?? DBNull.Value);
+                cmd.Parameters.AddWithValue("$max_kps", (object?)record.MaxKps ?? DBNull.Value);
+                cmd.Parameters.AddWithValue("$star_rating", (object?)record.StarRating ?? DBNull.Value);
+                cmd.Parameters.AddWithValue("$column_counts_json", (object?)record.ColumnCountsJson ?? DBNull.Value);
+                cmd.Parameters.AddWithValue("$kps_list_json", (object?)record.KpsListJson ?? DBNull.Value);
+                cmd.Parameters.AddWithValue("$file_size", 0L);
+                cmd.Parameters.AddWithValue("$last_modified_ticks", 0L);
+                cmd.Parameters.AddWithValue("$scanned_at", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+                cmd.ExecuteNonQuery();
+            }
+        }
+
+        public bool TryGet(string pathKey, out BmsAnalyticsRecord record)
+        {
+            record = null!;
+            ensureInitialized();
+
+            using var connection = openConnection();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT path_key, pp, xxy_sr, avg_kps, max_kps, star_rating, column_counts_json, kps_list_json FROM chart_analytics WHERE path_key = $path_key LIMIT 1;";
+            cmd.Parameters.AddWithValue("$path_key", pathKey);
+
+            using var reader = cmd.ExecuteReader();
+            if (!reader.Read())
+                return false;
+
+            record = readRecord(reader);
+            return true;
+        }
+
+        public IReadOnlyDictionary<string, BmsAnalyticsRecord> LoadAll()
+        {
+            ensureInitialized();
+            var result = new Dictionary<string, BmsAnalyticsRecord>(StringComparer.OrdinalIgnoreCase);
+
+            using var connection = openConnection();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT path_key, pp, xxy_sr, avg_kps, max_kps, star_rating, column_counts_json, kps_list_json FROM chart_analytics;";
+
+            using var reader = cmd.ExecuteReader();
+
+            while (reader.Read())
+            {
+                var record = readRecord(reader);
+                result[record.PathKey] = record;
+            }
+
+            return result;
+        }
+
+        private static BmsAnalyticsRecord readRecord(SqliteDataReader reader)
+        {
+            return new BmsAnalyticsRecord
+            {
+                PathKey = reader.GetString(0),
+                Pp = reader.IsDBNull(1) ? null : reader.GetDouble(1),
+                XxySr = reader.IsDBNull(2) ? null : reader.GetDouble(2),
+                AvgKps = reader.IsDBNull(3) ? null : reader.GetDouble(3),
+                MaxKps = reader.IsDBNull(4) ? null : reader.GetDouble(4),
+                StarRating = reader.IsDBNull(5) ? null : reader.GetDouble(5),
+                ColumnCountsJson = reader.IsDBNull(6) ? null : reader.GetString(6),
+                KpsListJson = reader.FieldCount > 7 && !reader.IsDBNull(7) ? reader.GetString(7) : null,
+            };
+        }
+
+        private void ensureInitialized()
+        {
+            using var connection = openConnection();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = @"
+CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+CREATE TABLE IF NOT EXISTS chart_analytics (
+    path_key TEXT PRIMARY KEY,
+    pp REAL,
+    xxy_sr REAL,
+    avg_kps REAL,
+    max_kps REAL,
+    star_rating REAL,
+    column_counts_json TEXT,
+    file_size INTEGER NOT NULL DEFAULT 0,
+    last_modified_ticks INTEGER NOT NULL DEFAULT 0,
+    scanned_at INTEGER NOT NULL DEFAULT 0
+);";
+            cmd.ExecuteNonQuery();
+
+            migrateSchema(connection);
+
+            using var versionCmd = connection.CreateCommand();
+            versionCmd.CommandText = "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', $v);";
+            versionCmd.Parameters.AddWithValue("$v", schema_version.ToString());
+            versionCmd.ExecuteNonQuery();
+        }
+
+        private static void migrateSchema(SqliteConnection connection)
+        {
+            if (!columnExists(connection, "chart_analytics", "kps_list_json"))
+            {
+                using var alter = connection.CreateCommand();
+                alter.CommandText = "ALTER TABLE chart_analytics ADD COLUMN kps_list_json TEXT;";
+                alter.ExecuteNonQuery();
+            }
+        }
+
+        private static bool columnExists(SqliteConnection connection, string table, string column)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = $"PRAGMA table_info({table});";
+
+            using var reader = cmd.ExecuteReader();
+
+            while (reader.Read())
+            {
+                if (string.Equals(reader.GetString(1), column, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+
+            return false;
+        }
+
+        private SqliteConnection openConnection()
+        {
+            var connection = new SqliteConnection($"Data Source={databasePath}");
+            connection.Open();
+            return connection;
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Analytics/BmsChartAnalyticsProcessor.cs
+++ b/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Analytics/BmsChartAnalyticsProcessor.cs
@@ -1,0 +1,145 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Text.Json;
+using osu.Framework.Audio;
+using osu.Game.Beatmaps;
+using osu.Game.EzOsuGame.Analysis;
+using osu.Game.Rulesets.BMS.Beatmaps;
+using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Mania.Beatmaps;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
+
+namespace osu.Game.Rulesets.BMS.UI.BmsSongSelect.Analytics
+{
+    public readonly record struct BmsChartAnalyticsResult(
+        double? Pp,
+        double? XxySr,
+        double? AvgKps,
+        double? MaxKps,
+        double? StarRating,
+        string? ColumnCountsJson,
+        string? KpsListJson);
+
+    /// <summary>
+    /// Chart-stream analytics: parse BMS → mania conversion → EZ metrics. No <see cref="BMSWorkingBeatmap"/> / keysound preload.
+    /// </summary>
+    public static class BmsChartAnalyticsProcessor
+    {
+        public static BmsChartAnalyticsResult? TryAnalyze(
+            BMSChartCache chart,
+            AudioManager audioManager,
+            CancellationToken cancellationToken = default)
+        {
+            if (BmsChartFileParser.TryParse(chart.FullPath, cancellationToken) is not BMSBeatmap bmsBeatmap)
+                return null;
+
+            applyChartMetadata(bmsBeatmap, chart);
+
+            var maniaBeatmap = ManiaConvertedWorkingBeatmap.ConvertToManiaBeatmap(bmsBeatmap);
+            applyPlayableDefaults(maniaBeatmap, cancellationToken);
+
+            var maniaRuleset = new ManiaRuleset();
+            var beatmapInfo = createBeatmapInfo(chart, maniaBeatmap);
+            var working = new BmsAnalyticsManiaWorkingBeatmap(beatmapInfo, maniaBeatmap, audioManager);
+
+            double star = maniaRuleset.CreateDifficultyCalculator(working)
+                                      .Calculate(Array.Empty<Mod>()).StarRating;
+
+            double? pp = null;
+            double? xxySr = null;
+            double? avgKps = null;
+            double? maxKps = null;
+            string? columnJson = null;
+            string? kpsListJson = null;
+
+            try
+            {
+                var scoreInfo = new ScoreInfo
+                {
+                    Ruleset = maniaRuleset.RulesetInfo,
+                    Statistics =
+                    {
+                        [HitResult.Perfect] = Math.Max(1, chart.TotalNotes > 0 ? chart.TotalNotes : maniaBeatmap.HitObjects.Count)
+                    }
+                };
+                pp = new BMSRuleset().CreatePerformanceCalculator().Calculate(scoreInfo, working).Total;
+            }
+            catch
+            {
+                // PP is optional for analytics rows.
+            }
+
+            var analysisProvider = new BMSRuleset().CreateEzAnalysisProvider();
+            var request = new EzAnalysisRequest(maniaBeatmap, 1.0, EzAnalysisScope.XxySr | EzAnalysisScope.RulesetSpecificRadarData);
+
+            if (analysisProvider.TryCompute(request, cancellationToken, out var analysis)
+                && analysis.TryGetValue(EzAnalysisFields.XXY_SR, out double sr))
+                xxySr = sr;
+
+            var (avg, max, kpsList) = OptimizedBeatmapCalculator.GetKpsOptimized(maniaBeatmap);
+            avgKps = avg;
+            maxKps = max;
+
+            if (kpsList.Count > 0)
+                kpsListJson = JsonSerializer.Serialize(kpsList);
+
+            var columnCounts = OptimizedBeatmapCalculator.GetColumnNoteCountsOptimized(maniaBeatmap);
+            columnJson = JsonSerializer.Serialize(columnCounts);
+
+            return new BmsChartAnalyticsResult(pp, xxySr, avgKps, maxKps, star, columnJson, kpsListJson);
+        }
+
+        private static void applyChartMetadata(BMSBeatmap bmsBeatmap, BMSChartCache chart)
+        {
+            if (chart.Bpm > 0)
+                bmsBeatmap.BeatmapInfo.BPM = chart.Bpm;
+
+            if (chart.TotalNotes > 0)
+            {
+                bmsBeatmap.BeatmapInfo.TotalObjectCount = chart.TotalNotes;
+                bmsBeatmap.BeatmapInfo.EndTimeObjectCount = chart.TotalNotes;
+            }
+
+            if (!string.IsNullOrEmpty(chart.Md5Hash))
+            {
+                bmsBeatmap.BeatmapInfo.MD5Hash = chart.Md5Hash;
+                bmsBeatmap.BeatmapInfo.Hash = chart.Md5Hash;
+            }
+        }
+
+        private static BeatmapInfo createBeatmapInfo(BMSChartCache chart, ManiaBeatmap maniaBeatmap)
+        {
+            var info = maniaBeatmap.BeatmapInfo;
+            info.Difficulty.CircleSize = maniaBeatmap.TotalColumns;
+
+            if (chart.Bpm > 0)
+                info.BPM = chart.Bpm;
+
+            if (!string.IsNullOrEmpty(chart.Md5Hash))
+            {
+                info.MD5Hash = chart.Md5Hash;
+                info.Hash = chart.Md5Hash;
+            }
+
+            return info;
+        }
+
+        private static void applyPlayableDefaults(ManiaBeatmap maniaBeatmap, CancellationToken cancellationToken)
+        {
+            var ruleset = new ManiaRuleset();
+            var processor = ruleset.CreateBeatmapProcessor(maniaBeatmap);
+            processor?.PreProcess();
+
+            foreach (var obj in maniaBeatmap.HitObjects)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                obj.ApplyDefaults(maniaBeatmap.ControlPointInfo, maniaBeatmap.Difficulty, cancellationToken);
+            }
+
+            processor?.PostProcess();
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Bars/BmsBar.cs
+++ b/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Bars/BmsBar.cs
@@ -1,0 +1,30 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.BMS.UI.BmsSongSelect.Bars
+{
+    public abstract class BmsBar
+    {
+        public abstract string Title { get; }
+
+        public virtual string Subtitle => string.Empty;
+
+        public virtual bool IsSelectable => false;
+
+        public virtual bool IsDirectory => false;
+    }
+
+    public abstract class BmsDirectoryBar : BmsBar
+    {
+        public override bool IsDirectory => true;
+
+        public abstract bool IsSortable { get; }
+
+        public abstract IReadOnlyList<BmsBar> GetChildren(BmsBarContext context);
+    }
+
+    public abstract class BmsSelectableBar : BmsBar
+    {
+        public override bool IsSelectable => true;
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Bars/BmsCommandBars.cs
+++ b/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Bars/BmsCommandBars.cs
@@ -1,0 +1,102 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Text.Json;
+using osu.Game.Rulesets.BMS.UI.BmsSongSelect.Filtering;
+
+namespace osu.Game.Rulesets.BMS.UI.BmsSongSelect.Bars
+{
+    public sealed class BmsContainerBar : BmsDirectoryBar
+    {
+        private readonly IReadOnlyList<BmsRajaFolderDefinition> children;
+
+        public BmsContainerBar(string title, IReadOnlyList<BmsRajaFolderDefinition> children)
+        {
+            Title = title;
+            this.children = children;
+        }
+
+        public override string Title { get; }
+
+        public override bool IsSortable => false;
+
+        public override IReadOnlyList<BmsBar> GetChildren(BmsBarContext context) => BmsFolderConfigLoader.BuildBars(children, context);
+    }
+
+    public sealed class BmsCommandBar : BmsDirectoryBar
+    {
+        private readonly string sql;
+        private readonly bool showInvisible;
+
+        public BmsCommandBar(string title, string sql, bool showInvisible)
+        {
+            Title = title;
+            this.sql = sql;
+            this.showInvisible = showInvisible;
+        }
+
+        public override string Title { get; }
+
+        public override bool IsSortable => true;
+
+        public override IReadOnlyList<BmsBar> GetChildren(BmsBarContext context)
+        {
+            var charts = context.SqlQuery.Execute(sql);
+            var bars = charts.Select(c => new BmsSongBar(c)).Cast<BmsBar>().ToList();
+
+            if (!showInvisible)
+                bars = bars.Where(b => b is not BmsSongBar song || context.KeyModeFilter.Matches(song.Chart.KeyCount)).ToList();
+
+            return bars;
+        }
+    }
+
+    public sealed class BmsSearchBar : BmsDirectoryBar
+    {
+        public string Query { get; }
+
+        public BmsSearchBar(string query)
+        {
+            Query = query;
+            Title = $"Search: {query}";
+        }
+
+        public override string Title { get; }
+
+        public override bool IsSortable => true;
+
+        public override IReadOnlyList<BmsBar> GetChildren(BmsBarContext context) => context.SqlQuery.SearchByText(Query).Select(c => new BmsSongBar(c)).Cast<BmsBar>().ToList();
+    }
+
+    public sealed class BmsSameFolderBar : BmsDirectoryBar
+    {
+        private readonly string folderCrc;
+
+        public BmsSameFolderBar(string folderPath)
+        {
+            folderCrc = BmsPathCrc.Compute(folderPath);
+            Title = "SAME FOLDER";
+        }
+
+        public override string Title { get; }
+
+        public override bool IsSortable => true;
+
+        public override IReadOnlyList<BmsBar> GetChildren(BmsBarContext context) => context.FolderTree.GetChildren(folderCrc);
+    }
+
+    public sealed class BmsRandomExecutableBar : BmsSelectableBar
+    {
+        public string RandomName { get; }
+        public IReadOnlyDictionary<string, JsonElement>? Filter { get; }
+
+        public BmsRandomExecutableBar(string randomName, IReadOnlyDictionary<string, JsonElement>? filter)
+        {
+            RandomName = randomName;
+            Filter = filter;
+            Title = $"[RANDOM] {randomName}";
+        }
+
+        public override string Title { get; }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Bars/BmsFolderBar.cs
+++ b/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Bars/BmsFolderBar.cs
@@ -1,0 +1,27 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.BMS.UI.BmsSongSelect.Bars
+{
+    public sealed class BmsFolderBar : BmsDirectoryBar
+    {
+        public string Crc { get; }
+        public string FullPath { get; }
+
+        private readonly BmsFolderNode? node;
+
+        public BmsFolderBar(string crc, string name, string fullPath, BmsFolderNode? node = null)
+        {
+            Crc = crc;
+            FullPath = fullPath;
+            this.node = node;
+            Title = string.IsNullOrEmpty(name) ? Path.GetFileName(fullPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)) : name;
+        }
+
+        public override string Title { get; }
+
+        public override bool IsSortable => true;
+
+        public override IReadOnlyList<BmsBar> GetChildren(BmsBarContext context) => context.FolderTree.GetChildren(Crc);
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Bars/BmsSectionLabelBar.cs
+++ b/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Bars/BmsSectionLabelBar.cs
@@ -1,0 +1,15 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.BMS.UI.BmsSongSelect.Bars
+{
+    /// <summary>
+    /// Non-interactive section header in the bar list (e.g. "曲库", "过滤").
+    /// </summary>
+    public sealed class BmsSectionLabelBar : BmsBar
+    {
+        public BmsSectionLabelBar(string title) => Title = title;
+
+        public override string Title { get; }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Bars/BmsSongBar.cs
+++ b/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Bars/BmsSongBar.cs
@@ -1,0 +1,27 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.BMS.Beatmaps;
+
+namespace osu.Game.Rulesets.BMS.UI.BmsSongSelect.Bars
+{
+    public sealed class BmsSongBar : BmsSelectableBar
+    {
+        public BMSChartCache Chart { get; }
+
+        public string PathKey => string.IsNullOrEmpty(Chart.Md5Hash)
+            ? BmsPathKeys.ComputeChartPathKey(Chart.FullPath)
+            : Chart.Md5Hash;
+
+        public BmsSongBar(BMSChartCache chart)
+        {
+            Chart = chart;
+            Title = string.IsNullOrWhiteSpace(chart.Title) ? chart.FileName : chart.Title;
+            Subtitle = $"{chart.Artist} / Lv.{chart.PlayLevel} / {chart.KeyCount}K";
+        }
+
+        public override string Title { get; }
+
+        public override string Subtitle { get; }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Bars/BmsTableBars.cs
+++ b/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Bars/BmsTableBars.cs
@@ -1,0 +1,69 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.BMS.UI.BmsSongSelect.Bars
+{
+    // TODO: 难度表 — 游戏内导入 .bmt、按表分组、IR 表同步
+
+    public interface IBmsDifficultyTableProvider
+    {
+        IReadOnlyList<BmsTableBar> GetTables();
+    }
+
+    public sealed class BmsDifficultyTableRegistry : IBmsDifficultyTableProvider
+    {
+        public IReadOnlyList<BmsTableBar> GetTables() => Array.Empty<BmsTableBar>();
+    }
+
+    public sealed class BmsTableBar : BmsDirectoryBar
+    {
+        public BmsTableBar(string tableName)
+        {
+            Title = tableName;
+        }
+
+        public override string Title { get; }
+
+        public override bool IsSortable => false;
+
+        public override IReadOnlyList<BmsBar> GetChildren(BmsBarContext context)
+        {
+            // TODO: 难度表 — HashBar 子项由 .bmt 解析生成
+            return new BmsBar[] { new BmsPlaceholderBar("难度表功能尚未实现") };
+        }
+    }
+
+    public sealed class BmsHashBar : BmsDirectoryBar
+    {
+        public BmsHashBar(string levelName)
+        {
+            Title = levelName;
+        }
+
+        public override string Title { get; }
+
+        public override bool IsSortable => true;
+
+        public override IReadOnlyList<BmsBar> GetChildren(BmsBarContext context)
+        {
+            // TODO: 难度表 — 按 sha256/md5 列表解析 SongBar
+            return Array.Empty<BmsBar>();
+        }
+    }
+
+    public sealed class BmsGradeBar : BmsSelectableBar
+    {
+        public BmsGradeBar(string courseName)
+        {
+            Title = courseName;
+        }
+
+        public override string Title { get; }
+    }
+
+    internal sealed class BmsPlaceholderBar : BmsBar
+    {
+        public BmsPlaceholderBar(string title) => Title = title;
+        public override string Title { get; }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BmsSongSelect/BmsBarContext.cs
+++ b/osu.Game.Rulesets.BMS/UI/BmsSongSelect/BmsBarContext.cs
@@ -1,0 +1,38 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Database;
+using osu.Game.Rulesets.BMS.Beatmaps;
+using osu.Game.Rulesets.BMS.Scoring.Lamp;
+using osu.Game.Rulesets.BMS.UI.BmsSongSelect.Analytics;
+using osu.Game.Rulesets.BMS.UI.BmsSongSelect.Filtering;
+
+namespace osu.Game.Rulesets.BMS.UI.BmsSongSelect
+{
+    public sealed class BmsBarContext
+    {
+        public required BMSBeatmapManager BeatmapManager { get; init; }
+
+        public required BmsFolderTree FolderTree { get; init; }
+
+        public required BmsSqlSongQuery SqlQuery { get; init; }
+
+        public required string FilterDatabasePath { get; init; }
+
+        public required BmsAnalyticsSqliteRepository Analytics { get; init; }
+
+        public required BmsLampStore LampStore { get; init; }
+
+        public required RealmAccess Realm { get; init; }
+
+        public BmsRajaKeyModeFilter KeyModeFilter { get; } = new BmsRajaKeyModeFilter();
+
+        public BmsSortPolicy SortPolicy { get; } = new BmsSortPolicy();
+
+        public bool ShowInvisibleCharts { get; set; }
+
+        public IReadOnlyList<BmsRajaSearchEntry> SearchHistory { get; internal set; } = Array.Empty<BmsRajaSearchEntry>();
+    }
+
+    public readonly record struct BmsRajaSearchEntry(string Query, DateTime AddedAt);
+}

--- a/osu.Game.Rulesets.BMS/UI/BmsSongSelect/BmsBarManager.cs
+++ b/osu.Game.Rulesets.BMS/UI/BmsSongSelect/BmsBarManager.cs
@@ -1,0 +1,299 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.BMS.UI.BmsSongSelect.Bars;
+using osu.Game.Rulesets.BMS.UI.BmsSongSelect.Filtering;
+
+namespace osu.Game.Rulesets.BMS.UI.BmsSongSelect
+{
+    public sealed class BmsBarManager
+    {
+        private readonly BmsBarContext context;
+        private readonly IBmsDifficultyTableProvider tableProvider;
+        private readonly IReadOnlyList<BmsRajaRandomDefinition> randomDefinitions;
+        private readonly Stack<BmsDirectoryBar> directoryStack = new Stack<BmsDirectoryBar>();
+        private readonly Stack<BmsBar> sourceBars = new Stack<BmsBar>();
+        private readonly List<BmsRajaSearchEntry> searchHistory = new List<BmsRajaSearchEntry>();
+
+        public IReadOnlyList<BmsBar> CurrentBars { get; private set; } = Array.Empty<BmsBar>();
+        public int SelectedIndex { get; private set; }
+        public string Breadcrumb { get; private set; } = string.Empty;
+
+        public event Action? Changed;
+
+        public BmsBarManager(BmsBarContext context, IBmsDifficultyTableProvider? tableProvider = null)
+        {
+            this.context = context;
+            this.tableProvider = tableProvider ?? new BmsDifficultyTableRegistry();
+            randomDefinitions = BmsFolderConfigLoader.LoadRandomDefinitions();
+        }
+
+        public void ResetToRoot() => UpdateBar(null);
+
+        public void UpdateBar(BmsDirectoryBar? bar)
+        {
+            if (bar == null)
+            {
+                directoryStack.Clear();
+                sourceBars.Clear();
+                CurrentBars = buildRootBars();
+            }
+            else
+            {
+                if (directoryStack.Contains(bar))
+                {
+                    while (directoryStack.Count > 0 && directoryStack.Peek() != bar)
+                    {
+                        directoryStack.Pop();
+                        if (sourceBars.Count > 0)
+                            sourceBars.Pop();
+                    }
+                }
+                else
+                {
+                    directoryStack.Push(bar);
+                }
+
+                CurrentBars = bar.GetChildren(context);
+            }
+
+            CurrentBars = applyPipeline(CurrentBars);
+            SelectedIndex = findNearestSelectableIndex(SelectedIndex);
+            updateBreadcrumb();
+            Changed?.Invoke();
+        }
+
+        private int findNearestSelectableIndex(int start)
+        {
+            if (CurrentBars.Count == 0)
+                return 0;
+
+            start = Math.Clamp(start, 0, CurrentBars.Count - 1);
+            if (CurrentBars[start] is not BmsSectionLabelBar)
+                return start;
+
+            for (int i = start + 1; i < CurrentBars.Count; i++)
+            {
+                if (CurrentBars[i] is not BmsSectionLabelBar)
+                    return i;
+            }
+
+            for (int i = start - 1; i >= 0; i--)
+            {
+                if (CurrentBars[i] is not BmsSectionLabelBar)
+                    return i;
+            }
+
+            return 0;
+        }
+
+        public void CloseFolder()
+        {
+            if (directoryStack.Count == 0)
+            {
+                context.SortPolicy.CycleNext();
+                CurrentBars = applyPipeline(buildRootBars());
+                Changed?.Invoke();
+                return;
+            }
+
+            directoryStack.Pop();
+            if (sourceBars.Count > 0)
+                sourceBars.Pop();
+
+            var parent = directoryStack.Count > 0 ? directoryStack.Peek() : null;
+            UpdateBar(parent);
+        }
+
+        public void MoveSelection(int delta)
+        {
+            if (CurrentBars.Count == 0)
+                return;
+
+            int index = SelectedIndex;
+
+            for (int step = 0; step < CurrentBars.Count; step++)
+            {
+                index = (index + delta + CurrentBars.Count) % CurrentBars.Count;
+                if (CurrentBars[index] is not BmsSectionLabelBar)
+                    break;
+            }
+
+            SelectedIndex = index;
+            Changed?.Invoke();
+        }
+
+        public BmsBar? GetSelectedBar() => CurrentBars.Count == 0 ? null : CurrentBars[SelectedIndex];
+
+        public void OpenSelected()
+        {
+            var bar = GetSelectedBar();
+            if (bar == null || bar is BmsSectionLabelBar)
+                return;
+
+            if (bar is BmsDirectoryBar dir)
+            {
+                sourceBars.Push(bar);
+                UpdateBar(dir);
+                return;
+            }
+
+            if (bar is BmsRandomExecutableBar randomBar)
+            {
+                var songs = CurrentBars.OfType<BmsSongBar>().Where(s => BmsRandomFilterEvaluator.Matches(s, randomBar.Filter, context)).ToList();
+                if (songs.Count == 0)
+                    return;
+
+                var pick = songs[Random.Shared.Next(songs.Count)];
+                SelectedIndex = Math.Max(0, CurrentBars.ToList().IndexOf(pick));
+                Changed?.Invoke();
+            }
+        }
+
+        public void ShowSameFolder()
+        {
+            if (GetSelectedBar() is not BmsSongBar song)
+                return;
+
+            var sameFolder = new BmsSameFolderBar(song.Chart.FolderPath);
+            sourceBars.Push(sameFolder);
+            UpdateBar(sameFolder);
+        }
+
+        public void AddSearch(string query)
+        {
+            if (string.IsNullOrWhiteSpace(query))
+                return;
+
+            searchHistory.Insert(0, new BmsRajaSearchEntry(query.Trim(), DateTime.UtcNow));
+            context.SearchHistory = searchHistory.Take(20).ToList();
+
+            var searchBar = new BmsSearchBar(query.Trim());
+            sourceBars.Push(searchBar);
+            UpdateBar(searchBar);
+        }
+
+        public BmsSongBar? GetSelectedSong()
+        {
+            if (GetSelectedBar() is BmsSongBar song)
+                return song;
+
+            if (GetSelectedBar() is BmsRandomExecutableBar)
+            {
+                OpenSelected();
+                return GetSelectedBar() as BmsSongBar;
+            }
+
+            return null;
+        }
+
+        private IReadOnlyList<BmsBar> buildRootBars()
+        {
+            var bars = new List<BmsBar>();
+
+            var roots = context.FolderTree.GetRootBars();
+
+            if (roots.Count > 0)
+            {
+                bars.Add(new BmsSectionLabelBar("── 曲库文件夹 ──"));
+                bars.AddRange(roots);
+            }
+
+            var commands = BmsFolderConfigLoader.BuildRootCommandBars(context);
+
+            if (commands.Count > 0)
+            {
+                bars.Add(new BmsSectionLabelBar("── 过滤 / 收藏 / 等级 ──"));
+                bars.AddRange(commands);
+            }
+
+            var tables = tableProvider.GetTables().Cast<BmsBar>().ToList();
+
+            if (tables.Count > 0)
+            {
+                bars.Add(new BmsSectionLabelBar("── 难度表 (TODO) ──"));
+                bars.AddRange(tables);
+            }
+
+            if (searchHistory.Count > 0)
+            {
+                bars.Add(new BmsSectionLabelBar("── 搜索历史 ──"));
+                foreach (var search in searchHistory.Take(5))
+                    bars.Add(new BmsSearchBar(search.Query));
+            }
+
+            return bars;
+        }
+
+        private IReadOnlyList<BmsBar> applyPipeline(IReadOnlyList<BmsBar> input)
+        {
+            var bars = input.ToList();
+
+            for (int attempt = 0; attempt < 6; attempt++)
+            {
+                bars = bars.Where(shouldShow).ToList();
+                if (bars.Any(b => b is BmsSongBar))
+                    break;
+
+                context.KeyModeFilter.CycleNext();
+            }
+
+            if (directoryStack.Count == 0 || directoryStack.Peek().IsSortable)
+                bars = context.SortPolicy.Sort(bars).ToList();
+
+            bars = prependRandomBars(bars);
+            return bars;
+        }
+
+        private bool shouldShow(BmsBar bar)
+        {
+            if (bar is BmsSectionLabelBar)
+                return true;
+
+            if (bar is BmsSongBar song)
+                return context.KeyModeFilter.Matches(song.Chart.KeyCount);
+
+            return true;
+        }
+
+        private List<BmsBar> prependRandomBars(List<BmsBar> bars)
+        {
+            var songs = bars.OfType<BmsSongBar>().ToList();
+            var randomBars = new List<BmsBar>();
+
+            foreach (var def in randomDefinitions)
+            {
+                int matchCount = string.IsNullOrEmpty(def.Name) || def.Name == "RANDOM SELECT"
+                    ? songs.Count
+                    : songs.Count(s => BmsRandomFilterEvaluator.Matches(s, def.Filter, context));
+
+                int required = def.Filter == null || def.Filter.Count == 0 ? 2 : 1;
+                if (matchCount >= required)
+                    randomBars.Add(new BmsRandomExecutableBar(def.Name, def.Filter));
+            }
+
+            randomBars.AddRange(bars);
+            return randomBars;
+        }
+
+        public void SetSelectedIndex(int index)
+        {
+            if (CurrentBars.Count == 0)
+                return;
+
+            SelectedIndex = Math.Clamp(index, 0, CurrentBars.Count - 1);
+            Changed?.Invoke();
+        }
+
+        private void updateBreadcrumb()
+        {
+            if (directoryStack.Count == 0)
+            {
+                Breadcrumb = "ROOT";
+                return;
+            }
+
+            Breadcrumb = string.Join(" > ", directoryStack.Select(d => d.Title));
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BmsSongSelect/BmsBarRenderer.cs
+++ b/osu.Game.Rulesets.BMS/UI/BmsSongSelect/BmsBarRenderer.cs
@@ -1,0 +1,325 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Events;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets.BMS.UI.BmsSongSelect.Analytics;
+using osu.Game.Rulesets.BMS.UI.BmsSongSelect.Bars;
+using osuTK;
+using osuTK.Graphics;
+using osuTK.Input;
+
+namespace osu.Game.Rulesets.BMS.UI.BmsSongSelect
+{
+    public partial class BmsBarRenderer : CompositeDrawable
+    {
+        private const int visible_rows = 28;
+        private const float row_height = 24;
+
+        private readonly BmsBarManager manager;
+        private readonly BmsBarContext context;
+        private readonly FillFlowContainer listFlow;
+        private readonly OsuSpriteText breadcrumbText;
+        private readonly OsuSpriteText statusText;
+        private readonly OsuSpriteText detailTitle;
+        private readonly OsuSpriteText detailBody;
+
+        public BmsBarRenderer(BmsBarManager manager, BmsBarContext context)
+        {
+            this.manager = manager;
+            this.context = context;
+
+            RelativeSizeAxes = Axes.Both;
+
+            InternalChild = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = new Color4(12, 14, 22, 255),
+                    },
+                    new Container
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Height = 72,
+                        Padding = new MarginPadding { Horizontal = 24, Vertical = 12 },
+                        Children = new Drawable[]
+                        {
+                            breadcrumbText = new OsuSpriteText
+                            {
+                                Font = OsuFont.GetFont(size: 18, weight: FontWeight.Bold),
+                                Text = "ROOT",
+                            },
+                            statusText = new OsuSpriteText
+                            {
+                                Anchor = Anchor.TopRight,
+                                Origin = Anchor.TopRight,
+                                Font = OsuFont.Default.With(size: 13),
+                                Colour = Colour4.Gray,
+                            },
+                            new OsuSpriteText
+                            {
+                                Anchor = Anchor.BottomLeft,
+                                Origin = Anchor.BottomLeft,
+                                Y = -4,
+                                Font = OsuFont.Default.With(size: 12),
+                                Colour = Colour4.Gray,
+                                Text = "↑↓ 移动 | Enter 进入/开始 | Esc/← 返回 | 1=KEY 2=排序 8=同文件夹",
+                            },
+                        },
+                    },
+                    new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Padding = new MarginPadding { Top = 72, Horizontal = 16, Bottom = 16 },
+                        Children = new Drawable[]
+                        {
+                            new Container
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Width = 0.58f,
+                                Children = new Drawable[]
+                                {
+                                    new Box
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        Colour = Colour4.Black.Opacity(0.25f),
+                                    },
+                                    new OsuScrollContainer
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        Padding = new MarginPadding(8),
+                                        Child = listFlow = new FillFlowContainer
+                                        {
+                                            RelativeSizeAxes = Axes.X,
+                                            AutoSizeAxes = Axes.Y,
+                                            Direction = FillDirection.Vertical,
+                                        },
+                                    },
+                                },
+                            },
+                            new Container
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Anchor = Anchor.TopRight,
+                                Origin = Anchor.TopRight,
+                                Width = 0.4f,
+                                Padding = new MarginPadding { Left = 12 },
+                                Children = new Drawable[]
+                                {
+                                    new Box
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        Colour = Colour4.White.Opacity(0.06f),
+                                    },
+                                    new FillFlowContainer
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        Direction = FillDirection.Vertical,
+                                        Padding = new MarginPadding(16),
+                                        Spacing = new Vector2(0, 8),
+                                        Children = new Drawable[]
+                                        {
+                                            new OsuSpriteText
+                                            {
+                                                Font = OsuFont.GetFont(size: 14, weight: FontWeight.Bold),
+                                                Text = "选中项详情",
+                                            },
+                                            detailTitle = new OsuSpriteText
+                                            {
+                                                Font = OsuFont.GetFont(size: 16, weight: FontWeight.Bold),
+                                                Text = "—",
+                                            },
+                                            detailBody = new OsuSpriteText
+                                            {
+                                                Font = OsuFont.Default.With(size: 13),
+                                                Colour = Colour4.LightGray,
+                                                Text = "选择曲目以预览分析数据",
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+
+            manager.Changed += refresh;
+        }
+
+        private void refresh()
+        {
+            breadcrumbText.Text = manager.Breadcrumb;
+            statusText.Text = $"KEY: {context.KeyModeFilter.Current} | 排序: {context.SortPolicy.Mode} | {manager.CurrentBars.Count} 项";
+            listFlow.Clear();
+
+            if (manager.CurrentBars.Count == 0)
+            {
+                listFlow.Add(new OsuSpriteText { Text = "(空)", Font = OsuFont.Default });
+                updateDetail(null);
+                return;
+            }
+
+            int start = Math.Max(0, manager.SelectedIndex - visible_rows / 2);
+            int end = Math.Min(manager.CurrentBars.Count, start + visible_rows);
+            start = Math.Max(0, end - visible_rows);
+
+            for (int i = start; i < end; i++)
+            {
+                var bar = manager.CurrentBars[i];
+                bool selected = i == manager.SelectedIndex;
+                int captured = i;
+                listFlow.Add(createRow(bar, selected, () =>
+                {
+                    manager.SetSelectedIndex(captured);
+                    manager.OpenSelected();
+                }));
+            }
+
+            updateDetail(manager.GetSelectedBar());
+        }
+
+        private void updateDetail(BmsBar? bar)
+        {
+            if (bar == null)
+            {
+                detailTitle.Text = "—";
+                detailBody.Text = string.Empty;
+                return;
+            }
+
+            detailTitle.Text = bar.Title;
+
+            if (bar is BmsSongBar song)
+            {
+                var c = song.Chart;
+                string analyticsLine = "分析: —";
+                if (context.Analytics.TryGet(song.PathKey, out BmsAnalyticsRecord record))
+                    analyticsLine = $"PP {record.Pp:0.#} | xxySR {record.XxySr:0.##} | KPS {record.AvgKps:0.#}/{record.MaxKps:0.#} | ★ {record.StarRating:0.##}";
+
+                detailBody.Text = string.Join("\n",
+                    $"艺术家: {c.Artist}",
+                    $"等级: Lv.{c.PlayLevel} | {c.KeyCount}K | {c.FileName}",
+                    $"BPM: {c.Bpm:0.#} | 音符: {c.TotalNotes}",
+                    $"路径: {c.FolderPath}",
+                    analyticsLine);
+            }
+            else if (bar is BmsDirectoryBar)
+            {
+                detailBody.Text = "目录 — 按 Enter 进入";
+            }
+            else
+            {
+                detailBody.Text = bar.Subtitle;
+            }
+        }
+
+        private Drawable createRow(BmsBar bar, bool selected, Action onActivate)
+        {
+            if (bar is BmsSectionLabelBar section)
+            {
+                return new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Height = 20,
+                    Padding = new MarginPadding { Top = 6, Bottom = 2 },
+                    Child = new OsuSpriteText
+                    {
+                        Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
+                        Colour = Colour4.Gray,
+                        Text = section.Title,
+                    },
+                };
+            }
+
+            string suffix = bar is BmsSongBar songBar ? formatAnalytics(songBar) : string.Empty;
+            string prefix = bar.IsDirectory ? "▶ " : bar is BmsRandomExecutableBar ? "🎲 " : "♪ ";
+            string text = prefix + bar.Title + (string.IsNullOrEmpty(suffix) ? string.Empty : $"    {suffix}");
+
+            return new BmsRajaBarRow(bar, selected, text, onActivate)
+            {
+                Height = row_height,
+            };
+        }
+
+        private string formatAnalytics(BmsSongBar song)
+        {
+            if (!context.Analytics.TryGet(song.PathKey, out BmsAnalyticsRecord record))
+                return "—";
+
+            return $"PP{record.Pp:0.#} SR{record.XxySr:0.##} KPS{record.AvgKps:0.#}";
+        }
+
+        protected override bool OnKeyDown(KeyDownEvent e)
+        {
+            switch (e.Key)
+            {
+                case Key.Up:
+                    manager.MoveSelection(-1);
+                    return true;
+
+                case Key.Down:
+                    manager.MoveSelection(1);
+                    return true;
+
+                case Key.Enter:
+                    manager.OpenSelected();
+                    return true;
+
+                case Key.Escape:
+                case Key.Left:
+                    manager.CloseFolder();
+                    return true;
+            }
+
+            return base.OnKeyDown(e);
+        }
+    }
+
+    public partial class BmsRajaBarRow : CompositeDrawable
+    {
+        private readonly Action onActivate;
+
+        public BmsRajaBarRow(BmsBar bar, bool selected, string displayText, Action onActivate)
+        {
+            this.onActivate = onActivate;
+            RelativeSizeAxes = Axes.X;
+
+            InternalChild = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = selected ? Colour4.SkyBlue.Opacity(0.4f) : Colour4.Transparent,
+                    },
+                    new OsuSpriteText
+                    {
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Padding = new MarginPadding { Left = 10, Right = 10 },
+                        Font = OsuFont.Default.With(size: 14),
+                        Text = displayText,
+                    },
+                },
+            };
+        }
+
+        protected override bool OnClick(ClickEvent e)
+        {
+            onActivate();
+            return true;
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BmsSongSelect/BmsFolderTree.cs
+++ b/osu.Game.Rulesets.BMS/UI/BmsSongSelect/BmsFolderTree.cs
@@ -1,0 +1,132 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.BMS.Beatmaps;
+using osu.Game.Rulesets.BMS.UI.BmsSongSelect.Bars;
+
+namespace osu.Game.Rulesets.BMS.UI.BmsSongSelect
+{
+    public sealed class BmsFolderTree
+    {
+        private readonly Dictionary<string, BmsFolderNode> nodesByCrc = new Dictionary<string, BmsFolderNode>(StringComparer.OrdinalIgnoreCase);
+        private readonly List<BmsRajaFolderRoot> roots = new List<BmsRajaFolderRoot>();
+
+        public IReadOnlyList<BmsRajaFolderRoot> Roots => roots;
+
+        public static BmsFolderTree Build(IReadOnlyList<string> libraryRoots, IEnumerable<BMSSongCache> songs)
+        {
+            var tree = new BmsFolderTree();
+            var rootEntries = libraryRoots.Where(Directory.Exists).ToList();
+
+            foreach (string root in rootEntries)
+            {
+                string rootCrc = BmsPathCrc.Compute(root);
+                var rootNode = tree.getOrCreateNode(rootCrc, null, Path.GetFileName(root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)), root);
+                tree.roots.Add(new BmsRajaFolderRoot(root, rootCrc, rootNode));
+            }
+
+            foreach (var song in songs)
+            {
+                string? matchedRoot = rootEntries.FirstOrDefault(r => song.FolderPath.StartsWith(r, StringComparison.OrdinalIgnoreCase));
+                if (matchedRoot == null)
+                    continue;
+
+                string relative = Path.GetRelativePath(matchedRoot, song.FolderPath);
+                string parentPath = matchedRoot;
+                string parentCrc = BmsPathCrc.Compute(matchedRoot);
+
+                if (!string.IsNullOrEmpty(relative) && relative != ".")
+                {
+                    foreach (string segment in relative.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar))
+                    {
+                        if (string.IsNullOrEmpty(segment))
+                            continue;
+
+                        parentPath = Path.Combine(parentPath, segment);
+                        string crc = BmsPathCrc.Compute(parentPath);
+                        tree.getOrCreateNode(crc, parentCrc, segment, parentPath);
+                        parentCrc = crc;
+                    }
+                }
+
+                if (tree.nodesByCrc.TryGetValue(parentCrc, out var leaf))
+                    leaf.Songs.Add(song);
+            }
+
+            return tree;
+        }
+
+        public bool TryGetNode(string crc, out BmsFolderNode node) => nodesByCrc.TryGetValue(crc, out node!);
+
+        public IReadOnlyList<BmsBar> GetRootBars()
+        {
+            var bars = new List<BmsBar>();
+
+            foreach (var root in roots)
+                bars.Add(new BmsFolderBar(root.Crc, root.DisplayName, root.Path, root.Node));
+
+            return bars;
+        }
+
+        public IReadOnlyList<BmsBar> GetChildren(string parentCrc)
+        {
+            if (!nodesByCrc.TryGetValue(parentCrc, out var node))
+                return Array.Empty<BmsBar>();
+
+            var result = new List<BmsBar>();
+
+            foreach (var child in node.Children.OrderBy(c => c.Name, StringComparer.OrdinalIgnoreCase))
+                result.Add(new BmsFolderBar(child.Crc, child.Name, child.FullPath, child));
+
+            foreach (var song in node.Songs.OrderBy(s => s.Title, StringComparer.OrdinalIgnoreCase))
+            {
+                foreach (var chart in song.Charts.OrderBy(c => c.PlayLevel).ThenBy(c => c.FileName, StringComparer.OrdinalIgnoreCase))
+                    result.Add(new BmsSongBar(chart));
+            }
+
+            return result;
+        }
+
+        private BmsFolderNode getOrCreateNode(string crc, string? parentCrc, string name, string fullPath)
+        {
+            if (nodesByCrc.TryGetValue(crc, out var existing))
+                return existing;
+
+            var node = new BmsFolderNode(crc, parentCrc, name, fullPath);
+            nodesByCrc[crc] = node;
+
+            if (parentCrc != null && nodesByCrc.TryGetValue(parentCrc, out var parent))
+                parent.Children.Add(node);
+
+            return node;
+        }
+    }
+
+    public sealed class BmsRajaFolderRoot
+    {
+        public BmsRajaFolderRoot(string path, string crc, BmsFolderNode node)
+        {
+            Path = path;
+            Crc = crc;
+            Node = node;
+            DisplayName = string.IsNullOrEmpty(node.Name)
+                ? System.IO.Path.GetFileName(path.TrimEnd(System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar))
+                : node.Name;
+        }
+
+        public string Path { get; }
+        public string Crc { get; }
+        public string DisplayName { get; }
+        public BmsFolderNode Node { get; }
+    }
+
+    public sealed class BmsFolderNode(string crc, string? parentCrc, string name, string fullPath)
+    {
+        public string Crc { get; } = crc;
+        public string? ParentCrc { get; } = parentCrc;
+        public string Name { get; } = name;
+        public string FullPath { get; } = fullPath;
+        public List<BmsFolderNode> Children { get; } = new List<BmsFolderNode>();
+        public List<BMSSongCache> Songs { get; } = new List<BMSSongCache>();
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BmsSongSelect/BmsPathCrc.cs
+++ b/osu.Game.Rulesets.BMS/UI/BmsSongSelect/BmsPathCrc.cs
@@ -1,0 +1,33 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Text;
+
+namespace osu.Game.Rulesets.BMS.UI.BmsSongSelect
+{
+    /// <summary>
+    /// CRC32 folder ids aligned with beatoraja <c>SongUtils.crc32</c> usage for folder navigation.
+    /// </summary>
+    internal static class BmsPathCrc
+    {
+        private const uint polynomial = 0xEDB88320;
+
+        public static string Compute(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return "e2977170";
+
+            byte[] bytes = Encoding.UTF8.GetBytes(value);
+            uint crc = 0xFFFFFFFF;
+
+            foreach (byte b in bytes)
+            {
+                crc ^= b;
+                for (int i = 0; i < 8; i++)
+                    crc = (crc & 1) != 0 ? (crc >> 1) ^ polynomial : crc >> 1;
+            }
+
+            return (~crc).ToString("x8");
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BmsSongSelect/BmsRajaKeyModeFilter.cs
+++ b/osu.Game.Rulesets.BMS/UI/BmsSongSelect/BmsRajaKeyModeFilter.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.BMS.UI.BmsSongSelect
+{
+    public enum BmsKeyMode
+    {
+        Any = 0,
+        Keys5 = 5,
+        Keys7 = 7,
+        Keys10 = 10,
+        Keys14 = 14,
+    }
+
+    public sealed class BmsRajaKeyModeFilter
+    {
+        private static readonly BmsKeyMode[] cycle =
+        {
+            BmsKeyMode.Any,
+            BmsKeyMode.Keys5,
+            BmsKeyMode.Keys7,
+            BmsKeyMode.Keys10,
+            BmsKeyMode.Keys14,
+        };
+
+        public BmsKeyMode Current { get; private set; } = BmsKeyMode.Any;
+
+        public void CycleNext()
+        {
+            int index = Array.IndexOf(cycle, Current);
+            Current = cycle[(index + 1) % cycle.Length];
+        }
+
+        public bool Matches(int keyCount)
+        {
+            return Current switch
+            {
+                BmsKeyMode.Any => true,
+                BmsKeyMode.Keys5 => keyCount == 5 || keyCount == 8,
+                BmsKeyMode.Keys7 => keyCount == 7 || keyCount == 9,
+                BmsKeyMode.Keys10 => keyCount == 10,
+                BmsKeyMode.Keys14 => keyCount == 14,
+                _ => true,
+            };
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BmsSongSelect/BmsRajaSongSelect.cs
+++ b/osu.Game.Rulesets.BMS/UI/BmsSongSelect/BmsRajaSongSelect.cs
@@ -1,0 +1,337 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Rendering;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input.Events;
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using osu.Framework.Screens;
+using osu.Game.Database;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Notifications;
+using osu.Game.Rulesets.BMS.Beatmaps;
+using osu.Game.Rulesets.BMS.Configuration;
+using osu.Game.Rulesets.BMS.Scoring.Lamp;
+using osu.Game.Rulesets.BMS.Scoring.Lamp.Persistence;
+using osu.Game.Rulesets.BMS.UI.BmsSongSelect.Analytics;
+using osu.Game.Rulesets.BMS.UI.BmsSongSelect.Bars;
+using osu.Game.Rulesets.BMS.UI.BmsSongSelect.Filtering;
+using osu.Game.Rulesets.BMS.UI.SongSelect;
+using osu.Game.Screens;
+using osu.Game.Screens.Footer;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Game.Rulesets.BMS.UI.BmsSongSelect
+{
+    /// <summary>
+    /// beatoraja-style BMS song select (Bar navigation). Standard carousel remains <see cref="BmsSoloSongSelect"/>.
+    /// </summary>
+    public partial class BmsBmsSongSelect : OsuScreen
+    {
+        private BMSBeatmapManager beatmapManager = null!;
+        private BmsBarManager barManager = null!;
+        private BmsBarContext barContext = null!;
+        private BmsChartPreviewPlayer previewPlayer = null!;
+        private TextBox searchTextBox = null!;
+        private RulesetInfo bmsRulesetInfo = null!;
+
+        private Bindable<string> libraryPathsBindable = null!;
+        private Bindable<string> legacyRootPathBindable = null!;
+
+        private BmsLampSqliteRepository? lampRepository;
+        private BmsAnalyticsSqliteRepository? analyticsRepository;
+        private BmsFilterDatabaseSync? filterSync;
+
+        [Cached(typeof(IBmsLampScheme))]
+        private readonly IBmsLampScheme lampScheme = new BeatorajaLampScheme();
+
+        [Cached]
+        private readonly BmsLampStore lampStore;
+
+        [Resolved]
+        private AudioManager audioManager { get; set; } = null!;
+
+        [Resolved]
+        private IRenderer renderer { get; set; } = null!;
+
+        [Resolved]
+        private Storage storage { get; set; } = null!;
+
+        [Resolved]
+        private RealmAccess realm { get; set; } = null!;
+
+        [Resolved(canBeNull: true)]
+        private INotificationOverlay? notifications { get; set; }
+
+        [Resolved(canBeNull: true)]
+        private MusicController? musicController { get; set; }
+
+        [Resolved]
+        private IRulesetConfigCache rulesetConfigCache { get; set; } = null!;
+
+        public BmsBmsSongSelect()
+        {
+            lampStore = new BmsLampStore(lampScheme);
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            var bmsRuleset = new BMSRuleset();
+            bmsRulesetInfo = bmsRuleset.RulesetInfo;
+
+            if (rulesetConfigCache.GetConfigFor(bmsRuleset) is BMSRulesetConfigManager bmsConfig)
+            {
+                libraryPathsBindable = bmsConfig.GetBindable<string>(BMSRulesetSetting.BmsLibraryPaths);
+                legacyRootPathBindable = bmsConfig.GetBindable<string>(BMSRulesetSetting.BmsRootPath);
+            }
+            else
+            {
+                libraryPathsBindable = new Bindable<string>(string.Empty);
+                legacyRootPathBindable = new Bindable<string>(string.Empty);
+            }
+
+            beatmapManager = BMSBeatmapManager.GetShared(storage);
+            syncConfiguredPaths();
+
+            BmsStoragePaths.EnsureInitialized(storage);
+            lampRepository = new BmsLampSqliteRepository(BmsStoragePaths.GetLampDatabasePath(storage));
+            lampStore.AttachRepository(lampRepository);
+
+            analyticsRepository = new BmsAnalyticsSqliteRepository(BmsStoragePaths.GetAnalyticsDatabasePath(storage));
+            filterSync = new BmsFilterDatabaseSync(BmsStoragePaths.GetFilterDatabasePath(storage));
+
+            rebuildBarContext();
+            barManager = new BmsBarManager(barContext);
+            barManager.ResetToRoot();
+
+            InternalChild = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    new BmsBarRenderer(barManager, barContext)
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    },
+                    new Container
+                    {
+                        Anchor = Anchor.TopRight,
+                        Origin = Anchor.TopRight,
+                        Size = new Vector2(380, 32),
+                        Margin = new MarginPadding { Top = 78, Right = 20 },
+                        Child = searchTextBox = new OsuTextBox
+                        {
+                            PlaceholderText = "搜索曲目 (Enter)",
+                            RelativeSizeAxes = Axes.Both,
+                        },
+                    },
+                    previewPlayer = new BmsChartPreviewPlayer
+                    {
+                        EnabledBindable = { Value = true },
+                    },
+                },
+            };
+
+            barManager.Changed += onBarSelectionChanged;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            if (beatmapManager.NeedsRealmSynchronization && beatmapManager.HasIndexedCharts)
+            {
+                try
+                {
+                    BMSOsuLibrarySynchronizer.Synchronize(beatmapManager, storage, realm, bmsRulesetInfo);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex, "[BMS] Raja initial library sync failed");
+                }
+            }
+
+            refreshFilterDatabase();
+            barManager.ResetToRoot();
+        }
+
+        public override void OnEntering(ScreenTransitionEvent e)
+        {
+            base.OnEntering(e);
+            musicController?.Stop();
+        }
+
+        protected override bool OnKeyDown(KeyDownEvent e)
+        {
+            if (e.Key == Key.F5 && e.ControlPressed)
+            {
+                refreshLibrary();
+                return true;
+            }
+
+            if (e.Key == Key.Number1)
+            {
+                barContext.KeyModeFilter.CycleNext();
+                barManager.ResetToRoot();
+                return true;
+            }
+
+            if (e.Key == Key.Number2)
+            {
+                barContext.SortPolicy.CycleNext();
+                barManager.ResetToRoot();
+                return true;
+            }
+
+            if (e.Key == Key.Number8)
+            {
+                barManager.ShowSameFolder();
+                return true;
+            }
+
+            if (e.Key == Key.Enter && searchTextBox.HasFocus)
+            {
+                barManager.AddSearch(searchTextBox.Text);
+                searchTextBox.Text = string.Empty;
+                return true;
+            }
+
+            if (e.Key == Key.Enter)
+            {
+                tryStartSelectedChart();
+                return true;
+            }
+
+            return base.OnKeyDown(e);
+        }
+
+        public override IReadOnlyList<ScreenFooterButton> CreateFooterButtons()
+        {
+            return new[]
+            {
+                new ScreenFooterButton { Text = "返回", Action = this.Exit },
+                new ScreenFooterButton { Text = "刷新曲库", Action = refreshLibrary },
+                new ScreenFooterButton { Text = "构建分析库", Action = buildAnalytics },
+            };
+        }
+
+        private void onBarSelectionChanged()
+        {
+            previewPlayer.StopPreview();
+
+            if (barManager.GetSelectedBar() is not BmsSongBar song)
+                return;
+
+            try
+            {
+                var working = new BMSWorkingBeatmap(song.Chart.FullPath, audioManager, renderer, song.Chart);
+                int previewTime = song.Chart.PreviewTime;
+                previewPlayer.OverridePreviewStartTime = previewTime >= 0 ? previewTime : 0;
+                previewPlayer.StartPreview(working);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "[BMS] Raja preview failed");
+            }
+        }
+
+        private void tryStartSelectedChart()
+        {
+            var song = barManager.GetSelectedSong();
+
+            if (song == null)
+            {
+                notifications?.Post(new SimpleNotification { Text = "请选择一个 BMS 谱面" });
+                return;
+            }
+
+            previewPlayer.StopPreview();
+            BmsSongSelectPlayHelper.TryLaunchFromChart(this, song.Chart.FullPath, song.Chart, null, audioManager, renderer, musicController, notifications);
+        }
+
+        private void refreshLibrary()
+        {
+            syncConfiguredPaths();
+            BmsSongSelectLibraryOperations.RunLibraryRefresh(
+                Scheduler,
+                beatmapManager,
+                storage,
+                realm,
+                bmsRulesetInfo,
+                notifications,
+                () =>
+                {
+                    rebuildBarContext();
+                    barManager = new BmsBarManager(barContext);
+                    barManager.Changed += onBarSelectionChanged;
+                    refreshFilterDatabase();
+                    barManager.ResetToRoot();
+                });
+        }
+
+        private void buildAnalytics()
+        {
+            if (analyticsRepository == null)
+                return;
+
+            BmsSongSelectAnalyticsOperations.RunAnalyticsBuild(
+                Scheduler,
+                beatmapManager,
+                analyticsRepository,
+                audioManager,
+                realm,
+                notifications,
+                onComplete: () => Schedule(() => barManager.ResetToRoot()));
+        }
+
+        private void refreshFilterDatabase()
+        {
+            if (filterSync == null || lampRepository == null)
+                return;
+
+            Task.Run(() =>
+            {
+                try
+                {
+                    filterSync.Rebuild(beatmapManager, lampRepository, realm, analyticsRepository);
+                    Schedule(() => barManager.ResetToRoot());
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex, "[BMS] filter database rebuild failed");
+                }
+            });
+        }
+
+        private void rebuildBarContext()
+        {
+            var roots = BMSRulesetConfigManager.ParseLibraryPaths(libraryPathsBindable.Value, legacyRootPathBindable.Value);
+            beatmapManager.SetRootPaths(roots);
+
+            var folderTree = BmsFolderTree.Build(roots, beatmapManager.LibraryCache?.Songs ?? Enumerable.Empty<BMSSongCache>());
+            string filterPath = BmsStoragePaths.GetFilterDatabasePath(storage);
+
+            barContext = new BmsBarContext
+            {
+                BeatmapManager = beatmapManager,
+                FolderTree = folderTree,
+                SqlQuery = new BmsSqlSongQuery(filterPath, beatmapManager),
+                FilterDatabasePath = filterPath,
+                Analytics = analyticsRepository ?? new BmsAnalyticsSqliteRepository(BmsStoragePaths.GetAnalyticsDatabasePath(storage)),
+                LampStore = lampStore,
+                Realm = realm,
+            };
+        }
+
+        private void syncConfiguredPaths() => beatmapManager.SetRootPaths(BMSRulesetConfigManager.ParseLibraryPaths(libraryPathsBindable.Value, legacyRootPathBindable.Value));
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BmsSongSelect/BmsSortPolicy.cs
+++ b/osu.Game.Rulesets.BMS/UI/BmsSongSelect/BmsSortPolicy.cs
@@ -1,0 +1,41 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.BMS.UI.BmsSongSelect.Bars;
+
+namespace osu.Game.Rulesets.BMS.UI.BmsSongSelect
+{
+    public enum BmsSortMode
+    {
+        Title,
+        Level,
+        Artist,
+        Folder,
+    }
+
+    public sealed class BmsSortPolicy
+    {
+        public BmsSortMode Mode { get; private set; } = BmsSortMode.Title;
+
+        public void CycleNext()
+        {
+            Mode = (BmsSortMode)(((int)Mode + 1) % Enum.GetValues<BmsSortMode>().Length);
+        }
+
+        public IReadOnlyList<BmsBar> Sort(IReadOnlyList<BmsBar> bars)
+        {
+            IEnumerable<BmsBar> folders = bars.Where(b => b.IsDirectory);
+            IEnumerable<BmsBar> songs = bars.Where(b => b is BmsSongBar);
+
+            songs = Mode switch
+            {
+                BmsSortMode.Level => songs.OrderBy(b => ((BmsSongBar)b).Chart.PlayLevel).ThenBy(b => b.Title, StringComparer.OrdinalIgnoreCase),
+                BmsSortMode.Artist => songs.OrderBy(b => ((BmsSongBar)b).Chart.Artist, StringComparer.OrdinalIgnoreCase).ThenBy(b => b.Title, StringComparer.OrdinalIgnoreCase),
+                BmsSortMode.Folder => songs.OrderBy(b => ((BmsSongBar)b).Chart.FolderPath, StringComparer.OrdinalIgnoreCase).ThenBy(b => b.Title, StringComparer.OrdinalIgnoreCase),
+                _ => songs.OrderBy(b => b.Title, StringComparer.OrdinalIgnoreCase),
+            };
+
+            return folders.Concat(songs).ToList();
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Filtering/BmsFilterDatabaseSync.cs
+++ b/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Filtering/BmsFilterDatabaseSync.cs
@@ -1,0 +1,179 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Microsoft.Data.Sqlite;
+using osu.Framework.Logging;
+using osu.Game.Database;
+using osu.Game.Rulesets.BMS.Beatmaps;
+using osu.Game.Rulesets.BMS.Scoring.Lamp.Persistence;
+using osu.Game.Rulesets.BMS.UI.BmsSongSelect.Analytics;
+
+namespace osu.Game.Rulesets.BMS.UI.BmsSongSelect.Filtering
+{
+    public sealed class BmsFilterDatabaseSync
+    {
+        private readonly string databasePath;
+        private readonly object writeLock = new object();
+
+        public BmsFilterDatabaseSync(string databasePath)
+        {
+            this.databasePath = databasePath;
+        }
+
+        public void Rebuild(
+            BMSBeatmapManager beatmapManager,
+            BmsLampSqliteRepository lampRepository,
+            RealmAccess realm,
+            BmsAnalyticsSqliteRepository? analytics = null)
+        {
+            var charts = beatmapManager.GetAllCharts().ToList();
+            var lamps = lampRepository.LoadAll().ToDictionary(r => r.BeatmapId, r => r);
+
+            var (songs, scores, informations) = BmsScoreSchemaBuilder.Build(charts, lamps, realm, analytics);
+
+            lock (writeLock)
+            {
+                using var connection = openConnection();
+                using var transaction = connection.BeginTransaction();
+
+                executeNonQuery(connection, "DROP TABLE IF EXISTS scorelog;");
+                executeNonQuery(connection, "DROP TABLE IF EXISTS score;");
+                executeNonQuery(connection, "DROP TABLE IF EXISTS information;");
+                executeNonQuery(connection, "DROP TABLE IF EXISTS song;");
+
+                executeNonQuery(connection, BmsFilterSchema.CREATE_SONG);
+                executeNonQuery(connection, BmsFilterSchema.CREATE_SCORE);
+                executeNonQuery(connection, BmsFilterSchema.CREATE_SCORELOG);
+                executeNonQuery(connection, BmsFilterSchema.CREATE_INFORMATION);
+
+                insertSongs(connection, songs);
+                insertScores(connection, scores);
+                insertScoreLogs(connection, scores);
+                insertInformation(connection, informations);
+
+                transaction.Commit();
+            }
+
+            Logger.Log($"[BMS] Raja filter DB rebuilt: {songs.Count} songs.", LoggingTarget.Database);
+        }
+
+        private static void insertSongs(SqliteConnection connection, IReadOnlyList<BmsSongRow> songs)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = @"
+INSERT INTO song (md5, sha256, title, subtitle, genre, artist, subartist, path, folder, parent, level, difficulty, mode, notes, favorite, maxbpm, minbpm, length, date, adddate)
+VALUES ($md5, $sha256, $title, $subtitle, $genre, $artist, $subartist, $path, $folder, $parent, $level, $difficulty, $mode, $notes, $favorite, $maxbpm, $minbpm, $length, 0, 0);";
+
+            foreach (var song in songs)
+            {
+                cmd.Parameters.Clear();
+                cmd.Parameters.AddWithValue("$md5", song.Md5);
+                cmd.Parameters.AddWithValue("$sha256", song.Sha256);
+                cmd.Parameters.AddWithValue("$title", song.Title);
+                cmd.Parameters.AddWithValue("$subtitle", song.Subtitle);
+                cmd.Parameters.AddWithValue("$genre", song.Genre);
+                cmd.Parameters.AddWithValue("$artist", song.Artist);
+                cmd.Parameters.AddWithValue("$subartist", song.Subartist);
+                cmd.Parameters.AddWithValue("$path", song.Path);
+                cmd.Parameters.AddWithValue("$folder", song.Folder);
+                cmd.Parameters.AddWithValue("$parent", BmsPathCrc.Compute(song.Folder));
+                cmd.Parameters.AddWithValue("$level", song.Level);
+                cmd.Parameters.AddWithValue("$difficulty", song.Difficulty);
+                cmd.Parameters.AddWithValue("$mode", song.Mode);
+                cmd.Parameters.AddWithValue("$notes", song.Notes);
+                cmd.Parameters.AddWithValue("$favorite", song.Favorite);
+                cmd.Parameters.AddWithValue("$maxbpm", song.MaxBpm);
+                cmd.Parameters.AddWithValue("$minbpm", song.MinBpm);
+                cmd.Parameters.AddWithValue("$length", song.Length);
+                cmd.ExecuteNonQuery();
+            }
+        }
+
+        private static void insertScores(SqliteConnection connection, IReadOnlyList<BmsScoreRow> scores)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = @"
+INSERT INTO score (sha256, mode, clear, playcount, clearcount, epg, lpg, egr, lgr, egd, lgd, ebd, lbd, epr, lpr, ems, lms, notes, combo, minbp, avgjudge, date)
+VALUES ($sha256, $mode, $clear, $playcount, $clearcount, $epg, $lpg, $egr, $lgr, 0, 0, 0, 0, 0, 0, 0, 0, $notes, $combo, $minbp, 2147483647, 0);";
+
+            foreach (var score in scores)
+            {
+                cmd.Parameters.Clear();
+                addScoreParameters(cmd, score);
+                cmd.ExecuteNonQuery();
+            }
+        }
+
+        private static void insertScoreLogs(SqliteConnection connection, IReadOnlyList<BmsScoreRow> scores)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = @"
+INSERT INTO scorelog (sha256, mode, clear, playcount, clearcount, epg, lpg, egr, lgr, notes, combo, minbp, date)
+VALUES ($sha256, $mode, $clear, $playcount, $clearcount, $epg, $lpg, $egr, $lgr, $notes, $combo, $minbp, 0);";
+
+            foreach (var score in scores)
+            {
+                cmd.Parameters.Clear();
+                addScoreParameters(cmd, score);
+                cmd.ExecuteNonQuery();
+            }
+        }
+
+        private static void addScoreParameters(SqliteCommand cmd, BmsScoreRow score)
+        {
+            cmd.Parameters.AddWithValue("$sha256", score.Sha256);
+            cmd.Parameters.AddWithValue("$mode", score.Mode);
+            cmd.Parameters.AddWithValue("$clear", score.Clear);
+            cmd.Parameters.AddWithValue("$playcount", score.Playcount);
+            cmd.Parameters.AddWithValue("$clearcount", score.Clearcount);
+            cmd.Parameters.AddWithValue("$epg", score.Epg);
+            cmd.Parameters.AddWithValue("$lpg", score.Lpg);
+            cmd.Parameters.AddWithValue("$egr", score.Egr);
+            cmd.Parameters.AddWithValue("$lgr", score.Lgr);
+            cmd.Parameters.AddWithValue("$notes", score.Notes);
+            cmd.Parameters.AddWithValue("$combo", score.Combo);
+            cmd.Parameters.AddWithValue("$minbp", score.Minbp);
+        }
+
+        private static void insertInformation(SqliteConnection connection, IReadOnlyList<BmsInformationRow> rows)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = @"
+INSERT INTO information (sha256, n, ln, s, ls, total, density, peakdensity, enddensity, mainbpm)
+VALUES ($sha256, $n, $ln, $s, $ls, $total, $density, $peakdensity, $enddensity, $mainbpm);";
+
+            foreach (var row in rows)
+            {
+                cmd.Parameters.Clear();
+                cmd.Parameters.AddWithValue("$sha256", row.Sha256);
+                cmd.Parameters.AddWithValue("$n", row.N);
+                cmd.Parameters.AddWithValue("$ln", row.Ln);
+                cmd.Parameters.AddWithValue("$s", row.S);
+                cmd.Parameters.AddWithValue("$ls", row.Ls);
+                cmd.Parameters.AddWithValue("$total", row.Total);
+                cmd.Parameters.AddWithValue("$density", row.Density);
+                cmd.Parameters.AddWithValue("$peakdensity", row.PeakDensity);
+                cmd.Parameters.AddWithValue("$enddensity", row.EndDensity);
+                cmd.Parameters.AddWithValue("$mainbpm", row.MainBpm);
+                cmd.ExecuteNonQuery();
+            }
+        }
+
+        private static void executeNonQuery(SqliteConnection connection, string sql)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = sql;
+            cmd.ExecuteNonQuery();
+        }
+
+        private SqliteConnection openConnection()
+        {
+            var connection = new SqliteConnection($"Data Source={databasePath}");
+            connection.Open();
+            using var pragma = connection.CreateCommand();
+            pragma.CommandText = "PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;";
+            pragma.ExecuteNonQuery();
+            return connection;
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Filtering/BmsFilterSchema.cs
+++ b/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Filtering/BmsFilterSchema.cs
@@ -1,0 +1,105 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.BMS.UI.BmsSongSelect.Filtering
+{
+    /// <summary>
+    /// SQLite layouts aligned with beatoraja song / score / scorelog / information tables
+    /// so <c>folder/default.json</c> WHERE clauses resolve without missing columns.
+    /// </summary>
+    internal static class BmsFilterSchema
+    {
+        public const string CREATE_SONG = @"
+CREATE TABLE song (
+    md5 TEXT,
+    sha256 TEXT PRIMARY KEY,
+    title TEXT,
+    subtitle TEXT,
+    genre TEXT,
+    artist TEXT,
+    subartist TEXT,
+    path TEXT,
+    folder TEXT,
+    parent TEXT,
+    level INTEGER,
+    difficulty INTEGER,
+    mode INTEGER,
+    notes INTEGER,
+    favorite INTEGER,
+    maxbpm INTEGER,
+    minbpm INTEGER,
+    length INTEGER,
+    date INTEGER,
+    adddate INTEGER
+);";
+
+        public const string CREATE_SCORE = @"
+CREATE TABLE score (
+    sha256 TEXT PRIMARY KEY,
+    mode INTEGER,
+    clear INTEGER,
+    playcount INTEGER,
+    clearcount INTEGER,
+    epg INTEGER,
+    lpg INTEGER,
+    egr INTEGER,
+    lgr INTEGER,
+    egd INTEGER,
+    lgd INTEGER,
+    ebd INTEGER,
+    lbd INTEGER,
+    epr INTEGER,
+    lpr INTEGER,
+    ems INTEGER,
+    lms INTEGER,
+    notes INTEGER,
+    combo INTEGER,
+    minbp INTEGER,
+    avgjudge INTEGER,
+    date INTEGER
+);";
+
+        public const string CREATE_SCORELOG = @"
+CREATE TABLE scorelog (
+    sha256 TEXT,
+    mode INTEGER,
+    clear INTEGER,
+    playcount INTEGER,
+    clearcount INTEGER,
+    epg INTEGER,
+    lpg INTEGER,
+    egr INTEGER,
+    lgr INTEGER,
+    notes INTEGER,
+    combo INTEGER,
+    minbp INTEGER,
+    date INTEGER
+);";
+
+        public const string CREATE_INFORMATION = @"
+CREATE TABLE information (
+    sha256 TEXT PRIMARY KEY,
+    n INTEGER,
+    ln INTEGER,
+    s INTEGER,
+    ls INTEGER,
+    total REAL,
+    density REAL,
+    peakdensity REAL,
+    enddensity REAL,
+    mainbpm REAL
+);";
+
+        /// <summary>
+        /// Mirrors beatoraja song database accessor join shape.
+        /// Note: This query template intentionally ends with "WHERE " to allow dynamic condition appending.
+        /// </summary>
+        public const string SELECT_DISTINCT_SHA256 = @"
+SELECT DISTINCT song.sha256
+FROM song
+LEFT OUTER JOIN information ON song.sha256 = information.sha256
+LEFT OUTER JOIN score ON song.sha256 = score.sha256
+LEFT OUTER JOIN scorelog ON score.sha256 = scorelog.sha256
+WHERE ";
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Filtering/BmsFolderConfigLoader.cs
+++ b/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Filtering/BmsFolderConfigLoader.cs
@@ -1,0 +1,78 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using osu.Game.Rulesets.BMS.UI.BmsSongSelect.Bars;
+
+namespace osu.Game.Rulesets.BMS.UI.BmsSongSelect.Filtering
+{
+    public sealed class BmsRajaFolderDefinition
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("sql")]
+        public string? Sql { get; set; }
+
+        [JsonPropertyName("folder")]
+        public List<BmsRajaFolderDefinition>? Folder { get; set; }
+
+        [JsonPropertyName("showall")]
+        public bool ShowAll { get; set; }
+    }
+
+    public sealed class BmsRajaRandomDefinition
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("filter")]
+        public Dictionary<string, JsonElement>? Filter { get; set; }
+    }
+
+    public static class BmsFolderConfigLoader
+    {
+        public static IReadOnlyList<BmsRajaFolderDefinition> LoadFolderDefinitions()
+        {
+            string json = readEmbedded("osu.Game.Rulesets.BMS.Resources.Raja.folder.default.json");
+            return JsonSerializer.Deserialize<List<BmsRajaFolderDefinition>>(json) ?? new List<BmsRajaFolderDefinition>();
+        }
+
+        public static IReadOnlyList<BmsRajaRandomDefinition> LoadRandomDefinitions()
+        {
+            string json = readEmbedded("osu.Game.Rulesets.BMS.Resources.Raja.random.default.json");
+            return JsonSerializer.Deserialize<List<BmsRajaRandomDefinition>>(json) ?? new List<BmsRajaRandomDefinition>();
+        }
+
+        public static IReadOnlyList<BmsBar> BuildRootCommandBars(BmsBarContext context)
+        {
+            return BuildBars(LoadFolderDefinitions(), context);
+        }
+
+        public static IReadOnlyList<BmsBar> BuildBars(IReadOnlyList<BmsRajaFolderDefinition> definitions, BmsBarContext context)
+        {
+            var bars = new List<BmsBar>();
+
+            foreach (var def in definitions)
+            {
+                if (def.Folder != null && def.Folder.Count > 0)
+                    bars.Add(new BmsContainerBar(def.Name, def.Folder));
+                else if (!string.IsNullOrWhiteSpace(def.Sql))
+                    bars.Add(new BmsCommandBar(def.Name, def.Sql, def.ShowAll));
+            }
+
+            return bars;
+        }
+
+        private static string readEmbedded(string resourceName)
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            using var stream = assembly.GetManifestResourceStream(resourceName)
+                               ?? throw new InvalidOperationException($"Missing embedded resource: {resourceName}");
+            using var reader = new StreamReader(stream);
+            return reader.ReadToEnd();
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Filtering/BmsInformationBuilder.cs
+++ b/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Filtering/BmsInformationBuilder.cs
@@ -1,0 +1,77 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+using osu.Game.Rulesets.BMS.Beatmaps;
+using osu.Game.Rulesets.BMS.UI.BmsSongSelect.Analytics;
+
+namespace osu.Game.Rulesets.BMS.UI.BmsSongSelect.Filtering
+{
+    internal readonly record struct BmsInformationRow(
+        string Sha256,
+        int N,
+        int Ln,
+        int S,
+        int Ls,
+        double Total,
+        double Density,
+        double PeakDensity,
+        double EndDensity,
+        double MainBpm);
+
+    internal static class BmsInformationBuilder
+    {
+        public static BmsInformationRow Build(BMSChartCache chart, string pathKey, RealmAccess realm, BmsAnalyticsSqliteRepository? analytics)
+        {
+            int notes = Math.Max(1, chart.TotalNotes);
+            int ln = chart.LongNoteCount;
+            int n = Math.Max(0, notes - ln);
+
+            double lengthSec = Math.Max(1.0, chart.Duration / 1000.0);
+            double mainBpm = chart.Bpm > 0 ? chart.Bpm : 130;
+
+            double density = notes / lengthSec * 4.0;
+            double peakDensity = density;
+            double endDensity = density * 0.85;
+
+            Guid beatmapId = BmsAnalyticsRealmWriteback.GetDeterministicBeatmapId(chart.FullPath);
+
+            realm.Run(r =>
+            {
+                var beatmap = r.Find<BeatmapInfo>(beatmapId);
+
+                if (beatmap == null)
+                    return;
+
+                if (beatmap.XxyStarRating >= 0)
+                    endDensity = beatmap.XxyStarRating;
+            });
+
+            // KPS detail remains in analytics.sqlite until a dedicated Realm field exists.
+            if (analytics != null && analytics.TryGet(pathKey, out var record))
+            {
+                if (record.AvgKps is > 0)
+                    density = record.AvgKps.Value;
+
+                if (record.MaxKps is > 0)
+                    peakDensity = record.MaxKps.Value;
+
+                if (record.XxySr is > 0 && endDensity <= density * 0.85)
+                    endDensity = record.XxySr.Value;
+            }
+
+            return new BmsInformationRow(
+                pathKey,
+                n,
+                ln,
+                0,
+                0,
+                chart.Total,
+                density,
+                peakDensity,
+                endDensity,
+                mainBpm);
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Filtering/BmsRandomFilterEvaluator.cs
+++ b/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Filtering/BmsRandomFilterEvaluator.cs
@@ -1,0 +1,59 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Text.Json;
+using Microsoft.Data.Sqlite;
+using osu.Game.Rulesets.BMS.UI.BmsSongSelect.Bars;
+
+namespace osu.Game.Rulesets.BMS.UI.BmsSongSelect.Filtering
+{
+    public static class BmsRandomFilterEvaluator
+    {
+        public static bool Matches(BmsSongBar song, IReadOnlyDictionary<string, JsonElement>? filter, BmsBarContext context)
+        {
+            if (filter == null || filter.Count == 0)
+                return true;
+
+            var scores = context.SqlQuery.Execute($"song.sha256 = '{song.PathKey}'");
+
+            if (scores.Count == 0)
+            {
+                return filter.Values.Any(v => v.ValueKind == JsonValueKind.String && !string.IsNullOrEmpty(v.GetString()))
+                       || filter.Values.Any(v => v.ValueKind == JsonValueKind.Number && v.GetInt32() != 0);
+            }
+
+            // Re-query score row via filter DB
+            using var connection = new SqliteConnection($"Data Source={getDbPath(context)}");
+            connection.Open();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT clear, playcount FROM score WHERE sha256 = $sha LIMIT 1;";
+            cmd.Parameters.AddWithValue("$sha", song.PathKey);
+            using var reader = cmd.ExecuteReader();
+            if (!reader.Read())
+                return false;
+
+            int clear = reader.GetInt32(0);
+            int playcount = reader.GetInt32(1);
+
+            foreach (var (key, value) in filter)
+            {
+                object? actual = key.ToLowerInvariant() switch
+                {
+                    "clear" => clear,
+                    "playcount" => playcount,
+                    _ => null,
+                };
+
+                if (actual == null)
+                    continue;
+
+                if (value.ValueKind == JsonValueKind.Number && actual is int intActual && value.GetInt32() != intActual)
+                    return false;
+            }
+
+            return true;
+        }
+
+        private static string getDbPath(BmsBarContext context) => context.FilterDatabasePath;
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Filtering/BmsScoreSchemaBuilder.cs
+++ b/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Filtering/BmsScoreSchemaBuilder.cs
@@ -1,0 +1,154 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Security.Cryptography;
+using System.Text;
+using osu.Game.Database;
+using osu.Game.Rulesets.BMS.Beatmaps;
+using osu.Game.Rulesets.BMS.Scoring.Lamp;
+using osu.Game.Rulesets.BMS.Scoring.Lamp.Persistence;
+using osu.Game.Rulesets.BMS.UI.BmsSongSelect.Analytics;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.BMS.UI.BmsSongSelect.Filtering
+{
+    internal readonly record struct BmsSongRow(
+        string Md5,
+        string Sha256,
+        string Title,
+        string Subtitle,
+        string Genre,
+        string Artist,
+        string Subartist,
+        string Path,
+        string Folder,
+        int Level,
+        int Difficulty,
+        int Mode,
+        int Notes,
+        int Favorite,
+        int MaxBpm,
+        int MinBpm,
+        int Length);
+
+    internal readonly record struct BmsScoreRow(
+        string Sha256,
+        int Mode,
+        int Clear,
+        int Playcount,
+        int Clearcount,
+        int Epg,
+        int Lpg,
+        int Egr,
+        int Lgr,
+        int Notes,
+        int Combo,
+        int Minbp);
+
+    internal static class BmsScoreSchemaBuilder
+    {
+        public static (
+            IReadOnlyList<BmsSongRow> songs,
+            IReadOnlyList<BmsScoreRow> scores,
+            IReadOnlyList<BmsInformationRow> informations)
+            Build(
+                IEnumerable<BMSChartCache> charts,
+                IReadOnlyDictionary<Guid, BmsLampRecord> lampsByBeatmapId,
+                RealmAccess realm,
+                BmsAnalyticsSqliteRepository? analytics)
+        {
+            var songs = new List<BmsSongRow>();
+            var scores = new List<BmsScoreRow>();
+            var informations = new List<BmsInformationRow>();
+
+            foreach (var chart in charts)
+            {
+                string pathKey = string.IsNullOrEmpty(chart.Md5Hash)
+                    ? BmsPathKeys.ComputeChartPathKey(chart.FullPath)
+                    : chart.Md5Hash;
+
+                string sha256 = pathKey;
+                string md5 = pathKey.Length >= 32 ? pathKey[..32] : pathKey;
+
+                songs.Add(new BmsSongRow(
+                    md5,
+                    sha256,
+                    chart.Title,
+                    chart.SubTitle,
+                    chart.Genre,
+                    chart.Artist,
+                    chart.SubArtist,
+                    chart.FileName,
+                    chart.FolderPath,
+                    chart.PlayLevel,
+                    chart.Rank,
+                    chart.KeyCount,
+                    Math.Max(1, chart.TotalNotes),
+                    0,
+                    (int)Math.Round(chart.MaxBpm > 0 ? chart.MaxBpm : chart.Bpm),
+                    (int)Math.Round(chart.MinBpm),
+                    (int)Math.Round(chart.Duration)));
+
+                scores.Add(buildScoreRow(chart, pathKey, lampsByBeatmapId, realm));
+                informations.Add(BmsInformationBuilder.Build(chart, pathKey, realm, analytics));
+            }
+
+            return (songs, scores, informations);
+        }
+
+        private static BmsScoreRow buildScoreRow(
+            BMSChartCache chart,
+            string pathKey,
+            IReadOnlyDictionary<Guid, BmsLampRecord> lampsByBeatmapId,
+            RealmAccess realm)
+        {
+            int clear = (int)BmsClearLamp.NoPlay;
+            int playcount = 0;
+            int clearcount = 0;
+            int epg = 0, lpg = 0, egr = 0, lgr = 0;
+            int notes = Math.Max(1, chart.TotalNotes);
+            int combo = 0;
+            int minbp = 0;
+
+            var best = BmsLocalScoreQueries.GetBestLocalScore(realm, pathKey);
+
+            if (best != null)
+            {
+                playcount = 1;
+                epg = best.Statistics.GetValueOrDefault(HitResult.Perfect);
+                egr = best.Statistics.GetValueOrDefault(HitResult.Great);
+                lgr = best.Statistics.GetValueOrDefault(HitResult.Good);
+                lpg = epg;
+                minbp = best.Statistics.GetValueOrDefault(HitResult.Miss);
+                combo = notes - minbp;
+                clear = best.Accuracy >= 0.95 ? (int)BmsClearLamp.Normal : (int)BmsClearLamp.Failed;
+                if (clear >= (int)BmsClearLamp.Normal)
+                    clearcount = 1;
+            }
+
+            Guid beatmapId = createDeterministicGuid($"bms:chart:{chart.FullPath}");
+
+            if (lampsByBeatmapId.TryGetValue(beatmapId, out var lamp))
+            {
+                clear = (int)lamp.Lamp;
+                playcount = Math.Max(playcount, 1);
+                lpg = lamp.PerfectGreatCount;
+                epg = lamp.PerfectGreatCount;
+                egr = lamp.GreatCount;
+                lgr = lamp.GoodCount;
+                minbp = lamp.MissCount;
+                combo = Math.Max(0, lamp.TotalNotes - lamp.MissCount);
+                if (clear >= (int)BmsClearLamp.Normal)
+                    clearcount = 1;
+            }
+
+            return new BmsScoreRow(pathKey, chart.KeyCount, clear, playcount, clearcount, epg, lpg, egr, lgr, notes, combo, minbp);
+        }
+
+        private static Guid createDeterministicGuid(string seed)
+        {
+            byte[] hash = MD5.HashData(Encoding.UTF8.GetBytes(seed));
+            return new Guid(hash);
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Filtering/BmsSqlSongQuery.cs
+++ b/osu.Game.Rulesets.BMS/UI/BmsSongSelect/Filtering/BmsSqlSongQuery.cs
@@ -1,0 +1,106 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Microsoft.Data.Sqlite;
+using osu.Framework.Logging;
+using osu.Game.Rulesets.BMS.Beatmaps;
+
+namespace osu.Game.Rulesets.BMS.UI.BmsSongSelect.Filtering
+{
+    public sealed class BmsSqlSongQuery
+    {
+        private readonly string databasePath;
+        private readonly BMSBeatmapManager beatmapManager;
+
+        public BmsSqlSongQuery(string databasePath, BMSBeatmapManager beatmapManager)
+        {
+            this.databasePath = databasePath;
+            this.beatmapManager = beatmapManager;
+        }
+
+        public IReadOnlyList<BMSChartCache> Execute(string whereClause)
+        {
+            var keys = new List<string>();
+
+            try
+            {
+                using var connection = new SqliteConnection($"Data Source={databasePath}");
+                connection.Open();
+
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = BmsFilterSchema.SELECT_DISTINCT_SHA256 + whereClause;
+
+                using var reader = cmd.ExecuteReader();
+                while (reader.Read())
+                    keys.Add(reader.GetString(0));
+            }
+            catch (SqliteException ex)
+            {
+                Logger.Log($"[BMS] Raja SQL filter failed: {ex.Message} | WHERE {whereClause}", LoggingTarget.Runtime, LogLevel.Important);
+                return Array.Empty<BMSChartCache>();
+            }
+
+            return resolveCharts(keys);
+        }
+
+        public IReadOnlyList<BMSChartCache> SearchByText(string text)
+        {
+            var keys = new List<string>();
+            string pattern = $"%{text}%";
+
+            using var connection = new SqliteConnection($"Data Source={databasePath}");
+            connection.Open();
+
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = @"
+SELECT sha256 FROM song
+WHERE rtrim(title||' '||subtitle||' '||artist||' '||subartist||' '||genre) LIKE $pattern
+GROUP BY sha256;";
+            cmd.Parameters.AddWithValue("$pattern", pattern);
+
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+                keys.Add(reader.GetString(0));
+
+            return resolveCharts(keys);
+        }
+
+        public IReadOnlyList<BMSChartCache> GetByFolderCrc(string folderCrc)
+        {
+            var keys = new List<string>();
+
+            using var connection = new SqliteConnection($"Data Source={databasePath}");
+            connection.Open();
+
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT sha256 FROM song WHERE parent = $parent GROUP BY sha256;";
+            cmd.Parameters.AddWithValue("$parent", folderCrc);
+
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+                keys.Add(reader.GetString(0));
+
+            return resolveCharts(keys);
+        }
+
+        private List<BMSChartCache> resolveCharts(IReadOnlyList<string> pathKeys)
+        {
+            var result = new List<BMSChartCache>();
+            var cache = beatmapManager.LibraryCache;
+            if (cache == null)
+                return result;
+
+            var byKey = cache.Songs
+                             .SelectMany(s => s.Charts)
+                             .ToDictionary(c => string.IsNullOrEmpty(c.Md5Hash) ? BmsPathKeys.ComputeChartPathKey(c.FullPath) : c.Md5Hash, c => c, StringComparer.OrdinalIgnoreCase);
+
+            foreach (string key in pathKeys)
+            {
+                if (byKey.TryGetValue(key, out var chart))
+                    result.Add(chart);
+            }
+
+            return result;
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/DrawableBMSRuleset.cs
+++ b/osu.Game.Rulesets.BMS/UI/DrawableBMSRuleset.cs
@@ -1,0 +1,116 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Input;
+using osu.Framework.Input.Bindings;
+using osu.Game.Beatmaps;
+using osu.Game.Input.Handlers;
+using osu.Game.Replays;
+using osu.Game.Rulesets.BMS.Objects;
+using osu.Game.Rulesets.BMS.Objects.Drawables;
+using osu.Game.Rulesets.BMS.Replays;
+using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Mania.Configuration;
+using osu.Game.Rulesets.Mania.UI;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.UI;
+using osu.Game.Rulesets.UI.Scrolling;
+
+namespace osu.Game.Rulesets.BMS.UI
+{
+    [Cached]
+    public partial class DrawableBMSRuleset : DrawableScrollingRuleset<BMSHitObject>
+    {
+        private const double default_time_range = 1500;
+
+        private BMSStageLayout? layoutCache;
+
+        /// <summary>
+        /// Stage layout for this beatmap (mods applied). Safe from <see cref="CreateInputManager"/> onward once <see cref="Beatmap"/> is set.
+        /// </summary>
+        private BMSStageLayout layout => layoutCache ??= BMSStageLayout.FromBeatmap(Beatmap);
+
+        private readonly BindableDouble maniaScrollSpeed = new BindableDouble();
+        private readonly BindableDouble maniaBaseSpeed = new BindableDouble();
+        private readonly BindableDouble maniaTimePerSpeed = new BindableDouble();
+        private readonly Bindable<ManiaScrollingDirection> maniaDirection = new Bindable<ManiaScrollingDirection>();
+
+        protected override bool RelativeScaleBeatLengths => true;
+
+        public int TotalColumns => layout.TotalColumns;
+
+        public DrawableBMSRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod>? mods = null)
+            : base(ruleset, beatmap, mods)
+        {
+            Direction.Value = ScrollingDirection.Down;
+            TimeRange.Value = default_time_range;
+        }
+
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+        {
+            var dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
+            dependencies.CacheAs(layout);
+            return dependencies;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(IRulesetConfigCache rulesetConfigCache)
+        {
+            var maniaConfig = rulesetConfigCache.GetConfigFor(new ManiaRuleset()) as ManiaRulesetConfigManager;
+
+            if (maniaConfig == null)
+                return;
+
+            maniaConfig.BindWith(ManiaRulesetSetting.ScrollDirection, maniaDirection);
+            maniaDirection.BindValueChanged(direction => Direction.Value = (ScrollingDirection)direction.NewValue, true);
+
+            maniaConfig.BindWith(ManiaRulesetSetting.ScrollBaseSpeed, maniaBaseSpeed);
+            maniaConfig.BindWith(ManiaRulesetSetting.ScrollTimePerSpeed, maniaTimePerSpeed);
+            maniaConfig.BindWith(ManiaRulesetSetting.ScrollSpeed, maniaScrollSpeed);
+
+            maniaScrollSpeed.BindValueChanged(speed =>
+            {
+                if (!AllowScrollSpeedAdjustment)
+                    return;
+
+                TimeRange.Value = DrawableManiaRuleset.ComputeScrollTime(speed.NewValue, maniaBaseSpeed.Value, maniaTimePerSpeed.Value);
+            });
+
+            TimeRange.Value = DrawableManiaRuleset.ComputeScrollTime(maniaScrollSpeed.Value, maniaBaseSpeed.Value, maniaTimePerSpeed.Value);
+        }
+
+        protected override Playfield CreatePlayfield() => new BMSPlayfield(layout);
+
+        protected override ReplayInputHandler CreateReplayInputHandler(Replay replay) => new BMSFramedReplayInputHandler(replay);
+
+        public override DrawableHitObject<BMSHitObject>? CreateDrawableRepresentation(BMSHitObject hitObject)
+        {
+            switch (hitObject)
+            {
+                case BMSHoldNote holdNote:
+                    return new DrawableBMSHoldNote(holdNote);
+
+                case BMSHoldNoteHead holdHead:
+                    return new DrawableBMSHoldNoteHead(holdHead);
+
+                case BMSHoldNoteTail holdTail:
+                    return new DrawableBMSHoldNoteTail(holdTail);
+
+                case BMSHoldNoteBody holdBody:
+                    return new DrawableBMSHoldNoteBody(holdBody);
+
+                case BMSNote note:
+                    return new DrawableBMSNote(note);
+            }
+
+            return null;
+        }
+
+        protected override PassThroughInputManager CreateInputManager() => new BMSInputManager(Ruleset.RulesetInfo, layout.TotalColumns, SimultaneousBindingMode.Unique);
+
+        protected override void AdjustScrollSpeed(int amount) => maniaScrollSpeed.Value += amount;
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/MainMenu/BmsMainMenuButtonInjector.cs
+++ b/osu.Game.Rulesets.BMS/UI/MainMenu/BmsMainMenuButtonInjector.cs
@@ -1,0 +1,221 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Events;
+using osu.Framework.Logging;
+using osu.Framework.Screens;
+using osu.Game.Rulesets.BMS.UI.SongSelect;
+using osu.Game.Screens.Menu;
+using osuTK.Graphics;
+using osuTK.Input;
+
+// ReSharper disable CheckNamespace
+
+namespace osu.Game.Rulesets.BMS.UI.MenuEntry
+{
+    /// <summary>
+    /// Injects an extra "BMS Game" button into the main-menu PLAY sub-row
+    /// without modifying any osu.Game code.
+    ///
+    /// The injector enters the OsuGame Drawable tree via <see cref="BmsRulesetIcon"/>
+    /// (returned from <see cref="BMSRuleset.CreateIcon"/>), resolves the running
+    /// <see cref="OsuGame"/>, listens to ScreenPushed and reflects into
+    /// <see cref="ButtonSystem"/> private members to add a regular
+    /// <see cref="MainMenuButton"/> alongside Solo / Multi / Playlists.
+    ///
+    /// All reflection failure paths degrade gracefully: the user can still reach
+    /// the BMS song select via the existing settings entry.
+    /// </summary>
+    public partial class BmsMainMenuButtonInjector : Drawable
+    {
+        /// <summary>
+        /// Factory for the screen that the injected "BMS Game" button pushes onto the screen stack.
+        /// Returns a <see cref="BmsSoloSongSelect"/> — a <c>SoloSongSelect</c> derivative that reuses every
+        /// official song-select sub-component (title wedge, details area, filter control, beatmap carousel)
+        /// while routing gameplay launches to the BMS-owned <see cref="BMSPlayerLoader"/>.
+        /// Exposed as a static factory so tests can lock the click target type without exercising the full UI.
+        /// </summary>
+        public static IScreen CreateBmsSongSelectScreen() => new BmsSoloSongSelect();
+
+        // One MainMenu instance gets injected at most once. ConditionalWeakTable
+        // means we don't keep MainMenus alive past their natural lifetime.
+        private static readonly ConditionalWeakTable<MainMenu, object> injected_menus = new ConditionalWeakTable<MainMenu, object>();
+
+        [Resolved(canBeNull: true)]
+        private OsuGame? osuGame { get; set; }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            if (osuGame == null)
+                return;
+
+            // ScreenStack is publicly exposed by OsuGame.
+            try
+            {
+                osuGame.ScreenStack.ScreenPushed += onScreenPushed;
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"BMS main-menu injector failed to subscribe ScreenPushed: {ex.Message}", LoggingTarget.Runtime, LogLevel.Important);
+                return;
+            }
+
+            // The very first MainMenu may already be on top of the stack at the
+            // time we load (Toolbar is created together with MainMenu).
+            tryInjectIfMainMenu(osuGame.ScreenStack.CurrentScreen);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (osuGame != null)
+            {
+                try
+                {
+                    osuGame.ScreenStack.ScreenPushed -= onScreenPushed;
+                }
+                catch
+                {
+                    // ignored — game host may already be tearing down.
+                }
+            }
+
+            base.Dispose(isDisposing);
+        }
+
+        private void onScreenPushed(IScreen lastScreen, IScreen newScreen) => tryInjectIfMainMenu(newScreen);
+
+        private void tryInjectIfMainMenu(IScreen? screen)
+        {
+            if (screen is not MainMenu mainMenu)
+                return;
+
+            if (injected_menus.TryGetValue(mainMenu, out _))
+                return;
+
+            // Defer until MainMenu has finished its own load (so Buttons/buttonsPlay are populated).
+            // Use our own Scheduler so we don't poke at MainMenu protected APIs.
+            Scheduler.Add(() => attemptInject(mainMenu));
+        }
+
+        private void attemptInject(MainMenu mainMenu)
+        {
+            if (injected_menus.TryGetValue(mainMenu, out _))
+                return;
+
+            if (!mainMenu.IsLoaded)
+            {
+                // MainMenu not ready yet — try again next frame.
+                Scheduler.AddDelayed(() => attemptInject(mainMenu), 50);
+                return;
+            }
+
+            if (inject(mainMenu))
+                injected_menus.Add(mainMenu, new object());
+        }
+
+        private bool inject(MainMenu mainMenu)
+        {
+            try
+            {
+                ButtonSystem? buttonSystem = getButtonSystem(mainMenu);
+
+                if (buttonSystem == null)
+                {
+                    Logger.Log("BMS main-menu injector: failed to access MainMenu.Buttons via reflection.", LoggingTarget.Runtime, LogLevel.Important);
+                    return false;
+                }
+
+                FieldInfo? buttonsPlayField = typeof(ButtonSystem).GetField("buttonsPlay", BindingFlags.Instance | BindingFlags.NonPublic);
+                FieldInfo? buttonAreaField = typeof(ButtonSystem).GetField("buttonArea", BindingFlags.Instance | BindingFlags.NonPublic);
+
+                if (buttonsPlayField == null || buttonAreaField == null)
+                {
+                    Logger.Log("BMS main-menu injector: ButtonSystem private fields renamed; aborting injection.", LoggingTarget.Runtime, LogLevel.Important);
+                    return false;
+                }
+
+                if (buttonsPlayField.GetValue(buttonSystem) is not List<MainMenuButton> buttonsPlay
+                    || buttonAreaField.GetValue(buttonSystem) is not ButtonArea buttonArea)
+                {
+                    Logger.Log("BMS main-menu injector: ButtonSystem private fields had unexpected types; aborting.", LoggingTarget.Runtime, LogLevel.Important);
+                    return false;
+                }
+
+                if (buttonsPlay.Count == 0)
+                {
+                    // ButtonSystem.load() not yet executed; retry shortly.
+                    Scheduler.AddDelayed(() => attemptInject(mainMenu), 50);
+                    return false;
+                }
+
+                var bmsButton = new MainMenuButton(
+                    "bms",
+                    @"button-default-select",
+                    FontAwesome.Solid.Music,
+                    new Color4(120, 80, 200, 255),
+                    onBmsClicked,
+                    Key.B)
+                {
+                    VisibleState = ButtonSystemState.Play,
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                };
+
+                // Insert just after Solo so the order reads "Solo / BMS / Multi / Playlists / Daily".
+                int insertIndex = Math.Min(1, buttonsPlay.Count);
+                buttonsPlay.Insert(insertIndex, bmsButton);
+
+                buttonArea.Add(bmsButton);
+
+                // Reflect current ButtonSystem state so the new button animates correctly.
+                bmsButton.ButtonSystemState = buttonSystem.State;
+
+                Logger.Log("BMS main-menu injector: BMS button installed.", LoggingTarget.Runtime, LogLevel.Verbose);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"BMS main-menu injector failed: {ex.Message}", LoggingTarget.Runtime, LogLevel.Important);
+                return false;
+            }
+        }
+
+        private static ButtonSystem? getButtonSystem(MainMenu mainMenu)
+        {
+            // MainMenu.Buttons is a protected field. Walk up the type hierarchy in case of subclassing.
+            for (Type? type = mainMenu.GetType(); type != null; type = type.BaseType)
+            {
+                FieldInfo? field = type.GetField("Buttons", BindingFlags.Instance | BindingFlags.NonPublic);
+                if (field != null && typeof(ButtonSystem).IsAssignableFrom(field.FieldType))
+                    return field.GetValue(mainMenu) as ButtonSystem;
+            }
+
+            return null;
+        }
+
+        private void onBmsClicked(MainMenuButton _, UIEvent __)
+        {
+            if (osuGame == null)
+                return;
+
+            try
+            {
+                // Push BMS's solo song-select derivative. It reuses osu.Game's full SongSelect UI tree but
+                // forces Ruleset.Value to BMS, syncs BMS catalog into Realm, and intercepts OnStart to push
+                // BMSPlayerLoader instead of the standard SoloPlayer launcher.
+                osuGame.PerformFromScreen(s => s.Push(CreateBmsSongSelectScreen()), new[] { typeof(MainMenu) });
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"BMS main-menu injector: failed to push BMS song select screen: {ex.Message}", LoggingTarget.Runtime, LogLevel.Important);
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/MainMenu/BmsRulesetIcon.cs
+++ b/osu.Game.Rulesets.BMS/UI/MainMenu/BmsRulesetIcon.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
+using osuTK;
+
+// ReSharper disable once CheckNamespace
+namespace osu.Game.Rulesets.BMS.UI.MenuEntry
+{
+    /// <summary>
+    /// Drawable returned by <see cref="BMSRuleset.CreateIcon"/>.
+    /// Wraps the visual icon so we can piggy-back a hidden <see cref="BmsMainMenuButtonInjector"/>
+    /// into the OsuGame Drawable tree without modifying any osu.Game code.
+    ///
+    /// Must NOT use <see cref="CompositeDrawable.AutoSizeAxes"/>: callers such as
+    /// <c>PanelBeatmapSet.SpreadDisplay</c> assign <see cref="Drawable.Size"/> directly on the
+    /// drawable returned from <see cref="Ruleset.CreateIcon"/>, which throws on auto-sized composites.
+    /// </summary>
+    public partial class BmsRulesetIcon : CompositeDrawable
+    {
+        public BmsRulesetIcon()
+        {
+            // Default to a size comparable to what other ruleset icons render at.
+            // Consumers (toolbar, beatmap set spread, etc.) typically overwrite this anyway.
+            Size = new Vector2(20);
+
+            InternalChildren = new Drawable[]
+            {
+                new SpriteIcon
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Icon = OsuIcon.RulesetMania,
+                },
+                new BmsMainMenuButtonInjector
+                {
+                    Alpha = 0f,
+                    AlwaysPresent = true,
+                },
+            };
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/SongSelect/BMSPlayerLoader.cs
+++ b/osu.Game.Rulesets.BMS/UI/SongSelect/BMSPlayerLoader.cs
@@ -1,0 +1,239 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Logging;
+using osu.Framework.Screens;
+using osu.Framework.Threading;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.BMS.Beatmaps;
+using osu.Game.Rulesets.BMS.Configuration;
+using osu.Game.Rulesets.Mania;
+using osu.Game.Screens;
+using osu.Game.Screens.Play;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.BMS.UI.SongSelect
+{
+    /// <summary>
+    /// Loader screen that prepares and starts BMS gameplay.
+    /// Uses BMS ruleset gameplay pipeline directly.
+    /// </summary>
+    public partial class BMSPlayerLoader : OsuScreen
+    {
+        public override bool DisallowExternalBeatmapRulesetChanges => true;
+
+        protected override bool InitialBackButtonVisibility => false;
+
+        private readonly BMSWorkingBeatmap workingBeatmap;
+        private readonly BMSGameplayRoute? gameplayRouteOverride;
+        private LoadingSpinner loadingSpinner = null!;
+        private OsuSpriteText statusText = null!;
+        private OsuSpriteText titleText = null!;
+        private ScheduledDelegate? scheduledLoadBeatmap;
+        private ScheduledDelegate? scheduledPushPlayer;
+        private ScheduledDelegate? scheduledExit;
+
+        [Resolved]
+        private AudioManager audioManager { get; set; } = null!;
+
+        [Resolved]
+        private IRulesetConfigCache rulesetConfigCache { get; set; } = null!;
+
+        /// <summary>
+        /// Construct a player loader with an explicit route override (mainly used by tests or special entries).
+        /// </summary>
+        public BMSPlayerLoader(BMSWorkingBeatmap workingBeatmap, BMSGameplayRoute? gameplayRouteOverride = null)
+        {
+            this.workingBeatmap = workingBeatmap;
+            this.gameplayRouteOverride = gameplayRouteOverride;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            InternalChildren = new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = Color4.Black,
+                },
+                new FillFlowContainer
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Direction = FillDirection.Vertical,
+                    AutoSizeAxes = Axes.Both,
+                    Spacing = new Vector2(0, 20),
+                    Children = new Drawable[]
+                    {
+                        new SpriteIcon
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Icon = FontAwesome.Solid.Music,
+                            Size = new Vector2(64),
+                            Colour = colours.Yellow,
+                        },
+                        titleText = new OsuSpriteText
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Text = "加载中...",
+                            Font = OsuFont.GetFont(size: 32, weight: FontWeight.Bold),
+                        },
+                        statusText = new OsuSpriteText
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Text = "正在解析 BMS 文件...",
+                            Font = OsuFont.GetFont(size: 18),
+                            Colour = colours.Yellow,
+                        },
+                        loadingSpinner = new LoadingSpinner
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Size = new Vector2(50),
+                        },
+                    },
+                },
+            };
+
+            loadingSpinner.Show();
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            // Start loading after a brief delay
+            scheduledLoadBeatmap = Scheduler.AddDelayed(loadBeatmap, 100);
+        }
+
+        private void loadBeatmap()
+        {
+            if (!this.IsCurrentScreen())
+                return;
+
+            try
+            {
+                statusText.Text = "正在解析谱面...";
+
+                // Force load the beatmap
+                var beatmap = workingBeatmap.Beatmap;
+
+                if (beatmap == null || beatmap.HitObjects.Count == 0)
+                {
+                    statusText.Text = "错误: 谱面加载失败或没有音符";
+                    loadingSpinner.Hide();
+                    scheduleExit(2000);
+                    return;
+                }
+
+                // Update title display
+                var metadata = workingBeatmap.BeatmapInfo.Metadata;
+                titleText.Text = string.IsNullOrEmpty(metadata.Title) ? "BMS" : metadata.Title;
+                statusText.Text = $"加载完成! {beatmap.HitObjects.Count} 个音符";
+
+                // Small delay then push to player
+                scheduledPushPlayer = Scheduler.AddDelayed(() =>
+                {
+                    if (!this.IsCurrentScreen())
+                        return;
+
+                    loadingSpinner.Hide();
+                    pushPlayer();
+                }, 500);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Failed to load BMS beatmap for play");
+                statusText.Text = $"加载失败: {ex.Message}";
+                loadingSpinner.Hide();
+                scheduleExit(3000);
+            }
+        }
+
+        private void pushPlayer()
+        {
+            if (!this.IsCurrentScreen())
+                return;
+
+            try
+            {
+                BMSGameplayRoute route = gameplayRouteOverride ?? resolveRouteFromConfig();
+
+                if (route == BMSGameplayRoute.BmsNative)
+                {
+                    Beatmap.Value = workingBeatmap;
+                    Ruleset.Value = new BMSNativeRuleset().RulesetInfo;
+                }
+                else
+                {
+                    var maniaWorkingBeatmap = new ManiaConvertedWorkingBeatmap(workingBeatmap, audioManager);
+                    Beatmap.Value = maniaWorkingBeatmap;
+                    Ruleset.Value = new ManiaRuleset().RulesetInfo;
+                }
+
+                var playerLoader = new PlayerLoader(() => new BmsPlayer());
+                this.Push(playerLoader);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Failed to push BMS player");
+                statusText.Text = $"启动游戏失败: {ex.Message}";
+                scheduleExit(3000);
+            }
+        }
+
+        private BMSGameplayRoute resolveRouteFromConfig()
+        {
+            try
+            {
+                if (rulesetConfigCache.GetConfigFor(new BMSRuleset()) is BMSRulesetConfigManager bmsConfig)
+                    return bmsConfig.Get<BMSGameplayRoute>(BMSRulesetSetting.GameplayRoute);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"BMSPlayerLoader: failed to read GameplayRoute config: {ex.Message}", LoggingTarget.Runtime, LogLevel.Important);
+            }
+
+            return BMSGameplayRoute.ManiaCompatibility;
+        }
+
+        private void scheduleExit(double delay)
+        {
+            scheduledExit?.Cancel();
+            scheduledExit = Scheduler.AddDelayed(() =>
+            {
+                if (this.IsCurrentScreen())
+                    this.Exit();
+            }, delay);
+        }
+
+        public override void OnEntering(ScreenTransitionEvent e)
+        {
+            base.OnEntering(e);
+            this.FadeInFromZero(300);
+        }
+
+        public override bool OnExiting(ScreenExitEvent e)
+        {
+            scheduledLoadBeatmap?.Cancel();
+            scheduledPushPlayer?.Cancel();
+            scheduledExit?.Cancel();
+            this.FadeOut(200);
+            return base.OnExiting(e);
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/SongSelect/BmsAnalyticsEzConverter.cs
+++ b/osu.Game.Rulesets.BMS/UI/SongSelect/BmsAnalyticsEzConverter.cs
@@ -1,0 +1,55 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Text.Json;
+using osu.Game.EzOsuGame.Analysis;
+using osu.Game.Rulesets.BMS.UI.BmsSongSelect.Analytics;
+
+namespace osu.Game.Rulesets.BMS.UI.SongSelect
+{
+    public static class BmsAnalyticsEzConverter
+    {
+        public static EzAnalysisResult? ToEzAnalysisResult(BmsAnalyticsRecord record)
+        {
+            if (record.Pp == null && record.XxySr == null && record.AvgKps == null && record.MaxKps == null && string.IsNullOrEmpty(record.ColumnCountsJson))
+                return null;
+
+            double avgKps = record.AvgKps ?? 0;
+            double maxKps = record.MaxKps ?? 0;
+            IReadOnlyList<double> kpsList = tryDeserializeKpsList(record.KpsListJson);
+            var kpsSummary = new KpsSummary(avgKps, maxKps, kpsList);
+
+            Dictionary<int, int>? columnCounts = null;
+
+            if (!string.IsNullOrEmpty(record.ColumnCountsJson))
+            {
+                try
+                {
+                    columnCounts = JsonSerializer.Deserialize<Dictionary<int, int>>(record.ColumnCountsJson);
+                }
+                catch
+                {
+                    // Ignore malformed JSON from older scans.
+                }
+            }
+
+            var maniaSummary = new EzManiaSummary(columnCounts, holdNoteCounts: null, xxySr: record.XxySr);
+            return new EzAnalysisResult(kpsSummary, record.Pp, maniaSummary);
+        }
+
+        private static IReadOnlyList<double> tryDeserializeKpsList(string? json)
+        {
+            if (string.IsNullOrEmpty(json))
+                return Array.Empty<double>();
+
+            try
+            {
+                return JsonSerializer.Deserialize<List<double>>(json) ?? new List<double>();
+            }
+            catch
+            {
+                return Array.Empty<double>();
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/SongSelect/BmsChartPreviewPlayer.cs
+++ b/osu.Game.Rulesets.BMS/UI/SongSelect/BmsChartPreviewPlayer.cs
@@ -1,0 +1,342 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Logging;
+using osu.Framework.Threading;
+using osu.Game.Audio;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.BMS.Beatmaps;
+using osu.Game.Rulesets.BMS.UI.BmsSongSelect.Analytics;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Legacy;
+
+namespace osu.Game.Rulesets.BMS.UI.SongSelect
+{
+    /// <summary>
+    /// BMS-native chart preview player, written specifically for the BMS song-select screen.
+    ///
+    /// Design rationale: BMS has no separate "BGM track" — everything (notes and background) is just
+    /// a sample placed on a channel at a specific time. This player therefore treats hit-object
+    /// samples and <see cref="BmsBackgroundSoundEvent"/>s as a single ordered timeline of samples,
+    /// exactly the way the BMS standard intends, and schedules each sample independently via
+    /// <see cref="Scheduler.AddDelayed(Action, double, bool)"/>. That avoids the silent-miss problem of
+    /// <c>EzPreviewTrackManager</c>'s coarse 16ms / 5ms-tolerance update loop on dense BMS keysound
+    /// charts, where most note samples used to fall outside the trigger window.
+    ///
+    /// Samples are resolved via the supplied <see cref="BMSWorkingBeatmap"/>'s skin (which already
+    /// owns a folder-mounted <see cref="ISampleStore"/>), so external BMS folders work without
+    /// touching osu.Game's sandboxed storage.
+    /// </summary>
+    public partial class BmsChartPreviewPlayer : CompositeDrawable
+    {
+        /// <summary>
+        /// Globally enable or disable this preview player. Mirrors <c>EzPreviewTrackManager.EnabledBindable</c>.
+        /// </summary>
+        public BindableBool EnabledBindable { get; } = new BindableBool();
+
+        /// <summary>
+        /// Override the preview start time (ms). When null, the chart's metadata <c>PreviewTime</c> is used,
+        /// or 0 if that's missing.
+        /// </summary>
+        public double? OverridePreviewStartTime { get; set; }
+
+        /// <summary>
+        /// When true, the preview restarts at <see cref="OverridePreviewStartTime"/> after every event has
+        /// fired (or after <see cref="LoopAfter"/> has elapsed since start). True by default to mirror
+        /// osu.Game's looping song-select preview UX.
+        /// </summary>
+        public bool Loop { get; set; } = true;
+
+        /// <summary>
+        /// Maximum runtime per loop (ms). When the preview reaches this time it loops back to start.
+        /// Defaults to 30 seconds, like osu.Game's preview.
+        /// </summary>
+        public double LoopAfter { get; set; } = 30_000;
+
+        /// <summary>
+        /// Cap one-shot scheduler tasks per loop so dense keysound charts do not flood the framework scheduler.
+        /// </summary>
+        private const int max_scheduled_samples_per_loop = 200;
+
+        [Resolved]
+        private AudioManager audioManager { get; set; } = null!;
+
+        // currentBeatmap is the beatmap whose skin we use to resolve samples.
+        private BMSWorkingBeatmap? currentBeatmap;
+        private double previewStartTime;
+        private readonly List<TimedSample> timeline = new List<TimedSample>();
+        private readonly List<ScheduledDelegate> scheduledTriggers = new List<ScheduledDelegate>();
+        private readonly List<SampleChannel> activeChannels = new List<SampleChannel>();
+        private ScheduledDelegate? loopRestartDelegate;
+
+        private bool playing;
+
+        /// <summary>
+        /// Start a fresh preview for <paramref name="beatmap"/>. Stops any in-flight preview first.
+        /// Returns true if the preview successfully started, false if disabled or no events were collected.
+        /// </summary>
+        public bool StartPreview(BMSWorkingBeatmap beatmap)
+        {
+            ArgumentNullException.ThrowIfNull(beatmap);
+
+            StopPreview();
+
+            if (!EnabledBindable.Value)
+                return false;
+
+            if (BmsAnalyticsScanService.IsRunning)
+                return false;
+
+            currentBeatmap = beatmap;
+
+            // Build timeline from hit-object samples (keysounds) + BMS background channels.
+            collectTimeline(beatmap);
+
+            if (timeline.Count == 0)
+            {
+                Logger.Log("[BMS] BmsChartPreviewPlayer: no preview events for chart, falling back to silent.", LoggingTarget.Runtime, LogLevel.Debug);
+                return false;
+            }
+
+            previewStartTime = OverridePreviewStartTime ?? beatmap.BeatmapInfo.Metadata.PreviewTime;
+            if (previewStartTime < 0)
+                previewStartTime = 0;
+
+            scheduleAllSamples();
+            playing = true;
+            return true;
+        }
+
+        public void StopPreview()
+        {
+            playing = false;
+
+            foreach (var d in scheduledTriggers)
+                d.Cancel();
+
+            scheduledTriggers.Clear();
+
+            loopRestartDelegate?.Cancel();
+            loopRestartDelegate = null;
+
+            stopActiveChannels();
+
+            timeline.Clear();
+            currentBeatmap = null;
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            StopPreview();
+            base.Dispose(isDisposing);
+        }
+
+        private void collectTimeline(BMSWorkingBeatmap beatmap)
+        {
+            timeline.Clear();
+
+            // 1) Background channels — exposed directly on BMSBeatmap.
+            if (beatmap.Beatmap is BMSBeatmap bmsBeatmap)
+            {
+                foreach (BmsBackgroundSoundEvent evt in bmsBeatmap.BackgroundSoundEvents)
+                {
+                    if (string.IsNullOrEmpty(evt.Filename))
+                        continue;
+
+                    timeline.Add(new TimedSample(evt.Time, evt.Filename, isBackground: true));
+                }
+            }
+
+            // 2) Note key-sounds — pull file lookups from each hit object's FileHitSampleInfo.
+            //    We use the playable beatmap (post-conversion) to align with what gameplay would actually play.
+            try
+            {
+                IBeatmap playable = beatmap.GetPlayableBeatmap(beatmap.BeatmapInfo.Ruleset);
+                addHitObjectSamples(playable.HitObjects);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"[BMS] BmsChartPreviewPlayer: failed to read playable hit objects for keysound preview: {ex.Message}", LoggingTarget.Runtime, LogLevel.Important);
+            }
+
+            timeline.Sort((a, b) => a.Time.CompareTo(b.Time));
+        }
+
+        private void addHitObjectSamples(IEnumerable<HitObject> hitObjects)
+        {
+            foreach (HitObject ho in hitObjects)
+            {
+                foreach (var sample in ho.Samples)
+                {
+                    if (sample is ConvertHitObjectParser.FileHitSampleInfo fileSample && !string.IsNullOrEmpty(fileSample.Filename))
+                        timeline.Add(new TimedSample(ho.StartTime, fileSample.Filename, isBackground: false));
+                }
+
+                if (ho.NestedHitObjects.Count > 0)
+                    addHitObjectSamples(ho.NestedHitObjects);
+            }
+        }
+
+        private void scheduleAllSamples()
+        {
+            if (currentBeatmap == null)
+                return;
+
+            loopRestartDelegate?.Cancel();
+            loopRestartDelegate = null;
+
+            double horizonTime = previewStartTime + LoopAfter;
+            int scheduled = 0;
+
+            for (int i = 0; i < timeline.Count; i++)
+            {
+                TimedSample evt = timeline[i];
+
+                if (evt.Time < previewStartTime - 1)
+                    continue;
+
+                if (evt.Time > horizonTime)
+                    break;
+
+                if (scheduled >= max_scheduled_samples_per_loop)
+                    break;
+
+                double delay = Math.Max(0, evt.Time - previewStartTime);
+                var captured = evt;
+
+                scheduledTriggers.Add(Scheduler.AddDelayed(() => triggerSample(captured), delay));
+                scheduled++;
+            }
+
+            if (Loop)
+                loopRestartDelegate = Scheduler.AddDelayed(restartLoop, LoopAfter);
+        }
+
+        private void triggerSample(TimedSample evt)
+        {
+            if (!playing || currentBeatmap == null)
+                return;
+
+            try
+            {
+                ISample? sample = currentBeatmap.Skin.GetSample(new FilenameSampleInfo(evt.Filename));
+
+                if (sample == null)
+                    return;
+
+                SampleChannel channel = sample.GetChannel();
+                channel.Play();
+                activeChannels.Add(channel);
+
+                pruneStoppedChannels();
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"[BMS] BmsChartPreviewPlayer: failed to play sample '{evt.Filename}': {ex.Message}", LoggingTarget.Runtime, LogLevel.Debug);
+            }
+        }
+
+        private void pruneStoppedChannels()
+        {
+            for (int i = activeChannels.Count - 1; i >= 0; i--)
+            {
+                SampleChannel ch = activeChannels[i];
+
+                if (ch.Playing)
+                    continue;
+
+                if (!ch.IsDisposed && !ch.ManualFree)
+                {
+                    try
+                    {
+                        ch.Dispose();
+                    }
+                    catch
+                    {
+                        // ignored — disposal race with audio thread is harmless here.
+                    }
+                }
+
+                activeChannels.RemoveAt(i);
+            }
+        }
+
+        private void stopActiveChannels()
+        {
+            foreach (SampleChannel ch in activeChannels)
+            {
+                try
+                {
+                    ch.Stop();
+
+                    if (!ch.IsDisposed && !ch.ManualFree)
+                        ch.Dispose();
+                }
+                catch
+                {
+                    // ignored — see pruneStoppedChannels.
+                }
+            }
+
+            activeChannels.Clear();
+        }
+
+        private void restartLoop()
+        {
+            if (!playing || currentBeatmap == null)
+                return;
+
+            BMSWorkingBeatmap b = currentBeatmap;
+
+            // Cancel the current set of scheduled triggers and active channels, then restart.
+            foreach (var d in scheduledTriggers)
+                d.Cancel();
+
+            scheduledTriggers.Clear();
+            stopActiveChannels();
+
+            scheduleAllSamples();
+            // scheduleAllSamples re-arms loopRestartDelegate.
+            _ = b;
+        }
+
+        private readonly struct TimedSample
+        {
+            public TimedSample(double time, string filename, bool isBackground)
+            {
+                Time = time;
+                Filename = filename;
+                IsBackground = isBackground;
+            }
+
+            public double Time { get; }
+            public string Filename { get; }
+
+            // Currently informational only — consumers may want to weight or mute one of the streams in future.
+            public bool IsBackground { get; }
+        }
+
+        /// <summary>
+        /// Minimal <see cref="ISampleInfo"/> implementation that just exposes a single filename so that
+        /// <see cref="osu.Game.Skinning.ISkin.GetSample(ISampleInfo)"/> can look up a BMS folder asset
+        /// by its declared <c>#WAVxx</c> name.
+        /// </summary>
+        private sealed class FilenameSampleInfo : ISampleInfo
+        {
+            private readonly string filename;
+
+            public FilenameSampleInfo(string filename)
+            {
+                this.filename = filename;
+            }
+
+            public IEnumerable<string> LookupNames => new[] { filename };
+            public int Volume => 100;
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/SongSelect/BmsSoloSongSelect.cs
+++ b/osu.Game.Rulesets.BMS/UI/SongSelect/BmsSoloSongSelect.cs
@@ -1,0 +1,467 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.Rendering;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using osu.Framework.Screens;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+using osu.Game.EzOsuGame.Overlays;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Notifications;
+using osu.Game.Rulesets.BMS.Beatmaps;
+using osu.Game.Rulesets.BMS.Configuration;
+using osu.Game.Rulesets.BMS.Scoring.Lamp;
+using osu.Game.Rulesets.BMS.Scoring.Lamp.Persistence;
+using osu.Game.Rulesets.BMS.UI.BmsSongSelect.Analytics;
+using osu.Game.Screens.Footer;
+using osu.Game.Screens.Select;
+
+namespace osu.Game.Rulesets.BMS.UI.SongSelect
+{
+    /// <summary>
+    /// BMS 选歌屏：派生自 osu.Game 的 <see cref="SoloSongSelect"/>，复用全部官方 carousel/wedge/details/filter UI。
+    ///
+    /// 关键不同：
+    /// 1. 进入时强制 <c>Ruleset.Value</c> = BMS，借助 <see cref="BeatmapInfoExtensions.AllowGameplayWithRuleset"/>
+    ///    对外部托管谱面集的限制，让 carousel 只显示 BMS 谱面（其他 ruleset 的曲在 BMS 下不显示）。
+    /// 2. 进入时刷一次 <see cref="BMSOsuLibrarySynchronizer.Synchronize"/>，把外部 BMS 文件夹 sync 到 osu Realm，
+    ///    让官方 <c>BeatmapStore</c> / <c>BeatmapCarousel</c> 能查询到。
+    /// 3. 重写 <see cref="OnStart"/>：不走 <c>SoloSongSelect</c> 的标准 <c>PlayerLoader</c>，从选中 BeatmapInfo 反查
+    ///    <see cref="BMSSourceReference"/> → 构造 <see cref="BMSWorkingBeatmap"/> → push <see cref="BMSPlayerLoader"/>。
+    /// 4. <c>ControlGlobalMusic</c> 关闭，自接 <see cref="BmsChartPreviewPlayer"/>：用键音重建预览，
+    ///    BMS 资源不进 Realm 文件存储所以走 <see cref="BMSWorkingBeatmap"/> 自带的外部目录解析。
+    /// 5. footer 多一颗"刷新曲库"，触发 <c>BMSBeatmapManager.ScanLibraryAsync</c> + Synchronize。
+    /// </summary>
+    public partial class BmsSoloSongSelect : SoloSongSelect
+    {
+        private BMSBeatmapManager beatmapManager = null!;
+        private BmsChartPreviewPlayer previewPlayer = null!;
+        private Bindable<string> libraryPathsBindable = null!;
+        private Bindable<string> legacyRootPathBindable = null!;
+        private RulesetInfo bmsRulesetInfo = null!;
+
+        // Lamp template wiring: scheme picks lamp-from-context rules, store keeps the best lamp per
+        // beatmap, and the IPanelAccentColourProvider bridge feeds those colours into osu.Game's
+        // panel accent strip. All three are [Cached] below so child UI (PanelBeatmap and any future
+        // lamp HUD widgets) can [Resolved] them. Swap schemes here later — nothing else needs to change.
+        // If osu.Game panels omit IPanelAccentColourProvider resolution, they use [Resolved(canBeNull: true)]
+        // and fall back to star colours; BMS gameplay and this screen still run — lamp strip is optional UI only.
+        [Cached(typeof(IBmsLampScheme))]
+        private readonly IBmsLampScheme lampScheme = new BeatorajaLampScheme();
+
+        [Cached]
+        private readonly BmsLampStore lampStore;
+
+        [Cached(typeof(IPanelAccentColourProvider))]
+        private readonly BmsLampAccentColourProvider lampAccentColourProvider;
+
+        // Backed by a private SQLite file under the BMS cache dir. Attached in BDL once we have
+        // access to the resolved Storage. osu.Game's Realm is intentionally untouched — that
+        // would force a schema-version bump and break clients without the BMS ruleset installed.
+        private BmsLampSqliteRepository? lampRepository;
+
+        // Snapshot of the global MusicController state at entry; restored on exit so the main-menu music
+        // resumes naturally after the user backs out of song select.
+        private bool capturedMusicControllerState;
+        private bool savedAllowTrackControl;
+
+        [Resolved]
+        private AudioManager audioManager { get; set; } = null!;
+
+        [Resolved]
+        private IRenderer renderer { get; set; } = null!;
+
+        [Resolved]
+        private Storage storage { get; set; } = null!;
+
+        [Resolved]
+        private RealmAccess realm { get; set; } = null!;
+
+        [Resolved(canBeNull: true)]
+        private MusicController? musicController { get; set; }
+
+        [Resolved(canBeNull: true)]
+        private INotificationOverlay? notifications { get; set; }
+
+        [Resolved]
+        private BeatmapManager beatmaps { get; set; } = null!;
+
+        public BmsSoloSongSelect()
+        {
+            lampStore = new BmsLampStore(lampScheme);
+            lampAccentColourProvider = new BmsLampAccentColourProvider(lampStore);
+
+            // BMS audio is not stored in osu's RealmFileStore. Disable SongSelect's standard MusicController
+            // preview loop and drive previews through BmsChartPreviewPlayer instead, which knows how to read
+            // BMS folders + key-sound samples directly.
+            ControlGlobalMusic = false;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(IRulesetConfigCache configCache)
+        {
+            var bmsRuleset = new BMSRuleset();
+            bmsRulesetInfo = bmsRuleset.RulesetInfo;
+            var config = configCache.GetConfigFor(bmsRuleset);
+
+            if (config is BMSRulesetConfigManager bmsConfig)
+            {
+                libraryPathsBindable = bmsConfig.GetBindable<string>(BMSRulesetSetting.BmsLibraryPaths);
+                legacyRootPathBindable = bmsConfig.GetBindable<string>(BMSRulesetSetting.BmsRootPath);
+            }
+            else
+            {
+                libraryPathsBindable = new Bindable<string>(string.Empty);
+                legacyRootPathBindable = new Bindable<string>(string.Empty);
+            }
+
+            beatmapManager = BMSBeatmapManager.GetShared(storage);
+            syncConfiguredPaths();
+
+            // Lamp DB lives under EzBMS next to the chart index. Repository init is internally try/catch so
+            // a corrupt sqlite file degrades to "no lamps" rather than blocking song-select from opening.
+            string lampDbPath = BmsStoragePaths.GetLampDatabasePath(storage);
+            lampRepository = new BmsLampSqliteRepository(lampDbPath);
+            lampStore.AttachRepository(lampRepository);
+
+            // BDL runs on the load thread, NOT the update thread. We deliberately don't mutate any global
+            // Bindable here (Ruleset / Beatmap / etc) — doing so would synchronously invoke ValueChanged
+            // subscribers whose update paths may transform Loaded drawables, throwing
+            // InvalidThreadForMutationException. All such mutations are deferred to LoadComplete.
+            AddInternal(previewPlayer = new BmsChartPreviewPlayer
+            {
+                EnabledBindable = { Value = true },
+            });
+        }
+
+        protected override void LoadComplete()
+        {
+            // Ruleset must be BMS before base.LoadComplete builds the carousel; externally hosted sets return false
+            // from AllowGameplayWithRuleset for non-BMS rulesets and would be filtered out entirely.
+            Ruleset.Value = bmsRulesetInfo;
+
+            syncConfiguredPaths();
+
+            // Sync before base.LoadComplete so the carousel binds to up-to-date Realm rows (stable beatmap IDs).
+            if (beatmapManager.NeedsRealmSynchronization && beatmapManager.HasIndexedCharts)
+            {
+                try
+                {
+                    BMSOsuLibrarySynchronizer.Synchronize(beatmapManager, storage, realm, bmsRulesetInfo);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex, "[BMS] initial library sync failed");
+                }
+            }
+
+            // BMS does not use EzKeyModeSelector; ignore any residual CircleSize range from FilterControl.
+            FilterControl.ApplyRequiredCriteria = criteria => criteria.CircleSize = default;
+
+            base.LoadComplete();
+
+            ensureBeatmapInfoExistsInRealm();
+            Scheduler.AddOnce(requestCarouselCriteriaRefresh);
+
+            Beatmap.BindValueChanged(_ => updatePreview(), true);
+            Ruleset.BindValueChanged(onRulesetChanged);
+        }
+
+        /// <summary>
+        /// Rebind the global working beatmap to a Realm-backed instance when the current selection's
+        /// <see cref="BeatmapInfo.ID"/> is missing (stale carousel item after catalog re-sync).
+        /// </summary>
+        private void ensureBeatmapInfoExistsInRealm()
+        {
+            var info = Beatmap.Value?.BeatmapInfo;
+
+            if (info == null || info.Ruleset.ShortName != "bms")
+                return;
+
+            bool exists = realm.Run(r => r.Find<BeatmapInfo>(info.ID) != null);
+
+            if (exists)
+                return;
+
+            if (beatmapManager.TryGetSourceReference(info.ID, out BMSSourceReference sourceRef))
+            {
+                string expectedRelative = BMSOsuLibrarySynchronizer.ComputeRelativeChartFilename(sourceRef.ChartPath, sourceRef.FolderPath);
+                string fileNameOnly = Path.GetFileName(sourceRef.ChartPath);
+
+                var replacement = realm.Run(r => r.All<BeatmapInfo>().AsEnumerable()
+                                                  .FirstOrDefault(b => b.BeatmapSet != null
+                                                                       && b.BeatmapSet.IsExternallyHosted
+                                                                       && string.Equals(b.Ruleset.ShortName, "bms", StringComparison.Ordinal)
+                                                                       && (string.Equals(b.Path, expectedRelative, StringComparison.OrdinalIgnoreCase)
+                                                                           || string.Equals(b.Path, fileNameOnly, StringComparison.OrdinalIgnoreCase)
+                                                                           || string.Equals(b.MD5Hash, sourceRef.Md5Hash, StringComparison.OrdinalIgnoreCase))));
+
+                if (replacement != null)
+                    Beatmap.Value = beatmaps.GetWorkingBeatmap(replacement, true);
+            }
+        }
+
+        public override void OnEntering(ScreenTransitionEvent e)
+        {
+            base.OnEntering(e);
+            suspendGlobalMusicController();
+
+            if (!beatmapManager.HasIndexedCharts)
+            {
+                notifications?.Post(new SimpleNotification
+                {
+                    Text = "BMS 曲库索引为空，请在设置中添加路径或点「刷新曲库」扫描",
+                    Icon = FontAwesome.Solid.InfoCircle,
+                });
+            }
+        }
+
+        public override void OnResuming(ScreenTransitionEvent e)
+        {
+            // ManiaCompatibility gameplay pushes ManiaConvertedWorkingBeatmap into the global Beatmap bindable and
+            // switches Ruleset to mania. Song select HUD (EzHUDRadarPanel, difficulty cache, …) may call
+            // GetPlayableBeatmap from background threads on that shared wrapper → concurrent ApplyDefaults on the
+            // same ManiaBeatmap → InvalidOperationException ("Collection was modified") or lifetime manager NRE.
+            // Restore Realm-backed WorkingBeatmap + BMS ruleset before base.OnResuming runs ensureGlobalBeatmapValid /
+            // external radar tasks.
+            restoreBmsSelectionStateAfterGameplay();
+
+            base.OnResuming(e);
+            suspendGlobalMusicController();
+            updatePreview();
+        }
+
+        /// <summary>
+        /// After returning from <see cref="BMSPlayerLoader"/> / Player, global Beatmap may still reference
+        /// <see cref="ManiaConvertedWorkingBeatmap"/> or <see cref="BMSWorkingBeatmap"/>; Ruleset may still be mania.
+        /// Reset so SongSelect and overlays always see the standard library working beatmap for the selected chart.
+        /// </summary>
+        private void restoreBmsSelectionStateAfterGameplay()
+        {
+            Ruleset.Value = bmsRulesetInfo;
+
+            var info = Beatmap.Value?.BeatmapInfo;
+            if (info == null)
+                return;
+
+            Beatmap.Value = beatmaps.GetWorkingBeatmap(info, true);
+        }
+
+        public override void OnSuspending(ScreenTransitionEvent e)
+        {
+            previewPlayer.StopPreview();
+            base.OnSuspending(e);
+        }
+
+        public override bool OnExiting(ScreenExitEvent e)
+        {
+            previewPlayer.StopPreview();
+            restoreGlobalMusicController();
+            return base.OnExiting(e);
+        }
+
+        protected override void OnStart()
+        {
+            var beatmapInfo = Beatmap.Value?.BeatmapInfo;
+
+            if (beatmapInfo == null || beatmapInfo.Ruleset.ShortName != "bms")
+            {
+                notifications?.Post(new SimpleNotification
+                {
+                    Text = "请先选择一个 BMS 谱面",
+                    Icon = FontAwesome.Solid.ExclamationTriangle,
+                });
+                return;
+            }
+
+            previewPlayer.StopPreview();
+            BmsSongSelectPlayHelper.TryLaunchFromBeatmapInfo(this, beatmapInfo, beatmapManager, audioManager, renderer, musicController, notifications);
+        }
+
+        public override IReadOnlyList<ScreenFooterButton> CreateFooterButtons()
+        {
+            // Strip osu/Ez2-only buttons that don't apply to BMS:
+            // - FooterButtonEzExport: exports beatmaps as .osz, but BMS charts aren't packaged into osu's Realm files.
+            // - FooterButtonEzPreView: opens an osu-format chart preview overlay; BMS uses BmsChartPreviewPlayer instead.
+            var buttons = base.CreateFooterButtons()
+                              .Where(button => button is not FooterButtonEzExport && button is not FooterButtonEzPreView)
+                              .ToList();
+
+            buttons.Add(new ScreenFooterButton
+            {
+                Text = "刷新曲库",
+                Icon = FontAwesome.Solid.SyncAlt,
+                Action = refreshLibrary,
+            });
+
+            return buttons;
+        }
+
+        private void onRulesetChanged(ValueChangedEvent<RulesetInfo> e)
+        {
+            if (!this.IsCurrentScreen())
+                return;
+
+            if (string.Equals(e.NewValue.ShortName, "bms", StringComparison.OrdinalIgnoreCase))
+                return;
+
+            // External ruleset switch (e.g. via toolbar): exit out of BMS selection cleanly.
+            this.Exit();
+        }
+
+        private void updatePreview()
+        {
+            previewPlayer.StopPreview();
+
+            if (!this.IsCurrentScreen())
+                return;
+
+            if (BmsAnalyticsScanService.IsRunning)
+                return;
+
+            var info = Beatmap.Value?.BeatmapInfo;
+
+            if (info == null || info.Ruleset.ShortName != "bms")
+                return;
+
+            if (!tryResolveBmsSource(info, out string chartPath, out var chartCache))
+                return;
+
+            try
+            {
+                var bmsWorking = new BMSWorkingBeatmap(chartPath, audioManager, renderer, chartCache);
+
+                int previewTime = chartCache?.PreviewTime ?? -1;
+                previewPlayer.OverridePreviewStartTime = previewTime >= 0 ? previewTime : 0;
+                previewPlayer.StartPreview(bmsWorking);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "[BMS] preview start failed");
+            }
+        }
+
+        private bool tryResolveBmsSource(BeatmapInfo info, out string chartPath, out BMSChartCache? chartCache) =>
+            BmsSongSelectPlayHelper.TryResolveSource(beatmapManager, info, out chartPath, out chartCache);
+
+        private void syncConfiguredPaths() => beatmapManager.SetRootPaths(BMSRulesetConfigManager.ParseLibraryPaths(libraryPathsBindable.Value, legacyRootPathBindable.Value));
+
+        /// <summary>
+        /// Re-run carousel filtering after Realm catalog changes without adding APIs to <see cref="FilterControl"/>.
+        /// </summary>
+        private void requestCarouselCriteriaRefresh()
+        {
+            const string sentinel = "\u200b";
+            FilterControl.Search(sentinel);
+            FilterControl.Search(string.Empty);
+        }
+
+        private void refreshLibrary()
+        {
+            syncConfiguredPaths();
+
+            if (beatmapManager.RootPaths.Count == 0)
+            {
+                notifications?.Post(new SimpleNotification
+                {
+                    Text = "请先在 BMS 设置中添加曲库路径",
+                    Icon = FontAwesome.Solid.ExclamationTriangle,
+                });
+                return;
+            }
+
+            var notification = new ProgressNotification
+            {
+                Text = "正在扫描 BMS 曲库...",
+                Progress = 0,
+            };
+
+            notifications?.Post(notification);
+
+            void onScanProgress(ValueChangedEvent<double> e) => Schedule(() => notification.Progress = (float)BmsLibraryImportPipeline.MapScanProgress(e.NewValue));
+
+            void onScanStatus(ValueChangedEvent<string> e) => Schedule(() => notification.Text = e.NewValue);
+
+            beatmapManager.ScanProgress.BindValueChanged(onScanProgress, true);
+            beatmapManager.StatusMessage.BindValueChanged(onScanStatus, true);
+
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await BmsLibraryImportPipeline.RunAsync(
+                        beatmapManager,
+                        storage,
+                        realm,
+                        bmsRulesetInfo,
+                        beatmapManager.RootPaths,
+                        p => Schedule(() =>
+                        {
+                            notification.Progress = (float)p.Progress;
+                            notification.Text = p.StatusMessage;
+                        })).ConfigureAwait(false);
+
+                    Schedule(() =>
+                    {
+                        ensureBeatmapInfoExistsInRealm();
+                        requestCarouselCriteriaRefresh();
+                        notification.Progress = 1f;
+                        notification.State = ProgressNotificationState.Completed;
+                    });
+                }
+                catch (Exception ex)
+                {
+                    Schedule(() =>
+                    {
+                        Logger.Error(ex, "[BMS] library import failed");
+                        notification.State = ProgressNotificationState.Cancelled;
+                        notifications?.Post(new SimpleNotification
+                        {
+                            Text = $"刷新失败：{ex.Message}",
+                            Icon = FontAwesome.Solid.ExclamationTriangle,
+                        });
+                    });
+                }
+                finally
+                {
+                    Schedule(() =>
+                    {
+                        beatmapManager.ScanProgress.ValueChanged -= onScanProgress;
+                        beatmapManager.StatusMessage.ValueChanged -= onScanStatus;
+                    });
+                }
+            });
+        }
+
+        private void suspendGlobalMusicController()
+        {
+            if (musicController == null)
+                return;
+
+            if (!capturedMusicControllerState)
+            {
+                savedAllowTrackControl = musicController.AllowTrackControl.Value;
+                capturedMusicControllerState = true;
+            }
+
+            // Stop without flipping UserPauseRequested — we want main-menu auto-resume after exit.
+            musicController.Stop();
+            musicController.AllowTrackControl.Value = false;
+        }
+
+        private void restoreGlobalMusicController()
+        {
+            if (musicController == null || !capturedMusicControllerState)
+                return;
+
+            musicController.AllowTrackControl.Value = savedAllowTrackControl;
+            capturedMusicControllerState = false;
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/SongSelect/BmsSongSelectAnalyticsOperations.cs
+++ b/osu.Game.Rulesets.BMS/UI/SongSelect/BmsSongSelectAnalyticsOperations.cs
@@ -1,0 +1,108 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Audio;
+using osu.Framework.Logging;
+using osu.Framework.Threading;
+using osu.Game.Database;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Notifications;
+using osu.Game.Rulesets.BMS.Beatmaps;
+using osu.Game.Rulesets.BMS.UI.BmsSongSelect.Analytics;
+
+namespace osu.Game.Rulesets.BMS.UI.SongSelect
+{
+    public static class BmsSongSelectAnalyticsOperations
+    {
+        public static void RunAnalyticsBuild(
+            Scheduler scheduler,
+            BMSBeatmapManager beatmapManager,
+            BmsAnalyticsSqliteRepository repository,
+            AudioManager audioManager,
+            RealmAccess realm,
+            INotificationOverlay? notifications,
+            Action? onComplete = null,
+            CancellationToken cancellationToken = default)
+        {
+            if (!beatmapManager.HasIndexedCharts)
+            {
+                notifications?.Post(new SimpleNotification { Text = "BMS 曲库为空，请先扫描曲库" });
+                return;
+            }
+
+            var notification = new ProgressNotification
+            {
+                Text = "正在构建 BMS 分析库...",
+                Progress = 0,
+            };
+
+            notifications?.Post(notification);
+
+            var progress = new Progress<BmsAnalyticsScanProgress>(p => postProgress(notification, p));
+
+            _ = Task.Run(async () =>
+            {
+                using var scanCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, notification.CancellationToken);
+                var token = scanCancellation.Token;
+
+                try
+                {
+                    await BmsAnalyticsScanService.RunAsync(
+                        beatmapManager,
+                        repository,
+                        audioManager,
+                        progress,
+                        token,
+                        realm).ConfigureAwait(false);
+
+                    if (token.IsCancellationRequested)
+                    {
+                        scheduler.Add(() => markCancelled(notification));
+                        return;
+                    }
+
+                    scheduler.Add(() =>
+                    {
+                        notification.Progress = 1f;
+                        notification.Text = "BMS 分析库构建完成";
+                        notification.State = ProgressNotificationState.Completed;
+                        notification.CompletionText = "BMS 分析库构建完成";
+                        onComplete?.Invoke();
+                    });
+                }
+                catch (OperationCanceledException)
+                {
+                    scheduler.Add(() => markCancelled(notification));
+                }
+                catch (Exception ex)
+                {
+                    scheduler.Add(() =>
+                    {
+                        Logger.Error(ex, "[BMS] analytics build failed");
+                        notification.State = ProgressNotificationState.Cancelled;
+                        notifications?.Post(new SimpleNotification { Text = $"分析库构建失败：{ex.Message}" });
+                    });
+                }
+            }, cancellationToken);
+        }
+
+        private static void postProgress(ProgressNotification notification, BmsAnalyticsScanProgress p)
+        {
+            if (notification.State is ProgressNotificationState.Cancelled or ProgressNotificationState.Completed)
+                return;
+
+            // ProgressNotification.Progress/Text already marshal via their own Scheduler.AddOnce on the update thread.
+            notification.Progress = (float)Math.Clamp(p.Progress, 0, 1);
+            notification.Text = p.Status;
+        }
+
+        private static void markCancelled(ProgressNotification notification)
+        {
+            if (notification.State == ProgressNotificationState.Completed)
+                return;
+
+            notification.State = ProgressNotificationState.Cancelled;
+            notification.Text = "BMS 分析已取消";
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/SongSelect/BmsSongSelectLibraryOperations.cs
+++ b/osu.Game.Rulesets.BMS/UI/SongSelect/BmsSongSelectLibraryOperations.cs
@@ -1,0 +1,74 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using osu.Framework.Threading;
+using osu.Game.Database;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Notifications;
+using osu.Game.Rulesets.BMS.Beatmaps;
+
+namespace osu.Game.Rulesets.BMS.UI.SongSelect
+{
+    public static class BmsSongSelectLibraryOperations
+    {
+        public static void RunLibraryRefresh(
+            Scheduler scheduler,
+            BMSBeatmapManager beatmapManager,
+            Storage storage,
+            RealmAccess realm,
+            RulesetInfo bmsRulesetInfo,
+            INotificationOverlay? notifications,
+            Action? onComplete = null)
+        {
+            if (beatmapManager.RootPaths.Count == 0)
+            {
+                notifications?.Post(new SimpleNotification { Text = "请先在 BMS 设置中添加曲库路径" });
+                return;
+            }
+
+            var notification = new ProgressNotification
+            {
+                Text = "正在扫描 BMS 曲库...",
+                Progress = 0,
+            };
+
+            notifications?.Post(notification);
+
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await BmsLibraryImportPipeline.RunAsync(
+                        beatmapManager,
+                        storage,
+                        realm,
+                        bmsRulesetInfo,
+                        beatmapManager.RootPaths,
+                        p => scheduler.Add(() =>
+                        {
+                            notification.Progress = (float)p.Progress;
+                            notification.Text = p.StatusMessage;
+                        })).ConfigureAwait(false);
+
+                    scheduler.Add(() =>
+                    {
+                        notification.Progress = 1f;
+                        notification.State = ProgressNotificationState.Completed;
+                        onComplete?.Invoke();
+                    });
+                }
+                catch (Exception ex)
+                {
+                    scheduler.Add(() =>
+                    {
+                        Logger.Error(ex, "[BMS] library import failed");
+                        notification.State = ProgressNotificationState.Cancelled;
+                        notifications?.Post(new SimpleNotification { Text = $"刷新失败：{ex.Message}" });
+                    });
+                }
+            });
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/UI/SongSelect/BmsSongSelectPlayHelper.cs
+++ b/osu.Game.Rulesets.BMS/UI/SongSelect/BmsSongSelectPlayHelper.cs
@@ -1,0 +1,105 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Audio;
+using osu.Framework.Graphics.Rendering;
+using osu.Framework.Logging;
+using osu.Framework.Screens;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Notifications;
+using osu.Game.Rulesets.BMS.Beatmaps;
+using osu.Game.Screens;
+
+namespace osu.Game.Rulesets.BMS.UI.SongSelect
+{
+    /// <summary>
+    /// Shared launch path from BMS song-select screens into <see cref="BMSPlayerLoader"/>.
+    /// </summary>
+    public static class BmsSongSelectPlayHelper
+    {
+        public static bool TryLaunchFromChart(
+            OsuScreen screen,
+            string chartPath,
+            BMSChartCache? chartCache,
+            BeatmapInfo? beatmapInfo,
+            AudioManager audioManager,
+            IRenderer renderer,
+            MusicController? musicController,
+            INotificationOverlay? notifications)
+        {
+            if (string.IsNullOrEmpty(chartPath))
+            {
+                notifications?.Post(new SimpleNotification
+                {
+                    Text = "未能定位 BMS 源文件，请刷新曲库",
+                });
+                return false;
+            }
+
+            try
+            {
+                BeatmapInfo? info = beatmapInfo?.Detach();
+                var workingBeatmap = new BMSWorkingBeatmap(chartPath, audioManager, renderer, chartCache, info);
+
+                Logger.Log(
+                    $"[BMS] StartGame chart resolve: title={chartCache?.Title}, file={chartCache?.FileName}, path={chartPath}",
+                    LoggingTarget.Runtime, LogLevel.Debug);
+
+                screen.Beatmap.Value = workingBeatmap;
+                musicController?.Stop();
+                screen.Push(new BMSPlayerLoader(workingBeatmap));
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Failed to launch BMS gameplay");
+                notifications?.Post(new SimpleNotification { Text = $"加载谱面失败：{ex.Message}" });
+                return false;
+            }
+        }
+
+        public static bool TryLaunchFromBeatmapInfo(
+            OsuScreen screen,
+            BeatmapInfo beatmapInfo,
+            BMSBeatmapManager beatmapManager,
+            AudioManager audioManager,
+            IRenderer renderer,
+            MusicController? musicController,
+            INotificationOverlay? notifications)
+        {
+            if (!TryResolveSource(beatmapManager, beatmapInfo, out string chartPath, out BMSChartCache? chartCache))
+            {
+                notifications?.Post(new SimpleNotification { Text = "未能定位 BMS 源文件，请刷新曲库" });
+                return false;
+            }
+
+            return TryLaunchFromChart(screen, chartPath, chartCache, beatmapInfo, audioManager, renderer, musicController, notifications);
+        }
+
+        public static bool TryResolveSource(BMSBeatmapManager beatmapManager, BeatmapInfo info, out string chartPath, out BMSChartCache? chartCache)
+        {
+            chartPath = string.Empty;
+            chartCache = null;
+
+            if (beatmapManager.TryGetSourceReference(info.ID, out BMSSourceReference byId))
+                chartPath = byId.ChartPath;
+            else if (!string.IsNullOrEmpty(info.MD5Hash) && beatmapManager.TryGetSourceReferenceByHash(info.MD5Hash, out BMSSourceReference byHash))
+                chartPath = byHash.ChartPath;
+            else
+                return false;
+
+            if (beatmapManager.LibraryCache != null)
+            {
+                string resolvedPath = chartPath;
+                chartCache = beatmapManager.LibraryCache.Songs
+                                           .SelectMany(s => s.Charts)
+                                           .FirstOrDefault(c => string.Equals(c.Md5Hash, info.MD5Hash, StringComparison.OrdinalIgnoreCase)
+                                                                || string.Equals(c.FullPath, resolvedPath, StringComparison.OrdinalIgnoreCase));
+            }
+
+            return !string.IsNullOrEmpty(chartPath);
+        }
+    }
+}

--- a/osu.Game.Rulesets.BMS/osu.Game.Rulesets.BMS.csproj
+++ b/osu.Game.Rulesets.BMS/osu.Game.Rulesets.BMS.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup Label="Project">
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Library</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Description>BMS/BME/BML/PMS format support for osu!lazer with full keysound support.</Description>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Nuget">
+    <Title>osu!bms (ruleset)</Title>
+    <PackageId>ppy.osu.Game.Rulesets.BMS</PackageId>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup Label="Project References">
+    <ProjectReference Include="..\osu.Game\osu.Game.csproj"/>
+    <ProjectReference Include="..\osu.Game.Rulesets.Mania\osu.Game.Rulesets.Mania.csproj"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>osu.Game.Rulesets.BMS.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+</Project>

--- a/osu.sln
+++ b/osu.sln
@@ -51,6 +51,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "osu.Framework", "..\osu-fra
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "osu.Framework.NativeLibs", "..\osu-framework\osu.Framework.NativeLibs\osu.Framework.NativeLibs.csproj", "{258E5281-A34F-4949-9B00-66B174C45619}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "osu.Game.Rulesets.BMS", "osu.Game.Rulesets.BMS\osu.Game.Rulesets.BMS.csproj", "{DA53BD59-58E3-4BCC-81B1-EF77C30B9191}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "osu.Game.Rulesets.BMS.Tests", "osu.Game.Rulesets.BMS.Tests\osu.Game.Rulesets.BMS.Tests.csproj", "{6206FA88-E8F5-4572-B182-B6BA4B0B52EF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -66,7 +70,6 @@ Global
 		{C92A607B-1FDD-4954-9F92-03FF547D9080}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C92A607B-1FDD-4954-9F92-03FF547D9080}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C92A607B-1FDD-4954-9F92-03FF547D9080}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C92A607B-1FDD-4954-9F92-03FF547D9080}.Release|Any CPU.Deploy.0 = Release|Any CPU
 		{58F6C80C-1253-4A0E-A465-B8C85EBEADF3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{58F6C80C-1253-4A0E-A465-B8C85EBEADF3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{58F6C80C-1253-4A0E-A465-B8C85EBEADF3}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -83,7 +86,6 @@ Global
 		{54377672-20B1-40AF-8087-5CF73BF3953A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{54377672-20B1-40AF-8087-5CF73BF3953A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{54377672-20B1-40AF-8087-5CF73BF3953A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{54377672-20B1-40AF-8087-5CF73BF3953A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{419659FD-72EA-4678-9EB8-B22A746CED70}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{419659FD-72EA-4678-9EB8-B22A746CED70}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{419659FD-72EA-4678-9EB8-B22A746CED70}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -91,24 +93,26 @@ Global
 		{3AD63355-D6B1-4365-8D31-5652C989BEF1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3AD63355-D6B1-4365-8D31-5652C989BEF1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3AD63355-D6B1-4365-8D31-5652C989BEF1}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3AD63355-D6B1-4365-8D31-5652C989BEF1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7E9E9C34-B204-406B-82E2-E01E900699CD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7E9E9C34-B204-406B-82E2-E01E900699CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7E9E9C34-B204-406B-82E2-E01E900699CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7E9E9C34-B204-406B-82E2-E01E900699CD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7E9E9C34-B204-406B-82E2-E01E900699CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B698561F-FB28-46B1-857E-3CA7B92F9D70}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B698561F-FB28-46B1-857E-3CA7B92F9D70}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B698561F-FB28-46B1-857E-3CA7B92F9D70}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B698561F-FB28-46B1-857E-3CA7B92F9D70}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6A2D5D58-0261-4A75-BE84-2BE8B076B7C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6A2D5D58-0261-4A75-BE84-2BE8B076B7C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6A2D5D58-0261-4A75-BE84-2BE8B076B7C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6A2D5D58-0261-4A75-BE84-2BE8B076B7C2}.Release|Any CPU.Build.0 = Release|Any CPU
 		{5672CA4D-1B37-425B-A118-A8DA26E78938}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5672CA4D-1B37-425B-A118-A8DA26E78938}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5672CA4D-1B37-425B-A118-A8DA26E78938}.Release|Any CPU.Build.0 = Release|Any CPU
 		{5672CA4D-1B37-425B-A118-A8DA26E78938}.Release|Any CPU.Deploy.0 = Release|Any CPU
 		{5672CA4D-1B37-425B-A118-A8DA26E78938}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E8F3B2C4-9D7A-4E6B-8C2F-7A9B12345678}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E8F3B2C4-9D7A-4E6B-8C2F-7A9B12345678}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E8F3B2C4-9D7A-4E6B-8C2F-7A9B12345678}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8F3B2C4-9D7A-4E6B-8C2F-7A9B12345678}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5672CA4D-1B37-425B-A118-A8DA26E78938}.Release|Any CPU.Deploy.0 = Release|Any CPU
 		{E8F3B2C4-9D7A-4E6B-8C2F-7A9B12345678}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E8F3B2C4-9D7A-4E6B-8C2F-7A9B12345678}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E8F3B2C4-9D7A-4E6B-8C2F-7A9B12345678}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -125,6 +129,14 @@ Global
 		{258E5281-A34F-4949-9B00-66B174C45619}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{258E5281-A34F-4949-9B00-66B174C45619}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{258E5281-A34F-4949-9B00-66B174C45619}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DA53BD59-58E3-4BCC-81B1-EF77C30B9191}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DA53BD59-58E3-4BCC-81B1-EF77C30B9191}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DA53BD59-58E3-4BCC-81B1-EF77C30B9191}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DA53BD59-58E3-4BCC-81B1-EF77C30B9191}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DA53BD59-58E3-4BCC-81B1-EF77C30B9191}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{6206FA88-E8F5-4572-B182-B6BA4B0B52EF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6206FA88-E8F5-4572-B182-B6BA4B0B52EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6206FA88-E8F5-4572-B182-B6BA4B0B52EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
一个BMS规则集，支持原生的BMS谱面格式，在程序内转换到osu兼容的beatmapinfo，并使用拓展信息增强适配。

设置菜单中使用路径向导添加外部路径，进入独有的选歌界面（备用的安全行为）。

游戏时技术路线为：mania 判定/血量/判定优先级/Skin + BMS 谱面时基驱动音频。