### PR TITLE
RoslynScriptedSkin

### DIFF
--- a/docs/SCRIPTED_SKIN_API.md
+++ b/docs/SCRIPTED_SKIN_API.md
@@ -1,0 +1,145 @@
+# 脚本皮肤 API 文档
+
+本文只记录当前实现中可直接使用的接口与核心类。
+
+## 1. `IScriptedSkin`
+
+文件：`osu.Game/EzOsuGame/ScriptedSkin/IScriptedSkin.cs`
+
+```csharp
+public interface IScriptedSkin : IDisposable
+{
+    void Initialize(ISkinSource baseSkin, IStorageResourceProvider resources);
+    Drawable? GetDrawableComponent(ISkinComponentLookup lookup);
+    Texture? GetTexture(string componentName, WrapMode wrapModeS = default, WrapMode wrapModeT = default);
+    ISample? GetSample(ISampleInfo sampleInfo);
+    IBindable<TValue>? GetConfig<TLookup, TValue>(TLookup lookup)
+        where TLookup : notnull
+        where TValue : notnull;
+
+    string Name { get; }
+    string Author { get; }
+    Version Version { get; }
+}
+```
+
+说明：
+
+- `Initialize()` 仅在皮肤初始化时调用一次
+- `Get*()` 返回 `null` 表示回退到默认链路
+
+## 2. `IScriptedSkinMetadata`（可选）
+
+文件：`osu.Game/EzOsuGame/ScriptedSkin/IScriptedSkin.cs`
+
+```csharp
+public interface IScriptedSkinMetadata
+{
+    bool Protected { get; }
+}
+```
+
+用途：
+
+- 提供脚本皮肤的保护状态元数据
+- 不实现也可正常使用脚本皮肤
+
+## 3. `SandboxedScriptRunner`
+
+文件：`osu.Game/EzOsuGame/ScriptedSkin/SandboxedScriptRunner.cs`
+
+关键方法：
+
+```csharp
+Task<IScriptedSkin> LoadScriptAsync(string scriptPath)
+Task<T> LoadScriptAsync<T>(string scriptPath, params object?[] ctorArgs) where T : class
+Task<SkinInfo?> LoadScriptInfoAsync(string scriptPath)
+void ClearCache(string scriptPath)
+```
+
+行为：
+
+- 用 Roslyn 编译 `.csx`
+- 支持直接返回对象、反射实例化类型、以及 `Skin -> IScriptedSkin` 适配
+- 有程序集白名单与危险 API 关键字检查
+
+## 4. `ScriptedSkinWrapper`
+
+文件：`osu.Game/Skinning/ScriptedSkinWrapper.cs`
+
+构造函数：
+
+```csharp
+public ScriptedSkinWrapper(
+    ISkinSource skinSource,
+    IStorageResourceProvider resources,
+    IScriptedSkin scriptedSkin,
+    SandboxedScriptRunner? scriptRunner = null,
+    SkinInfo? skinInfo = null)
+```
+
+关键成员：
+
+```csharp
+public SandboxedScriptRunner ScriptRunner { get; }
+public IScriptedSkin GetScriptedSkin()
+public Task<bool> ReloadAsync(string scriptPath)
+```
+
+说明：
+
+- 包装脚本皮肤到标准 `Skin` 体系
+- 可以复用外部传入的 `SkinInfo`（保留 `Protected`）
+
+## 5. `SkinManager` 脚本相关方法
+
+文件：`osu.Game/Skinning/SkinManager.cs`
+
+```csharp
+public string GetScriptPath(SkinInfo skinInfo)
+public static string GetScriptPathStatic(SkinInfo skinInfo)
+public void StartScriptWatching()
+public Task<bool> TriggerScriptReload(string scriptPath)
+```
+
+内部关键流程：
+
+- `scanForScriptedSkins()`：扫描并注册脚本皮肤
+- `GetSkin()`：按 `SkinInfo` 加载脚本并构建 `ScriptedSkinWrapper`
+
+## 6. `ManiaScriptedSkinTransformer`
+
+文件：`osu.Game.Rulesets.Mania/Skinning/Scripted/ManiaScriptedSkinTransformer.cs`
+
+行为：
+
+- 加载 Mania 专用脚本 transformer（若存在）
+- 查找优先级：
+  - `Mania{MainScriptStem}Transformer.csx`
+  - `ManiaTransformer.csx`
+- `GetConfig` / `GetDrawableComponent` 优先走 Mania transformer，再回退
+
+## 7. 热重载 API
+
+文件：`osu.Game/EzOsuGame/ScriptedSkin/HotReloadManager.cs`
+
+```csharp
+public event Action<string, bool>? SkinReloaded;
+public void StartWatching(string directory)
+public void StopWatching()
+public Task<bool> TriggerReload(string scriptPath)
+public ReloadStatus GetReloadStatus(string scriptPath)
+```
+
+`ReloadStatus`：
+
+```csharp
+public enum ReloadState { Idle, Reloading, Success, Failed }
+public class ReloadStatus
+{
+    public ReloadState State { get; set; }
+    public DateTime? LastReloadTime { get; set; }
+    public string? ErrorMessage { get; set; }
+}
+```
+

--- a/docs/SCRIPTED_SKIN_OVERVIEW.md
+++ b/docs/SCRIPTED_SKIN_OVERVIEW.md
@@ -1,0 +1,107 @@
+# 脚本皮肤说明文档
+
+本文描述当前分支里脚本皮肤功能的实际行为（以代码为准）。
+
+## 1. 目标
+
+脚本皮肤用于把 `.csx` 放在 `EzResources/ScriptedSkin/` 下，游戏内自动发现并加载。同一目录可同时放置与传统皮肤相同的 `skin.ini`、图层 `*.json` 与素材文件。
+
+## 2. 目录与命名
+
+推荐结构：
+
+```text
+EzResources/
+└── ScriptedSkin/
+    └── TestScriptedSkin/
+        ├── TestScriptedSkin.csx
+        ├── ManiaTestScriptedSkinTransformer.csx
+        ├── skin.ini
+        └── MainHUDComponents.json   # 可选，与传统皮肤一致
+```
+
+命名规则：
+
+- **主脚本（推荐）**：`<SkinName>Skin.csx`
+- **Mania 扩展（推荐）**：`Mania<SkinName>SkinTransformer.csx`
+- **兼容旧命名**：`Skin.csx`、`ManiaTransformer.csx`
+
+脚本约定：
+
+- `.csx` 请使用全局命名空间（不要写 `namespace`）
+
+## 3. 发现与加载流程
+
+对应实现：`osu.Game/Skinning/SkinManager.cs`
+
+1. 扫描 `EzResources/ScriptedSkin/*` 子目录。
+2. 每个子目录通过以下优先级寻找主脚本：
+   - `*Skin.csx`（按文件名排序取第一个）
+   - `Skin.csx`
+   - 其他 `.csx`（排除 `*Transformer.csx`）
+3. 读取脚本元数据（优先 `CreateInfo()`，其次类型反射推断）。
+4. 生成虚拟 `SkinInfo`：
+   - `ID`：按目录名稳定生成
+   - `Hash`：保存目录名用于路径反查
+   - `InstantiationInfo`：`ScriptedSkinWrapper`
+5. 在皮肤列表显示；选择时加载脚本并包装为 `ScriptedSkinWrapper`。
+6. 加载时自动把脚本目录挂载为 `Skin` 的 fallback 资源存储，从而读取同目录的 `skin.ini` 与 `GlobalSkinnableContainers` 对应的 `*.json`。
+
+## 4. 游戏内显示名规则
+
+对应实现：`osu.Game/Skinning/SkinInfo.cs`
+
+脚本皮肤显示名固定模板：
+
+```text
+[Script] {Name} {Creator}
+```
+
+其中：
+
+- 仅脚本皮肤使用该模板
+- `Creator` 为空时自动 `TrimEnd()`，不会残留尾部空格
+
+## 5. Protected 行为
+
+脚本皮肤可设置 `Protected`，行为与内置受保护皮肤一致。
+
+来源：
+
+- 主脚本 `CreateInfo()` 返回 `SkinInfo` 时的 `Protected`
+- 或脚本公开 `bool Protected` 属性（反射读取）
+
+效果：
+
+- `Protected = true` 时，编辑器触发修改会先走 `EnsureMutableSkin()` 生成副本
+- 不会直接改原皮肤
+
+## 6. Mania Transformer 行为
+
+对应实现：`osu.Game.Rulesets.Mania/Skinning/Scripted/ManiaScriptedSkinTransformer.cs`
+
+进入 Mania 后，会在主脚本同目录按以下顺序找 Mania 脚本：
+
+1. `Mania{MainScriptStem}Transformer.csx`
+2. `ManiaTransformer.csx`
+
+如果找到则先委托给该 transformer；未提供时回退到脚本默认行为和 Mania 默认配置。
+
+## 7. 热重载
+
+对应实现：
+
+- `osu.Game/EzOsuGame/ScriptedSkin/HotReloadManager.cs`
+- `osu.Game/EzOsuGame/ScriptedSkin/ScriptFileWatcher.cs`
+- `osu.Game/Skinning/SkinManager.cs`
+
+行为：
+
+- 监控 `EzResources/ScriptedSkin/` 下 `.csx` 变化
+- 自动防抖重载（500ms）
+- 可手动触发 `SkinManager.TriggerScriptReload(scriptPath)`
+
+## 8. 当前示例
+
+- `docs/TestScriptedSkin/TestScriptedSkin.csx`
+- `docs/TestScriptedSkin/ManiaTestScriptedSkinTransformer.csx`

--- a/docs/SCRIPTED_SKIN_README.md
+++ b/docs/SCRIPTED_SKIN_README.md
@@ -1,0 +1,23 @@
+# 脚本皮肤文档入口
+
+`docs` 目录下脚本皮肤相关文档统一在这里索引。
+
+## 文档清单
+
+- `docs/SCRIPTED_SKIN_OVERVIEW.md`：系统说明与命名/加载规则
+- `docs/SCRIPTED_SKIN_API.md`：接口与关键类 API
+- `docs/SCRIPTED_SKIN_USAGE.md`：从零开始的使用步骤
+
+## 示例文件
+
+- `docs/TestScriptedSkin/TestScriptedSkin.csx`
+- `docs/TestScriptedSkin/ManiaTestScriptedSkinTransformer.csx`
+
+## 快速规则
+
+- 根目录：`EzResources/ScriptedSkin/<FolderName>/`
+- 主脚本推荐：`<FolderName>Skin.csx`
+- Mania 脚本推荐：`Mania<FolderName>SkinTransformer.csx`
+- 兼容旧命名：`Skin.csx`、`ManiaTransformer.csx`
+- `.csx` 使用全局命名空间（不要写 `namespace`）
+- 游戏显示名模板：`[Script] {Name} {Creator}`（`Creator` 为空时自动省略尾部空格）

--- a/docs/SCRIPTED_SKIN_USAGE.md
+++ b/docs/SCRIPTED_SKIN_USAGE.md
@@ -1,0 +1,151 @@
+# 脚本皮肤使用文档
+
+本页是当前版本的实际使用流程。
+
+## 1. 快速开始
+
+### 第一步：创建目录
+
+```text
+EzResources/
+└── ScriptedSkin/
+    └── TestScriptedSkin/
+```
+
+### 第二步：放入脚本文件
+
+复制以下示例（含 `skin.ini`，可选 `MainHUDComponents.json` 等图层配置）：
+
+- `docs/TestScriptedSkin/TestScriptedSkin.csx`
+- `docs/TestScriptedSkin/ManiaTestScriptedSkinTransformer.csx`
+- `docs/TestScriptedSkin/skin.ini`
+
+仓库内也可直接参考：`EzResources/ScriptedSkin/TestScriptedSkin/`（需同步到游戏实际使用的 `EzResources` 目录）。
+
+到：
+
+```text
+EzResources/ScriptedSkin/TestScriptedSkin/
+        ├── TestScriptedSkin.csx
+        ├── ManiaTestScriptedSkinTransformer.csx
+        ├── skin.ini
+        └── MainHUDComponents.json   # 可选
+```
+
+### 第三步：启动并选择皮肤
+
+1. 启动游戏
+2. 打开皮肤选择
+3. 选择 `[Script] TestScriptedSkin`
+
+## 2. 资源文件（skin.ini / json / 贴图）
+
+脚本目录即皮肤根目录，可与普通皮肤一样放置：
+
+- `skin.ini`：由 `Skin` 基类自动解析为 `Configuration`
+- `{GlobalSkinnableContainers}.json`：例如 `MainHUDComponents.json`
+- 贴图、音效等素材文件
+
+主脚本构造函数需把目录资源传给基类：
+
+```csharp
+public MySkin(SkinInfo skin, IStorageResourceProvider resources, IResourceStore<byte[]>? fallbackStore = null)
+    : base(skin, resources, fallbackStore)
+{
+}
+```
+
+加载器会在实例化时自动注入脚本目录的 fallback store。
+
+## 3. 文件命名建议
+
+推荐：
+
+- 主脚本：`<SkinName>Skin.csx`
+- Mania 扩展：`Mania<SkinName>SkinTransformer.csx`
+
+兼容：
+
+- 主脚本：`Skin.csx`
+- Mania 扩展：`ManiaTransformer.csx`
+
+## 4. 如何把现有 `Ez2` 方案改成脚本
+
+目标：
+
+- `Ez2Skin.cs` -> `TestScriptedSkin.csx`
+- `ManiaEz2SkinTransformer.cs` -> `ManiaTestScriptedSkinTransformer.csx`
+
+操作建议：
+
+1. 先复制类代码到对应 `.csx`
+2. 删除 `namespace`，脚本应使用全局命名空间
+3. 用 `CreateInfo()` 设置你想要的 `Name`、`Creator`、`Protected`
+4. 启动游戏验证显示与行为
+
+## 5. 显示名与作者
+
+脚本皮肤显示模板固定：
+
+```text
+[Script] {Name} {Creator}
+```
+
+说明：
+
+- `Name`、`Creator` 来自脚本元数据（如 `CreateInfo()`）
+- `Creator` 为空时不显示尾部空格
+
+## 6. 保护模式（Protected）
+
+若脚本元数据里 `Protected = true`：
+
+- 编辑时会先创建副本
+- 不会直接修改原脚本皮肤
+
+这与内置受保护皮肤的编辑策略一致。
+
+## 7. 热重载
+
+- 修改 `.csx` 保存后会自动重载
+- 监听目录是 `EzResources/ScriptedSkin/`
+- 也可以走手动重载按钮（调用 `TriggerScriptReload`）
+
+## 8. 常见问题
+
+### 看不到皮肤
+
+检查：
+
+1. 路径是否在 `EzResources/ScriptedSkin/<目录>/`
+2. 目录内是否有可识别主脚本（参考命名建议）
+3. 脚本是否可编译（查看 runtime log）
+
+### Mania 扩展不生效
+
+检查文件名：
+
+1. `Mania{MainScriptStem}Transformer.csx`
+2. 或 `ManiaTransformer.csx`
+
+### 选择后回退默认皮肤
+
+通常是脚本加载异常：
+
+- 语法错误
+- 构造签名不匹配
+- 引用受沙箱限制的 API
+
+## 9. 推荐实践
+
+- 主脚本里尽量提供 `CreateInfo()`
+- `Name` 使用稳定值，避免频繁改名影响识别
+- `Creator` 填真实作者标记，方便列表辨识
+- 先跑主脚本，再加 Mania transformer
+
+## 10. 参考
+
+- 总入口：`docs/SCRIPTED_SKIN_README.md`
+- 说明文档：`docs/SCRIPTED_SKIN_OVERVIEW.md`
+- API 文档：`docs/SCRIPTED_SKIN_API.md`
+- 示例：`docs/TestScriptedSkin/`

--- a/docs/TestScriptedSkin/ManiaTestScriptedSkinTransformer.csx
+++ b/docs/TestScriptedSkin/ManiaTestScriptedSkinTransformer.csx
@@ -1,0 +1,106 @@
+// ============================================================================
+// ManiaTestScriptedSkinTransformer.csx
+// ============================================================================
+// 推荐命名：Mania<SkinName>SkinTransformer.csx
+// 兼容旧命名：ManiaTransformer.csx
+//
+// 这个示例展示的是“脚本皮肤的 Mania 专用 transformer”。
+// 它在主皮肤脚本的基础上，为 Mania 提供专用配置和组件。
+// ============================================================================
+
+using System.Linq;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Logging;
+using osu.Game.Beatmaps;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.HUD;
+using osu.Game.Rulesets.Mania.Beatmaps;
+using osu.Game.Rulesets.Mania.EzMania;
+using osu.Game.Rulesets.Mania.EzMania.HUD;
+using osu.Game.Rulesets.Mania.Skinning.EzStylePro;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Screens.Play.HUD.HitErrorMeters;
+using osu.Game.Skinning;
+using osuTK;
+using osuTK.Graphics;
+
+public class ManiaTestScriptedSkinTransformer : SkinTransformer
+{
+    private readonly ManiaBeatmap beatmap;
+
+    public ManiaTestScriptedSkinTransformer(ISkin skin, IBeatmap beatmap)
+        : base(skin)
+    {
+        this.beatmap = (ManiaBeatmap)beatmap;
+    }
+
+    public override Drawable? GetDrawableComponent(ISkinComponentLookup lookup)
+    {
+        switch (lookup)
+        {
+            case ManiaSkinComponentLookup maniaComponent:
+                switch (maniaComponent.Component)
+                {
+                    case ManiaSkinComponents.ColumnBackground:
+                        return new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = new Color4(0.12f, 0.16f, 0.22f, 1f),
+                        };
+                }
+                break;
+
+            case GlobalSkinnableContainerLookup containerLookup:
+                if (containerLookup.Lookup == GlobalSkinnableContainers.MainHUDComponents)
+                {
+                    return new DefaultSkinComponentsContainer(container =>
+                    {
+                        var hitTiming = container.ChildrenOfType<EzHUDHitTiming>().ToArray();
+                        if (hitTiming.Length >= 2)
+                        {
+                            hitTiming[0].Anchor = Anchor.Centre;
+                            hitTiming[0].Origin = Anchor.Centre;
+                            hitTiming[0].X = -500;
+                            hitTiming[1].Anchor = Anchor.Centre;
+                            hitTiming[1].Origin = Anchor.Centre;
+                            hitTiming[1].X = 500;
+                        }
+                    })
+                    {
+                        new EzHUDHitTiming(),
+                        new EzHUDHitTiming(),
+                        new EzHUDComboTitle(),
+                        new EzHUDComboCounter(),
+                        new EzHUDKeyCounterDisplay(),
+                        new EzHUDHitTimingColumns(),
+                        new BarHitErrorMeter(),
+                        new EzHUDHitResultScore(),
+                    };
+                }
+                break;
+        }
+
+        return base.GetDrawableComponent(lookup);
+    }
+
+    public override IBindable<TValue>? GetConfig<TLookup, TValue>(TLookup lookup)
+    {
+        if (lookup is ManiaSkinConfigurationLookup maniaLookup)
+        {
+            switch (maniaLookup.Lookup)
+            {
+                case LegacyManiaSkinConfigurationLookups.ColumnWidth:
+                    return SkinUtils.As<TValue>(new Bindable<float>(64));
+
+                case LegacyManiaSkinConfigurationLookups.HitPosition:
+                    return SkinUtils.As<TValue>(new Bindable<float>(430));
+
+                case LegacyManiaSkinConfigurationLookups.ColumnBackgroundColour:
+                    return SkinUtils.As<TValue>(new Bindable<Color4>(Color4.Black));
+            }
+        }
+
+        return base.GetConfig<TLookup, TValue>(lookup);
+    }
+}

--- a/docs/TestScriptedSkin/TestScriptedSkin.csx
+++ b/docs/TestScriptedSkin/TestScriptedSkin.csx
@@ -1,0 +1,122 @@
+// ============================================================================
+// TestScriptedSkin.csx
+// ============================================================================
+// 推荐命名：<SkinName>Skin.csx
+// 兼容旧命名：Skin.csx
+//
+// 这个示例展示的是“脚本皮肤主文件”的最小可用模板。
+// 它是一个 Skin 子类：
+// - 可以复用现有皮肤资源
+// - 可以通过 CreateInfo() 暴露脚本元数据
+// - 可以被脚本加载器自动识别
+// ============================================================================
+
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using osu.Framework.Audio.Sample;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Textures;
+using osu.Game.Audio;
+using osu.Game.Beatmaps.Formats;
+using osu.Game.Extensions;
+using osu.Game.IO;
+using osu.Game.EzOsuGame.HUD;
+using osu.Game.Screens.Play.HUD;
+using osu.Game.Screens.Play.HUD.JudgementCounter;
+using osu.Game.Skinning.Components;
+using osuTK;
+using osuTK.Graphics;
+
+public class TestScriptedSkin : Skin
+{
+    public static SkinInfo CreateInfo() => new SkinInfo
+    {
+        Name = "TestScriptedSkin",
+        Creator = "Your Name",
+        Protected = true,
+        InstantiationInfo = typeof(TestScriptedSkin).GetInvariantInstantiationInfo(),
+    };
+
+    protected readonly IStorageResourceProvider Resources;
+
+    public TestScriptedSkin(IStorageResourceProvider resources)
+        : this(CreateInfo(), resources)
+    {
+    }
+
+    [UsedImplicitly(ImplicitUseKindFlags.InstantiatedWithFixedConstructorSignature)]
+    public TestScriptedSkin(SkinInfo skin, IStorageResourceProvider resources, IResourceStore<byte[]>? fallbackStore = null)
+        : base(skin, resources, fallbackStore)
+    {
+        Resources = resources;
+    }
+
+    public override Texture? GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT) => Textures?.Get(componentName, wrapModeS, wrapModeT);
+
+    public override ISample GetSample(ISampleInfo sampleInfo)
+    {
+        string lookup = sampleInfo.LookupNames.FirstOrDefault() ?? "virtual";
+        return new SampleVirtual(lookup);
+    }
+
+    public override Drawable? GetDrawableComponent(ISkinComponentLookup lookup)
+    {
+        switch (lookup)
+        {
+            case GlobalSkinnableContainerLookup containerLookup:
+                switch (containerLookup.Lookup)
+                {
+                    case GlobalSkinnableContainers.MainHUDComponents:
+                        return new DefaultSkinComponentsContainer(container =>
+                        {
+                            var score = container.OfType<EzHUDScoreCounter>().FirstOrDefault();
+                            if (score != null)
+                            {
+                                score.Anchor = Anchor.TopLeft;
+                                score.Origin = Anchor.TopLeft;
+                                score.Position = new Vector2(20, 20);
+                                score.ShowLabel.Value = false;
+                            }
+                        })
+                        {
+                            Children = new Drawable[]
+                            {
+                                new EzHUDScoreCounter(),
+                                new DefaultHealthDisplay(),
+                                new JudgementCounterDisplay
+                                {
+                                    FillMode = FillMode.Fill,
+                                    FlowDirection = { Value = Direction.Vertical },
+                                    Anchor = Anchor.CentreLeft,
+                                    Origin = Anchor.CentreLeft,
+                                    Position = new Vector2(20, 0),
+                                },
+                            }
+                        };
+                }
+
+                return null;
+        }
+
+        return base.GetDrawableComponent(lookup);
+    }
+
+    public override IBindable<TValue>? GetConfig<TLookup, TValue>(TLookup lookup)
+    {
+        switch (lookup)
+        {
+            case GlobalSkinColours global:
+                if (global == GlobalSkinColours.ComboColours)
+                    return SkinUtils.As<TValue>(new Bindable<IReadOnlyList<Color4>?>(Configuration.ComboColours));
+                break;
+
+            case SkinComboColourLookup comboColour:
+                return SkinUtils.As<TValue>(new Bindable<Color4>(getComboColour(Configuration, comboColour.ColourIndex)));
+        }
+
+        return null;
+    }
+
+    private static Color4 getComboColour(IHasComboColours source, int colourIndex) => source.ComboColours![colourIndex % source.ComboColours.Count];
+}

--- a/docs/TestScriptedSkin/skin.ini
+++ b/docs/TestScriptedSkin/skin.ini
@@ -1,0 +1,10 @@
+[General]
+Name: TestScriptedSkin
+Author: Scripted Skin Test
+Version: latest
+
+[Colours]
+Combo1: 255,192,0
+Combo2: 0,202,0
+Combo3: 18,124,255
+Combo4: 242,24,57

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -41,6 +41,7 @@ using osu.Game.Rulesets.Mania.Skinning.Ez2;
 using osu.Game.Rulesets.Mania.Skinning.EzStylePro;
 using osu.Game.Rulesets.Mania.Skinning.Legacy;
 using osu.Game.Rulesets.Mania.Skinning.SbI;
+using osu.Game.Rulesets.Mania.Skinning.Scripted;
 using osu.Game.Rulesets.Mania.UI;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Replays.Types;
@@ -106,6 +107,10 @@ namespace osu.Game.Rulesets.Mania
 
                 case LegacySkin:
                     return new ManiaLegacySkinTransformer(skin, beatmap);
+
+                // ✨ 脚本皮肤支持：使用通用的 ScriptedSkinTransformer
+                case ScriptedSkinWrapper:
+                    return new ManiaScriptedSkinTransformer(skin, beatmap);
             }
 
             return null;

--- a/osu.Game.Rulesets.Mania/Skinning/Scripted/ManiaScriptedSkinTransformer.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Scripted/ManiaScriptedSkinTransformer.cs
@@ -1,0 +1,111 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.IO;
+using System.Linq;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Logging;
+using osu.Game.Beatmaps;
+using osu.Game.Skinning;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Mania.Skinning.Scripted
+{
+    /// <summary>
+    /// Mania 规则集的脚本皮肤 Transformer。
+    /// 自动检测并加载 ManiaTransformer.csx（如果存在）。
+    /// </summary>
+    public class ManiaScriptedSkinTransformer : SkinTransformer
+    {
+        private readonly SkinTransformer? maniaTransformer;
+
+        public ManiaScriptedSkinTransformer(ISkin skin, IBeatmap beatmap)
+            : base(skin)
+        {
+            // ✨ 尝试加载 Mania 专用的 transformer
+            if (skin is ScriptedSkinWrapper wrapper)
+            {
+                maniaTransformer = loadManiaTransformer(wrapper, skin, beatmap);
+            }
+        }
+
+        /// <summary>
+        /// 加载 Mania 专用的 transformer 脚本
+        /// </summary>
+        private SkinTransformer? loadManiaTransformer(ScriptedSkinWrapper wrapper, ISkin skin, IBeatmap beatmap)
+        {
+            try
+            {
+                // 获取脚本目录
+                string? scriptPath = wrapper.ScriptPath ?? SkinManager.GetScriptPathStatic(wrapper.SkinInfo.Value);
+                if (string.IsNullOrEmpty(scriptPath))
+                    return null;
+
+                string scriptDirectory = Path.GetDirectoryName(scriptPath)!;
+                string skinStem = Path.GetFileNameWithoutExtension(scriptPath);
+                string[] candidatePaths =
+                {
+                    Path.Combine(scriptDirectory, $"Mania{skinStem}Transformer.csx"),
+                    Path.Combine(scriptDirectory, "ManiaTransformer.csx"),
+                };
+
+                string maniaTransformerPath = candidatePaths.FirstOrDefault(File.Exists) ?? string.Empty;
+
+                if (string.IsNullOrEmpty(maniaTransformerPath))
+                    return null;
+
+                Logger.Log($"发现 Mania Transformer: {Path.GetFileName(maniaTransformerPath)}", LoggingTarget.Information);
+                return wrapper.ScriptRunner.LoadScriptAsync<SkinTransformer>(maniaTransformerPath, skin, beatmap).GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"加载 Mania Transformer 失败: {ex.Message}", LoggingTarget.Runtime, LogLevel.Error);
+                return null;
+            }
+        }
+
+        public override IBindable<TValue>? GetConfig<TLookup, TValue>(TLookup lookup)
+        {
+            // 1️⃣ 如果有 Mania transformer，先尝试从它获取配置
+            var transformerConfig = maniaTransformer?.GetConfig<TLookup, TValue>(lookup);
+            if (transformerConfig != null)
+                return transformerConfig;
+
+            // 2️⃣ 尝试从基础脚本皮肤获取配置
+            var scriptConfig = base.GetConfig<TLookup, TValue>(lookup);
+            if (scriptConfig != null)
+                return scriptConfig;
+
+            // 3️⃣ 如果都没提供，使用 Mania 默认配置
+            if (lookup is ManiaSkinConfigurationLookup maniaLookup)
+            {
+                switch (maniaLookup.Lookup)
+                {
+                    case LegacyManiaSkinConfigurationLookups.ColumnWidth:
+                        return SkinUtils.As<TValue>(new Bindable<float>(64));
+
+                    case LegacyManiaSkinConfigurationLookups.HitPosition:
+                        return SkinUtils.As<TValue>(new Bindable<float>(430));
+
+                    case LegacyManiaSkinConfigurationLookups.ColumnBackgroundColour:
+                        return SkinUtils.As<TValue>(new Bindable<Color4>(Color4.Black));
+                }
+            }
+
+            return null;
+        }
+
+        public override Drawable? GetDrawableComponent(ISkinComponentLookup lookup)
+        {
+            // 1️⃣ 如果有 Mania transformer，先尝试从它获取组件
+            var transformerComponent = maniaTransformer?.GetDrawableComponent(lookup);
+            if (transformerComponent != null)
+                return transformerComponent;
+
+            // 2️⃣ 回退到基础脚本皮肤
+            return base.GetDrawableComponent(lookup);
+        }
+    }
+}

--- a/osu.Game.Tests/Skins/ScriptedSkinLoaderTest.cs
+++ b/osu.Game.Tests/Skins/ScriptedSkinLoaderTest.cs
@@ -1,0 +1,100 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using osu.Framework.Graphics.Rendering.Dummy;
+using osu.Game.EzOsuGame.ScriptedSkin;
+using osu.Game.IO;
+using osu.Game.Rulesets.Mania.Beatmaps;
+using osu.Game.Skinning;
+using osuTK.Graphics;
+
+namespace osu.Game.Tests.Skins
+{
+    [TestFixture]
+    public class ScriptedSkinLoaderTest
+    {
+        private static string fixtureDirectory => Path.Combine(findRepositoryRoot(), "docs", "TestScriptedSkin");
+
+        private static string findRepositoryRoot()
+        {
+            var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+            while (directory != null)
+            {
+                if (Directory.Exists(Path.Combine(directory.FullName, "docs", "TestScriptedSkin")))
+                    return directory.FullName;
+
+                directory = directory.Parent;
+            }
+
+            throw new InvalidOperationException("Could not locate docs/TestScriptedSkin fixture directory.");
+        }
+
+        [Test]
+        public void TestFixtureDirectoryExists()
+        {
+            Assert.That(Directory.Exists(fixtureDirectory), Is.True, $"Fixture directory not found: {fixtureDirectory}");
+            Assert.That(File.Exists(Path.Combine(fixtureDirectory, "TestScriptedSkin.csx")), Is.True);
+            Assert.That(File.Exists(Path.Combine(fixtureDirectory, "skin.ini")), Is.True);
+        }
+
+        [Test]
+        public async Task TestMainScriptCompiles()
+        {
+            var runner = new SandboxedScriptRunner();
+            string scriptPath = Path.Combine(fixtureDirectory, "TestScriptedSkin.csx");
+
+            SkinInfo? info = await runner.LoadScriptInfoAsync(scriptPath);
+
+            Assert.That(info, Is.Not.Null);
+            Assert.That(info!.Name, Is.EqualTo("TestScriptedSkin"));
+        }
+
+        [Test]
+        public async Task TestMainScriptLoadsWithSkinIni()
+        {
+            var runner = new SandboxedScriptRunner();
+            string scriptPath = Path.Combine(fixtureDirectory, "TestScriptedSkin.csx");
+
+            var resources = createMockResourceProvider();
+            var skinInfo = new SkinInfo { Name = "TestScriptedSkin", Creator = "Test" };
+
+            IScriptedSkin skin = await runner.LoadScriptAsync<IScriptedSkin>(scriptPath, skinInfo, resources.Object);
+
+            Assert.That(skin, Is.Not.Null);
+            Assert.That(skin.Name, Is.EqualTo("TestScriptedSkin"));
+
+            var combo = skin.GetConfig<GlobalSkinColours, IReadOnlyList<Color4>>(GlobalSkinColours.ComboColours);
+            Assert.That(combo?.Value, Is.Not.Null);
+            Assert.That(combo!.Value.Count, Is.GreaterThan(0));
+        }
+
+        [Test]
+        public async Task TestManiaTransformerCompiles()
+        {
+            var runner = new SandboxedScriptRunner();
+            string scriptPath = Path.Combine(fixtureDirectory, "ManiaTestScriptedSkinTransformer.csx");
+
+            var beatmap = new ManiaBeatmap(new StageDefinition(4));
+            var mockSkin = new Mock<ISkin>();
+
+            SkinTransformer transformer = await runner.LoadScriptAsync<SkinTransformer>(scriptPath, mockSkin.Object, beatmap);
+
+            Assert.That(transformer, Is.Not.Null);
+            Assert.That(transformer.GetType().Name, Is.EqualTo("ManiaTestScriptedSkinTransformer"));
+        }
+
+        private static Mock<IStorageResourceProvider> createMockResourceProvider()
+        {
+            var mock = new Mock<IStorageResourceProvider>();
+            mock.Setup(m => m.Renderer).Returns(new DummyRenderer());
+            return mock;
+        }
+    }
+}

--- a/osu.Game/Extensions/TypeExtensions.cs
+++ b/osu.Game/Extensions/TypeExtensions.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace osu.Game.Extensions
 {
-    internal static class TypeExtensions
+    public static class TypeExtensions
     {
         /// <summary>
         /// Returns <paramref name="type"/>'s <see cref="Type.AssemblyQualifiedName"/>
@@ -19,7 +19,7 @@ namespace osu.Game.Extensions
         /// Leaving only the type and assembly names in such a scenario allows to preserve compatibility
         /// across assembly versions.
         /// </remarks>
-        internal static string GetInvariantInstantiationInfo(this Type type)
+        public static string GetInvariantInstantiationInfo(this Type type)
         {
             string? assemblyQualifiedName = type.AssemblyQualifiedName;
             if (assemblyQualifiedName == null)

--- a/osu.Game/EzOsuGame/Edit/EzSkinEditorScreen.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinEditorScreen.cs
@@ -2,9 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Logging;
 using osu.Framework.Screens;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
@@ -333,6 +335,45 @@ namespace osu.Game.EzOsuGame.Edit
                 var configEditor = new ScriptedSkinConfigEditor();
                 configEditor.SetSkin(scriptedSkin);
 
+                // 创建重载按钮
+                var reloadButton = new ReloadScriptButton
+                {
+                    Text = "重载脚本",
+                    RelativeSizeAxes = Axes.X,
+                    Height = 40,
+                    Action = () =>
+                    {
+                        // 使用 Task.Run 在后台线程执行异步操作，避免 async void
+                        _ = Task.Run(async () =>
+                        {
+                            try
+                            {
+                                // 获取当前脚本路径
+                                string scriptPath = skinManager.GetScriptPath(scriptedWrapper.SkinInfo.Value);
+
+                                if (!string.IsNullOrEmpty(scriptPath))
+                                {
+                                    bool success = await skinManager.TriggerScriptReload(scriptPath).ConfigureAwait(false);
+
+                                    if (success)
+                                    {
+                                        // 在主线程刷新配置编辑器
+                                        Schedule(() =>
+                                        {
+                                            configEditor.SetSkin(scriptedWrapper.GetScriptedSkin());
+                                        });
+                                    }
+                                }
+                            }
+                            catch (Exception ex)
+                            {
+                                // 记录错误但不崩溃
+                                Logger.Log($"重载脚本失败: {ex.Message}", LoggingTarget.Runtime, LogLevel.Error);
+                            }
+                        });
+                    }
+                };
+
                 settingsScrollContainer!.Child = new FillFlowContainer
                 {
                     RelativeSizeAxes = Axes.X,
@@ -348,6 +389,7 @@ namespace osu.Game.EzOsuGame.Edit
                             Colour = Color4.White,
                             Font = OsuFont.Default.With(size: 18, weight: FontWeight.Bold),
                         },
+                        reloadButton,
                         configEditor,
                     }
                 };
@@ -437,6 +479,16 @@ namespace osu.Game.EzOsuGame.Edit
             private void load(OverlayColourProvider? overlayColourProvider, OsuColour colours)
             {
                 BackgroundColour = overlayColourProvider?.Background3 ?? colours.Blue3;
+                Content.CornerRadius = 5;
+            }
+        }
+
+        private partial class ReloadScriptButton : OsuButton
+        {
+            [BackgroundDependencyLoader]
+            private void load(OsuColour colours)
+            {
+                BackgroundColour = colours.Green3;
                 Content.CornerRadius = 5;
             }
         }

--- a/osu.Game/EzOsuGame/Edit/EzSkinEditorScreen.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinEditorScreen.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Screens;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.EzOsuGame.ScriptedSkin;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
@@ -324,7 +325,34 @@ namespace osu.Game.EzOsuGame.Edit
         {
             var currentSkin = getEditorSkin();
 
-            if (provider != null)
+            // 检查是否为脚本皮肤
+            if (currentSkin is ScriptedSkinWrapper scriptedWrapper)
+            {
+                var scriptedSkin = scriptedWrapper.GetScriptedSkin();
+
+                var configEditor = new ScriptedSkinConfigEditor();
+                configEditor.SetSkin(scriptedSkin);
+
+                settingsScrollContainer!.Child = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Vertical,
+                    Spacing = new Vector2(0, 15),
+                    Padding = new MarginPadding(10),
+                    Children = new Drawable[]
+                    {
+                        new OsuSpriteText
+                        {
+                            Text = "脚本皮肤配置",
+                            Colour = Color4.White,
+                            Font = OsuFont.Default.With(size: 18, weight: FontWeight.Bold),
+                        },
+                        configEditor,
+                    }
+                };
+            }
+            else if (provider != null)
             {
                 // Provider may provide a full parameters UI; prefer that when available.
                 settingsScrollContainer!.Child = provider.CreateParametersPart(currentSkin);

--- a/osu.Game/EzOsuGame/ScriptedSkin/ConfigControlFactory.cs
+++ b/osu.Game/EzOsuGame/ScriptedSkin/ConfigControlFactory.cs
@@ -1,0 +1,224 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.EzOsuGame.ScriptedSkin
+{
+    /// <summary>
+    /// 配置控件工厂，根据配置元数据自动创建对应的 UI 控件。
+    /// </summary>
+    public static class ConfigControlFactory
+    {
+        /// <summary>
+        /// 根据属性类型创建对应的配置控件。
+        /// </summary>
+        public static Drawable CreateControl(ConfigMetadata metadata, Action<object?> onValueChanged)
+        {
+            var container = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(0, 5),
+                Padding = new MarginPadding { Bottom = 15 }
+            };
+
+            // 标题和描述
+            container.Add(createHeader(metadata));
+
+            // 根据类型创建控件
+            Drawable control = metadata.PropertyType switch
+            {
+                Type t when t == typeof(float) => createFloatSlider(metadata, onValueChanged),
+                Type t when t == typeof(int) => createIntSlider(metadata, onValueChanged),
+                Type t when t == typeof(bool) => createCheckbox(metadata, onValueChanged),
+                Type t when t == typeof(string) => createTextBox(metadata, onValueChanged),
+                Type t when t == typeof(Color4) => createColorPicker(metadata, onValueChanged),
+                _ => createUnsupportedControl(metadata)
+            };
+
+            container.Add(control);
+
+            return container;
+        }
+
+        private static Container createHeader(ConfigMetadata metadata)
+        {
+            return new Container
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Children = new Drawable[]
+                {
+                    new OsuSpriteText
+                    {
+                        Text = metadata.DisplayName,
+                        Font = OsuFont.Default.With(size: 14, weight: FontWeight.Bold),
+                        Colour = Color4.White,
+                    },
+                    new OsuSpriteText
+                    {
+                        Text = metadata.Description ?? string.Empty,
+                        Font = OsuFont.Default.With(size: 11),
+                        Colour = Color4.Gray,
+                        Y = 18,
+                    }
+                }
+            };
+        }
+
+        private static SliderBar<float> createFloatSlider(ConfigMetadata metadata, Action<object?> onValueChanged)
+        {
+            float min = metadata.Min is float fmin ? fmin : 0f;
+            float max = metadata.Max is float fmax ? fmax : 1f;
+            float value = metadata.DefaultValue is float fval ? fval : (min + max) / 2;
+
+            var bindable = new BindableFloat(value) { MinValue = min, MaxValue = max };
+            bindable.ValueChanged += e => onValueChanged(e.NewValue);
+
+            return new RoundedSliderBar<float>
+            {
+                RelativeSizeAxes = Axes.X,
+                Current = bindable,
+            };
+        }
+
+        private static SliderBar<int> createIntSlider(ConfigMetadata metadata, Action<object?> onValueChanged)
+        {
+            int min = metadata.Min is int imin ? imin : 0;
+            int max = metadata.Max is int imax ? imax : 100;
+            int value = metadata.DefaultValue is int ival ? ival : (min + max) / 2;
+
+            var bindable = new BindableInt(value) { MinValue = min, MaxValue = max };
+            bindable.ValueChanged += e => onValueChanged(e.NewValue);
+
+            return new RoundedSliderBar<int>
+            {
+                RelativeSizeAxes = Axes.X,
+                Current = bindable,
+            };
+        }
+
+        private static OsuCheckbox createCheckbox(ConfigMetadata metadata, Action<object?> onValueChanged)
+        {
+            bool value = metadata.DefaultValue is bool bval && bval;
+
+            var bindable = new BindableBool(value);
+            bindable.ValueChanged += e => onValueChanged(e.NewValue);
+
+            return new OsuCheckbox
+            {
+                Current = bindable,
+                LabelText = metadata.DisplayName,
+            };
+        }
+
+        private static OsuTextBox createTextBox(ConfigMetadata metadata, Action<object?> onValueChanged)
+        {
+            string value = metadata.DefaultValue as string ?? string.Empty;
+
+            var textbox = new OsuTextBox
+            {
+                RelativeSizeAxes = Axes.X,
+                Text = value,
+                PlaceholderText = "Enter value...",
+            };
+
+            textbox.OnCommit += (sender, isNew) =>
+            {
+                if (isNew)
+                    onValueChanged(textbox.Text);
+            };
+
+            return textbox;
+        }
+
+        private static Container createColorPicker(ConfigMetadata metadata, Action<object?> onValueChanged)
+        {
+            // 简化的颜色选择器（实际项目中可能需要更复杂的实现）
+            string hexValue = metadata.DefaultValue as string ?? "#FFFFFFFF";
+
+            try
+            {
+                Color4 color = Colour4.FromHex(hexValue);
+
+                var container = new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Height = 30,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = color,
+                        },
+                        new OsuSpriteText
+                        {
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
+                            Text = hexValue,
+                            Font = OsuFont.Default.With(size: 12),
+                            Colour = getContrastColor(color),
+                            X = 10,
+                        }
+                    }
+                };
+
+                // TODO: 添加点击事件打开颜色选择对话框
+                // 这里简化处理，实际需要集成颜色选择器组件
+
+                return container;
+            }
+            catch
+            {
+                return new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Height = 30,
+                    Child = new OsuSpriteText
+                    {
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Text = "Invalid color format",
+                        Colour = Color4.Red,
+                    }
+                };
+            }
+        }
+
+        private static Color4 getContrastColor(Color4 background)
+        {
+            // 计算亮度，决定使用黑色还是白色文字
+            float luminance = (0.299f * background.R + 0.587f * background.G + 0.114f * background.B) / 255f;
+            return luminance > 0.5f ? Color4.Black : Color4.White;
+        }
+
+        private static Container createUnsupportedControl(ConfigMetadata metadata)
+        {
+            return new Container
+            {
+                RelativeSizeAxes = Axes.X,
+                Height = 30,
+                Child = new OsuSpriteText
+                {
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    Text = $"Unsupported type: {metadata.PropertyType.Name}",
+                    Colour = Color4.Orange,
+                }
+            };
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/ScriptedSkin/HotReloadManager.cs
+++ b/osu.Game/EzOsuGame/ScriptedSkin/HotReloadManager.cs
@@ -1,0 +1,193 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using osu.Framework.Graphics;
+using osu.Framework.Logging;
+
+namespace osu.Game.EzOsuGame.ScriptedSkin
+{
+    /// <summary>
+    /// 热重载管理器，管理脚本皮肤的热重载流程。
+    /// </summary>
+    public partial class HotReloadManager : Component
+    {
+        private readonly ScriptFileWatcher fileWatcher;
+        private readonly SandboxedScriptRunner scriptRunner;
+        private readonly ConcurrentDictionary<string, ReloadStatus> reloadStatuses = new ConcurrentDictionary<string, ReloadStatus>();
+
+        private const string logger_prefix = "[HotReloadManager]";
+
+        /// <summary>
+        /// 当皮肤重载完成时触发的事件。
+        /// </summary>
+        public event Action<string, bool>? SkinReloaded;
+
+        public HotReloadManager(SandboxedScriptRunner runner)
+        {
+            scriptRunner = runner;
+            fileWatcher = new ScriptFileWatcher();
+            fileWatcher.ScriptModified += onScriptModified;
+        }
+
+        /// <summary>
+        /// 开始监控指定目录的脚本文件。
+        /// </summary>
+        public void StartWatching(string directory)
+        {
+            fileWatcher.StartWatching(directory);
+            Logger.Log($"{logger_prefix} Started watching scripts in: {directory}", LoggingTarget.Information);
+        }
+
+        /// <summary>
+        /// 停止监控。
+        /// </summary>
+        public void StopWatching()
+        {
+            fileWatcher.StopWatching();
+        }
+
+        /// <summary>
+        /// 手动触发指定脚本的重载。
+        /// </summary>
+        public async Task<bool> TriggerReload(string scriptPath)
+        {
+            Logger.Log($"{logger_prefix} Manual reload triggered for: {scriptPath}", LoggingTarget.Information);
+            return await reloadScript(scriptPath).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// 获取指定脚本的重载状态。
+        /// </summary>
+        public ReloadStatus GetReloadStatus(string scriptPath)
+        {
+            return reloadStatuses.TryGetValue(scriptPath, out var status)
+                ? status
+                : new ReloadStatus { State = ReloadState.Idle };
+        }
+
+        private void onScriptModified(string scriptPath)
+        {
+            Logger.Log($"{logger_prefix} Auto-reload triggered for: {scriptPath}", LoggingTarget.Information);
+
+            // 使用 Task.Run 在后台线程执行异步操作，避免 async void
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await reloadScript(scriptPath).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Log($"{logger_prefix} Unexpected error in auto-reload: {ex.Message}", LoggingTarget.Runtime, LogLevel.Error);
+                }
+            });
+        }
+
+        private async Task<bool> reloadScript(string scriptPath)
+        {
+            // 更新状态为重载中
+            updateStatus(scriptPath, ReloadState.Reloading, null);
+
+            try
+            {
+                // 清除旧的编译缓存
+                scriptRunner.ClearCache(scriptPath);
+
+                // 重新加载脚本
+                var newSkin = await scriptRunner.LoadScriptAsync(scriptPath).ConfigureAwait(false);
+
+                // 更新状态为成功
+                updateStatus(scriptPath, ReloadState.Success, null);
+
+                // 触发事件通知
+                SkinReloaded?.Invoke(scriptPath, true);
+
+                Logger.Log($"{logger_prefix} Successfully reloaded: {newSkin.Name}", LoggingTarget.Information);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                // 更新状态为失败
+                updateStatus(scriptPath, ReloadState.Failed, ex.Message);
+
+                // 触发事件通知
+                SkinReloaded?.Invoke(scriptPath, false);
+
+                Logger.Log($"{logger_prefix} Failed to reload script: {ex.Message}", LoggingTarget.Runtime, LogLevel.Error);
+                return false;
+            }
+        }
+
+        private void updateStatus(string scriptPath, ReloadState state, string? errorMessage)
+        {
+            var status = new ReloadStatus
+            {
+                State = state,
+                LastReloadTime = DateTime.Now,
+                ErrorMessage = errorMessage
+            };
+
+            reloadStatuses[scriptPath] = status;
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (isDisposing)
+            {
+                fileWatcher.Dispose();
+            }
+
+            base.Dispose(isDisposing);
+        }
+    }
+
+    /// <summary>
+    /// 重载状态枚举。
+    /// </summary>
+    public enum ReloadState
+    {
+        /// <summary>
+        /// 空闲状态，未进行重载。
+        /// </summary>
+        Idle,
+
+        /// <summary>
+        /// 正在重载中。
+        /// </summary>
+        Reloading,
+
+        /// <summary>
+        /// 重载成功。
+        /// </summary>
+        Success,
+
+        /// <summary>
+        /// 重载失败。
+        /// </summary>
+        Failed
+    }
+
+    /// <summary>
+    /// 重载状态信息。
+    /// </summary>
+    public class ReloadStatus
+    {
+        /// <summary>
+        /// 当前重载状态。
+        /// </summary>
+        public ReloadState State { get; set; } = ReloadState.Idle;
+
+        /// <summary>
+        /// 最后一次重载的时间。
+        /// </summary>
+        public DateTime? LastReloadTime { get; set; }
+
+        /// <summary>
+        /// 如果重载失败，包含错误信息。
+        /// </summary>
+        public string? ErrorMessage { get; set; }
+    }
+}

--- a/osu.Game/EzOsuGame/ScriptedSkin/IScriptedSkin.cs
+++ b/osu.Game/EzOsuGame/ScriptedSkin/IScriptedSkin.cs
@@ -1,0 +1,80 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Audio.Sample;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Textures;
+using osu.Game.Audio;
+using osu.Game.IO;
+using osu.Game.Skinning;
+
+namespace osu.Game.EzOsuGame.ScriptedSkin
+{
+    /// <summary>
+    /// 脚本化皮肤的统一接口，用户编写的 .csx 文件必须实现此接口。
+    /// </summary>
+    /// <remarks>
+    /// 此接口定义了脚本皮肤需要实现的核心方法，允许用户通过 C# 脚本自定义皮肤行为。
+    /// 脚本将在沙箱环境中执行，以确保安全性。
+    /// </remarks>
+    public interface IScriptedSkin : IDisposable
+    {
+        /// <summary>
+        /// 皮肤初始化（在加载时调用一次）。
+        /// </summary>
+        /// <param name="baseSkin">基础皮肤源，可用于回退查找。</param>
+        /// <param name="resources">资源提供者，用于访问游戏资源。</param>
+        void Initialize(ISkinSource baseSkin, IStorageResourceProvider resources);
+
+        /// <summary>
+        /// 获取 Drawable 组件（核心方法）。
+        /// </summary>
+        /// <param name="lookup">组件查找条件。</param>
+        /// <returns>Drawable 组件实例，或 null 表示使用默认实现。</returns>
+        Drawable? GetDrawableComponent(ISkinComponentLookup lookup);
+
+        /// <summary>
+        /// 获取纹理。
+        /// </summary>
+        /// <param name="componentName">纹理名称。</param>
+        /// <param name="wrapModeS">水平方向的纹理包裹模式。</param>
+        /// <param name="wrapModeT">垂直方向的纹理包裹模式。</param>
+        /// <returns>纹理实例，或 null 表示未找到。</returns>
+        Texture? GetTexture(string componentName, WrapMode wrapModeS = default, WrapMode wrapModeT = default);
+
+        /// <summary>
+        /// 获取音效。
+        /// </summary>
+        /// <param name="sampleInfo">音效信息。</param>
+        /// <returns>音效实例，或 null 表示未找到。</returns>
+        ISample? GetSample(ISampleInfo sampleInfo);
+
+        /// <summary>
+        /// 获取配置值。
+        /// </summary>
+        /// <typeparam name="TLookup">查找类型。</typeparam>
+        /// <typeparam name="TValue">值类型。</typeparam>
+        /// <param name="lookup">配置查找条件。</param>
+        /// <returns>配置值的 Bindable 包装，或 null 表示未找到。</returns>
+        IBindable<TValue>? GetConfig<TLookup, TValue>(TLookup lookup)
+            where TLookup : notnull
+            where TValue : notnull;
+
+        /// <summary>
+        /// 皮肤名称（用于在 UI 中显示）。
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// 作者信息。
+        /// </summary>
+        string Author { get; }
+
+        /// <summary>
+        /// 版本号。
+        /// </summary>
+        Version Version { get; }
+    }
+}

--- a/osu.Game/EzOsuGame/ScriptedSkin/IScriptedSkin.cs
+++ b/osu.Game/EzOsuGame/ScriptedSkin/IScriptedSkin.cs
@@ -77,4 +77,19 @@ namespace osu.Game.EzOsuGame.ScriptedSkin
         /// </summary>
         Version Version { get; }
     }
+
+    /// <summary>
+    /// 可选的脚本皮肤元数据接口。
+    /// </summary>
+    /// <remarks>
+    /// 仅当脚本需要参与受保护皮肤、导入/编辑策略时实现。
+    /// 不实现时默认视为未保护，保持旧脚本兼容。
+    /// </remarks>
+    public interface IScriptedSkinMetadata
+    {
+        /// <summary>
+        /// 脚本皮肤是否受保护。
+        /// </summary>
+        bool Protected { get; }
+    }
 }

--- a/osu.Game/EzOsuGame/ScriptedSkin/SandboxedScriptRunner.cs
+++ b/osu.Game/EzOsuGame/ScriptedSkin/SandboxedScriptRunner.cs
@@ -165,6 +165,16 @@ namespace osu.Game.EzOsuGame.ScriptedSkin
         }
 
         /// <summary>
+        /// 清除指定脚本的编译缓存，强制下次加载时重新编译。
+        /// </summary>
+        /// <param name="scriptPath">脚本文件的完整路径。</param>
+        public void ClearCache(string scriptPath)
+        {
+            cache.RemoveByPath(scriptPath);
+            Logger.Log($"{LOGGER_PREFIX} Cache cleared for: {Path.GetFileName(scriptPath)}", LoggingTarget.Information);
+        }
+
+        /// <summary>
         /// 验证脚本的安全性，阻止危险操作。
         /// </summary>
         /// <param name="scriptCode">脚本源代码。</param>

--- a/osu.Game/EzOsuGame/ScriptedSkin/SandboxedScriptRunner.cs
+++ b/osu.Game/EzOsuGame/ScriptedSkin/SandboxedScriptRunner.cs
@@ -6,13 +6,20 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Scripting;
 using Microsoft.CodeAnalysis.Scripting;
+using osu.Framework.Audio.Sample;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Textures;
 using osu.Framework.Logging;
-using osuTK;
+using osu.Game.Audio;
+using osu.Game.Extensions;
+using osu.Game.IO;
+using osu.Game.Skinning;
 
 namespace osu.Game.EzOsuGame.ScriptedSkin
 {
@@ -27,8 +34,6 @@ namespace osu.Game.EzOsuGame.ScriptedSkin
     {
         internal static readonly string LOGGER_PREFIX = "ScriptedSkin";
 
-        private static readonly ScriptOptions safe_script_options;
-
         private readonly ScriptCompilationCache cache;
 
         /// <summary>
@@ -37,39 +42,6 @@ namespace osu.Game.EzOsuGame.ScriptedSkin
         public SandboxedScriptRunner()
         {
             cache = new ScriptCompilationCache();
-        }
-
-        static SandboxedScriptRunner()
-        {
-            // 定义允许引用的程序集白名单
-            var allowedAssemblies = new[]
-            {
-                typeof(IScriptedSkin).Assembly, // osu.Game
-                typeof(Drawable).Assembly, // osu.Framework
-                typeof(Vector2).Assembly, // osuTK
-                typeof(Console).Assembly, // System.Runtime
-                typeof(List<>).Assembly, // System.Collections
-                typeof(Enumerable).Assembly, // System.Linq
-            };
-
-            // 构建安全的脚本选项
-            safe_script_options = ScriptOptions.Default
-                                               .WithReferences(allowedAssemblies)
-                                               .WithImports(
-                                                   "System",
-                                                   "System.Collections.Generic",
-                                                   "System.Linq",
-                                                   "osu.Framework.Graphics",
-                                                   "osu.Framework.Graphics.Containers",
-                                                   "osu.Framework.Graphics.Shapes",
-                                                   "osu.Framework.Bindables",
-                                                   "osuTK",
-                                                   "osuTK.Graphics",
-                                                   "osu.Game.Skinning",
-                                                   "osu.Game.Skinning.ScriptedSkin"
-                                               )
-                                               .WithMetadataResolver(new SafeMetadataResolver());
-
             Logger.Log("SandboxedScriptRunner initialized with security restrictions.", LoggingTarget.Information);
         }
 
@@ -82,17 +54,30 @@ namespace osu.Game.EzOsuGame.ScriptedSkin
         /// <exception cref="ScriptSecurityException">安全验证失败时抛出。</exception>
         /// <exception cref="ScriptExecutionException">执行失败时抛出。</exception>
         public async Task<IScriptedSkin> LoadScriptAsync(string scriptPath)
+            => await LoadScriptAsync<IScriptedSkin>(scriptPath).ConfigureAwait(false);
+
+        /// <summary>
+        /// 异步加载并编译脚本文件，返回指定目标类型的实例。
+        /// </summary>
+        /// <typeparam name="T">目标类型。</typeparam>
+        /// <param name="scriptPath">脚本文件的完整路径。</param>
+        /// <param name="ctorArgs">构造函数参数。</param>
+        /// <returns>编译后的实例。</returns>
+        /// <exception cref="ScriptCompilationException">编译失败时抛出。</exception>
+        /// <exception cref="ScriptSecurityException">安全验证失败时抛出。</exception>
+        /// <exception cref="ScriptExecutionException">执行失败时抛出。</exception>
+        public async Task<T> LoadScriptAsync<T>(string scriptPath, params object?[] ctorArgs)
+            where T : class
         {
             if (!File.Exists(scriptPath))
                 throw new FileNotFoundException($"Script file not found: {scriptPath}");
 
-            // 尝试从缓存中获取
-            if (cache.TryGet(scriptPath, out var cachedSkin))
+            if (typeof(T) == typeof(IScriptedSkin) && cache.TryGet(scriptPath, out var cachedSkin))
             {
                 if (cachedSkin != null)
                 {
                     Logger.Log($"{LOGGER_PREFIX} Using cached skin: {cachedSkin.Name}", LoggingTarget.Information);
-                    return cachedSkin;
+                    return (T)cachedSkin;
                 }
             }
 
@@ -107,7 +92,7 @@ namespace osu.Game.EzOsuGame.ScriptedSkin
             try
             {
                 // 创建脚本对象
-                var script = CSharpScript.Create<IScriptedSkin>(scriptCode, safe_script_options);
+                var script = CSharpScript.Create(scriptCode, ScriptedSkinCompilation.Options);
 
                 // 获取编译结果并检查错误
                 var compilation = script.GetCompilation();
@@ -133,20 +118,18 @@ namespace osu.Game.EzOsuGame.ScriptedSkin
                     }
                 }
 
-                // 执行脚本（创建实例）
-                Logger.Log($"{LOGGER_PREFIX} Executing script...", LoggingTarget.Information);
                 var state = await script.RunAsync().ConfigureAwait(false);
-                var skin = state.ReturnValue;
+                var instance = instantiateFromReturnValue<T>(state.ReturnValue, scriptPath, ctorArgs);
+                if (instance != null)
+                    return cacheAndReturn(scriptPath, instance);
 
-                if (skin == null)
-                    throw new ScriptExecutionException("Script did not return an IScriptedSkin instance.");
+                var loadedAssembly = emitAssembly(compilation, scriptPath);
+                var reflected = instantiateFromAssembly<T>(loadedAssembly, scriptPath, ctorArgs);
 
-                // 添加到缓存
-                cache.Add(scriptPath, skin);
+                if (reflected != null)
+                    return cacheAndReturn(scriptPath, reflected);
 
-                Logger.Log($"{LOGGER_PREFIX} Successfully loaded skin: {skin.Name} v{skin.Version} by {skin.Author}", LoggingTarget.Information);
-
-                return skin;
+                throw new ScriptExecutionException($"Script did not expose a usable {typeof(T).Name} implementation.");
             }
             catch (CompilationErrorException ex)
             {
@@ -161,6 +144,247 @@ namespace osu.Game.EzOsuGame.ScriptedSkin
             {
                 Logger.Log($"{LOGGER_PREFIX} Unexpected error during script execution: {ex}", LoggingTarget.Runtime);
                 throw new ScriptExecutionException($"Failed to execute script: {ex.Message}", ex);
+            }
+        }
+
+        private static Assembly emitAssembly(Compilation compilation, string scriptPath)
+        {
+            using var peStream = new MemoryStream();
+
+            var emitResult = compilation.Emit(peStream);
+
+            if (!emitResult.Success)
+                throw new ScriptCompilationException(emitResult.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).ToList());
+
+            return Assembly.Load(peStream.ToArray());
+        }
+
+        private T? instantiateFromReturnValue<T>(object? returnValue, string scriptPath, object?[] ctorArgs)
+            where T : class
+        {
+            if (returnValue == null)
+                return null;
+
+            if (returnValue is T typed)
+                return typed;
+
+            if (typeof(T) == typeof(IScriptedSkin) && returnValue is Skin skin)
+                return (T)(object)new SkinScriptedSkinAdapter(skin);
+
+            Logger.Log($"{LOGGER_PREFIX} Script returned {returnValue.GetType().Name}, which cannot be used as {typeof(T).Name} for {Path.GetFileName(scriptPath)}.", LoggingTarget.Information);
+            return null;
+        }
+
+        private T? instantiateFromAssembly<T>(Assembly assembly, string scriptPath, object?[] ctorArgs)
+            where T : class
+        {
+            string expectedTypeName = Path.GetFileNameWithoutExtension(scriptPath);
+            var candidateTypes = assembly.GetTypes()
+                                         .Where(type => !type.IsAbstract && !type.IsInterface)
+                                         .Where(matchesTargetType<T>)
+                                         .OrderByDescending(type => string.Equals(type.Name, expectedTypeName, StringComparison.Ordinal))
+                                         .ThenBy(type => type.FullName, StringComparer.Ordinal)
+                                         .ToArray();
+
+            foreach (var type in candidateTypes)
+            {
+                foreach (object?[] args in expandCtorArgs(scriptPath, ctorArgs))
+                {
+                    var instance = adaptInstance<T>(tryCreateInstance(type, args));
+                    if (instance != null)
+                        return instance;
+                }
+            }
+
+            return null;
+        }
+
+        private static IEnumerable<object?[]> expandCtorArgs(string scriptPath, object?[] ctorArgs)
+        {
+            yield return ctorArgs;
+
+            var fallbackStore = ScriptedSkinCompilation.CreateDirectoryResourceStore(scriptPath);
+
+            if (fallbackStore == null)
+                yield break;
+
+            switch (ctorArgs.Length)
+            {
+                case 0:
+                    yield return new object?[] { fallbackStore };
+
+                    break;
+
+                case 1:
+                    yield return new[] { ctorArgs[0], fallbackStore };
+
+                    break;
+
+                case 2:
+                    yield return new[] { ctorArgs[0], ctorArgs[1], fallbackStore };
+
+                    break;
+            }
+        }
+
+        private static bool matchesTargetType<T>(Type type)
+            where T : class
+        {
+            if (typeof(T).IsAssignableFrom(type))
+                return true;
+
+            return typeof(T) == typeof(IScriptedSkin) && typeof(Skin).IsAssignableFrom(type);
+        }
+
+        private static object? tryCreateInstance(Type type, object?[] ctorArgs)
+        {
+            if (ctorArgs.Length == 0)
+            {
+                if (Activator.CreateInstance(type) is object direct)
+                    return direct;
+            }
+
+            foreach (var ctor in type.GetConstructors())
+            {
+                var parameters = ctor.GetParameters();
+                if (parameters.Length != ctorArgs.Length)
+                    continue;
+
+                bool compatible = true;
+
+                for (int i = 0; i < parameters.Length; i++)
+                {
+                    object? arg = ctorArgs[i];
+
+                    if (arg == null)
+                    {
+                        if (parameters[i].ParameterType.IsValueType && Nullable.GetUnderlyingType(parameters[i].ParameterType) == null)
+                        {
+                            compatible = false;
+                            break;
+                        }
+
+                        continue;
+                    }
+
+                    if (!parameters[i].ParameterType.IsInstanceOfType(arg))
+                    {
+                        compatible = false;
+                        break;
+                    }
+                }
+
+                if (!compatible)
+                    continue;
+
+                return ctor.Invoke(ctorArgs);
+            }
+
+            return null;
+        }
+
+        private static T? adaptInstance<T>(object? instance)
+            where T : class
+        {
+            if (instance == null)
+                return null;
+
+            if (instance is T typed)
+                return typed;
+
+            if (typeof(T) == typeof(IScriptedSkin) && instance is Skin skin)
+                return (T)(object)new SkinScriptedSkinAdapter(skin);
+
+            return null;
+        }
+
+        private T cacheAndReturn<T>(string scriptPath, T instance)
+            where T : class
+        {
+            if (typeof(T) == typeof(IScriptedSkin) && instance is IScriptedSkin scriptedSkin)
+                cache.Add(scriptPath, scriptedSkin);
+
+            return instance;
+        }
+
+        /// <summary>
+        /// 尝试提取脚本中声明的 <see cref="SkinInfo"/> 元数据。
+        /// </summary>
+        public async Task<SkinInfo?> LoadScriptInfoAsync(string scriptPath)
+        {
+            if (!File.Exists(scriptPath))
+                throw new FileNotFoundException($"Script file not found: {scriptPath}");
+
+            string scriptCode = await File.ReadAllTextAsync(scriptPath).ConfigureAwait(false);
+            validateScriptSafety(scriptCode, scriptPath);
+
+            try
+            {
+                var script = CSharpScript.Create(scriptCode, ScriptedSkinCompilation.Options);
+                var compilation = script.GetCompilation();
+                var diagnostics = compilation.GetDiagnostics();
+
+                var errors = diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).ToList();
+                if (errors.Any())
+                    throw new ScriptCompilationException(errors);
+
+                var assembly = emitAssembly(compilation, scriptPath);
+                string expectedTypeName = Path.GetFileNameWithoutExtension(scriptPath);
+
+                var candidateTypes = assembly.GetTypes()
+                                             .Where(type => !type.IsAbstract && !type.IsInterface)
+                                             .OrderByDescending(type => string.Equals(type.Name, expectedTypeName, StringComparison.Ordinal))
+                                             .ThenBy(type => type.FullName, StringComparer.Ordinal)
+                                             .ToArray();
+
+                foreach (var type in candidateTypes)
+                {
+                    var createInfo = type.GetMethod("CreateInfo", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
+
+                    if (createInfo?.ReturnType == typeof(SkinInfo) && createInfo.GetParameters().Length == 0)
+                    {
+                        if (createInfo.Invoke(null, null) is SkinInfo skinInfo)
+                            return skinInfo;
+                    }
+
+                    if (typeof(Skin).IsAssignableFrom(type) && type.GetConstructor(Type.EmptyTypes) != null)
+                    {
+                        if (Activator.CreateInstance(type) is Skin skin)
+                            return skin.SkinInfo.Value;
+                    }
+
+                    if (typeof(IScriptedSkin).IsAssignableFrom(type) && type.GetConstructor(Type.EmptyTypes) != null)
+                    {
+                        if (Activator.CreateInstance(type) is IScriptedSkin scriptedSkin)
+                        {
+                            var protectedProperty = scriptedSkin.GetType().GetProperty("Protected", BindingFlags.Public | BindingFlags.Instance);
+
+                            if (protectedProperty?.PropertyType == typeof(bool) && protectedProperty.GetValue(scriptedSkin) is bool isProtected)
+                            {
+                                return new SkinInfo(scriptedSkin.Name, scriptedSkin.Author, typeof(ScriptedSkinWrapper).GetInvariantInstantiationInfo())
+                                {
+                                    Protected = isProtected,
+                                };
+                            }
+
+                            return new SkinInfo(scriptedSkin.Name, scriptedSkin.Author, typeof(ScriptedSkinWrapper).GetInvariantInstantiationInfo());
+                        }
+                    }
+                }
+
+                return null;
+            }
+            catch (CompilationErrorException ex)
+            {
+                throw new ScriptCompilationException(ex.Diagnostics);
+            }
+            catch (ScriptCompilationException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new ScriptExecutionException($"Failed to read script metadata: {ex.Message}", ex);
             }
         }
 
@@ -220,18 +444,12 @@ namespace osu.Game.EzOsuGame.ScriptedSkin
     /// </summary>
     internal class SafeMetadataResolver : MetadataReferenceResolver
     {
-        private static readonly HashSet<string> allowed_assemblies = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        private readonly HashSet<string> allowedAssemblies;
+
+        public SafeMetadataResolver(IEnumerable<string> allowedAssemblyNames)
         {
-            "osu.Game",
-            "osu.Framework",
-            "osuTK",
-            "System.Runtime",
-            "System.Collections",
-            "System.Linq",
-            "System.Core",
-            "mscorlib",
-            "netstandard",
-        };
+            allowedAssemblies = new HashSet<string>(allowedAssemblyNames, StringComparer.OrdinalIgnoreCase);
+        }
 
         public override bool ResolveMissingAssemblies => false;
 
@@ -242,10 +460,10 @@ namespace osu.Game.EzOsuGame.ScriptedSkin
         {
             string assemblyName = Path.GetFileNameWithoutExtension(reference);
 
-            if (!allowed_assemblies.Contains(assemblyName))
+            if (!allowedAssemblies.Contains(assemblyName))
             {
                 string message = $"Assembly '{assemblyName}' is not allowed in scripted skins. " +
-                                 $"Allowed assemblies: {string.Join(", ", allowed_assemblies)}";
+                                 $"Allowed assemblies: {string.Join(", ", allowedAssemblies)}";
                 Logger.Log(message, LoggingTarget.Runtime, LogLevel.Important);
                 throw new ScriptSecurityException(message);
             }
@@ -256,6 +474,42 @@ namespace osu.Game.EzOsuGame.ScriptedSkin
         public override bool Equals(object? other) => other is SafeMetadataResolver;
 
         public override int GetHashCode() => nameof(SafeMetadataResolver).GetHashCode();
+    }
+
+    /// <summary>
+    /// 将 <see cref="Skin"/> 适配为 <see cref="IScriptedSkin"/>。
+    /// </summary>
+    internal sealed class SkinScriptedSkinAdapter : IScriptedSkin
+    {
+        private readonly Skin skin;
+
+        public SkinScriptedSkinAdapter(Skin skin)
+        {
+            this.skin = skin;
+        }
+
+        public void Initialize(ISkinSource baseSkin, IStorageResourceProvider resources)
+        {
+        }
+
+        public Drawable? GetDrawableComponent(ISkinComponentLookup lookup) => skin.GetDrawableComponent(lookup);
+
+        public Texture? GetTexture(string componentName, WrapMode wrapModeS = default, WrapMode wrapModeT = default) => skin.GetTexture(componentName, wrapModeS, wrapModeT);
+
+        public ISample? GetSample(ISampleInfo sampleInfo) => skin.GetSample(sampleInfo);
+
+        public IBindable<TValue>? GetConfig<TLookup, TValue>(TLookup lookup)
+            where TLookup : notnull
+            where TValue : notnull
+            => skin.GetConfig<TLookup, TValue>(lookup);
+
+        public string Name => skin.Name;
+
+        public string Author => skin.SkinInfo.Value.Creator;
+
+        public Version Version => skin.GetType().GetProperty("Version", BindingFlags.Public | BindingFlags.Instance)?.GetValue(skin) as Version ?? new Version(1, 0, 0);
+
+        public void Dispose() => skin.Dispose();
     }
 
     /// <summary>

--- a/osu.Game/EzOsuGame/ScriptedSkin/SandboxedScriptRunner.cs
+++ b/osu.Game/EzOsuGame/ScriptedSkin/SandboxedScriptRunner.cs
@@ -1,0 +1,241 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Scripting;
+using Microsoft.CodeAnalysis.Scripting;
+using osu.Framework.Graphics;
+using osu.Framework.Logging;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.ScriptedSkin
+{
+    /// <summary>
+    /// 沙箱化的脚本执行器，负责加载、编译和执行用户编写的皮肤脚本。
+    /// </summary>
+    /// <remarks>
+    /// 此执行器通过限制可访问的 API 和文件系统操作来确保安全性，
+    /// 防止恶意脚本对系统造成损害或在游戏中作弊。
+    /// </remarks>
+    public class SandboxedScriptRunner
+    {
+        private static readonly ScriptOptions safe_script_options;
+        internal static readonly Logger LOGGER = Logger.GetLogger("ScriptedSkin");
+
+        static SandboxedScriptRunner()
+        {
+            // 定义允许引用的程序集白名单
+            var allowedAssemblies = new[]
+            {
+                typeof(IScriptedSkin).Assembly, // osu.Game
+                typeof(Drawable).Assembly, // osu.Framework
+                typeof(Vector2).Assembly, // osuTK
+                typeof(Console).Assembly, // System.Runtime
+                typeof(List<>).Assembly, // System.Collections
+                typeof(Enumerable).Assembly, // System.Linq
+            };
+
+            // 构建安全的脚本选项
+            safe_script_options = ScriptOptions.Default
+                                               .WithReferences(allowedAssemblies)
+                                               .WithImports(
+                                                   "System",
+                                                   "System.Collections.Generic",
+                                                   "System.Linq",
+                                                   "osu.Framework.Graphics",
+                                                   "osu.Framework.Graphics.Containers",
+                                                   "osu.Framework.Graphics.Shapes",
+                                                   "osu.Framework.Bindables",
+                                                   "osuTK",
+                                                   "osuTK.Graphics",
+                                                   "osu.Game.Skinning",
+                                                   "osu.Game.Skinning.ScriptedSkin"
+                                               )
+                                               .WithMetadataResolver(new SafeMetadataResolver());
+
+            Logger.Log("SandboxedScriptRunner initialized with security restrictions.", LoggingTarget.Information);
+        }
+
+        /// <summary>
+        /// 异步加载并编译脚本文件。
+        /// </summary>
+        /// <param name="scriptPath">脚本文件的完整路径。</param>
+        /// <returns>编译后的 IScriptedSkin 实例。</returns>
+        /// <exception cref="ScriptCompilationException">编译失败时抛出。</exception>
+        /// <exception cref="ScriptSecurityException">安全验证失败时抛出。</exception>
+        /// <exception cref="ScriptExecutionException">执行失败时抛出。</exception>
+        public async Task<IScriptedSkin> LoadScriptAsync(string scriptPath)
+        {
+            if (!File.Exists(scriptPath))
+                throw new FileNotFoundException($"Script file not found: {scriptPath}");
+
+            Logger.Log($"Loading script: {Path.GetFileName(scriptPath)}", LoggingTarget.Information);
+
+            // 读取脚本内容
+            string scriptCode = await File.ReadAllTextAsync(scriptPath).ConfigureAwait(false);
+
+            // 验证脚本安全性
+            validateScriptSafety(scriptCode, scriptPath);
+
+            try
+            {
+                // 创建脚本对象
+                var script = CSharpScript.Create<IScriptedSkin>(scriptCode, safe_script_options);
+
+                // 获取编译结果并检查错误
+                var compilation = script.GetCompilation();
+                var diagnostics = compilation.GetDiagnostics();
+
+                var errors = diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).ToList();
+
+                if (errors.Any())
+                {
+                    var exception = new ScriptCompilationException(errors);
+                    Logger.Log($"Compilation failed: {exception.GetFormattedErrors()}", LoggingTarget.Runtime);
+                    throw exception;
+                }
+
+                // 记录警告信息
+                var warnings = diagnostics.Where(d => d.Severity == DiagnosticSeverity.Warning).ToList();
+
+                if (warnings.Any())
+                {
+                    foreach (var warning in warnings)
+                    {
+                        Logger.Log($"Warning: {warning.GetMessage()} (Line {warning.Location.GetLineSpan().StartLinePosition.Line + 1})", LoggingTarget.Information);
+                    }
+                }
+
+                // 执行脚本（创建实例）
+                Logger.Log("Executing script...", LoggingTarget.Information);
+                var state = await script.RunAsync().ConfigureAwait(false);
+                var skin = state.ReturnValue;
+
+                if (skin == null)
+                    throw new ScriptExecutionException("Script did not return an IScriptedSkin instance.");
+
+                Logger.Log($"Successfully loaded skin: {skin.Name} v{skin.Version} by {skin.Author}", LoggingTarget.Information);
+
+                return skin;
+            }
+            catch (CompilationErrorException ex)
+            {
+                Logger.Log($"Compilation error: {ex.Message}", LoggingTarget.Runtime);
+                throw new ScriptCompilationException(ex.Diagnostics);
+            }
+            catch (ScriptExecutionException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"Unexpected error during script execution: {ex}", LoggingTarget.Runtime);
+                throw new ScriptExecutionException($"Failed to execute script: {ex.Message}", ex);
+            }
+        }
+
+        /// <summary>
+        /// 验证脚本的安全性，阻止危险操作。
+        /// </summary>
+        /// <param name="scriptCode">脚本源代码。</param>
+        /// <param name="scriptPath">脚本文件路径（用于错误报告）。</param>
+        /// <exception cref="ScriptSecurityException">发现不安全代码时抛出。</exception>
+        private void validateScriptSafety(string scriptCode, string scriptPath)
+        {
+            // 定义禁止的 API 模式
+            var forbiddenPatterns = new Dictionary<string, string>
+            {
+                { "System.IO.File", "File system access is forbidden" },
+                { "System.IO.Directory", "Directory operations are forbidden" },
+                { "System.Net", "Network access is forbidden" },
+                { "System.Diagnostics", "Process operations are forbidden" },
+                { "System.Reflection", "Reflection is forbidden for security reasons" },
+                { "unsafe", "Unsafe code is not allowed" },
+                { "DllImport", "P/Invoke is forbidden" },
+                { "Marshal", "Memory manipulation is forbidden" },
+            };
+
+            foreach (var kvp in forbiddenPatterns)
+            {
+                if (scriptCode.Contains(kvp.Key))
+                {
+                    string message = $"Security violation in {Path.GetFileName(scriptPath)}: {kvp.Value}. " +
+                                     $"Forbidden API: '{kvp.Key}'";
+                    Logger.Log(message, LoggingTarget.Runtime);
+                    throw new ScriptSecurityException(message);
+                }
+            }
+
+            // 检查是否使用了命名空间声明（应该使用全局命名空间）
+            if (scriptCode.Contains("namespace "))
+            {
+                Logger.Log($"Warning: Script {Path.GetFileName(scriptPath)} contains namespace declaration. " +
+                           "Scripts should use global namespace for simplicity.", LoggingTarget.Information);
+            }
+        }
+    }
+
+    /// <summary>
+    /// 安全的元数据解析器，限制脚本可引用的程序集。
+    /// </summary>
+    internal class SafeMetadataResolver : MetadataReferenceResolver
+    {
+        private static readonly HashSet<string> allowed_assemblies = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "osu.Game",
+            "osu.Framework",
+            "osuTK",
+            "System.Runtime",
+            "System.Collections",
+            "System.Linq",
+            "System.Core",
+            "mscorlib",
+            "netstandard",
+        };
+
+        public override bool ResolveMissingAssemblies => false;
+
+        public override ImmutableArray<PortableExecutableReference> ResolveReference(
+            string reference,
+            string? baseFilePath,
+            MetadataReferenceProperties properties)
+        {
+            string assemblyName = Path.GetFileNameWithoutExtension(reference);
+
+            if (!allowed_assemblies.Contains(assemblyName))
+            {
+                string message = $"Assembly '{assemblyName}' is not allowed in scripted skins. " +
+                                 $"Allowed assemblies: {string.Join(", ", allowed_assemblies)}";
+                Logger.Log(message, LoggingTarget.Runtime);
+                throw new ScriptSecurityException(message);
+            }
+
+            return ImmutableArray.Create(MetadataReference.CreateFromFile(reference));
+        }
+
+        public override bool Equals(object? other) => other is SafeMetadataResolver;
+
+        public override int GetHashCode() => nameof(SafeMetadataResolver).GetHashCode();
+    }
+
+    /// <summary>
+    /// 受限的文件解析器，禁止访问脚本目录外的文件。
+    /// </summary>
+    /// <remarks>
+    /// 由于 Roslyn 的 SourceFileResolver API 限制，此类的实际文件访问限制
+    /// 主要通过 SafeMetadataResolver 和静态代码分析来实现。
+    /// </remarks>
+    internal class RestrictedFileResolver : SourceFileResolver
+    {
+        public RestrictedFileResolver()
+            : base(Array.Empty<string>(), Directory.GetCurrentDirectory())
+        {
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/ScriptedSkin/SandboxedScriptRunner.cs
+++ b/osu.Game/EzOsuGame/ScriptedSkin/SandboxedScriptRunner.cs
@@ -25,8 +25,19 @@ namespace osu.Game.EzOsuGame.ScriptedSkin
     /// </remarks>
     public class SandboxedScriptRunner
     {
+        internal static readonly string LOGGER_PREFIX = "ScriptedSkin";
+
         private static readonly ScriptOptions safe_script_options;
-        internal static readonly Logger LOGGER = Logger.GetLogger("ScriptedSkin");
+
+        private readonly ScriptCompilationCache cache;
+
+        /// <summary>
+        /// 创建沙箱脚本执行器实例。
+        /// </summary>
+        public SandboxedScriptRunner()
+        {
+            cache = new ScriptCompilationCache();
+        }
 
         static SandboxedScriptRunner()
         {
@@ -75,7 +86,17 @@ namespace osu.Game.EzOsuGame.ScriptedSkin
             if (!File.Exists(scriptPath))
                 throw new FileNotFoundException($"Script file not found: {scriptPath}");
 
-            Logger.Log($"Loading script: {Path.GetFileName(scriptPath)}", LoggingTarget.Information);
+            // 尝试从缓存中获取
+            if (cache.TryGet(scriptPath, out var cachedSkin))
+            {
+                if (cachedSkin != null)
+                {
+                    Logger.Log($"{LOGGER_PREFIX} Using cached skin: {cachedSkin.Name}", LoggingTarget.Information);
+                    return cachedSkin;
+                }
+            }
+
+            Logger.Log($"{LOGGER_PREFIX} Loading script: {Path.GetFileName(scriptPath)}", LoggingTarget.Information);
 
             // 读取脚本内容
             string scriptCode = await File.ReadAllTextAsync(scriptPath).ConfigureAwait(false);
@@ -97,7 +118,7 @@ namespace osu.Game.EzOsuGame.ScriptedSkin
                 if (errors.Any())
                 {
                     var exception = new ScriptCompilationException(errors);
-                    Logger.Log($"Compilation failed: {exception.GetFormattedErrors()}", LoggingTarget.Runtime);
+                    Logger.Log($"{LOGGER_PREFIX} Compilation failed: {exception.GetFormattedErrors()}", LoggingTarget.Runtime);
                     throw exception;
                 }
 
@@ -108,25 +129,28 @@ namespace osu.Game.EzOsuGame.ScriptedSkin
                 {
                     foreach (var warning in warnings)
                     {
-                        Logger.Log($"Warning: {warning.GetMessage()} (Line {warning.Location.GetLineSpan().StartLinePosition.Line + 1})", LoggingTarget.Information);
+                        Logger.Log($"{LOGGER_PREFIX} Warning: {warning.GetMessage()} (Line {warning.Location.GetLineSpan().StartLinePosition.Line + 1})", LoggingTarget.Information);
                     }
                 }
 
                 // 执行脚本（创建实例）
-                Logger.Log("Executing script...", LoggingTarget.Information);
+                Logger.Log($"{LOGGER_PREFIX} Executing script...", LoggingTarget.Information);
                 var state = await script.RunAsync().ConfigureAwait(false);
                 var skin = state.ReturnValue;
 
                 if (skin == null)
                     throw new ScriptExecutionException("Script did not return an IScriptedSkin instance.");
 
-                Logger.Log($"Successfully loaded skin: {skin.Name} v{skin.Version} by {skin.Author}", LoggingTarget.Information);
+                // 添加到缓存
+                cache.Add(scriptPath, skin);
+
+                Logger.Log($"{LOGGER_PREFIX} Successfully loaded skin: {skin.Name} v{skin.Version} by {skin.Author}", LoggingTarget.Information);
 
                 return skin;
             }
             catch (CompilationErrorException ex)
             {
-                Logger.Log($"Compilation error: {ex.Message}", LoggingTarget.Runtime);
+                Logger.Log($"{LOGGER_PREFIX} Compilation error: {ex.Message}", LoggingTarget.Runtime);
                 throw new ScriptCompilationException(ex.Diagnostics);
             }
             catch (ScriptExecutionException)
@@ -135,7 +159,7 @@ namespace osu.Game.EzOsuGame.ScriptedSkin
             }
             catch (Exception ex)
             {
-                Logger.Log($"Unexpected error during script execution: {ex}", LoggingTarget.Runtime);
+                Logger.Log($"{LOGGER_PREFIX} Unexpected error during script execution: {ex}", LoggingTarget.Runtime);
                 throw new ScriptExecutionException($"Failed to execute script: {ex.Message}", ex);
             }
         }
@@ -175,7 +199,7 @@ namespace osu.Game.EzOsuGame.ScriptedSkin
             // 检查是否使用了命名空间声明（应该使用全局命名空间）
             if (scriptCode.Contains("namespace "))
             {
-                Logger.Log($"Warning: Script {Path.GetFileName(scriptPath)} contains namespace declaration. " +
+                Logger.Log($"{LOGGER_PREFIX} Warning: Script {Path.GetFileName(scriptPath)} contains namespace declaration. " +
                            "Scripts should use global namespace for simplicity.", LoggingTarget.Information);
             }
         }
@@ -212,7 +236,7 @@ namespace osu.Game.EzOsuGame.ScriptedSkin
             {
                 string message = $"Assembly '{assemblyName}' is not allowed in scripted skins. " +
                                  $"Allowed assemblies: {string.Join(", ", allowed_assemblies)}";
-                Logger.Log(message, LoggingTarget.Runtime);
+                Logger.Log(message, LoggingTarget.Runtime, LogLevel.Important);
                 throw new ScriptSecurityException(message);
             }
 

--- a/osu.Game/EzOsuGame/ScriptedSkin/ScriptCompilationCache.cs
+++ b/osu.Game/EzOsuGame/ScriptedSkin/ScriptCompilationCache.cs
@@ -1,0 +1,165 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Security.Cryptography;
+using osu.Framework.Logging;
+
+namespace osu.Game.EzOsuGame.ScriptedSkin
+{
+    /// <summary>
+    /// 脚本编译缓存，避免重复编译相同的脚本文件以提升性能。
+    /// </summary>
+    /// <remarks>
+    /// 此缓存基于文件内容的 SHA256 哈希值作为键，确保只有在脚本内容真正改变时才重新编译。
+    /// 缓存会在内存中保存已编译的脚本实例，直到被显式清除或对象销毁。
+    /// </remarks>
+    public class ScriptCompilationCache : IDisposable
+    {
+        private readonly ConcurrentDictionary<string, CachedEntry> cache = new ConcurrentDictionary<string, CachedEntry>();
+        private static readonly Logger logger = Logger.GetLogger("ScriptCompilationCache");
+
+        /// <summary>
+        /// 获取缓存中的条目数量。
+        /// </summary>
+        public int Count => cache.Count;
+
+        /// <summary>
+        /// 尝试从缓存中获取已编译的脚本实例。
+        /// </summary>
+        /// <param name="scriptPath">脚本文件的完整路径。</param>
+        /// <param name="skin">如果缓存命中，返回编译后的皮肤实例；否则为 null。</param>
+        /// <returns>如果缓存命中返回 true，否则返回 false。</returns>
+        public bool TryGet(string scriptPath, out IScriptedSkin? skin)
+        {
+            if (!File.Exists(scriptPath))
+            {
+                skin = null;
+                return false;
+            }
+
+            string cacheKey = computeCacheKey(scriptPath);
+
+            if (cache.TryGetValue(cacheKey, out var entry))
+            {
+                // 检查文件是否已修改
+                var lastWriteTime = File.GetLastWriteTimeUtc(scriptPath);
+
+                if (entry.LastModified == lastWriteTime)
+                {
+                    Logger.Log($"Cache hit for {Path.GetFileName(scriptPath)}", LoggingTarget.Information);
+                    skin = entry.Skin;
+                    return true;
+                }
+
+                // 文件已修改，移除旧缓存
+                Logger.Log($"Cache invalidated for {Path.GetFileName(scriptPath)} (file modified)", LoggingTarget.Information);
+                RemoveByPath(scriptPath);
+            }
+
+            skin = null;
+            return false;
+        }
+
+        /// <summary>
+        /// 将编译后的脚本实例添加到缓存中。
+        /// </summary>
+        /// <param name="scriptPath">脚本文件的完整路径。</param>
+        /// <param name="skin">编译后的皮肤实例。</param>
+        public void Add(string scriptPath, IScriptedSkin skin)
+        {
+            if (!File.Exists(scriptPath))
+                throw new FileNotFoundException($"Script file not found: {scriptPath}");
+
+            string cacheKey = computeCacheKey(scriptPath);
+            var lastWriteTime = File.GetLastWriteTimeUtc(scriptPath);
+
+            // 如果已存在相同键的缓存，先清理旧实例
+            if (cache.TryGetValue(cacheKey, out var oldEntry))
+            {
+                oldEntry.Skin?.Dispose();
+            }
+
+            cache[cacheKey] = new CachedEntry(skin, lastWriteTime, scriptPath);
+            Logger.Log($"Cached compiled script: {Path.GetFileName(scriptPath)} (Total: {cache.Count})", LoggingTarget.Information);
+        }
+
+        /// <summary>
+        /// 根据脚本路径移除缓存条目。
+        /// </summary>
+        /// <param name="scriptPath">脚本文件的完整路径。</param>
+        /// <returns>如果成功移除返回 true，否则返回 false。</returns>
+        public bool RemoveByPath(string scriptPath)
+        {
+            string cacheKey = computeCacheKey(scriptPath);
+
+            if (cache.TryRemove(cacheKey, out var entry))
+            {
+                entry.Skin?.Dispose();
+                Logger.Log($"Removed from cache: {Path.GetFileName(scriptPath)}", LoggingTarget.Information);
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// 清除所有缓存条目并释放相关资源。
+        /// </summary>
+        public void Clear()
+        {
+            Logger.Log($"Clearing all cached scripts ({cache.Count} entries)", LoggingTarget.Information);
+
+            foreach (var entry in cache.Values)
+            {
+                entry.Skin?.Dispose();
+            }
+
+            cache.Clear();
+        }
+
+        /// <summary>
+        /// 计算脚本文件的缓存键（基于文件路径和内容哈希）。
+        /// </summary>
+        /// <param name="scriptPath">脚本文件的完整路径。</param>
+        /// <returns>缓存键字符串。</returns>
+        private static string computeCacheKey(string scriptPath)
+        {
+            // 使用文件路径作为主要标识
+            string fullPath = Path.GetFullPath(scriptPath);
+
+            // 可选：添加文件内容哈希以增强准确性
+            // 这样即使文件被替换为同名但内容不同的文件也能正确识别
+            try
+            {
+                using var sha256 = SHA256.Create();
+                using var stream = File.OpenRead(fullPath);
+                byte[] hash = sha256.ComputeHash(stream);
+                string hashString = Convert.ToBase64String(hash);
+
+                // 结合路径和哈希生成唯一键
+                return $"{fullPath}|{hashString}";
+            }
+            catch
+            {
+                // 如果无法计算哈希，仅使用路径
+                return fullPath;
+            }
+        }
+
+        /// <summary>
+        /// 释放缓存占用的资源。
+        /// </summary>
+        public void Dispose()
+        {
+            Clear();
+        }
+
+        /// <summary>
+        /// 缓存条目，包含编译后的皮肤实例和元数据。
+        /// </summary>
+        private record CachedEntry(IScriptedSkin Skin, DateTime LastModified, string SourcePath);
+    }
+}

--- a/osu.Game/EzOsuGame/ScriptedSkin/ScriptExceptions.cs
+++ b/osu.Game/EzOsuGame/ScriptedSkin/ScriptExceptions.cs
@@ -1,0 +1,72 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace osu.Game.EzOsuGame.ScriptedSkin
+{
+    /// <summary>
+    /// 脚本编译时发生的错误。
+    /// </summary>
+    public class ScriptCompilationException : Exception
+    {
+        /// <summary>
+        /// 编译诊断信息列表。
+        /// </summary>
+        public IReadOnlyList<Diagnostic> Diagnostics { get; }
+
+        /// <summary>
+        /// 创建编译异常。
+        /// </summary>
+        /// <param name="diagnostics">编译诊断信息。</param>
+        public ScriptCompilationException(IEnumerable<Diagnostic> diagnostics)
+            : base($"Script compilation failed with {diagnostics.Count()} error(s).")
+        {
+            Diagnostics = diagnostics.ToList();
+        }
+
+        /// <summary>
+        /// 获取格式化的错误消息。
+        /// </summary>
+        /// <returns>包含所有编译错误的字符串。</returns>
+        public string GetFormattedErrors()
+        {
+            var errors = Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error);
+            return string.Join("\n", errors.Select(d => $"[{d.Id}] {d.GetMessage()} (Line {d.Location.GetLineSpan().StartLinePosition.Line + 1})"));
+        }
+    }
+
+    /// <summary>
+    /// 脚本执行时发生的错误。
+    /// </summary>
+    public class ScriptExecutionException : Exception
+    {
+        /// <summary>
+        /// 创建执行异常。
+        /// </summary>
+        /// <param name="message">错误消息。</param>
+        /// <param name="innerException">内部异常。</param>
+        public ScriptExecutionException(string message, Exception? innerException = null)
+            : base(message, innerException)
+        {
+        }
+    }
+
+    /// <summary>
+    /// 脚本安全验证失败时抛出的异常。
+    /// </summary>
+    public class ScriptSecurityException : Exception
+    {
+        /// <summary>
+        /// 创建安全异常。
+        /// </summary>
+        /// <param name="message">错误消息。</param>
+        public ScriptSecurityException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/ScriptedSkin/ScriptFileWatcher.cs
+++ b/osu.Game/EzOsuGame/ScriptedSkin/ScriptFileWatcher.cs
@@ -1,0 +1,143 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.IO;
+using System.Timers;
+using osu.Framework.Logging;
+
+namespace osu.Game.EzOsuGame.ScriptedSkin
+{
+    /// <summary>
+    /// 脚本文件监控器，监听指定目录下的 .csx 文件变化。
+    /// </summary>
+    /// <remarks>
+    /// 使用防抖机制避免频繁触发重载事件。
+    /// 当文件被修改、创建或删除时，会延迟一段时间后触发事件。
+    /// </remarks>
+    public class ScriptFileWatcher : IDisposable
+    {
+        private FileSystemWatcher? watcher;
+        private Timer? debounceTimer;
+        private string? pendingFilePath;
+        private const double debounce_delay_ms = 500; // 防抖延迟 500ms
+
+        private const string logger_prefix = "[ScriptFileWatcher]";
+
+        /// <summary>
+        /// 当脚本文件被修改时触发的事件。
+        /// </summary>
+        public event Action<string>? ScriptModified;
+
+        /// <summary>
+        /// 开始监控指定目录下的脚本文件。
+        /// </summary>
+        /// <param name="directory">要监控的目录路径。</param>
+        public void StartWatching(string directory)
+        {
+            if (!Directory.Exists(directory))
+            {
+                Logger.Log($"{logger_prefix} Directory does not exist: {directory}", LoggingTarget.Information);
+                return;
+            }
+
+            StopWatching();
+
+            watcher = new FileSystemWatcher(directory)
+            {
+                Filter = "*.csx",
+                IncludeSubdirectories = true,
+                NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.DirectoryName
+            };
+
+            watcher.Changed += onFileChanged;
+            watcher.Created += onFileChanged;
+            watcher.Deleted += onFileChanged;
+            watcher.Renamed += onFileRenamed;
+
+            watcher.EnableRaisingEvents = true;
+
+            Logger.Log($"{logger_prefix} Started watching directory: {directory}", LoggingTarget.Information);
+        }
+
+        /// <summary>
+        /// 停止监控。
+        /// </summary>
+        public void StopWatching()
+        {
+            if (watcher != null)
+            {
+                watcher.EnableRaisingEvents = false;
+                watcher.Dispose();
+                watcher = null;
+
+                Logger.Log($"{logger_prefix} Stopped watching scripts", LoggingTarget.Information);
+            }
+
+            stopDebounceTimer();
+        }
+
+        private void onFileChanged(object sender, FileSystemEventArgs e)
+        {
+            Logger.Log($"{logger_prefix} File changed: {e.FullPath} ({e.ChangeType})", LoggingTarget.Information);
+            triggerDebounce(e.FullPath);
+        }
+
+        private void onFileRenamed(object sender, RenamedEventArgs e)
+        {
+            Logger.Log($"{logger_prefix} File renamed: {e.OldFullPath} -> {e.FullPath}", LoggingTarget.Information);
+
+            // 旧文件删除，触发一次
+            triggerDebounce(e.OldFullPath);
+
+            // 新文件创建，触发一次
+            triggerDebounce(e.FullPath);
+        }
+
+        private void triggerDebounce(string filePath)
+        {
+            // 只关注 .csx 文件
+            if (!filePath.EndsWith(".csx", StringComparison.OrdinalIgnoreCase))
+                return;
+
+            pendingFilePath = filePath;
+
+            // 重置防抖定时器
+            stopDebounceTimer();
+            debounceTimer = new Timer(debounce_delay_ms);
+            debounceTimer.Elapsed += onDebounceElapsed;
+            debounceTimer.AutoReset = false;
+            debounceTimer.Start();
+        }
+
+        private void onDebounceElapsed(object? sender, ElapsedEventArgs e)
+        {
+            if (pendingFilePath != null)
+            {
+                Logger.Log($"{logger_prefix} Triggering reload for: {Path.GetFileName(pendingFilePath)}", LoggingTarget.Information);
+
+                // 在主线程触发事件（如果需要）
+                ScriptModified?.Invoke(pendingFilePath);
+
+                pendingFilePath = null;
+            }
+
+            stopDebounceTimer();
+        }
+
+        private void stopDebounceTimer()
+        {
+            if (debounceTimer != null)
+            {
+                debounceTimer.Stop();
+                debounceTimer.Dispose();
+                debounceTimer = null;
+            }
+        }
+
+        public void Dispose()
+        {
+            StopWatching();
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/ScriptedSkin/ScriptedSkinCompilation.cs
+++ b/osu.Game/EzOsuGame/ScriptedSkin/ScriptedSkinCompilation.cs
@@ -1,0 +1,204 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Scripting;
+using osu.Framework.Audio.Sample;
+using osu.Framework.Graphics;
+using osu.Framework.IO.Stores;
+using osu.Framework.Platform;
+using osu.Game.Beatmaps;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.ScriptedSkin
+{
+    /// <summary>
+    /// 构建脚本皮肤 Roslyn 编译选项（程序集引用与全局 using）。
+    /// </summary>
+    internal static class ScriptedSkinCompilation
+    {
+        private static readonly string[] additional_assembly_names =
+        {
+            "osu.Game.Rulesets.Mania",
+            "JetBrains.Annotations",
+        };
+
+        private static readonly string[] global_imports =
+        {
+            "System",
+            "System.Collections.Generic",
+            "System.Linq",
+            "JetBrains.Annotations",
+            "osu.Framework.Audio.Sample",
+            "osu.Framework.Bindables",
+            "osu.Framework.Extensions",
+            "osu.Framework.Graphics",
+            "osu.Framework.Graphics.Containers",
+            "osu.Framework.Graphics.Shapes",
+            "osu.Framework.Graphics.Textures",
+            "osu.Framework.IO.Stores",
+            "osu.Framework.Testing",
+            "osu.Game.Audio",
+            "osu.Game.Beatmaps",
+            "osu.Game.Beatmaps.Formats",
+            "osu.Game.Extensions",
+            "osu.Game.IO",
+            "osu.Game.EzOsuGame.Configuration",
+            "osu.Game.EzOsuGame.HUD",
+            "osu.Game.EzOsuGame.ScriptedSkin",
+            "osu.Game.Rulesets.Mania.Beatmaps",
+            "osu.Game.Rulesets.Mania.EzMania",
+            "osu.Game.Rulesets.Mania.EzMania.HUD",
+            "osu.Game.Rulesets.Mania.Skinning.Ez2",
+            "osu.Game.Rulesets.Mania.Skinning.EzStylePro",
+            "osu.Game.Rulesets.Mania",
+            "osu.Game.Rulesets.Mania.Skinning",
+            "osu.Game.Rulesets.Mania.Skinning.Scripted",
+            "osu.Game.Rulesets.Scoring",
+            "osu.Game.Screens.Play.HUD",
+            "osu.Game.Screens.Play.HUD.HitErrorMeters",
+            "osu.Game.Screens.Play.HUD.JudgementCounter",
+            "osu.Game.Skinning",
+            "osu.Game.Skinning.Components",
+            "osuTK",
+            "osuTK.Graphics",
+        };
+
+        private static readonly Lazy<ScriptOptions> script_options = new Lazy<ScriptOptions>(buildScriptOptions);
+
+        public static ScriptOptions Options => script_options.Value;
+
+        public static IReadOnlyCollection<string> AllowedAssemblyNames { get; } = buildAllowedAssemblyNames();
+
+        public static IResourceStore<byte[]>? CreateDirectoryResourceStore(string scriptPath)
+        {
+            string? directory = Path.GetDirectoryName(scriptPath);
+
+            if (string.IsNullOrEmpty(directory) || !Directory.Exists(directory))
+                return null;
+
+            return new StorageBackedResourceStore(new NativeStorage(directory));
+        }
+
+        private static ScriptOptions buildScriptOptions()
+        {
+            var references = new HashSet<Assembly>
+            {
+                typeof(object).Assembly,
+                typeof(Attribute).Assembly,
+                typeof(Enumerable).Assembly,
+                typeof(List<>).Assembly,
+                typeof(Task).Assembly,
+                typeof(IScriptedSkin).Assembly,
+                typeof(Drawable).Assembly,
+                typeof(Vector2).Assembly,
+                typeof(IBeatmap).Assembly,
+                typeof(Sample).Assembly,
+            };
+
+            foreach (string assemblyName in additional_assembly_names)
+            {
+                Assembly? assembly = resolveAssembly(assemblyName);
+
+                if (assembly != null)
+                    references.Add(assembly);
+            }
+
+            foreach (Assembly reference in references.ToArray())
+            {
+                foreach (AssemblyName dependency in reference.GetReferencedAssemblies())
+                {
+                    if (!isAllowedDependency(dependency.Name))
+                        continue;
+
+                    Assembly? dependencyAssembly = resolveAssembly(dependency.Name!);
+
+                    if (dependencyAssembly != null)
+                        references.Add(dependencyAssembly);
+                }
+            }
+
+            return ScriptOptions.Default
+                                .WithReferences(references)
+                                .WithImports(global_imports);
+        }
+
+        private static IReadOnlyCollection<string> buildAllowedAssemblyNames()
+        {
+            var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "osu.Game",
+                "osu.Game.Rulesets.Mania",
+                "osu.Framework",
+                "osuTK",
+                "System.Runtime",
+                "System.Collections",
+                "System.Linq",
+                "System.Core",
+                "mscorlib",
+                "netstandard",
+                "JetBrains.Annotations",
+                "osu.Framework.Testing",
+            };
+
+            foreach (string assemblyName in additional_assembly_names)
+            {
+                Assembly? assembly = resolveAssembly(assemblyName);
+                string? name = assembly?.GetName().Name;
+
+                if (!string.IsNullOrEmpty(name))
+                    names.Add(name);
+            }
+
+            return names;
+        }
+
+        internal static Assembly? ResolveAssembly(string assemblyName) => resolveAssembly(assemblyName);
+
+        private static bool isAllowedDependency(string? assemblyName)
+        {
+            if (string.IsNullOrEmpty(assemblyName))
+                return false;
+
+            if (AllowedAssemblyNames.Contains(assemblyName))
+                return true;
+
+            return assemblyName.StartsWith("System.", StringComparison.Ordinal)
+                   || assemblyName.StartsWith("Microsoft.", StringComparison.Ordinal)
+                   || assemblyName.StartsWith("osu.", StringComparison.Ordinal)
+                   || assemblyName.StartsWith("netstandard", StringComparison.Ordinal)
+                   || assemblyName.StartsWith("mscorlib", StringComparison.Ordinal);
+        }
+
+        private static Assembly? resolveAssembly(string assemblyName)
+        {
+            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                if (string.Equals(assembly.GetName().Name, assemblyName, StringComparison.OrdinalIgnoreCase))
+                    return assembly;
+            }
+
+            try
+            {
+                return Assembly.Load(assemblyName);
+            }
+            catch
+            {
+            }
+
+            string gameAssemblyPath = typeof(ScriptedSkinCompilation).Assembly.Location;
+
+            if (string.IsNullOrEmpty(gameAssemblyPath))
+                return null;
+
+            string candidate = Path.Combine(Path.GetDirectoryName(gameAssemblyPath)!, assemblyName + ".dll");
+
+            return File.Exists(candidate) ? Assembly.LoadFrom(candidate) : null;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/ScriptedSkin/ScriptedSkinConfigEditor.cs
+++ b/osu.Game/EzOsuGame/ScriptedSkin/ScriptedSkinConfigEditor.cs
@@ -1,0 +1,185 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.EzOsuGame.ScriptedSkin
+{
+    /// <summary>
+    /// 脚本皮肤配置编辑器，动态生成 [SkinConfig] 属性的 UI 控件。
+    /// </summary>
+    public partial class ScriptedSkinConfigEditor : Container
+    {
+        private IScriptedSkin? scriptedSkin;
+        private FillFlowContainer? configControlsContainer;
+        private readonly Dictionary<string, object?> pendingChanges = new Dictionary<string, object?>();
+
+        [Resolved]
+        private OsuColour colours { get; set; } = null!;
+
+        public ScriptedSkinConfigEditor()
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+        }
+
+        /// <summary>
+        /// 设置要编辑的脚本皮肤实例。
+        /// </summary>
+        public void SetSkin(IScriptedSkin skin)
+        {
+            scriptedSkin = skin;
+            BuildConfigUI();
+        }
+
+        /// <summary>
+        /// 构建配置 UI，扫描所有 [SkinConfig] 属性并生成对应控件。
+        /// </summary>
+        public void BuildConfigUI()
+        {
+            Clear();
+
+            if (scriptedSkin == null)
+            {
+                Add(createNoSkinMessage());
+                return;
+            }
+
+            // 获取所有带 [SkinConfig] 标记的属性
+            var configProperties = getConfigProperties();
+
+            if (!configProperties.Any())
+            {
+                Add(createNoConfigMessage());
+                return;
+            }
+
+            // 创建滚动容器
+            var scrollContainer = new OsuScrollContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                Height = 400, // 固定高度，超出部分滚动
+            };
+
+            configControlsContainer = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(0, 10),
+                Padding = new MarginPadding(10),
+            };
+
+            // 为每个配置属性创建控件
+            foreach (var property in configProperties)
+            {
+                var attribute = property.GetCustomAttribute<SkinConfigAttribute>();
+                if (attribute == null)
+                    continue;
+
+                var metadata = ConfigMetadata.FromProperty(property, attribute);
+                var control = ConfigControlFactory.CreateControl(metadata, value =>
+                {
+                    pendingChanges[metadata.PropertyName] = value;
+                    applyPendingChanges();
+                });
+
+                configControlsContainer.Add(control);
+            }
+
+            scrollContainer.Child = configControlsContainer;
+            Add(scrollContainer);
+        }
+
+        /// <summary>
+        /// 应用待处理的更改到脚本皮肤。
+        /// </summary>
+        private void applyPendingChanges()
+        {
+            if (scriptedSkin == null)
+                return;
+
+            var type = scriptedSkin.GetType();
+
+            foreach (var kvp in pendingChanges)
+            {
+                var property = type.GetProperty(kvp.Key);
+
+                if (property != null && property.CanWrite)
+                {
+                    try
+                    {
+                        property.SetValue(scriptedSkin, kvp.Value);
+                    }
+                    catch (Exception ex)
+                    {
+                        Framework.Logging.Logger.Log($"Failed to set property '{kvp.Key}': {ex.Message}",
+                            Framework.Logging.LoggingTarget.Runtime,
+                            Framework.Logging.LogLevel.Error);
+                    }
+                }
+            }
+
+            // 清除已应用的更改
+            pendingChanges.Clear();
+        }
+
+        /// <summary>
+        /// 获取所有带 [SkinConfig] 标记的属性。
+        /// </summary>
+        private IEnumerable<PropertyInfo> getConfigProperties()
+        {
+            if (scriptedSkin == null)
+                return Enumerable.Empty<PropertyInfo>();
+
+            var type = scriptedSkin.GetType();
+            return type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                       .Where(p => p.GetCustomAttribute<SkinConfigAttribute>() != null);
+        }
+
+        private Container createNoSkinMessage()
+        {
+            return new Container
+            {
+                RelativeSizeAxes = Axes.X,
+                Height = 100,
+                Child = new OsuSpriteText
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Text = "No scripted skin loaded",
+                    Font = OsuFont.Default.With(size: 16),
+                    Colour = Color4.Gray,
+                }
+            };
+        }
+
+        private Container createNoConfigMessage()
+        {
+            return new Container
+            {
+                RelativeSizeAxes = Axes.X,
+                Height = 100,
+                Child = new OsuSpriteText
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Text = "No configurable properties found\nAdd [SkinConfig] attributes to your script",
+                    Font = OsuFont.Default.With(size: 14),
+                    Colour = Color4.Gray,
+                }
+            };
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/ScriptedSkin/SkinConfigAttribute.cs
+++ b/osu.Game/EzOsuGame/ScriptedSkin/SkinConfigAttribute.cs
@@ -1,0 +1,123 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Reflection;
+
+namespace osu.Game.EzOsuGame.ScriptedSkin
+{
+    /// <summary>
+    /// 标记可配置的属性，会在 EzSkinEditorScreen 中自动生成对应的 UI 控件。
+    /// </summary>
+    /// <remarks>
+    /// 使用此属性标记脚本皮肤中的公共属性，编辑器会自动识别并生成相应的配置界面。
+    /// 支持的类型包括：float（滑块）、int（整数滑块）、bool（开关）、Color4（颜色选择器）、string（文本输入）。
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// [SkinConfig("Note Scale", min: 0.5f, max: 2.0f, default: 1.0f, description: "调整 Note 的大小")]
+    /// public float NoteScale { get; set; } = 1.0f;
+    ///
+    /// [SkinConfig("Combo Color", default: "#FF6B6B", description: "连击时的颜色")]
+    /// public Color4 ComboColor { get; set; } = new Color4(1.0f, 0.42f, 0.42f, 1.0f);
+    /// </code>
+    /// </example>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class SkinConfigAttribute : Attribute
+    {
+        /// <summary>
+        /// 在 UI 中显示的友好名称。
+        /// </summary>
+        public string DisplayName { get; }
+
+        /// <summary>
+        /// 默认值。
+        /// </summary>
+        public object? DefaultValue { get; set; }
+
+        /// <summary>
+        /// 最小值（仅适用于数值类型）。
+        /// </summary>
+        public object? Min { get; set; }
+
+        /// <summary>
+        /// 最大值（仅适用于数值类型）。
+        /// </summary>
+        public object? Max { get; set; }
+
+        /// <summary>
+        /// 属性的描述信息，会在鼠标悬浮时显示。
+        /// </summary>
+        public string? Description { get; set; }
+
+        /// <summary>
+        /// 创建配置属性标记。
+        /// </summary>
+        /// <param name="displayName">显示名称。</param>
+        public SkinConfigAttribute(string displayName)
+        {
+            DisplayName = displayName;
+        }
+    }
+
+    /// <summary>
+    /// 配置项的元数据，用于在运行时动态生成 UI。
+    /// </summary>
+    public class ConfigMetadata
+    {
+        /// <summary>
+        /// 属性名称（代码中使用）。
+        /// </summary>
+        public string PropertyName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// 显示名称（UI 中显示）。
+        /// </summary>
+        public string DisplayName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// 属性类型。
+        /// </summary>
+        public Type PropertyType { get; set; } = typeof(object);
+
+        /// <summary>
+        /// 默认值。
+        /// </summary>
+        public object? DefaultValue { get; set; }
+
+        /// <summary>
+        /// 最小值。
+        /// </summary>
+        public object? Min { get; set; }
+
+        /// <summary>
+        /// 最大值。
+        /// </summary>
+        public object? Max { get; set; }
+
+        /// <summary>
+        /// 描述信息。
+        /// </summary>
+        public string? Description { get; set; }
+
+        /// <summary>
+        /// 从属性和标记中提取元数据。
+        /// </summary>
+        /// <param name="property">属性信息。</param>
+        /// <param name="attribute">配置标记。</param>
+        /// <returns>配置元数据实例。</returns>
+        public static ConfigMetadata FromProperty(PropertyInfo property, SkinConfigAttribute attribute)
+        {
+            return new ConfigMetadata
+            {
+                PropertyName = property.Name,
+                DisplayName = attribute.DisplayName,
+                PropertyType = property.PropertyType,
+                DefaultValue = attribute.DefaultValue,
+                Min = attribute.Min,
+                Max = attribute.Max,
+                Description = attribute.Description,
+            };
+        }
+    }
+}

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -598,6 +598,10 @@ namespace osu.Game
             }).Where(m => m != null);
 
             Localisation.AddLocaleMappings(localeMappings);
+
+            // 启动脚本皮肤文件监控
+            var skinManager = Dependencies.Get<SkinManager>();
+            skinManager.StartScriptWatching();
         }
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent) =>

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -94,6 +95,12 @@ namespace osu.Game.Overlays.Settings.Sections
                                   + "\n3.游戏内PS、图片导出(包括渐变动画)",
                     Action = () => skinEditor?.ToggleEzSkinEditor(),
                 },
+                new SettingsButtonV2
+                {
+                    Text = "重载脚本皮肤",
+                    TooltipText = "手动重载 ScriptedSkin 目录下的脚本并刷新列表",
+                    Action = reloadScriptedSkins,
+                },
             };
         }
 
@@ -125,10 +132,25 @@ namespace osu.Game.Overlays.Settings.Sections
             if (!sender.Any())
                 return;
             // For simplicity repopulate the full list.
+            refreshSkinsList();
+        }
+
+        private void refreshSkinsList()
+        {
             dropdownItems.Clear();
             dropdownItems.AddRange(skins.GetAllUsableSkins());
 
             Schedule(() => skinDropdown.Items = dropdownItems);
+        }
+
+        private void reloadScriptedSkins()
+        {
+            _ = Task.Run(async () =>
+            {
+                int reloaded = await skins.ReloadAllScriptedSkins().ConfigureAwait(false);
+                Logger.Log($"Scripted skins reloaded: {reloaded}", LoggingTarget.Information);
+                Schedule(refreshSkinsList);
+            });
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Skinning/ScriptedSkinWrapper.cs
+++ b/osu.Game/Skinning/ScriptedSkinWrapper.cs
@@ -24,25 +24,25 @@ namespace osu.Game.Skinning
     /// </remarks>
     public class ScriptedSkinWrapper : Skin
     {
-        private readonly ISkinSource skinSource;
-        private readonly IStorageResourceProvider resources;
         private readonly IScriptedSkin scriptedSkin;
-        private readonly SandboxedScriptRunner scriptRunner;
 
-        /// <summary>
-        /// 创建脚本皮肤包装器。
-        /// </summary>
         /// <param name="skinSource">皮肤源（用于回退）。</param>
         /// <param name="resources">资源提供者。</param>
         /// <param name="scriptedSkin">底层脚本皮肤实例。</param>
         /// <param name="scriptRunner">脚本执行器（用于热重载）。</param>
-        public ScriptedSkinWrapper(ISkinSource skinSource, IStorageResourceProvider resources, IScriptedSkin scriptedSkin, SandboxedScriptRunner? scriptRunner = null)
-            : base(createInfoForScriptedSkin(scriptedSkin), resources)
+        /// <param name="skinInfo">可选的原始皮肤信息，用于保留脚本皮肤的 Protected 等元数据。</param>
+        /// <param name="scriptPath">脚本文件路径。</param>
+        public ScriptedSkinWrapper(ISkinSource skinSource,
+                                   IStorageResourceProvider resources,
+                                   IScriptedSkin scriptedSkin,
+                                   SandboxedScriptRunner? scriptRunner = null,
+                                   SkinInfo? skinInfo = null,
+                                   string? scriptPath = null)
+            : base(createInfoForScriptedSkin(scriptedSkin, skinInfo), resources)
         {
-            this.skinSource = skinSource;
-            this.resources = resources;
             this.scriptedSkin = scriptedSkin;
-            this.scriptRunner = scriptRunner ?? new SandboxedScriptRunner();
+            ScriptRunner = scriptRunner ?? new SandboxedScriptRunner();
+            ScriptPath = scriptPath;
 
             // 初始化脚本皮肤
             try
@@ -58,17 +58,36 @@ namespace osu.Game.Skinning
         /// <summary>
         /// 为脚本皮肤创建 SkinInfo。
         /// </summary>
-        private static SkinInfo createInfoForScriptedSkin(IScriptedSkin skin)
+        private static SkinInfo createInfoForScriptedSkin(IScriptedSkin skin, SkinInfo? skinInfo)
         {
+            if (skinInfo != null)
+                return skinInfo;
+
+            bool isProtected = false;
+
+            var protectedProperty = skin.GetType().GetProperty("Protected");
+            if (protectedProperty?.PropertyType == typeof(bool) && protectedProperty.GetValue(skin) is bool protectedValue)
+                isProtected = protectedValue;
+
             return new SkinInfo
             {
                 ID = Guid.NewGuid(), // 脚本皮肤使用动态生成的 ID
                 Name = $"{skin.Name} [Scripted]",
                 Creator = skin.Author,
-                Protected = false, // 脚本皮肤不是受保护的
+                Protected = isProtected,
                 InstantiationInfo = typeof(ScriptedSkinWrapper).GetInvariantInstantiationInfo(),
             };
         }
+
+        /// <summary>
+        /// 获取用于加载后续脚本文件的脚本执行器。
+        /// </summary>
+        public SandboxedScriptRunner ScriptRunner { get; }
+
+        /// <summary>
+        /// 获取脚本皮肤的脚本路径（如果可用）。
+        /// </summary>
+        public string? ScriptPath { get; }
 
         public override Drawable? GetDrawableComponent(ISkinComponentLookup lookup)
         {
@@ -83,7 +102,7 @@ namespace osu.Game.Skinning
             }
         }
 
-        public override Texture? GetTexture(string componentName, WrapMode wrapModeS = default, WrapMode wrapModeT = default)
+        public override Texture? GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT)
         {
             try
             {
@@ -153,7 +172,7 @@ namespace osu.Game.Skinning
         {
             try
             {
-                var newSkin = await scriptRunner.LoadScriptAsync(scriptPath).ConfigureAwait(false);
+                var newSkin = await ScriptRunner.LoadScriptAsync(scriptPath).ConfigureAwait(false);
 
                 // 清理旧实例
                 scriptedSkin.Dispose();

--- a/osu.Game/Skinning/ScriptedSkinWrapper.cs
+++ b/osu.Game/Skinning/ScriptedSkinWrapper.cs
@@ -153,7 +153,7 @@ namespace osu.Game.Skinning
         {
             try
             {
-                var newSkin = await scriptRunner.LoadScriptAsync(scriptPath);
+                var newSkin = await scriptRunner.LoadScriptAsync(scriptPath).ConfigureAwait(false);
 
                 // 清理旧实例
                 scriptedSkin.Dispose();

--- a/osu.Game/Skinning/ScriptedSkinWrapper.cs
+++ b/osu.Game/Skinning/ScriptedSkinWrapper.cs
@@ -1,0 +1,173 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Threading.Tasks;
+using osu.Framework.Audio.Sample;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.Logging;
+using osu.Game.Audio;
+using osu.Game.Extensions;
+using osu.Game.EzOsuGame.ScriptedSkin;
+using osu.Game.IO;
+
+namespace osu.Game.Skinning
+{
+    /// <summary>
+    /// 将 IScriptedSkin 包装为标准的 Skin 对象，以便与现有的皮肤系统兼容。
+    /// </summary>
+    /// <remarks>
+    /// 此包装器实现了 Skin 的所有抽象方法，并将调用委托给底层的 IScriptedSkin 实例。
+    /// 这使得脚本皮肤可以无缝集成到现有的皮肤选择和管理系统中。
+    /// </remarks>
+    public class ScriptedSkinWrapper : Skin
+    {
+        private readonly ISkinSource skinSource;
+        private readonly IStorageResourceProvider resources;
+        private readonly IScriptedSkin scriptedSkin;
+        private readonly SandboxedScriptRunner scriptRunner;
+
+        /// <summary>
+        /// 创建脚本皮肤包装器。
+        /// </summary>
+        /// <param name="skinSource">皮肤源（用于回退）。</param>
+        /// <param name="resources">资源提供者。</param>
+        /// <param name="scriptedSkin">底层脚本皮肤实例。</param>
+        /// <param name="scriptRunner">脚本执行器（用于热重载）。</param>
+        public ScriptedSkinWrapper(ISkinSource skinSource, IStorageResourceProvider resources, IScriptedSkin scriptedSkin, SandboxedScriptRunner? scriptRunner = null)
+            : base(createInfoForScriptedSkin(scriptedSkin), resources)
+        {
+            this.skinSource = skinSource;
+            this.resources = resources;
+            this.scriptedSkin = scriptedSkin;
+            this.scriptRunner = scriptRunner ?? new SandboxedScriptRunner();
+
+            // 初始化脚本皮肤
+            try
+            {
+                scriptedSkin.Initialize(skinSource, resources);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"Failed to initialize scripted skin '{scriptedSkin.Name}': {ex.Message}", LoggingTarget.Runtime, LogLevel.Error);
+            }
+        }
+
+        /// <summary>
+        /// 为脚本皮肤创建 SkinInfo。
+        /// </summary>
+        private static SkinInfo createInfoForScriptedSkin(IScriptedSkin skin)
+        {
+            return new SkinInfo
+            {
+                ID = Guid.NewGuid(), // 脚本皮肤使用动态生成的 ID
+                Name = $"{skin.Name} [Scripted]",
+                Creator = skin.Author,
+                Protected = false, // 脚本皮肤不是受保护的
+                InstantiationInfo = typeof(ScriptedSkinWrapper).GetInvariantInstantiationInfo(),
+            };
+        }
+
+        public override Drawable? GetDrawableComponent(ISkinComponentLookup lookup)
+        {
+            try
+            {
+                return scriptedSkin.GetDrawableComponent(lookup);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"Error in scripted skin GetDrawableComponent: {ex.Message}", LoggingTarget.Runtime, LogLevel.Error);
+                return null;
+            }
+        }
+
+        public override Texture? GetTexture(string componentName, WrapMode wrapModeS = default, WrapMode wrapModeT = default)
+        {
+            try
+            {
+                return scriptedSkin.GetTexture(componentName, wrapModeS, wrapModeT);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"Error in scripted skin GetTexture: {ex.Message}", LoggingTarget.Runtime, LogLevel.Error);
+                return null;
+            }
+        }
+
+        public override ISample? GetSample(ISampleInfo sampleInfo)
+        {
+            try
+            {
+                return scriptedSkin.GetSample(sampleInfo);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"Error in scripted skin GetSample: {ex.Message}", LoggingTarget.Runtime, LogLevel.Error);
+                return null;
+            }
+        }
+
+        public override IBindable<TValue>? GetConfig<TLookup, TValue>(TLookup lookup)
+        {
+            try
+            {
+                return scriptedSkin.GetConfig<TLookup, TValue>(lookup);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"Error in scripted skin GetConfig: {ex.Message}", LoggingTarget.Runtime, LogLevel.Error);
+                return null;
+            }
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (isDisposing)
+            {
+                try
+                {
+                    scriptedSkin.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    Logger.Log($"Error disposing scripted skin: {ex.Message}", LoggingTarget.Runtime, LogLevel.Error);
+                }
+            }
+
+            base.Dispose(isDisposing);
+        }
+
+        /// <summary>
+        /// 获取底层的脚本皮肤实例（用于编辑器等高级功能）。
+        /// </summary>
+        public IScriptedSkin GetScriptedSkin() => scriptedSkin;
+
+        /// <summary>
+        /// 重新加载脚本（用于热重载）。
+        /// </summary>
+        /// <param name="scriptPath">脚本文件路径。</param>
+        /// <returns>是否成功重新加载。</returns>
+        public async Task<bool> ReloadAsync(string scriptPath)
+        {
+            try
+            {
+                var newSkin = await scriptRunner.LoadScriptAsync(scriptPath);
+
+                // 清理旧实例
+                scriptedSkin.Dispose();
+
+                // 替换为新实例（注意：这里需要特殊处理，因为字段是 readonly）
+                // 实际实现中可能需要重新创建整个包装器
+                Logger.Log($"Reloaded scripted skin: {newSkin.Name}", LoggingTarget.Information);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"Failed to reload scripted skin: {ex.Message}", LoggingTarget.Runtime, LogLevel.Error);
+                return false;
+            }
+        }
+    }
+}

--- a/osu.Game/Skinning/SkinInfo.cs
+++ b/osu.Game/Skinning/SkinInfo.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
+using osu.Game.Extensions;
 using osu.Game.Database;
 using osu.Game.IO;
 using osu.Game.Models;
@@ -89,6 +90,9 @@ namespace osu.Game.Skinning
 
         public override string ToString()
         {
+            if (InstantiationInfo == typeof(ScriptedSkinWrapper).GetInvariantInstantiationInfo())
+                return $"[Script] {Name} {Creator}".TrimEnd();
+
             string author = string.IsNullOrEmpty(Creator) ? string.Empty : $"({Creator})";
             return $"{Name} {author}".Trim();
         }

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 #nullable disable
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
@@ -14,15 +15,20 @@ using JetBrains.Annotations;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.Stores;
+using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Framework.Threading;
 using osu.Framework.Utils;
 using osu.Game.Audio;
 using osu.Game.Database;
+using osu.Game.Extensions;
+using osu.Game.EzOsuGame;
+using osu.Game.EzOsuGame.ScriptedSkin;
 using osu.Game.IO;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Utils;
@@ -61,6 +67,8 @@ namespace osu.Game.Skinning
 
         private readonly IResourceStore<byte[]> userFiles;
 
+        private readonly SandboxedScriptRunner scriptRunner;
+
         private Skin ezProSkin { get; }
         private Skin sbiSkin { get; }
         private Skin argonSkin { get; }
@@ -94,6 +102,8 @@ namespace osu.Game.Skinning
             this.resources = resources;
 
             userFiles = new StorageBackedResourceStore(storage.GetStorageForDirectory("files"));
+
+            scriptRunner = new SandboxedScriptRunner();
 
             skinImporter = new SkinImporter(storage, realm, this)
             {
@@ -263,7 +273,92 @@ namespace osu.Game.Skinning
         /// </summary>
         /// <param name="skinInfo">The skin to lookup.</param>
         /// <returns>A <see cref="Skin"/> instance correlating to the provided <see cref="SkinInfo"/>.</returns>
-        public Skin GetSkin(SkinInfo skinInfo) => skinInfo.CreateInstance(this);
+        public Skin GetSkin(SkinInfo skinInfo)
+        {
+            // 检查是否为脚本皮肤（通过查找 .csx 文件）
+            if (isScriptedSkin(skinInfo))
+            {
+                try
+                {
+                    string scriptPath = getScriptPath(skinInfo);
+                    IScriptedSkin scriptedSkin = scriptRunner.LoadScriptAsync(scriptPath).GetResultSafely();
+                    return new ScriptedSkinWrapper(this, this, scriptedSkin, scriptRunner);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Log($"Failed to load scripted skin '{skinInfo.Name}': {ex.Message}", LoggingTarget.Runtime, LogLevel.Error);
+                    // 回退到默认皮肤
+                    return trianglesSkin;
+                }
+            }
+
+            // 传统皮肤加载逻辑
+            return skinInfo.CreateInstance(this);
+        }
+
+        /// <summary>
+        /// 检查皮肤是否为脚本皮肤（包含 .csx 文件）。
+        /// </summary>
+        private bool isScriptedSkin(SkinInfo skinInfo)
+        {
+            if (!skinInfo.IsManaged)
+                return false;
+
+            try
+            {
+                string scriptPath = getScriptPath(skinInfo);
+                return !string.IsNullOrEmpty(scriptPath) && File.Exists(scriptPath);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// 获取脚本文件的路径。
+        /// </summary>
+        private string getScriptPath(SkinInfo skinInfo)
+        {
+            // 脚本皮肤统一放在 EzResources/ScriptedSkin/ 目录下
+            // 使用皮肤名称作为子目录名
+            string scriptDirectory = Path.Combine(EzModifyPath.RESOURCES_PATH, "ScriptedSkin", skinInfo.Name);
+
+            // 查找第一个 .csx 文件
+            if (Directory.Exists(scriptDirectory))
+            {
+                string[] csxFiles = Directory.GetFiles(scriptDirectory, "*.csx", SearchOption.TopDirectoryOnly);
+                return csxFiles.FirstOrDefault();
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// 获取皮肤目录路径。
+        /// </summary>
+        private string getSkinDirectory(SkinInfo skinInfo)
+        {
+            // 尝试从 Realm 中获取皮肤的文件存储路径
+            return Realm.Run(r =>
+            {
+                var managedSkin = r.Find<SkinInfo>(skinInfo.ID);
+                if (managedSkin == null)
+                    return null;
+
+                // 获取皮肤的根目录
+                var files = managedSkin.Files.ToArray();
+                if (files.Length == 0)
+                    return null;
+
+                // 假设第一个文件在皮肤根目录下
+                var firstFile = files[0].File;
+                string storagePath = firstFile.GetStoragePath();
+
+                // 返回父目录（皮肤根目录）
+                return Path.GetDirectoryName(storagePath);
+            });
+        }
 
         /// <summary>
         /// Ensure that the current skin is in a state it can accept user modifications.
@@ -419,8 +514,7 @@ namespace osu.Game.Skinning
         public Task<IEnumerable<Live<SkinInfo>>> Import(ProgressNotification notification, ImportTask[] tasks, ImportParameters parameters = default) =>
             skinImporter.Import(notification, tasks, parameters);
 
-        public Task<Live<SkinInfo>> ImportAsUpdate(ProgressNotification notification, ImportTask task, SkinInfo original) =>
-            skinImporter.ImportAsUpdate(notification, task, original);
+        public Task<Live<SkinInfo>> ImportAsUpdate(ProgressNotification notification, ImportTask task, SkinInfo original) => skinImporter.ImportAsUpdate(notification, task, original);
 
         public Task<ExternalEditOperation<SkinInfo>> BeginExternalEditing(SkinInfo model) => skinImporter.BeginExternalEditing(model);
 

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -9,6 +9,8 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -69,6 +71,9 @@ namespace osu.Game.Skinning
 
         private readonly SandboxedScriptRunner scriptRunner;
 
+        [CanBeNull]
+        private readonly HotReloadManager hotReloadManager;
+
         private Skin ezProSkin { get; }
         private Skin sbiSkin { get; }
         private Skin argonSkin { get; }
@@ -104,6 +109,10 @@ namespace osu.Game.Skinning
             userFiles = new StorageBackedResourceStore(storage.GetStorageForDirectory("files"));
 
             scriptRunner = new SandboxedScriptRunner();
+
+            // 初始化热重载管理器
+            hotReloadManager = new HotReloadManager(scriptRunner);
+            hotReloadManager.SkinReloaded += onScriptReloaded;
 
             skinImporter = new SkinImporter(storage, realm, this)
             {
@@ -193,6 +202,11 @@ namespace osu.Game.Skinning
                 skins.Add(realm.Find<SkinInfo>(SkinInfo.SBI_SKIN).ToLive(Realm));
                 skins.Add(random_skin_info);
 
+                // 扫描并添加脚本皮肤
+                var scriptedSkins = scanForScriptedSkins();
+                foreach (var skin in scriptedSkins)
+                    skins.Add(skin);
+
                 var userSkins = realm.All<SkinInfo>()
                                      .Where(s => !s.DeletePending && !s.Protected)
                                      .AsEnumerable()
@@ -281,8 +295,8 @@ namespace osu.Game.Skinning
                 try
                 {
                     string scriptPath = getScriptPath(skinInfo);
-                    IScriptedSkin scriptedSkin = scriptRunner.LoadScriptAsync(scriptPath).GetResultSafely();
-                    return new ScriptedSkinWrapper(this, this, scriptedSkin, scriptRunner);
+                    IScriptedSkin scriptedSkin = scriptRunner.LoadScriptAsync<IScriptedSkin>(scriptPath, skinInfo, this).GetResultSafely();
+                    return new ScriptedSkinWrapper(this, this, scriptedSkin, scriptRunner, skinInfo, scriptPath);
                 }
                 catch (Exception ex)
                 {
@@ -301,9 +315,6 @@ namespace osu.Game.Skinning
         /// </summary>
         private bool isScriptedSkin(SkinInfo skinInfo)
         {
-            if (!skinInfo.IsManaged)
-                return false;
-
             try
             {
                 string scriptPath = getScriptPath(skinInfo);
@@ -316,22 +327,71 @@ namespace osu.Game.Skinning
         }
 
         /// <summary>
+        /// 扫描 EzResources/ScriptedSkin/ 目录，发现所有脚本皮肤。
+        /// </summary>
+        private List<Live<SkinInfo>> scanForScriptedSkins()
+        {
+            var scriptedSkins = new List<Live<SkinInfo>>();
+
+            string scriptBasePath = Path.Combine(getEzResourcesBasePath(), "ScriptedSkin");
+
+            if (!Directory.Exists(scriptBasePath))
+                return scriptedSkins;
+
+            // 遍历所有子目录
+            foreach (string skinDir in Directory.GetDirectories(scriptBasePath))
+            {
+                string skinName = Path.GetFileName(skinDir);
+                string scriptPath = findPrimaryScriptPath(skinDir);
+
+                if (!string.IsNullOrEmpty(scriptPath))
+                {
+                    try
+                    {
+                        SkinInfo scriptMetadata = scriptRunner.LoadScriptInfoAsync(scriptPath).GetResultSafely() ?? new SkinInfo
+                        {
+                            Name = skinName,
+                            Creator = string.Empty,
+                            Protected = false,
+                        };
+
+                        scriptMetadata.ID = generateScriptedSkinId(skinName);
+                        scriptMetadata.Hash = skinName;
+                        scriptMetadata.InstantiationInfo = typeof(ScriptedSkinWrapper).GetInvariantInstantiationInfo();
+
+                        scriptedSkins.Add(scriptMetadata.ToLiveUnmanaged());
+
+                        Logger.Log($"发现脚本皮肤: {scriptMetadata}", LoggingTarget.Information);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Log($"发现脚本皮肤失败: {skinName} - {ex.Message}", LoggingTarget.Runtime, LogLevel.Error);
+                    }
+                }
+            }
+
+            return scriptedSkins;
+        }
+
+        /// <summary>
+        /// 基于皮肤名称生成稳定的 GUID。
+        /// </summary>
+        private Guid generateScriptedSkinId(string skinName)
+        {
+            // 使用 MD5 哈希生成稳定的 GUID
+            byte[] hash = MD5.HashData(
+                Encoding.UTF8.GetBytes($"scripted_{skinName}")
+            );
+            return new Guid(hash.Take(16).ToArray());
+        }
+
+        /// <summary>
         /// 获取脚本文件的路径。
         /// </summary>
         private string getScriptPath(SkinInfo skinInfo)
         {
-            // 脚本皮肤统一放在 EzResources/ScriptedSkin/ 目录下
-            // 使用皮肤名称作为子目录名
-            string scriptDirectory = Path.Combine(EzModifyPath.RESOURCES_PATH, "ScriptedSkin", skinInfo.Name);
-
-            // 查找第一个 .csx 文件
-            if (Directory.Exists(scriptDirectory))
-            {
-                string[] csxFiles = Directory.GetFiles(scriptDirectory, "*.csx", SearchOption.TopDirectoryOnly);
-                return csxFiles.FirstOrDefault();
-            }
-
-            return null;
+            string scriptDirectory = getScriptDirectory(skinInfo);
+            return scriptDirectory == null ? null : findPrimaryScriptPath(scriptDirectory);
         }
 
         /// <summary>
@@ -579,6 +639,178 @@ namespace osu.Game.Skinning
             }
 
             CurrentSkinInfo.Value = skinInfo ?? trianglesSkin.SkinInfo;
+        }
+
+        /// <summary>
+        /// 启动脚本文件监控（在游戏启动时调用）。
+        /// </summary>
+        public void StartScriptWatching()
+        {
+            if (hotReloadManager == null)
+                return;
+
+            string scriptPath = Path.Combine(getEzResourcesBasePath(), "ScriptedSkin");
+
+            if (Directory.Exists(scriptPath))
+            {
+                hotReloadManager.StartWatching(scriptPath);
+                Logger.Log($"开始监控脚本目录: {scriptPath}", LoggingTarget.Information);
+            }
+        }
+
+        /// <summary>
+        /// 获取指定皮肤的脚本文件路径。
+        /// </summary>
+        /// <param name="skinInfo">皮肤信息</param>
+        /// <returns>脚本文件路径，如果不是脚本皮肤则返回 null</returns>
+        public string GetScriptPath(SkinInfo skinInfo)
+        {
+            return getScriptPath(skinInfo);
+        }
+
+        /// <summary>
+        /// 获取指定皮肤的脚本文件路径（静态方法）。
+        /// </summary>
+        /// <param name="skinInfo">皮肤信息</param>
+        /// <returns>脚本文件路径，如果不是脚本皮肤则返回 null</returns>
+        public static string GetScriptPathStatic(SkinInfo skinInfo)
+        {
+            string scriptDirectory = getScriptDirectoryStatic(skinInfo);
+            return scriptDirectory == null ? null : findPrimaryScriptPath(scriptDirectory);
+        }
+
+        private string getScriptDirectory(SkinInfo skinInfo)
+        {
+            string scriptBasePath = Path.Combine(getEzResourcesBasePath(), "ScriptedSkin");
+
+            if (!string.IsNullOrWhiteSpace(skinInfo.Hash))
+            {
+                string hashDirectory = Path.Combine(scriptBasePath, skinInfo.Hash);
+
+                if (Directory.Exists(hashDirectory))
+                    return hashDirectory;
+            }
+
+            if (skinInfo.Name.StartsWith("[Script] ", StringComparison.Ordinal))
+            {
+                string skinName = skinInfo.Name.Substring("[Script] ".Length);
+                string scriptDirectory = Path.Combine(scriptBasePath, skinName);
+
+                if (Directory.Exists(scriptDirectory))
+                    return scriptDirectory;
+            }
+
+            string directDirectory = Path.Combine(scriptBasePath, skinInfo.Name);
+            return Directory.Exists(directDirectory) ? directDirectory : null;
+        }
+
+        private static string getScriptDirectoryStatic(SkinInfo skinInfo)
+        {
+            string scriptBasePath = Path.Combine(Path.GetFullPath(EzModifyPath.RESOURCES_PATH), "ScriptedSkin");
+
+            if (!string.IsNullOrWhiteSpace(skinInfo.Hash))
+            {
+                string hashDirectory = Path.Combine(scriptBasePath, skinInfo.Hash);
+
+                if (Directory.Exists(hashDirectory))
+                    return hashDirectory;
+            }
+
+            if (skinInfo.Name.StartsWith("[Script] ", StringComparison.Ordinal))
+            {
+                string skinName = skinInfo.Name.Substring("[Script] ".Length);
+                string scriptDirectory = Path.Combine(scriptBasePath, skinName);
+
+                if (Directory.Exists(scriptDirectory))
+                    return scriptDirectory;
+            }
+
+            string directDirectory = Path.Combine(scriptBasePath, skinInfo.Name);
+            return Directory.Exists(directDirectory) ? directDirectory : null;
+        }
+
+        private string getEzResourcesBasePath()
+        {
+            string? basePath = host.Storage?.GetFullPath(EzModifyPath.RESOURCES_PATH);
+            return string.IsNullOrWhiteSpace(basePath) ? EzModifyPath.RESOURCES_PATH : basePath;
+        }
+
+        public async Task<int> ReloadAllScriptedSkins()
+        {
+            if (hotReloadManager == null)
+                return 0;
+
+            string scriptBasePath = Path.Combine(getEzResourcesBasePath(), "ScriptedSkin");
+
+            if (!Directory.Exists(scriptBasePath))
+                return 0;
+
+            int reloaded = 0;
+
+            foreach (string skinDir in Directory.GetDirectories(scriptBasePath))
+            {
+                string scriptPath = findPrimaryScriptPath(skinDir);
+                if (string.IsNullOrEmpty(scriptPath))
+                    continue;
+
+                if (await hotReloadManager.TriggerReload(scriptPath).ConfigureAwait(false))
+                    reloaded++;
+            }
+
+            return reloaded;
+        }
+
+        private static string findPrimaryScriptPath(string scriptDirectory)
+        {
+            if (!Directory.Exists(scriptDirectory))
+                return null;
+
+            string[] preferred = Directory.GetFiles(scriptDirectory, "*Skin.csx", SearchOption.TopDirectoryOnly)
+                                          .OrderBy(Path.GetFileName, StringComparer.OrdinalIgnoreCase)
+                                          .ToArray();
+
+            if (preferred.Length > 0)
+                return preferred.FirstOrDefault();
+
+            string skinFile = Path.Combine(scriptDirectory, "Skin.csx");
+            if (File.Exists(skinFile))
+                return skinFile;
+
+            return Directory.GetFiles(scriptDirectory, "*.csx", SearchOption.TopDirectoryOnly)
+                            .Where(file => !Path.GetFileNameWithoutExtension(file).EndsWith("Transformer", StringComparison.OrdinalIgnoreCase))
+                            .OrderBy(Path.GetFileName, StringComparer.OrdinalIgnoreCase)
+                            .FirstOrDefault();
+        }
+
+        /// <summary>
+        /// 手动触发指定脚本的重载。
+        /// </summary>
+        /// <param name="scriptPath">脚本文件路径</param>
+        /// <returns>是否成功重载</returns>
+        public async Task<bool> TriggerScriptReload(string scriptPath)
+        {
+            if (hotReloadManager == null)
+                return false;
+
+            return await hotReloadManager.TriggerReload(scriptPath).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// 脚本重载完成时的回调。
+        /// </summary>
+        private void onScriptReloaded(string scriptPath, bool success)
+        {
+            if (success)
+            {
+                Logger.Log($"脚本重载成功: {Path.GetFileName(scriptPath)}", LoggingTarget.Information);
+
+                // 通知当前皮肤更新（触发 UI 刷新）
+                scheduler.Add(() => SourceChanged?.Invoke());
+            }
+            else
+            {
+                Logger.Log($"脚本重载失败: {Path.GetFileName(scriptPath)}", LoggingTarget.Runtime, LogLevel.Error);
+            }
         }
     }
 }

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="10.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="10.0.5" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.8.0" />
     <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
     <PackageReference Include="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />


### PR DESCRIPTION
使用Roslyn原生脚本技术路线

脚本皮肤统一存放在：`EzResources/ScriptedSkin/{皮肤名称}/`，每个脚本皮肤使用自己的子目录。
皮肤资源加载通过 `EzResourceStore` 加载 `EzResources` 路径下的自定义资源

名称识别 `[Script] ` 前缀(带空格)，自动添加到皮肤下拉栏中。