### PR TITLE
step 6, 版本号控制xxysr过期

### DIFF
--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -89,8 +89,11 @@ namespace osu.Game.Database
                 Logger.Log("Beginning background data store processing..");
 
                 clearOutdatedStarRatings();
-                populateMissingXxyStarRatings();
                 populateMissingStarRatings();
+
+                clearOutdatedXxyStarRatings();
+                populateMissingXxyStarRatings();
+
                 populateMissingPerformancePoints();
                 populateMissingBeatmapTagFlags();
                 processOnlineBeatmapSetsWithNoUpdate();
@@ -145,6 +148,44 @@ namespace osu.Game.Database
                     });
 
                     Logger.Log($"Finished resetting {countReset} beatmap sets for {ruleset.Name}");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Check whether the databased xxy calculation version matches the latest ruleset provided version.
+        /// If it doesn't, clear out existing xxy values so they can be incrementally recalculated.
+        /// </summary>
+        private void clearOutdatedXxyStarRatings()
+        {
+            foreach (var ruleset in rulesetStore.AvailableRulesets)
+            {
+                if (!EzXxyStarRatingSupport.SupportsRuleset(ruleset))
+                    continue;
+
+                int currentVersion = ruleset.CreateInstance().CreateDifficultyCalculator(gameBeatmap.Value).Version;
+
+                if (ruleset.LastAppliedXxySrVersion < currentVersion)
+                {
+                    Logger.Log($"Resetting XxyStarRatings for {ruleset.Name} (XxySR version updated from {ruleset.LastAppliedXxySrVersion} to {currentVersion})");
+
+                    int countReset = 0;
+
+                    realmAccess.Write(r =>
+                    {
+                        foreach (var b in r.All<BeatmapInfo>())
+                        {
+                            if (b.Ruleset.ShortName == ruleset.ShortName)
+                            {
+                                b.XxyStarRating = -1;
+                                countReset++;
+                            }
+                        }
+
+                        r.Find<RulesetInfo>(ruleset.ShortName)!.LastAppliedXxySrVersion = currentVersion;
+                    });
+
+                    Logger.Log($"Finished resetting {countReset} beatmaps for xxy {ruleset.Name}");
                 }
             }
         }

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -103,19 +103,20 @@ namespace osu.Game.Database
         /// 51   2025-07-22    Add ScoreInfo.Pauses.
         ///
         /// Ez2Lazer-only revisions are tracked separately via <see cref="EZ_REALM_SCHEMA_VERSION"/>.
-        /// The on-disk Realm schema version is <see cref="file_schema_version"/> (schema_version * 1000 + EZ_REALM_SCHEMA_VERSION, currently 51005).
+        /// The on-disk Realm schema version is <see cref="file_schema_version"/> (schema_version * 1000 + EZ_REALM_SCHEMA_VERSION, currently 51006).
         /// Ez v1: Add ScoreInfo.ManiaHitMode and ManiaHealthMode.
         /// Ez v2: Add BeatmapInfo.HasVideo and HasStoryboard.
         /// Ez v3: Add BeatmapInfo.XxyStarRating.
         /// Ez v4: Add BeatmapInfo.PerformancePoints.
         /// Ez v5: Change BeatmapInfo.HasVideo/HasStoryboard to nullable (null = unknown).
+        /// Ez v6: Add RulesetInfo.LastAppliedXxySrVersion.
         /// </summary>
         private const int schema_version = 51;
 
         /// <summary>
         /// Ez2Lazer schema revision. Bump when adding Ez-persisted fields; do not change <see cref="schema_version"/> for Ez-only work.
         /// </summary>
-        public const int EZ_REALM_SCHEMA_VERSION = 5;
+        public const int EZ_REALM_SCHEMA_VERSION = 6;
 
         private const int file_schema_version = schema_version * 1000 + EZ_REALM_SCHEMA_VERSION;
 
@@ -1395,6 +1396,12 @@ namespace osu.Game.Database
                         beatmap.HasVideo = null;
                         beatmap.HasStoryboard = null;
                     }
+
+                    break;
+
+                case 6:
+                    foreach (var ruleset in migration.NewRealm.All<RulesetInfo>())
+                        ruleset.LastAppliedXxySrVersion = 0;
 
                     break;
             }

--- a/osu.Game/Rulesets/RulesetInfo.cs
+++ b/osu.Game/Rulesets/RulesetInfo.cs
@@ -26,6 +26,11 @@ namespace osu.Game.Rulesets
         /// </summary>
         public int LastAppliedDifficultyVersion { get; set; }
 
+        /// <summary>
+        /// Stores the last applied XxySR version used to invalidate persisted <see cref="Beatmaps.BeatmapInfo.XxyStarRating"/>.
+        /// </summary>
+        public int LastAppliedXxySrVersion { get; set; }
+
         public RulesetInfo(string shortName, string name, string instantiationInfo, int onlineID)
         {
             ShortName = shortName;
@@ -92,6 +97,7 @@ namespace osu.Game.Rulesets
             InstantiationInfo = InstantiationInfo,
             Available = Available,
             LastAppliedDifficultyVersion = LastAppliedDifficultyVersion,
+            LastAppliedXxySrVersion = LastAppliedXxySrVersion,
         };
 
         public Ruleset CreateInstance()


### PR DESCRIPTION
升级到v6版。添加 LastAppliedXxyDifficultyVersion 记录sr版本，实现过期控制。
逻辑：若 LastAppliedXxyDifficultyVersion < currentVersion，清空该 ruleset 所有 XxyStarRating = -1，并更新版本号