### PR TITLE
实装新mania谱面预览模式 StaticFullMap / StaticScroll

### DIFF
--- a/osu.Game/EzOsuGame/Overlays/EzBeatmapPreviewOverlay.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzBeatmapPreviewOverlay.cs
@@ -116,6 +116,7 @@ namespace osu.Game.EzOsuGame.Overlays
         private ScheduledDelegate? scheduledSelectionLoad;
         private Drawable? pendingPreviewRoot;
         private DrawableRuleset? drawableRuleset;
+        private IManiaStaticPreviewRenderer? maniaStaticRenderer;
         private PreviewDensityController densityController = null!;
         private Bindable<double> previewDensity = null!;
 
@@ -131,11 +132,17 @@ namespace osu.Game.EzOsuGame.Overlays
         private string currentBeatmapHash = string.Empty;
 
         // 指示在隐藏时是否应立即释放所有引用（默认 true：隐藏即释放）。
-        private bool releaseOnHide = true;
+        private bool releaseOnHide { get; } = true;
 
         private bool dynamicMode => previewMode.Value == EzBeatmapPreviewMode.Dynamic;
 
+        private bool customManiaStaticMode => isManiaRuleset(currentRuleset)
+                                              && (previewMode.Value == EzBeatmapPreviewMode.StaticFullMap || previewMode.Value == EzBeatmapPreviewMode.StaticScroll);
+
+        private bool fullMapMode => previewMode.Value == EzBeatmapPreviewMode.StaticFullMap;
+
         private bool expanded;
+        private bool fullMapFocusActive;
 
         public readonly Bindable<bool> ExpandedState = new Bindable<bool>();
 
@@ -612,13 +619,22 @@ namespace osu.Game.EzOsuGame.Overlays
                 }
             }
 
-            panelWidth = panelWidthManuallyAdjusted
-                ? clampPanelWidth(panelWidth <= 0 ? getDefaultPanelWidth() : panelWidth)
-                : getDefaultPanelWidth();
-
-            panelHeight = clampPanelHeight(panelHeight);
-
             float targetPanelY = expanded ? 0 : 14;
+
+            if (!fullMapFocusActive)
+            {
+                panelWidth = panelWidthManuallyAdjusted
+                    ? clampPanelWidth(panelWidth <= 0 ? getDefaultPanelWidth() : panelWidth)
+                    : getDefaultPanelWidth();
+
+                panelHeight = clampPanelHeight(panelHeight);
+            }
+            else
+            {
+                panelWidth = DrawWidth;
+                panelHeight = DrawHeight;
+                targetPanelY = 0;
+            }
 
             if (panelWidth != lastAppliedPanelWidth)
             {
@@ -632,7 +648,7 @@ namespace osu.Game.EzOsuGame.Overlays
                 lastAppliedPanelHeight = panelHeight;
             }
 
-            panelContainer.X = panel_left_margin;
+            panelContainer.X = fullMapFocusActive ? 0 : panel_left_margin;
 
             if (targetPanelY != lastAppliedPanelY)
             {
@@ -643,7 +659,7 @@ namespace osu.Game.EzOsuGame.Overlays
             float viewportWidth = stageViewport.DrawWidth;
             float viewportHeight = stageViewport.DrawHeight;
 
-            if (viewportWidth != lastViewportWidth || viewportHeight != lastViewportHeight)
+            if (!customManiaStaticMode && (viewportWidth != lastViewportWidth || viewportHeight != lastViewportHeight))
             {
                 float scale = Math.Min(viewportWidth / stageScaleContainer.Width, viewportHeight / stageScaleContainer.Height);
                 float clampedScale = Math.Max(0.05f, scale);
@@ -660,6 +676,14 @@ namespace osu.Game.EzOsuGame.Overlays
 
             if (!expanded)
                 return;
+
+            if (customManiaStaticMode && maniaStaticRenderer != null)
+            {
+                maniaStaticRenderer.SetCurrentTime(previewClock.CurrentTime);
+                maniaStaticRenderer.SetDensity((float)previewDensity.Value);
+                updateProgressDisplay(previewClock.CurrentTime);
+                return;
+            }
 
             if (dynamicMode && drawableRuleset != null)
             {
@@ -722,12 +746,26 @@ namespace osu.Game.EzOsuGame.Overlays
             if (base.OnMouseDown(e))
                 return true;
 
+            if (customManiaStaticMode && fullMapMode && stageViewport.ReceivePositionalInputAt(e.ScreenSpaceMousePosition))
+            {
+                setFullMapFocusState(true);
+                return true;
+            }
+
             return isWithinPanel(e.ScreenSpaceMousePosition);
+        }
+
+        protected override void OnMouseUp(MouseUpEvent e)
+        {
+            if (fullMapFocusActive)
+                setFullMapFocusState(false);
+
+            base.OnMouseUp(e);
         }
 
         protected override bool OnScroll(ScrollEvent e)
         {
-            if (!expanded || drawableRuleset == null)
+            if (!expanded)
                 return base.OnScroll(e);
 
             var panelQuad = panelContainer.ScreenSpaceDrawQuad;
@@ -738,6 +776,28 @@ namespace osu.Game.EzOsuGame.Overlays
                 return base.OnScroll(e);
 
             // Alt + Scroll: 调整滚动规则集的时间跨度（note 疏密）
+            if (e.CurrentState.Keyboard.AltPressed && customManiaStaticMode)
+            {
+                float before = (float)previewDensity.Value;
+                float after = Math.Clamp(before + Math.Sign(e.ScrollDelta.Y) * 0.05f, 0.1f, 5f);
+
+                if (Math.Abs(after - before) > 0.001f)
+                {
+                    previewDensity.Value = after;
+                    maniaStaticRenderer?.SetDensity(after);
+                    string densityText = $"{after:F2}x";
+                    setStateText(densityText);
+
+                    Scheduler.AddDelayed(() =>
+                    {
+                        if (stateText.Text == densityText)
+                            setStateText(string.Empty);
+                    }, 1000);
+
+                    return true;
+                }
+            }
+
             if (e.CurrentState.Keyboard.AltPressed
                 && drawableRuleset is IDrawableScrollingRuleset scrolling
                 && densityController.TryAdjust(scrolling, Math.Sign(e.ScrollDelta.Y), out float displayDensity))
@@ -834,11 +894,18 @@ namespace osu.Game.EzOsuGame.Overlays
             if (cancellationToken.IsCancellationRequested || eventVersion != selectionEventVersion || !expanded)
                 return;
 
-            if (cancellationToken.IsCancellationRequested || eventVersion != selectionEventVersion || !expanded)
+            if (isManiaRuleset(rulesetInfo)
+                && (previewMode.Value == EzBeatmapPreviewMode.StaticFullMap || previewMode.Value == EzBeatmapPreviewMode.StaticScroll))
+            {
+                setupManiaStaticPreview(playableBeatmap);
                 return;
+            }
 
             var ruleset = rulesetInfo.CreateInstance();
             var newDrawableRuleset = ruleset.CreateDrawableRulesetWith(playableBeatmap);
+
+            stageScaleContainer.RelativeSizeAxes = Axes.None;
+            stageScaleContainer.Size = new Vector2(640, 480);
 
             newDrawableRuleset.Clock = framedPreviewClock;
             newDrawableRuleset.FrameStablePlayback = false;
@@ -867,6 +934,7 @@ namespace osu.Game.EzOsuGame.Overlays
 
                 stageScaleContainer.Child = loaded;
                 drawableRuleset = newDrawableRuleset;
+                maniaStaticRenderer = null;
 
                 // Capture after the ruleset has finished loading so TargetTimeRange / TimeRange are initialised.
                 Schedule(() =>
@@ -954,6 +1022,8 @@ namespace osu.Game.EzOsuGame.Overlays
 
         private void disposePreviewResources()
         {
+            setFullMapFocusState(false);
+
             // First, clear the visual container (this disposes children on the update thread).
             if (stageScaleContainer.Count > 0)
             {
@@ -964,6 +1034,8 @@ namespace osu.Game.EzOsuGame.Overlays
             }
 
             drawableRuleset = null;
+            maniaStaticRenderer?.Dispose();
+            maniaStaticRenderer = null;
             densityController.DisposeSession();
         }
 
@@ -1079,9 +1151,18 @@ namespace osu.Game.EzOsuGame.Overlays
         private void onPreviewModeChanged()
         {
             updatePreviewModeButtons();
+            setFullMapFocusState(false);
 
             nextDynamicLoopStartTime = 0;
             previewClock.Stop();
+
+            if (customManiaStaticMode && expanded && playableBeatmap != null)
+            {
+                setupManiaStaticPreview(playableBeatmap);
+                previewClock.Seek(Math.Clamp(previewClock.CurrentTime, beatmapMinTime, beatmapMaxTime));
+                updateProgressDisplay(previewClock.CurrentTime);
+                return;
+            }
 
             if (!dynamicMode || !expanded || drawableRuleset == null)
             {
@@ -1121,6 +1202,53 @@ namespace osu.Game.EzOsuGame.Overlays
         }
 
         private static bool isManiaRuleset(RulesetInfo? ruleset) => ruleset?.OnlineID == 3;
+
+        private void setupManiaStaticPreview(IBeatmap beatmap)
+        {
+            ManiaPreviewData data = ManiaPreviewGeometryBuilder.Build(beatmap);
+
+            var renderer = previewMode.Value switch
+            {
+                EzBeatmapPreviewMode.StaticFullMap => (IManiaStaticPreviewRenderer)new StaticFullMapPreviewRenderer(),
+                EzBeatmapPreviewMode.StaticScroll => new StaticScrollPreviewRenderer(),
+                _ => null
+            };
+
+            if (renderer == null)
+                return;
+
+            renderer.SetData(data);
+            renderer.SetDensity((float)previewDensity.Value);
+            renderer.SetCurrentTime(previewClock.CurrentTime);
+
+            stageScaleContainer.RelativeSizeAxes = Axes.Both;
+            stageScaleContainer.Scale = Vector2.One;
+            stageScaleContainer.Size = Vector2.One;
+            stageScaleContainer.Child = (Drawable)renderer;
+
+            maniaStaticRenderer?.Dispose();
+            maniaStaticRenderer = renderer;
+            drawableRuleset = null;
+        }
+
+        private void setFullMapFocusState(bool focused)
+        {
+            if (fullMapFocusActive == focused)
+                return;
+
+            fullMapFocusActive = focused;
+
+            previewModeButtonList.FadeTo(focused ? 0 : 1, 100, Easing.OutQuint);
+            timeline.FadeTo(focused ? 0 : 1, 100, Easing.OutQuint);
+            progressText.FadeTo(focused ? 0 : 1, 100, Easing.OutQuint);
+            loadTimeText.FadeTo(focused ? 0 : 1, 100, Easing.OutQuint);
+            topResizeHandle.FadeTo(focused ? 0 : 1, 100, Easing.OutQuint);
+            rightResizeHandle.FadeTo(focused ? 0 : 1, 100, Easing.OutQuint);
+            stateText.FadeTo(focused ? 0 : stateText.Alpha, 100, Easing.OutQuint);
+
+            if (maniaStaticRenderer is StaticFullMapPreviewRenderer fullMapRenderer)
+                fullMapRenderer.SetZoom(focused);
+        }
 
         private readonly record struct LoadedPreviewData(
             long Version,

--- a/osu.Game/EzOsuGame/Overlays/Preview/ManiaPreviewBatchDrawable.cs
+++ b/osu.Game/EzOsuGame/Overlays/Preview/ManiaPreviewBatchDrawable.cs
@@ -1,0 +1,154 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Rendering;
+using osu.Framework.Graphics.Rendering.Vertices;
+using osu.Framework.Graphics.Shaders;
+using osu.Framework.Graphics.Textures;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.Overlays.Preview
+{
+    public partial class ManiaPreviewBatchDrawable : Drawable
+    {
+        private readonly List<PreviewQuad> quads = new List<PreviewQuad>();
+
+        private Texture texture = null!;
+        private IShader shader = null!;
+
+        public ManiaPreviewBatchDrawable()
+        {
+            RelativeSizeAxes = Axes.Both;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(IRenderer renderer, ShaderManager shaders)
+        {
+            texture = renderer.WhitePixel;
+            shader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE);
+        }
+
+        public void SetQuads(IEnumerable<PreviewQuad> geometry)
+        {
+            quads.Clear();
+            quads.AddRange(geometry);
+            Invalidate(Invalidation.DrawNode);
+        }
+
+        protected override DrawNode CreateDrawNode() => new ManiaPreviewBatchDrawNode(this);
+
+        private class ManiaPreviewBatchDrawNode : DrawNode
+        {
+            protected new ManiaPreviewBatchDrawable Source => (ManiaPreviewBatchDrawable)base.Source;
+
+            private readonly List<PreviewQuad> localQuads = new List<PreviewQuad>();
+            private IVertexBatch<TexturedVertex2D>? quadBatch;
+            private Texture texture = null!;
+            private IShader shader = null!;
+
+            public ManiaPreviewBatchDrawNode(ManiaPreviewBatchDrawable source)
+                : base(source)
+            {
+            }
+
+            public override void ApplyState()
+            {
+                base.ApplyState();
+                texture = Source.texture;
+                shader = Source.shader;
+
+                localQuads.Clear();
+                localQuads.AddRange(Source.quads);
+            }
+
+            protected override void Draw(IRenderer renderer)
+            {
+                if (localQuads.Count == 0)
+                    return;
+
+                shader.Bind();
+                if (!renderer.BindTexture(texture))
+                    return;
+
+                const int max_quads_per_batch = 10922;
+
+                renderer.PushLocalMatrix(DrawInfo.Matrix);
+                quadBatch ??= renderer.CreateQuadBatch<TexturedVertex2D>(Math.Min(localQuads.Count, max_quads_per_batch), 4);
+
+                RectangleF textureRect = texture.GetTextureRect();
+                Vector4 textureRectangle = new Vector4(0, 0, 1, 1);
+                Vector2 blendRange = Vector2.One;
+
+                for (int offset = 0; offset < localQuads.Count; offset += max_quads_per_batch)
+                {
+                    int chunk = Math.Min(max_quads_per_batch, localQuads.Count - offset);
+
+                    if (quadBatch.Size < chunk && quadBatch.Size != IRenderer.MAX_QUADS)
+                        quadBatch = renderer.CreateQuadBatch<TexturedVertex2D>(Math.Min(quadBatch.Size * 2, max_quads_per_batch), 4);
+
+                    var add = quadBatch.AddAction;
+
+                    for (int i = 0; i < chunk; i++)
+                    {
+                        PreviewQuad quad = localQuads[offset + i];
+
+                        Vector2 tl = new Vector2(quad.X, quad.Y);
+                        Vector2 tr = new Vector2(quad.X + quad.Width, quad.Y);
+                        Vector2 br = new Vector2(quad.X + quad.Width, quad.Y + quad.Height);
+                        Vector2 bl = new Vector2(quad.X, quad.Y + quad.Height);
+
+                        add(new TexturedVertex2D(renderer)
+                        {
+                            Position = tl,
+                            TexturePosition = textureRect.TopLeft,
+                            TextureRect = textureRectangle,
+                            BlendRange = blendRange,
+                            Colour = quad.Colour
+                        });
+                        add(new TexturedVertex2D(renderer)
+                        {
+                            Position = tr,
+                            TexturePosition = textureRect.TopRight,
+                            TextureRect = textureRectangle,
+                            BlendRange = blendRange,
+                            Colour = quad.Colour
+                        });
+                        add(new TexturedVertex2D(renderer)
+                        {
+                            Position = br,
+                            TexturePosition = textureRect.BottomRight,
+                            TextureRect = textureRectangle,
+                            BlendRange = blendRange,
+                            Colour = quad.Colour
+                        });
+                        add(new TexturedVertex2D(renderer)
+                        {
+                            Position = bl,
+                            TexturePosition = textureRect.BottomLeft,
+                            TextureRect = textureRectangle,
+                            BlendRange = blendRange,
+                            Colour = quad.Colour
+                        });
+                    }
+
+                    quadBatch.Draw();
+                }
+
+                renderer.PopLocalMatrix();
+                shader.Unbind();
+            }
+
+            protected override void Dispose(bool isDisposing)
+            {
+                base.Dispose(isDisposing);
+                quadBatch?.Dispose();
+                quadBatch = null;
+            }
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Overlays/Preview/ManiaPreviewGeometryBuilder.cs
+++ b/osu.Game/EzOsuGame/Overlays/Preview/ManiaPreviewGeometryBuilder.cs
@@ -1,0 +1,111 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+
+namespace osu.Game.EzOsuGame.Overlays.Preview
+{
+    public static class ManiaPreviewGeometryBuilder
+    {
+        public static ManiaPreviewData Build(IBeatmap beatmap)
+        {
+            var hitObjects = beatmap.HitObjects;
+            if (hitObjects.Count == 0)
+                return new ManiaPreviewData(4, 0, 1, Array.Empty<double>(), Array.Empty<ManiaPreviewNote>());
+
+            int totalColumns = getTotalColumns(beatmap, hitObjects);
+            double minTime = hitObjects.Min(h => h.StartTime);
+            double maxTime = hitObjects.Max(h => h.GetEndTime());
+            maxTime = Math.Max(maxTime, minTime + 1);
+
+            var notes = new List<ManiaPreviewNote>(hitObjects.Count);
+
+            foreach (HitObject obj in hitObjects)
+            {
+                if (obj is not IHasColumn hasColumn)
+                    continue;
+
+                double endTime = obj is IHasDuration hasDuration ? obj.StartTime + Math.Max(0, hasDuration.Duration) : obj.StartTime;
+                notes.Add(new ManiaPreviewNote(obj.StartTime, Math.Max(endTime, obj.StartTime), Math.Clamp(hasColumn.Column, 0, totalColumns - 1)));
+            }
+
+            notes.Sort((a, b) => a.StartTime.CompareTo(b.StartTime));
+
+            return new ManiaPreviewData(
+                totalColumns,
+                minTime,
+                maxTime,
+                generateBarLines(beatmap.ControlPointInfo, minTime, maxTime),
+                notes);
+        }
+
+        private static int getTotalColumns(IBeatmap beatmap, IReadOnlyList<HitObject> objects)
+        {
+            int byDifficulty = (int)Math.Round(beatmap.BeatmapInfo.Difficulty.CircleSize);
+            int maxColumn = 0;
+
+            foreach (HitObject obj in objects)
+            {
+                if (obj is IHasColumn hasColumn)
+                    maxColumn = Math.Max(maxColumn, hasColumn.Column + 1);
+            }
+
+            return Math.Max(1, Math.Max(byDifficulty, maxColumn));
+        }
+
+        private static List<double> generateBarLines(ControlPointInfo controlPoints, double minTime, double maxTime)
+        {
+            var barLines = new List<double>();
+            var timingPoints = controlPoints.TimingPoints;
+
+            if (timingPoints.Count == 0)
+            {
+                fillDefaultBarLines(barLines, minTime, maxTime);
+                return barLines;
+            }
+
+            for (int i = 0; i < timingPoints.Count; i++)
+            {
+                TimingControlPoint current = timingPoints[i];
+                double segmentStart = Math.Max(current.Time, minTime);
+                double segmentEnd = i + 1 < timingPoints.Count ? Math.Min(timingPoints[i + 1].Time, maxTime) : maxTime;
+
+                if (segmentEnd <= segmentStart)
+                    continue;
+
+                double barLength = Math.Max(1, current.BeatLength * Math.Max(1, current.TimeSignature.Numerator));
+                double first = current.OmitFirstBarLine ? current.Time + barLength : current.Time;
+
+                if (first > segmentEnd)
+                    continue;
+
+                double line = first + Math.Ceiling((segmentStart - first) / barLength) * barLength;
+
+                for (; line <= segmentEnd; line += barLength)
+                {
+                    if (line >= minTime && line <= maxTime)
+                        barLines.Add(line);
+                }
+            }
+
+            if (barLines.Count == 0)
+                fillDefaultBarLines(barLines, minTime, maxTime);
+
+            barLines.Sort();
+            return barLines;
+        }
+
+        private static void fillDefaultBarLines(List<double> barLines, double minTime, double maxTime)
+        {
+            const double default_bar_length = 2000;
+            for (double t = minTime; t <= maxTime; t += default_bar_length)
+                barLines.Add(t);
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Overlays/Preview/ManiaStaticPreviewPrimitives.cs
+++ b/osu.Game/EzOsuGame/Overlays/Preview/ManiaStaticPreviewPrimitives.cs
@@ -1,0 +1,29 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osuTK.Graphics;
+
+namespace osu.Game.EzOsuGame.Overlays.Preview
+{
+    public readonly record struct ManiaPreviewNote(double StartTime, double EndTime, int Column);
+
+    public readonly record struct ManiaPreviewData(
+        int TotalColumns,
+        double MinTime,
+        double MaxTime,
+        IReadOnlyList<double> BarLines,
+        IReadOnlyList<ManiaPreviewNote> Notes);
+
+    public readonly record struct PreviewQuad(float X, float Y, float Width, float Height, Color4 Colour);
+
+    public interface IManiaStaticPreviewRenderer : IDisposable
+    {
+        void SetData(ManiaPreviewData data);
+
+        void SetCurrentTime(double time);
+
+        void SetDensity(float density);
+    }
+}

--- a/osu.Game/EzOsuGame/Overlays/Preview/StaticFullMapPreviewRenderer.cs
+++ b/osu.Game/EzOsuGame/Overlays/Preview/StaticFullMapPreviewRenderer.cs
@@ -1,0 +1,99 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osuTK.Graphics;
+
+namespace osu.Game.EzOsuGame.Overlays.Preview
+{
+    public partial class StaticFullMapPreviewRenderer : CompositeDrawable, IManiaStaticPreviewRenderer
+    {
+        private readonly ManiaPreviewBatchDrawable batchDrawable;
+        private ManiaPreviewData data;
+        private bool hasData;
+        private bool focusZoomed;
+
+        public StaticFullMapPreviewRenderer()
+        {
+            RelativeSizeAxes = Axes.Both;
+            InternalChild = batchDrawable = new ManiaPreviewBatchDrawable();
+        }
+
+        protected override void UpdateAfterChildren()
+        {
+            base.UpdateAfterChildren();
+
+            if (hasData)
+                rebuild();
+        }
+
+        public void SetData(ManiaPreviewData data)
+        {
+            this.data = data;
+            hasData = true;
+            rebuild();
+        }
+
+        public void SetCurrentTime(double time)
+        {
+        }
+
+        public void SetDensity(float density)
+        {
+        }
+
+        public void SetZoom(bool zoomed)
+        {
+            if (focusZoomed == zoomed)
+                return;
+
+            focusZoomed = zoomed;
+            Scale = new osuTK.Vector2(focusZoomed ? 1.25f : 1.0f);
+        }
+
+        private void rebuild()
+        {
+            if (DrawWidth <= 1 || DrawHeight <= 1)
+                return;
+
+            var quads = new List<PreviewQuad>(data.Notes.Count + data.BarLines.Count + data.TotalColumns + 2);
+
+            float laneWidth = DrawWidth / Math.Max(1, data.TotalColumns);
+            float timeSpan = (float)Math.Max(1, data.MaxTime - data.MinTime);
+            float laneLineThickness = Math.Max(1, DrawWidth * 0.0015f);
+            float barThickness = Math.Max(1, DrawHeight * 0.0015f);
+            float noteHeight = Math.Max(1.5f, DrawHeight * 0.0035f);
+
+            for (int c = 1; c < data.TotalColumns; c++)
+            {
+                float x = c * laneWidth - laneLineThickness * 0.5f;
+                quads.Add(new PreviewQuad(x, 0, laneLineThickness, DrawHeight, Color4.White.Opacity(0.14f)));
+            }
+
+            foreach (double barTime in data.BarLines)
+            {
+                float y = (float)((barTime - data.MinTime) / timeSpan * DrawHeight);
+                quads.Add(new PreviewQuad(0, y, DrawWidth, barThickness, Color4.White.Opacity(0.25f)));
+            }
+
+            foreach (ManiaPreviewNote note in data.Notes)
+            {
+                float x = note.Column * laneWidth + laneWidth * 0.15f;
+                float width = laneWidth * 0.7f;
+
+                float y0 = (float)((note.StartTime - data.MinTime) / timeSpan * DrawHeight);
+                float y1 = (float)((note.EndTime - data.MinTime) / timeSpan * DrawHeight);
+                float h = Math.Max(noteHeight, y1 - y0);
+
+                var colour = note.EndTime - note.StartTime > 1 ? new Color4(120, 198, 255, 220) : new Color4(255, 210, 120, 230);
+                quads.Add(new PreviewQuad(x, y0, width, h, colour));
+            }
+
+            batchDrawable.SetQuads(quads);
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Overlays/Preview/StaticScrollPreviewRenderer.cs
+++ b/osu.Game/EzOsuGame/Overlays/Preview/StaticScrollPreviewRenderer.cs
@@ -1,0 +1,193 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.EzOsuGame.Overlays.Preview
+{
+    public partial class StaticScrollPreviewRenderer : CompositeDrawable, IManiaStaticPreviewRenderer
+    {
+        private float columnSpacing { get; } = 16f;
+        private float laneInsetRatio { get; } = 0.12f;
+
+        private readonly Container content;
+        private readonly ManiaPreviewBatchDrawable batchDrawable;
+
+        private ManiaPreviewData data;
+        private bool hasData;
+        private double currentTime;
+        private float density = 1;
+
+        public StaticScrollPreviewRenderer()
+        {
+            RelativeSizeAxes = Axes.Both;
+            InternalChild = content = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Child = batchDrawable = new ManiaPreviewBatchDrawable()
+            };
+        }
+
+        protected override void UpdateAfterChildren()
+        {
+            base.UpdateAfterChildren();
+
+            if (hasData)
+            {
+                rebuild();
+                updateScrollOffset();
+            }
+        }
+
+        public void SetData(ManiaPreviewData data)
+        {
+            this.data = data;
+            hasData = true;
+            rebuild();
+            updateScrollOffset();
+        }
+
+        public void SetCurrentTime(double time)
+        {
+            currentTime = time;
+            updateScrollOffset();
+        }
+
+        public void SetDensity(float density)
+        {
+            float clamped = Math.Clamp(density, 0.1f, 5f);
+
+            if (Math.Abs(this.density - clamped) <= 0.001f)
+                return;
+
+            this.density = clamped;
+            rebuild();
+            updateScrollOffset();
+        }
+
+        private void rebuild()
+        {
+            if (DrawWidth <= 1 || DrawHeight <= 1)
+                return;
+
+            int measuresPerColumn = getMeasuresPerColumn();
+            var quads = new List<PreviewQuad>(data.Notes.Count + data.BarLines.Count + data.TotalColumns * 4);
+
+            IReadOnlyList<double> boundaries = buildMeasureBoundaries();
+            int segmentCount = Math.Max(1, boundaries.Count - 1);
+            int columnCount = Math.Max(1, (segmentCount + measuresPerColumn - 1) / measuresPerColumn);
+
+            float columnWidth = Math.Max(80, DrawWidth * 0.18f);
+            float laneWidth = columnWidth / Math.Max(1, data.TotalColumns);
+            float contentWidth = columnCount * columnWidth + Math.Max(0, columnCount - 1) * columnSpacing;
+            float laneLineThickness = Math.Max(1, DrawWidth * 0.0014f);
+            float barThickness = Math.Max(1, DrawHeight * 0.0016f);
+            float minNoteHeight = Math.Max(1.2f, DrawHeight * 0.004f);
+
+            content.Size = new Vector2(contentWidth, DrawHeight);
+            batchDrawable.Size = new Vector2(contentWidth, DrawHeight);
+
+            for (int col = 0; col < columnCount; col++)
+            {
+                float panelX = col * (columnWidth + columnSpacing);
+                int startSegment = col * measuresPerColumn;
+                int endSegment = Math.Min(segmentCount, startSegment + measuresPerColumn);
+                double startTime = boundaries[startSegment];
+                double endTime = boundaries[endSegment];
+                float span = (float)Math.Max(1, endTime - startTime);
+
+                quads.Add(new PreviewQuad(panelX, 0, 1.2f, DrawHeight, Color4.White.Opacity(0.2f)));
+                quads.Add(new PreviewQuad(panelX + columnWidth, 0, 1.2f, DrawHeight, Color4.White.Opacity(0.2f)));
+
+                for (int lane = 1; lane < data.TotalColumns; lane++)
+                {
+                    float x = panelX + lane * laneWidth - laneLineThickness * 0.5f;
+                    quads.Add(new PreviewQuad(x, 0, laneLineThickness, DrawHeight, Color4.White.Opacity(0.12f)));
+                }
+
+                for (int seg = startSegment; seg <= endSegment; seg++)
+                {
+                    float y = (float)((boundaries[seg] - startTime) / span * DrawHeight);
+                    quads.Add(new PreviewQuad(panelX, y, columnWidth, barThickness, Color4.White.Opacity(0.23f)));
+                }
+            }
+
+            foreach (ManiaPreviewNote note in data.Notes)
+            {
+                int segIndex = locateSegment(boundaries, note.StartTime);
+                int col = segIndex / measuresPerColumn;
+                int colFirstSegment = col * measuresPerColumn;
+                int colLastSegment = Math.Min(segmentCount, colFirstSegment + measuresPerColumn);
+                double colStartTime = boundaries[colFirstSegment];
+                double colEndTime = boundaries[colLastSegment];
+
+                float panelX = col * (columnWidth + columnSpacing);
+                float span = (float)Math.Max(1, colEndTime - colStartTime);
+                float laneX = panelX + note.Column * laneWidth + laneWidth * laneInsetRatio;
+                float laneW = laneWidth * (1 - laneInsetRatio * 2);
+
+                float y0 = (float)((note.StartTime - colStartTime) / span * DrawHeight);
+                float y1 = (float)((Math.Min(note.EndTime, colEndTime) - colStartTime) / span * DrawHeight);
+                float h = Math.Max(minNoteHeight, y1 - y0);
+
+                var colour = note.EndTime - note.StartTime > 1 ? new Color4(121, 201, 255, 220) : new Color4(255, 214, 124, 230);
+                quads.Add(new PreviewQuad(laneX, y0, laneW, h, colour));
+            }
+
+            batchDrawable.SetQuads(quads);
+        }
+
+        private void updateScrollOffset()
+        {
+            if (!hasData || content.DrawWidth <= DrawWidth)
+            {
+                content.X = 0;
+                return;
+            }
+
+            double ratio = (currentTime - data.MinTime) / Math.Max(1, data.MaxTime - data.MinTime);
+            ratio = Math.Clamp(ratio, 0, 1);
+            float maxOffset = content.DrawWidth - DrawWidth;
+            content.X = (float)(maxOffset * ratio);
+        }
+
+        private IReadOnlyList<double> buildMeasureBoundaries()
+        {
+            if (data.BarLines.Count < 2)
+                return new[] { data.MinTime, data.MaxTime };
+
+            var boundaries = new List<double>(data.BarLines.Count + 2);
+
+            if (data.BarLines[0] > data.MinTime)
+                boundaries.Add(data.MinTime);
+
+            boundaries.AddRange(data.BarLines);
+
+            if (boundaries[^1] < data.MaxTime)
+                boundaries.Add(data.MaxTime);
+
+            return boundaries;
+        }
+
+        private int getMeasuresPerColumn() => Math.Clamp((int)Math.Round(2f / density), 1, 8);
+
+        private static int locateSegment(IReadOnlyList<double> boundaries, double time)
+        {
+            int last = boundaries.Count - 2;
+
+            for (int i = 0; i <= last; i++)
+            {
+                if (time < boundaries[i + 1])
+                    return i;
+            }
+
+            return Math.Max(0, last);
+        }
+    }
+}


### PR DESCRIPTION
在 EzBeatmapPreviewOverlay 中正式接入 StaticFullMap / StaticScroll 分支，不再走原先“非 Dynamic 共用路径”。
新增高性能批量绘制管线（DrawNode + IVertexBatch<TexturedVertex2D>），避免每个 note 一个 Box：
osu.Game/EzOsuGame/Overlays/Preview/ManiaPreviewBatchDrawable.cs
新增 mania 预览数据构建（note + barline + 列数）：
osu.Game/EzOsuGame/Overlays/Preview/ManiaPreviewGeometryBuilder.cs
osu.Game/EzOsuGame/Overlays/Preview/ManiaStaticPreviewPrimitives.cs
新增两个模式渲染器（都放在你要求的 Overlays/Preview 下）：
osu.Game/EzOsuGame/Overlays/Preview/StaticFullMapPreviewRenderer.cs
osu.Game/EzOsuGame/Overlays/Preview/StaticScrollPreviewRenderer.cs
StaticFullMap 已实现：
全谱一屏映射（含 barline、淡化轨道列线、简化 note/hold note 绘制）
鼠标按住谱面区域进入聚焦放大，松开恢复（仅该模式生效）
聚焦时隐藏模式按钮/时间轴/加载文字/resize handle 等 UI 元素
StaticScroll 已实现：
按“小节段”分列，列从左到右拼接
默认每列 2 小节
倍率（Alt+滚轮）映射到“每列小节数”（密度高 -> 每列小节更少）
随当前时间进行横向偏移，形成卷轴浏览效果