### PR TITLE
改进帧数管理

### DIFF
--- a/osu.Game/EzOsuGame/Configuration/Ez2ConfigManager.cs
+++ b/osu.Game/EzOsuGame/Configuration/Ez2ConfigManager.cs
@@ -79,6 +79,7 @@ namespace osu.Game.EzOsuGame.Configuration
             SetDefault(Ez2Setting.AccuracyCutoffS, 0.95, 0.95, 1, 0.005);
             SetDefault(Ez2Setting.AccuracyCutoffA, 0.9, 0.9, 1, 0.005);
 
+            SetDefault(Ez2Setting.UpdateFrameLimiter, FrameSync.Unlimited);
             SetDefault(Ez2Setting.EzAnalysisRecEnabled, true);
             SetDefault(Ez2Setting.EzAnalysisSqliteEnabled, true);
             SetDefault(Ez2Setting.HideMainMenuOnlineBanner, false);
@@ -739,6 +740,8 @@ namespace osu.Game.EzOsuGame.Configuration
         GameplayDisableCmdSpace,
         AccuracyCutoffS,
         AccuracyCutoffA,
+
+        UpdateFrameLimiter,
 
         EzAnalysisRecEnabled,
         EzAnalysisSqliteEnabled,

--- a/osu.Game/EzOsuGame/Configuration/FrameSyncExtensions.cs
+++ b/osu.Game/EzOsuGame/Configuration/FrameSyncExtensions.cs
@@ -1,0 +1,33 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Configuration;
+using osu.Framework.Threading;
+
+namespace osu.Game.EzOsuGame.Configuration
+{
+    public static class FrameSyncExtensions
+    {
+        public static double ToUpdateHz(this FrameSync frameSync, int refreshRate, bool allowBenchmarkUnlimited)
+        {
+            if (refreshRate <= 0)
+                refreshRate = 60;
+
+            int updateLimiter = frameSync switch
+            {
+                FrameSync.VSync => refreshRate * 2,
+                FrameSync.Limit2x => refreshRate * 2,
+                FrameSync.Limit4x => refreshRate * 4,
+                FrameSync.Limit8x => refreshRate * 8,
+                FrameSync.Unlimited => int.MaxValue,
+                _ => refreshRate * 2,
+            };
+
+            if (!allowBenchmarkUnlimited)
+                updateLimiter = Math.Min(GameThread.DEFAULT_ACTIVE_HZ, updateLimiter);
+
+            return updateLimiter;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Configuration/FrameSyncExtensions.cs
+++ b/osu.Game/EzOsuGame/Configuration/FrameSyncExtensions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using osu.Framework.Configuration;
-using osu.Framework.Threading;
 
 namespace osu.Game.EzOsuGame.Configuration
 {
@@ -25,7 +24,7 @@ namespace osu.Game.EzOsuGame.Configuration
             };
 
             if (!allowBenchmarkUnlimited)
-                updateLimiter = Math.Min(GameThread.DEFAULT_ACTIVE_HZ, updateLimiter);
+                updateLimiter = Math.Min(8000, updateLimiter);
 
             return updateLimiter;
         }

--- a/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
@@ -36,6 +36,13 @@ namespace osu.Game.EzOsuGame.Localization
         public static readonly EzLocalizationManager.EzLocalisableString EZ_GAME_SECTION_HEADER = new EzLocalizationManager.EzLocalisableString("Ez游玩设置", "Ez Gameplay");
         public static readonly EzLocalizationManager.EzLocalisableString EZ_UI_SETTINGS_HEADER = new EzLocalizationManager.EzLocalisableString("Ez 界面设置", "Ez UI Settings");
 
+        public static readonly EzLocalizationManager.EzLocalisableString UPDATE_FRAME_LIMITER =
+            new EzLocalizationManager.EzLocalisableString("Update 帧率限制", "Update frame limiter");
+
+        public static readonly EzLocalizationManager.EzLocalisableString UPDATE_FRAME_LIMITER_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "限制游戏逻辑更新（Update）线程的最高帧率。Draw 帧率仍由图形设置中的「帧率限制」控制。",
+            "Limits the maximum update rate of the game logic thread. Draw frame rate is still controlled by the \"Frame limiter\" setting in Graphics.");
+
         public static readonly EzLocalizationManager.EzLocalisableString HIDE_MAIN_MENU_ONLINE_BANNER =
             new EzLocalizationManager.EzLocalisableString("屏蔽主界面底部新闻广告", "Hide main menu bottom news banner");
 

--- a/osu.Game/EzOsuGame/Overlays/EzUISettings.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzUISettings.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Configuration;
 using osu.Framework.Localisation;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -20,6 +21,15 @@ namespace osu.Game.EzOsuGame.Overlays
         {
             AddRange(new Drawable[]
             {
+                new SettingsItemV2(new FormEnumDropdown<FrameSync>
+                {
+                    Caption = EzSettingsStrings.UPDATE_FRAME_LIMITER,
+                    HintText = EzSettingsStrings.UPDATE_FRAME_LIMITER_TOOLTIP,
+                    Current = ezConfig.GetBindable<FrameSync>(Ez2Setting.UpdateFrameLimiter),
+                })
+                {
+                    Keywords = new[] { "fps", "framerate", "update", "frame", "limiter", "ez" }
+                },
                 new SettingsItemV2(new FormCheckBox
                 {
                     Caption = EzSettingsStrings.EZ_ANALYSIS_REC_ENABLED,

--- a/osu.Game/EzOsuGame/Overlays/EzUISettings.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzUISettings.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Configuration;
 using osu.Framework.Localisation;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -21,15 +20,6 @@ namespace osu.Game.EzOsuGame.Overlays
         {
             AddRange(new Drawable[]
             {
-                new SettingsItemV2(new FormEnumDropdown<FrameSync>
-                {
-                    Caption = EzSettingsStrings.UPDATE_FRAME_LIMITER,
-                    HintText = EzSettingsStrings.UPDATE_FRAME_LIMITER_TOOLTIP,
-                    Current = ezConfig.GetBindable<FrameSync>(Ez2Setting.UpdateFrameLimiter),
-                })
-                {
-                    Keywords = new[] { "fps", "framerate", "update", "frame", "limiter", "ez" }
-                },
                 new SettingsItemV2(new FormCheckBox
                 {
                     Caption = EzSettingsStrings.EZ_ANALYSIS_REC_ENABLED,

--- a/osu.Game/Graphics/UserInterface/FPSCounter.cs
+++ b/osu.Game/Graphics/UserInterface/FPSCounter.cs
@@ -231,7 +231,9 @@ namespace osu.Game.Graphics.UserInterface
 
         private void updateFpsDisplay()
         {
-            counterDrawFPS.Colour = getColour(displayedFpsCount / aimDrawFPS);
+            counterDrawFPS.Colour = displayedFpsCount > 1000
+                ? colours.Lime0
+                : getColour(displayedFpsCount / aimDrawFPS);
             counterDrawFPS.Text = $"{displayedFpsCount:#,0} fps";
         }
 
@@ -241,7 +243,10 @@ namespace osu.Game.Graphics.UserInterface
                 ? $"{displayedFrameTime:N1} ms"
                 : $"{displayedFrameTime:N0} ms";
 
-            counterUpdateFrameTime.Colour = getColour((1000 / displayedFrameTime) / aimUpdateFPS);
+            double displayedUpdateFps = 1000 / displayedFrameTime;
+            counterUpdateFrameTime.Colour = displayedUpdateFps > 1000
+                ? colours.Lime0
+                : getColour(displayedUpdateFps / aimUpdateFPS);
         }
 
         private bool updateAimFPS()

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -644,8 +644,7 @@ namespace osu.Game
 
             updateFrameLimiter.BindValueChanged(_ => apply(), true);
 
-            if (Host.Window != null)
-                Host.Window.CurrentDisplayMode.BindValueChanged(_ => apply());
+            Host.Window?.CurrentDisplayMode.BindValueChanged(_ => apply());
         }
 
         #region Exit handling

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -322,6 +322,8 @@ namespace osu.Game
             GlobalConfigStore.Config = LocalConfig;
             GlobalConfigStore.EzConfig = Ez2ConfigManager;
             dependencies.Cache(Ez2ConfigManager);
+
+            bindUpdateFrameLimiter(Ez2ConfigManager);
             EzSkinInfo = new EzSkinInfo(Ez2ConfigManager);
             dependencies.CacheAs<IEzSkinInfo>(EzSkinInfo);
             dependencies.CacheAs(EzResourceStore = new EzResourceStore(Ez2ConfigManager, Host.Renderer, Audio, Storage, realm));
@@ -619,6 +621,31 @@ namespace osu.Game
                 : new OsuConfigManager(Storage);
 
             host.ExceptionThrown += onExceptionThrown;
+        }
+
+        private void bindUpdateFrameLimiter(Ez2ConfigManager ezConfig)
+        {
+            var updateFrameLimiter = ezConfig.GetBindable<FrameSync>(Ez2Setting.UpdateFrameLimiter);
+
+            void apply()
+            {
+                int refreshRate = 60;
+
+                if (Host.Window != null)
+                {
+                    refreshRate = (int)MathF.Round(Host.Window.CurrentDisplayMode.Value.RefreshRate);
+
+                    if (refreshRate <= 0)
+                        refreshRate = 60;
+                }
+
+                Host.MaximumUpdateHz = updateFrameLimiter.Value.ToUpdateHz(refreshRate, Host.AllowBenchmarkUnlimitedFrames);
+            }
+
+            updateFrameLimiter.BindValueChanged(_ => apply(), true);
+
+            if (Host.Window != null)
+                Host.Window.CurrentDisplayMode.BindValueChanged(_ => apply());
         }
 
         #region Exit handling

--- a/osu.Game/Overlays/Settings/Sections/Graphics/RendererSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/RendererSettings.cs
@@ -9,6 +9,8 @@ using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Framework.Platform;
 using osu.Game.Configuration;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Localization;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Localisation;
 using osu.Game.Overlays.Dialog;
@@ -22,7 +24,7 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
         private bool automaticRendererInUse;
 
         [BackgroundDependencyLoader]
-        private void load(FrameworkConfigManager config, OsuConfigManager osuConfig, IDialogOverlay? dialogOverlay, OsuGame? game, GameHost host)
+        private void load(FrameworkConfigManager config, OsuConfigManager osuConfig, IDialogOverlay? dialogOverlay, OsuGame? game, GameHost host, Ez2ConfigManager ezConfig)
         {
             var renderer = config.GetBindable<RendererType>(FrameworkSetting.Renderer);
             automaticRendererInUse = renderer.Value == RendererType.Automatic;
@@ -38,6 +40,15 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
                 })
                 {
                     Keywords = new[] { @"compatibility", @"directx" },
+                },
+                new SettingsItemV2(new FormEnumDropdown<FrameSync>
+                {
+                    Caption = EzSettingsStrings.UPDATE_FRAME_LIMITER,
+                    HintText = EzSettingsStrings.UPDATE_FRAME_LIMITER_TOOLTIP,
+                    Current = ezConfig.GetBindable<FrameSync>(Ez2Setting.UpdateFrameLimiter),
+                })
+                {
+                    Keywords = new[] { "fps", "framerate", "update", "frame", "limiter", "ez" }
                 },
                 // TODO: this needs to be a custom dropdown at some point
                 new SettingsItemV2(new FormEnumDropdown<FrameSync>


### PR DESCRIPTION
1. 帧率限制拆分 游戏原设置只影响Draw，由Ez新增下拉设置修改Update帧数。

2. Ez UI 设置 在 Ez 界面设置（EzUISettings）第一项加入 Update 帧率限制下拉框，文案见 EzSettingsStrings.UPDATE_FRAME_LIMITER。

3. FPS 计数器 FPSCounter 中：当 FPS > 1000 时，update / draw 行文字显示为绿色（Lime0），不再按与目标帧率的比例着色。