### PR TITLE
step 5, Tag 改为三态 bool? 使用更好的数据回填

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapRecommendations.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapRecommendations.cs
@@ -279,6 +279,8 @@ namespace osu.Game.Tests.Visual.SongSelect
                 {
                 }
 
+                public double ComputeXxyStarRating(BeatmapInfo beatmapInfo) => -1;
+
                 public void Dispose()
                 {
                 }

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -105,14 +105,16 @@ namespace osu.Game.Beatmaps
         public double PerformancePoints { get; set; } = -1;
 
         /// <summary>
-        /// Ez2Lazer: Whether the beatmap set's storyboard file contains a video event. Populated by <see cref="BeatmapUpdater"/>.
+        /// Ez2Lazer: Whether the beatmap set's storyboard file contains a video event.
+        /// Null means not computed yet.
         /// </summary>
-        public bool HasVideo { get; set; }
+        public bool? HasVideo { get; set; }
 
         /// <summary>
-        /// Ez2Lazer: Whether the beatmap set's storyboard file contains sprite/animation events. Populated by <see cref="BeatmapUpdater"/>.
+        /// Ez2Lazer: Whether the beatmap set's storyboard file contains sprite/animation events.
+        /// Null means not computed yet.
         /// </summary>
-        public bool HasStoryboard { get; set; }
+        public bool? HasStoryboard { get; set; }
 
         [Indexed]
         public string MD5Hash { get; set; } = string.Empty;

--- a/osu.Game/Beatmaps/BeatmapUpdater.cs
+++ b/osu.Game/Beatmaps/BeatmapUpdater.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Beatmaps
                     beatmap.HasVideo = tagSummary.HasVideo;
                     beatmap.HasStoryboard = tagSummary.HasStoryboard;
 
-                    updateXxyStarRating(beatmap, working);
+                    updateXxyStarRating(beatmap);
                     updatePerformancePoints(beatmap, working);
                 }
 
@@ -102,22 +102,26 @@ namespace osu.Game.Beatmaps
             });
         }
 
-        private void updateXxyStarRating(BeatmapInfo beatmap, WorkingBeatmap working)
+        public double ComputeXxyStarRating(BeatmapInfo beatmapInfo)
         {
-            if (!EzXxyStarRatingSupport.SupportsBeatmap(working.Beatmap, beatmap.Ruleset))
-            {
-                beatmap.XxyStarRating = -1;
-                return;
-            }
+            var working = workingBeatmapCache.GetWorkingBeatmap(beatmapInfo);
+
+            if (!EzXxyStarRatingSupport.SupportsBeatmap(working.Beatmap, beatmapInfo.Ruleset))
+                return -1;
 
             if (beatmapManager == null)
-                return;
+                return -1;
 
-            var lookup = new EzAnalysisLookupCache(beatmap, beatmap.Ruleset, mods: null);
+            var lookup = new EzAnalysisLookupCache(beatmapInfo, beatmapInfo.Ruleset, mods: null);
 
-            beatmap.XxyStarRating = EzAnalysisComputation.TryComputeXxySr(beatmapManager, lookup, CancellationToken.None, out double xxySr)
+            return EzAnalysisComputation.TryComputeXxySr(beatmapManager, lookup, CancellationToken.None, out double xxySr)
                 ? xxySr
                 : -1;
+        }
+
+        private void updateXxyStarRating(BeatmapInfo beatmap)
+        {
+            beatmap.XxyStarRating = ComputeXxyStarRating(beatmap);
         }
 
         private void updatePerformancePoints(BeatmapInfo beatmap, WorkingBeatmap working)

--- a/osu.Game/Beatmaps/IBeatmapUpdater.cs
+++ b/osu.Game/Beatmaps/IBeatmapUpdater.cs
@@ -31,5 +31,12 @@ namespace osu.Game.Beatmaps
         /// <param name="beatmapInfo">The managed beatmap to update. A transaction will be opened to apply changes.</param>
         /// <param name="lookupScope">The preferred scope to use for metadata lookup.</param>
         void ProcessObjectCounts(BeatmapInfo beatmapInfo, MetadataLookupScope lookupScope = MetadataLookupScope.LocalCacheFirst);
+
+        /// <summary>
+        /// Computes baseline xxy star rating for a beatmap without running full-set processing.
+        /// </summary>
+        /// <param name="beatmapInfo">Beatmap to compute for.</param>
+        /// <returns>The computed value, or -1 when unsupported / failed.</returns>
+        double ComputeXxyStarRating(BeatmapInfo beatmapInfo);
     }
 }

--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -200,7 +200,10 @@ namespace osu.Game.Database
                 var beatmap = realmAccess.Run(r => r.Find<BeatmapInfo>(id)?.Detach());
 
                 if (beatmap == null)
-                    return;
+                {
+                    ++failedCount;
+                    continue;
+                }
 
                 try
                 {

--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -18,7 +18,6 @@ using osu.Framework.Platform;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.EzOsuGame.Analysis;
-using osu.Game.EzOsuGame.Configuration;
 using osu.Game.Extensions;
 using osu.Game.Online.API;
 using osu.Game.Overlays;
@@ -75,10 +74,9 @@ namespace osu.Game.Database
         [Resolved]
         private OsuConfigManager config { get; set; } = null!;
 
-        [Resolved]
-        private Ez2ConfigManager ezConfig { get; set; } = null!;
-
         private LocalCachedBeatmapMetadataSource localMetadataSource = null!;
+
+        private const int max_beatmap_backfill_items_per_pass = 300;
 
         protected virtual int TimeToSleepDuringGameplay => 30000;
 
@@ -93,8 +91,10 @@ namespace osu.Game.Database
                 Logger.Log("Beginning background data store processing..");
 
                 clearOutdatedStarRatings();
-                populateMissingStarRatings();
                 populateMissingEzBeatmapRealmFields();
+                populateMissingStarRatings();
+                populateMissingXxyStarRatings();
+                populateMissingPerformancePoints();
                 processOnlineBeatmapSetsWithNoUpdate();
                 // Note that the previous method will also update these on a fresh run.
                 processBeatmapsWithMissingObjectCounts();
@@ -165,7 +165,12 @@ namespace osu.Game.Database
             realmAccess.Run(r =>
             {
                 foreach (var b in r.All<BeatmapInfo>().Where(b => b.StarRating < 0 && b.BeatmapSet != null))
+                {
                     beatmapIds.Add(b.ID);
+
+                    if (beatmapIds.Count >= max_beatmap_backfill_items_per_pass)
+                        break;
+                }
             });
 
             if (beatmapIds.Count == 0)
@@ -234,75 +239,222 @@ namespace osu.Game.Database
         }
 
         /// <summary>
-        /// Backfill Ez Realm columns on <see cref="BeatmapInfo"/> (baseline xxy / PP, and opportunistic tag refresh) via <see cref="IBeatmapUpdater.Process"/>.
-        /// Always runs incrementally for missing xxy/PP to avoid expensive full-library rewrites on version bumps.
+        /// Incrementally backfill missing baseline xxy star ratings on <see cref="BeatmapInfo"/>.
+        /// Behaviour intentionally mirrors <see cref="populateMissingStarRatings"/>: beatmap-level query, beatmap-level compute and write.
         /// </summary>
-        private void populateMissingEzBeatmapRealmFields()
+        private void populateMissingXxyStarRatings()
         {
-            const int target_version = RealmAccess.EZ_REALM_SCHEMA_VERSION;
-            int lastBackfillVersion = ezConfig.Get<int>(Ez2Setting.EzRealmMetadataBackfillVersion);
-            HashSet<Guid> beatmapSetIds = new HashSet<Guid>();
+            HashSet<Guid> beatmapIds = new HashSet<Guid>();
 
-            Logger.Log($"Querying for beatmap sets requiring Ez Realm metadata backfill (target ez version {target_version})...");
+            Logger.Log("Querying for beatmaps with missing xxy star ratings...");
 
             realmAccess.Run(r =>
             {
-                foreach (var beatmap in r.All<BeatmapInfo>().Where(b => b.BeatmapSet != null && (b.PerformancePoints < 0
-                                                                                                 || (b.XxyStarRating < 0 && EzXxyStarRatingSupport.SupportsRuleset(b.Ruleset)))))
-                    beatmapSetIds.Add(beatmap.BeatmapSet!.ID);
+                foreach (var b in r.All<BeatmapInfo>().Where(b => b.XxyStarRating < 0 && b.BeatmapSet != null && EzXxyStarRatingSupport.SupportsRuleset(b.Ruleset)))
+                {
+                    beatmapIds.Add(b.ID);
+
+                    if (beatmapIds.Count >= max_beatmap_backfill_items_per_pass)
+                        break;
+                }
             });
 
-            if (beatmapSetIds.Count == 0)
-            {
-                if (lastBackfillVersion < target_version)
-                    ezConfig.SetValue(Ez2Setting.EzRealmMetadataBackfillVersion, target_version);
-
+            if (beatmapIds.Count == 0)
                 return;
-            }
 
-            Logger.Log($"Found {beatmapSetIds.Count} beatmap sets which require Ez Realm metadata population.");
+            Logger.Log($"Found {beatmapIds.Count} beatmaps which require xxy star rating reprocessing.");
 
-            var notification = showProgressNotification(
-                beatmapSetIds.Count,
-                "Populating Ez beatmap metadata in Realm",
-                "beatmap sets have been updated with Ez tag/xxy/PP metadata");
+            var notification = showProgressNotification(beatmapIds.Count, "Reprocessing xxy star rating for beatmaps", "beatmaps' xxy star ratings have been updated");
 
             int processedCount = 0;
             int failedCount = 0;
 
-            foreach (var id in beatmapSetIds)
+            foreach (Guid id in beatmapIds)
             {
                 if (notification?.State == ProgressNotificationState.Cancelled)
                     break;
 
-                updateNotificationProgress(notification, processedCount, beatmapSetIds.Count);
+                updateNotificationProgress(notification, processedCount, beatmapIds.Count);
 
                 sleepIfRequired();
 
-                realmAccess.Run(r =>
+                var beatmap = realmAccess.Run(r => r.Find<BeatmapInfo>(id)?.Detach());
+
+                if (beatmap == null)
                 {
-                    var set = r.Find<BeatmapSetInfo>(id);
+                    ++failedCount;
+                    continue;
+                }
 
-                    if (set == null)
-                        return;
+                try
+                {
+                    double xxyStarRating = beatmapUpdater.ComputeXxyStarRating(beatmap);
 
-                    try
+                    realmAccess.Write(r =>
                     {
-                        beatmapUpdater.Process(set, MetadataLookupScope.None);
-                        ++processedCount;
-                    }
-                    catch (Exception e)
-                    {
-                        Logger.Log($"Ez Realm metadata backfill failed on {set}: {e}");
-                        ++failedCount;
-                    }
-                });
+                        if (r.Find<BeatmapInfo>(id) is BeatmapInfo liveBeatmapInfo)
+                            liveBeatmapInfo.XxyStarRating = xxyStarRating;
+                    });
+                    ((IWorkingBeatmapCache)beatmapManager).Invalidate(beatmap);
+                    ++processedCount;
+                }
+                catch (Exception e)
+                {
+                    Logger.Log($"Background xxy processing failed on {beatmap}: {e}");
+                    ++failedCount;
+                }
             }
 
-            completeNotification(notification, processedCount, beatmapSetIds.Count, failedCount);
+            completeNotification(notification, processedCount, beatmapIds.Count, failedCount);
+        }
 
-            if (lastBackfillVersion < target_version && notification?.State != ProgressNotificationState.Cancelled)
-                ezConfig.SetValue(Ez2Setting.EzRealmMetadataBackfillVersion, target_version);
+        /// <summary>
+        /// Backfill Ez Realm tag columns on <see cref="BeatmapInfo"/> (baseline HasVideo/HasStoryboard).
+        /// This method is intentionally separated from <see cref="BeatmapUpdater.Process"/> so we don't accidentally
+        /// recompute unrelated fields (star / xxy / pp) during PP/xxy backfills.
+        /// </summary>
+        private void populateMissingEzBeatmapRealmFields()
+        {
+            HashSet<Guid> beatmapIds = new HashSet<Guid>();
+            Logger.Log("Querying for beatmaps requiring Ez Realm tag backfill...");
+
+            realmAccess.Run(r =>
+            {
+                foreach (var beatmap in r.All<BeatmapInfo>().Where(b => b.BeatmapSet != null && (b.HasVideo == null || b.HasStoryboard == null)))
+                {
+                    beatmapIds.Add(beatmap.ID);
+
+                    if (beatmapIds.Count >= max_beatmap_backfill_items_per_pass)
+                        break;
+                }
+            });
+
+            if (beatmapIds.Count == 0)
+                return;
+
+            Logger.Log($"Found {beatmapIds.Count} beatmaps which require Ez Realm tag population.");
+
+            var notification = showProgressNotification(
+                beatmapIds.Count,
+                "Populating Ez beatmap tags in Realm",
+                "beatmaps have been updated with Ez tags");
+
+            int processedCount = 0;
+            int failedCount = 0;
+
+            foreach (var id in beatmapIds)
+            {
+                if (notification?.State == ProgressNotificationState.Cancelled)
+                    break;
+
+                updateNotificationProgress(notification, processedCount, beatmapIds.Count);
+
+                sleepIfRequired();
+
+                var beatmap = realmAccess.Run(r => r.Find<BeatmapInfo>(id)?.Detach());
+
+                if (beatmap == null)
+                {
+                    ++failedCount;
+                    continue;
+                }
+
+                try
+                {
+                    var working = beatmapManager.GetWorkingBeatmap(beatmap);
+                    var tagSummary = EzBeatmapTagParser.Parse(working);
+
+                    realmAccess.Write(r =>
+                    {
+                        if (r.Find<BeatmapInfo>(id) is BeatmapInfo liveBeatmapInfo)
+                        {
+                            liveBeatmapInfo.HasVideo = tagSummary.HasVideo;
+                            liveBeatmapInfo.HasStoryboard = tagSummary.HasStoryboard;
+                        }
+                    });
+
+                    ((IWorkingBeatmapCache)beatmapManager).Invalidate(beatmap);
+                    ++processedCount;
+                }
+                catch (Exception e)
+                {
+                    Logger.Log($"Background tag processing failed on {beatmap}: {e}");
+                    ++failedCount;
+                }
+            }
+
+            completeNotification(notification, processedCount, beatmapIds.Count, failedCount);
+        }
+
+        private void populateMissingPerformancePoints()
+        {
+            HashSet<Guid> beatmapIds = new HashSet<Guid>();
+
+            Logger.Log("Querying for beatmaps with missing baseline PP...");
+
+            realmAccess.Run(r =>
+            {
+                foreach (var b in r.All<BeatmapInfo>().Where(b => b.BeatmapSet != null && b.PerformancePoints < 0))
+                {
+                    beatmapIds.Add(b.ID);
+
+                    if (beatmapIds.Count >= max_beatmap_backfill_items_per_pass)
+                        break;
+                }
+            });
+
+            if (beatmapIds.Count == 0)
+                return;
+
+            Logger.Log($"Found {beatmapIds.Count} beatmaps which require PP reprocessing.");
+
+            var notification = showProgressNotification(beatmapIds.Count, "Reprocessing baseline PP for beatmaps", "beatmaps' baseline PP has been updated");
+
+            int processedCount = 0;
+            int failedCount = 0;
+
+            foreach (Guid id in beatmapIds)
+            {
+                if (notification?.State == ProgressNotificationState.Cancelled)
+                    break;
+
+                updateNotificationProgress(notification, processedCount, beatmapIds.Count);
+
+                sleepIfRequired();
+
+                var beatmap = realmAccess.Run(r => r.Find<BeatmapInfo>(id)?.Detach());
+
+                if (beatmap == null)
+                {
+                    ++failedCount;
+                    continue;
+                }
+
+                try
+                {
+                    var lookup = new EzAnalysisLookupCache(beatmap, beatmap.Ruleset, mods: null);
+
+                    double performancePoints = EzAnalysisComputation.TryComputePerformancePoints(beatmapManager, lookup, CancellationToken.None, out double computedPp)
+                        ? computedPp
+                        : -1;
+
+                    realmAccess.Write(r =>
+                    {
+                        if (r.Find<BeatmapInfo>(id) is BeatmapInfo liveBeatmapInfo)
+                            liveBeatmapInfo.PerformancePoints = performancePoints;
+                    });
+
+                    ((IWorkingBeatmapCache)beatmapManager).Invalidate(beatmap);
+                    ++processedCount;
+                }
+                catch (Exception e)
+                {
+                    Logger.Log($"Background PP processing failed on {beatmap}: {e}");
+                    ++failedCount;
+                }
+            }
+
+            completeNotification(notification, processedCount, beatmapIds.Count, failedCount);
         }
 
         private void processOnlineBeatmapSetsWithNoUpdate()

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -103,18 +103,19 @@ namespace osu.Game.Database
         /// 51   2025-07-22    Add ScoreInfo.Pauses.
         ///
         /// Ez2Lazer-only revisions are tracked separately via <see cref="EZ_REALM_SCHEMA_VERSION"/>.
-        /// The on-disk Realm schema version is <see cref="file_schema_version"/> (schema_version * 1000 + EZ_REALM_SCHEMA_VERSION, currently 51004).
+        /// The on-disk Realm schema version is <see cref="file_schema_version"/> (schema_version * 1000 + EZ_REALM_SCHEMA_VERSION, currently 51005).
         /// Ez v1: Add ScoreInfo.ManiaHitMode and ManiaHealthMode.
         /// Ez v2: Add BeatmapInfo.HasVideo and HasStoryboard.
         /// Ez v3: Add BeatmapInfo.XxyStarRating.
         /// Ez v4: Add BeatmapInfo.PerformancePoints.
+        /// Ez v5: Change BeatmapInfo.HasVideo/HasStoryboard to nullable (null = unknown).
         /// </summary>
         private const int schema_version = 51;
 
         /// <summary>
         /// Ez2Lazer schema revision. Bump when adding Ez-persisted fields; do not change <see cref="schema_version"/> for Ez-only work.
         /// </summary>
-        public const int EZ_REALM_SCHEMA_VERSION = 4;
+        public const int EZ_REALM_SCHEMA_VERSION = 5;
 
         private const int file_schema_version = schema_version * 1000 + EZ_REALM_SCHEMA_VERSION;
 
@@ -1385,6 +1386,15 @@ namespace osu.Game.Database
                 case 4:
                     foreach (var beatmap in migration.NewRealm.All<BeatmapInfo>())
                         beatmap.PerformancePoints = -1;
+
+                    break;
+
+                case 5:
+                    foreach (var beatmap in migration.NewRealm.All<BeatmapInfo>())
+                    {
+                        beatmap.HasVideo = null;
+                        beatmap.HasStoryboard = null;
+                    }
 
                     break;
             }

--- a/osu.Game/EzOsuGame/Analysis/EzAnalysisPersistentStore.cs
+++ b/osu.Game/EzOsuGame/Analysis/EzAnalysisPersistentStore.cs
@@ -390,6 +390,7 @@ LIMIT 1;
                     double averageKps = reader.GetDouble(4);
                     double maxKps = reader.GetDouble(5);
                     string kpsListJson = reader.GetString(6);
+                    // Baseline PP/Xxy are sourced from Realm fields; main sqlite legacy columns are ignored.
                     double? pp = beatmap.PerformancePoints >= 0 ? beatmap.PerformancePoints : null;
                     long maniaUpdatedAt = reader.IsDBNull(7) ? 0 : reader.GetInt64(7);
                     double? xxySr = beatmap.XxyStarRating >= 0 ? beatmap.XxyStarRating : null;

--- a/osu.Game/EzOsuGame/Analysis/EzAnalysisSchemaManager.cs
+++ b/osu.Game/EzOsuGame/Analysis/EzAnalysisSchemaManager.cs
@@ -15,6 +15,8 @@ namespace osu.Game.EzOsuGame.Analysis
     /// </summary>
     internal static class EzAnalysisSchemaManager
     {
+        // Note: main sqlite remains v6-compatible for now. Legacy columns (pp/tag/xxy_sr) are schema-only
+        // compatibility baggage and must not be used as primary runtime data sources.
         public const int ANALYSIS_VERSION = EzAnalysisPersistentStore.ANALYSIS_VERSION;
         public const int MAIN_SCHEMA_VERSION = 2;
         public const string MAIN_DATABASE_KIND = "ez_analysis";

--- a/osu.Game/EzOsuGame/UserInterface/EzDisplay.Tag.cs
+++ b/osu.Game/EzOsuGame/UserInterface/EzDisplay.Tag.cs
@@ -96,10 +96,10 @@ namespace osu.Game.EzOsuGame.UserInterface
 
             var userTags = beatmap.Metadata.UserTags.Take(max_visible_tags);
 
-            if (beatmap.HasVideo)
+            if (beatmap.HasVideo == true)
                 tagFlow.Add(new IconTag(FontAwesome.Solid.Film, BeatmapsetsStrings.ShowInfoVideo));
 
-            if (beatmap.HasStoryboard)
+            if (beatmap.HasStoryboard == true)
                 tagFlow.Add(new IconTag(FontAwesome.Solid.Image, BeatmapsetsStrings.ShowInfoStoryboard));
 
             foreach (string tag in userTags)

--- a/osu.Game/Screens/Select/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/Select/BeatmapCarouselFilterGrouping.cs
@@ -95,6 +95,9 @@ namespace osu.Game.Screens.Select
                     if (operationDifficulties != null && operationDifficulties.TryGetValue(beatmap, out double difficulty))
                         return difficulty;
 
+                    if (criteria.Group == GroupMode.XxyStarRating)
+                        return beatmap.XxyStarRating;
+
                     return beatmap.StarRating;
                 }
 

--- a/osu.Game/Screens/Select/BeatmapCarouselFilterMatching.cs
+++ b/osu.Game/Screens/Select/BeatmapCarouselFilterMatching.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Screens.Select
                 if (beatmap.Hidden)
                     continue;
 
-                double starDifficultyForFilter = beatmap.StarRating;
+                double starDifficultyForFilter = useXxyForStarFilter ? beatmap.XxyStarRating : beatmap.StarRating;
 
                 if (operationDifficulties != null && operationDifficulties.TryGetValue(beatmap, out double operationDifficulty))
                     starDifficultyForFilter = operationDifficulty;

--- a/osu.Game/Screens/Select/FilterCriteria.cs
+++ b/osu.Game/Screens/Select/FilterCriteria.cs
@@ -318,6 +318,7 @@ namespace osu.Game.Screens.Select
                 case SortMode.Length:
                 case SortMode.Difficulty:
                 case SortMode.XxyStarRating:
+                case SortMode.PP:
                     return true;
 
                 default:

--- a/osu.Game/Screens/Select/RealmPopulatingOnlineLookupSource.cs
+++ b/osu.Game/Screens/Select/RealmPopulatingOnlineLookupSource.cs
@@ -100,6 +100,11 @@ namespace osu.Game.Screens.Select
                         if (dbBeatmap.MatchesOnlineVersion && dbBeatmap.Status != onlineBeatmap.Status)
                             dbBeatmap.Status = onlineBeatmap.Status;
 
+                        // Fill Ez tag tri-state opportunistically from online set metadata.
+                        dbBeatmap.HasVideo ??= onlineBeatmapSet.HasVideo;
+
+                        dbBeatmap.HasStoryboard ??= onlineBeatmapSet.HasStoryboard;
+
                         onlineBeatmap.BeatmapSet = onlineBeatmapSet;
                         HashSet<string> userTags = onlineBeatmap.GetTopUserTags(confirmedOnly: true)
                                                                 .Select(t => t.Tag.Name)

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -1250,35 +1250,66 @@ namespace osu.Game.Screens.Select
 
         private CancellationTokenSource? onlineLookupCancellation;
         private Task<APIBeatmapSet?>? currentOnlineLookup;
+        private readonly HashSet<int> requestedOnlineLookupSetIds = new HashSet<int>();
+        private readonly Dictionary<int, APIBeatmapSet?> onlineLookupCache = new Dictionary<int, APIBeatmapSet?>();
+        private const int max_online_lookup_sets_per_session = 120;
 
         private void fetchOnlineInfo(bool force = false)
         {
             var beatmapSetInfo = Beatmap.Value.BeatmapSetInfo;
+            int onlineSetId = beatmapSetInfo.OnlineID;
 
-            if (lastLookupResult.Value?.Result?.OnlineID == beatmapSetInfo.OnlineID && !force)
+            if (lastLookupResult.Value?.Result?.OnlineID == onlineSetId && !force)
                 return;
 
             onlineLookupCancellation?.Cancel();
             onlineLookupCancellation = null;
 
-            if (beatmapSetInfo.OnlineID < 0)
+            if (onlineSetId < 0)
             {
+                lastLookupResult.Value = BeatmapSetLookupResult.Completed(null);
+                return;
+            }
+
+            if (!force && onlineLookupCache.TryGetValue(onlineSetId, out var cached))
+            {
+                lastLookupResult.Value = BeatmapSetLookupResult.Completed(cached);
+                return;
+            }
+
+            bool isNewLookupSet = requestedOnlineLookupSetIds.Add(onlineSetId);
+
+            if (isNewLookupSet && requestedOnlineLookupSetIds.Count > max_online_lookup_sets_per_session)
+            {
+                requestedOnlineLookupSetIds.Remove(onlineSetId);
+                Logger.Log($"Skipping online beatmap set lookup for {onlineSetId}: per-session lookup cap ({max_online_lookup_sets_per_session}) reached.", LoggingTarget.Network);
                 lastLookupResult.Value = BeatmapSetLookupResult.Completed(null);
                 return;
             }
 
             lastLookupResult.Value = BeatmapSetLookupResult.InProgress();
             onlineLookupCancellation = new CancellationTokenSource();
-            currentOnlineLookup = onlineLookupSource.GetBeatmapSetAsync(beatmapSetInfo.OnlineID, onlineLookupCancellation.Token);
+            currentOnlineLookup = onlineLookupSource.GetBeatmapSetAsync(onlineSetId, onlineLookupCancellation.Token);
             currentOnlineLookup.ContinueWith(t =>
             {
                 if (t.IsCompletedSuccessfully)
-                    Schedule(() => lastLookupResult.Value = BeatmapSetLookupResult.Completed(t.GetResultSafely()));
+                {
+                    APIBeatmapSet? result = t.GetResultSafely();
+                    Schedule(() =>
+                    {
+                        onlineLookupCache[onlineSetId] = result;
+                        lastLookupResult.Value = BeatmapSetLookupResult.Completed(result);
+                    });
+                }
 
                 if (t.Exception != null)
                 {
                     Logger.Log($"Error when fetching online beatmap set: {t.Exception}", LoggingTarget.Network);
-                    Schedule(() => lastLookupResult.Value = BeatmapSetLookupResult.Completed(null));
+                    Schedule(() =>
+                    {
+                        onlineLookupCache[onlineSetId] = null;
+                        lastLookupResult.Value = BeatmapSetLookupResult.Completed(null);
+                    });
                 }
             });
         }


### PR DESCRIPTION
BeatmapUpdater 保持原功能，新增增量入口

在 osu.Game/Beatmaps/IBeatmapUpdater.cs 新增 ComputeXxyStarRating(BeatmapInfo)
在 osu.Game/Beatmaps/BeatmapUpdater.cs 实现该方法，并让原 updateXxyStarRating() 复用它（不改 Process() 对外行为）
Tag 改为三态 bool?

osu.Game/Beatmaps/BeatmapInfo.cs
HasVideo / HasStoryboard 从 bool 改为 bool?
语义：null=未计算，false/true=已计算结果
osu.Game/Database/RealmAccess.cs
EZ_REALM_SCHEMA_VERSION 从 4 升到 5
新增 Ez migration case 5：把历史数据初始化为 null（进入按需补算语义）
启动回填改为“字段级按需 + 分批执行”

osu.Game/Database/BackgroundDataStoreProcessor.cs
tag 只处理 HasVideo == null || HasStoryboard == null
star/xxy/pp 继续按缺值补算
所有回填任务增加每次上限：max_beatmap_backfill_items_per_pass = 300，避免一次性全量计算
xxy 回填改为走 beatmapUpdater.ComputeXxyStarRating()，职责更清晰
在线轻量补全（仅当前选中 set + 限流）

osu.Game/Screens/Select/SongSelect.cs
增加会话级请求上限 max_online_lookup_sets_per_session = 120
仅当前选中 set 触发（原逻辑即如此），新增去重与结果缓存，防止重复请求放大
osu.Game/Screens/Select/RealmPopulatingOnlineLookupSource.cs
收到 GetBeatmapSetRequest 结果时，仅当本地 tag 为 null 才写入 HasVideo/HasStoryboard
兼容修正

osu.Game/EzOsuGame/UserInterface/EzDisplay.Tag.cs 适配 nullable 判断（== true）
osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapRecommendations.cs 补实现新接口方法
文档同步：Ez2Lazer.wiki/EzClientRealm-架构-中文.md（三态与轻量在线补全策略）