### PR TITLE
改进realm中的分析加载路线

### DIFF
--- a/osu.Game/EzOsuGame/Analysis/EzAnalysisCache.cs
+++ b/osu.Game/EzOsuGame/Analysis/EzAnalysisCache.cs
@@ -25,12 +25,12 @@ using osu.Game.Screens.Select;
 namespace osu.Game.EzOsuGame.Analysis
 {
     /// <summary>
-    /// 选歌分析前台缓存。
+    /// 选歌分析前台缓存，对齐官方 <see cref="BeatmapDifficultyCache"/> 的 mod 按需重算语义。
     ///
-    /// 职责尽量对齐官方 BeatmapDifficultyCache：
-    /// - 自身负责当前 ruleset/mods 下的前台查询、bindable 跟踪与失效更新。
-    /// - SQLite 持久化结果仅作为默认 ruleset + 无 mod 时的基线读取来源。
-    /// - 不承担预热、补算、写库职责。
+    /// - L1 Realm 基线 xxy/PP：由 UI 直读 <see cref="BeatmapInfo"/>（见 <see cref="EzSongSelectAnalysisDisplay"/>），不经本 cache。
+    /// - L2 主 SQLite：NoMod 时仅提供 kps/KPC 切片（<see cref="EzAnalysisDatabase.TryGetStoredSqliteSlice"/>）。
+    /// - L3 本 cache：当前 ruleset/mods 下的动态 <see cref="EzAnalysisResult"/>（含 mod 后 xxy/PP/kps）。
+    /// 不承担预热、Realm 回填或分支库写入。
     /// </summary>
     public partial class EzAnalysisCache : MemoryCachingComponent<EzAnalysisLookupCache, EzAnalysisResult?>
     {
@@ -127,8 +127,10 @@ namespace osu.Game.EzOsuGame.Analysis
         {
             var bindable = new BindableBeatmapEzAnalysis(beatmapInfo, cancellationToken);
 
-            if (analysisDatabase.TryGetStoredAnalysis(beatmapInfo, beatmapInfo.Ruleset, out var storedAnalysis))
-                bindable.Value = storedAnalysis;
+            // NoMod：仅预填主 SQLite 的 kps/KPC 切片；xxy/PP 占位由面板直读 Realm（对齐 StarRating）。
+            if (currentMods.Value.Count == 0
+                && analysisDatabase.TryGetStoredSqliteSlice(beatmapInfo, beatmapInfo.Ruleset, out var storedSlice))
+                bindable.Value = storedSlice;
 
             if (beatmapInfo is BeatmapInfo localBeatmapInfo)
                 updateBindable(bindable, localBeatmapInfo, currentRuleset.Value, currentMods.Value, cancellationToken, computationDelay);
@@ -151,8 +153,8 @@ namespace osu.Game.EzOsuGame.Analysis
 
             if (localBeatmapInfo != null
                 && EzAnalysisDatabase.CanUseStoredAnalysis(localBeatmapInfo, rulesetInfo, mods)
-                && analysisDatabase.TryGetStoredAnalysis(beatmapInfo, rulesetInfo, out var storedAnalysis))
-                return Task.FromResult<EzAnalysisResult?>(storedAnalysis);
+                && analysisDatabase.TryGetStoredSqliteSlice(beatmapInfo, rulesetInfo, out var storedSlice))
+                return Task.FromResult<EzAnalysisResult?>(storedSlice);
 
             return Task.FromResult<EzAnalysisResult?>(null);
 
@@ -164,8 +166,8 @@ namespace osu.Game.EzOsuGame.Analysis
                     return dynamicAnalysis;
 
                 if (EzAnalysisDatabase.CanUseStoredAnalysis(dynamicBeatmapInfo, dynamicRulesetInfo, mods)
-                    && analysisDatabase.TryGetStoredAnalysis(dynamicBeatmapInfo, dynamicRulesetInfo, out var fallbackStoredAnalysis))
-                    return fallbackStoredAnalysis;
+                    && analysisDatabase.TryGetStoredSqliteSlice(dynamicBeatmapInfo, dynamicRulesetInfo, out var fallbackStoredSlice))
+                    return fallbackStoredSlice;
 
                 return null;
             }
@@ -189,8 +191,8 @@ namespace osu.Game.EzOsuGame.Analysis
         public IReadOnlyDictionary<Guid, double> GetActiveSongsBranchPpValues(IEnumerable<BeatmapInfo> beatmaps, IRulesetInfo? rulesetInfo, IReadOnlyList<Mod>? mods = null)
             => analysisDatabase.GetActiveSongsBranchPpValues(beatmaps, rulesetInfo, mods);
 
-        public IReadOnlyDictionary<Guid, double> GetStoredXxySrValues(IEnumerable<BeatmapInfo> beatmaps, IRulesetInfo? rulesetInfo, IReadOnlyList<Mod>? mods = null)
-            => analysisDatabase.GetStoredXxySrValues(beatmaps, rulesetInfo, mods);
+        public IReadOnlyDictionary<Guid, double> GetBaselineXxySrFromRealm(IEnumerable<BeatmapInfo> beatmaps, IRulesetInfo? rulesetInfo, IReadOnlyList<Mod>? mods = null)
+            => analysisDatabase.GetBaselineXxySrFromRealm(beatmaps, rulesetInfo, mods);
 
         public IReadOnlyDictionary<Guid, double> GetStoredPpValues(IEnumerable<BeatmapInfo> beatmaps, IRulesetInfo? rulesetInfo, IReadOnlyList<Mod>? mods = null)
             => analysisDatabase.GetStoredPpValues(beatmaps, rulesetInfo, mods);
@@ -248,9 +250,6 @@ namespace osu.Game.EzOsuGame.Analysis
 
         private void updateTrackedBindables()
         {
-            if (!runtimeAnalysisEnabled.Value)
-                return;
-
             lock (bindableUpdateLock)
             {
                 cancelTrackedBindableUpdate();

--- a/osu.Game/EzOsuGame/Analysis/EzAnalysisCache.cs
+++ b/osu.Game/EzOsuGame/Analysis/EzAnalysisCache.cs
@@ -129,7 +129,8 @@ namespace osu.Game.EzOsuGame.Analysis
 
             // NoMod：仅预填主 SQLite 的 kps/KPC 切片；xxy/PP 占位由面板直读 Realm（对齐 StarRating）。
             if (currentMods.Value.Count == 0
-                && analysisDatabase.TryGetStoredSqliteSlice(beatmapInfo, beatmapInfo.Ruleset, out var storedSlice))
+                && beatmapInfo is BeatmapInfo seedBeatmapInfo
+                && analysisDatabase.TryGetStoredSqliteSlice(seedBeatmapInfo, currentRuleset.Value, out var storedSlice))
                 bindable.Value = storedSlice;
 
             if (beatmapInfo is BeatmapInfo localBeatmapInfo)

--- a/osu.Game/EzOsuGame/Analysis/EzAnalysisComputation.cs
+++ b/osu.Game/EzOsuGame/Analysis/EzAnalysisComputation.cs
@@ -67,6 +67,47 @@ namespace osu.Game.EzOsuGame.Analysis
         public static EzAnalysisResult Compute(BeatmapManager beatmapManager, in EzAnalysisLookupCache lookup, CancellationToken cancellationToken = default)
             => Compute(beatmapManager.GetWorkingBeatmap(lookup.BeatmapInfo), lookup, cancellationToken);
 
+        /// <summary>
+        /// 主 SQLite 预热/回填专用：仅计算 kps 与 mania 列统计（NoMod），不写 xxy/PP（由 Realm 维护）。
+        /// </summary>
+        public static EzAnalysisResult ComputePersistedSqliteSlice(BeatmapManager beatmapManager, in EzAnalysisLookupCache lookup,
+                                                                   CancellationToken cancellationToken = default)
+            => ComputePersistedSqliteSlice(beatmapManager.GetWorkingBeatmap(lookup.BeatmapInfo), lookup, cancellationToken);
+
+        public static EzAnalysisResult ComputePersistedSqliteSlice(WorkingBeatmap workingBeatmap, in EzAnalysisLookupCache lookup, CancellationToken cancellationToken = default)
+        {
+            PlayableCachedWorkingBeatmap playableWorkingBeatmap = new PlayableCachedWorkingBeatmap(workingBeatmap);
+
+            bool onlyKps = !EzAnalysisProviderBridge.HasAnalysisProvider(lookup.Ruleset);
+            IBeatmap analysisBeatmap = playableWorkingBeatmap.GetPlayableBeatmap(lookup.Ruleset, lookup.OrderedMods, cancellationToken);
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var (averageKps, maxKps, kpsList, columnCounts, holdNoteCounts) = OptimizedBeatmapCalculator.GetAllDataOptimized(analysisBeatmap, onlyKps: onlyKps);
+
+            double rate = getRateAdjustMultiplier(lookup.OrderedMods);
+
+            if (!Precision.AlmostEquals(rate, 1.0))
+            {
+                averageKps *= rate;
+                maxKps *= rate;
+
+                for (int i = 0; i < kpsList.Count; i++)
+                    kpsList[i] *= rate;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            kpsList = OptimizedBeatmapCalculator.DownsampleToFixedCount(kpsList, OptimizedBeatmapCalculator.DEFAULT_KPS_GRAPH_POINTS);
+
+            var commonSummary = new KpsSummary(averageKps, maxKps, kpsList);
+            EzManiaSummary? maniaSummary = onlyKps
+                ? null
+                : new EzManiaSummary(columnCounts, holdNoteCounts, xxySr: null);
+
+            return new EzAnalysisResult(commonSummary, pp: null, maniaSummary);
+        }
+
         public static EzAnalysisResult Compute(WorkingBeatmap workingBeatmap, in EzAnalysisLookupCache lookup, CancellationToken cancellationToken = default)
         {
             PlayableCachedWorkingBeatmap playableWorkingBeatmap = new PlayableCachedWorkingBeatmap(workingBeatmap);

--- a/osu.Game/EzOsuGame/Analysis/EzAnalysisDatabase.cs
+++ b/osu.Game/EzOsuGame/Analysis/EzAnalysisDatabase.cs
@@ -25,12 +25,12 @@ using osu.Game.Rulesets.UI;
 namespace osu.Game.EzOsuGame.Analysis
 {
     /// <summary>
-    /// 选歌分析数据库入口。
+    /// 选歌分析持久化入口（主 SQLite + 分支库）。
     ///
-    /// 职责对齐官方选歌读取链路：
-    /// - SQLite 持久化结果作为选歌基线数据源。
-    /// - 运行时分析缓存仅负责当前 ruleset/mods 的动态修正。
-    /// - 启动预热与运行期补算由外部后台处理器驱动，不再挂在 cache 上。
+    /// 三层数据（见 <see cref="EzSongSelectAnalysisDisplay"/>）：
+    /// - L1 Realm：<see cref="BeatmapInfo.XxyStarRating"/> / <see cref="BeatmapInfo.PerformancePoints"/>，不受 SQLite 开关影响。
+    /// - L2 主 SQLite（<see cref="Ez2Setting.EzAnalysisSqliteEnabled"/>）：仅 kps + mania 列统计；分支库另存 mod 快照 xxy/PP。
+    /// - L3 动态重算：由 <see cref="EzAnalysisCache"/> 负责，非本类职责。
     /// </summary>
     public class EzAnalysisDatabase
     {
@@ -74,7 +74,10 @@ namespace osu.Game.EzOsuGame.Analysis
             sqliteAnalysisEnabled = ezConfig.GetBindable<bool>(Ez2Setting.EzAnalysisSqliteEnabled);
         }
 
-        public bool TryGetStoredAnalysis(IBeatmapInfo beatmapInfo, IRulesetInfo? rulesetInfo, out EzAnalysisResult result)
+        /// <summary>
+        /// 读取主 SQLite 中的 kps/KPC 切片（NoMod）。不含 xxy/PP。
+        /// </summary>
+        public bool TryGetStoredSqliteSlice(IBeatmapInfo beatmapInfo, IRulesetInfo? rulesetInfo, out EzAnalysisResult result)
         {
             result = default;
 
@@ -140,11 +143,12 @@ namespace osu.Game.EzOsuGame.Analysis
             return getResolvedActiveBranchValues(beatmaps, rulesetInfo, createModsProfileFingerprint(mods), persistentStore.GetSongsBranchPpValues, empty_pp_values);
         }
 
-        public IReadOnlyDictionary<Guid, double> GetStoredXxySrValues(IEnumerable<BeatmapInfo> beatmaps, IRulesetInfo? rulesetInfo, IReadOnlyList<Mod>? mods = null)
+        /// <summary>
+        /// NoMod 基线 xxy：直读 Realm（对齐 carousel 读 <see cref="BeatmapInfo.StarRating"/>）。
+        /// 有 mod 时仅返回已激活且指纹匹配的分支库值（需 SQLite 开关）。
+        /// </summary>
+        public IReadOnlyDictionary<Guid, double> GetBaselineXxySrFromRealm(IEnumerable<BeatmapInfo> beatmaps, IRulesetInfo? rulesetInfo, IReadOnlyList<Mod>? mods = null)
         {
-            if (!sqliteAnalysisEnabled.Value || !EzAnalysisPersistentStore.Enabled)
-                return empty_xxy_sr_values;
-
             var beatmapList = beatmaps.Distinct().ToList();
 
             if (beatmapList.Count == 0)
@@ -152,20 +156,19 @@ namespace osu.Game.EzOsuGame.Analysis
 
             if (IsActiveSongsBranchFor(rulesetInfo, mods))
             {
+                if (!sqliteAnalysisEnabled.Value || !EzAnalysisPersistentStore.Enabled)
+                    return empty_xxy_sr_values;
+
                 return getResolvedActiveBranchValues(beatmapList, rulesetInfo, createModsProfileFingerprint(mods), persistentStore.GetSongsBranchValues, empty_xxy_sr_values);
             }
 
             if (mods?.Any() == true)
                 return empty_xxy_sr_values;
 
-            var eligibleBeatmaps = beatmapList.Where(b => CanUseStoredAnalysis(b, rulesetInfo, mods: null)).ToList();
-
-            if (eligibleBeatmaps.Count == 0)
-                return empty_xxy_sr_values;
-
-            var resolvedValues = persistentStore.GetStoredXxySrValues(eligibleBeatmaps);
+            var resolvedValues = persistentStore.GetBaselineXxySrFromRealm(beatmapList);
             return resolvedValues.Count == 0 ? empty_xxy_sr_values : resolvedValues;
         }
+
 
         public IReadOnlyDictionary<Guid, double> GetStoredPpValues(IEnumerable<BeatmapInfo> beatmaps, IRulesetInfo? rulesetInfo, IReadOnlyList<Mod>? mods = null)
         {
@@ -695,7 +698,7 @@ namespace osu.Game.EzOsuGame.Analysis
 
                 var workingBeatmap = beatmapManager.GetWorkingBeatmap(lookup.BeatmapInfo);
 
-                EzAnalysisResult result = EzAnalysisComputation.Compute(workingBeatmap, lookup, cancellationToken);
+                EzAnalysisResult result = EzAnalysisComputation.ComputePersistedSqliteSlice(workingBeatmap, lookup, cancellationToken);
 
                 if (skipExistingComparison)
                     persistentStore.Store(beatmapInfo, result);

--- a/osu.Game/EzOsuGame/Analysis/EzAnalysisPersistentStore.cs
+++ b/osu.Game/EzOsuGame/Analysis/EzAnalysisPersistentStore.cs
@@ -258,7 +258,10 @@ namespace osu.Game.EzOsuGame.Analysis
             }
         }
 
-        public IReadOnlyDictionary<Guid, double> GetStoredXxySrValues(IEnumerable<BeatmapInfo> beatmaps)
+        /// <summary>
+        /// NoMod 基线 xxy：从 <see cref="BeatmapInfo.XxyStarRating"/> 聚合（非 SQLite）。
+        /// </summary>
+        public IReadOnlyDictionary<Guid, double> GetBaselineXxySrFromRealm(IEnumerable<BeatmapInfo> beatmaps)
         {
             var beatmapList = beatmaps.Distinct().ToList();
 
@@ -393,10 +396,8 @@ LIMIT 1;
                     double averageKps = reader.GetDouble(4);
                     double maxKps = reader.GetDouble(5);
                     string kpsListJson = reader.GetString(6);
-                    // Baseline PP/Xxy are sourced from Realm fields; main sqlite legacy columns are ignored.
-                    double? pp = beatmap.PerformancePoints >= 0 ? beatmap.PerformancePoints : null;
+                    // 主库仅持久化 kps/KPC；xxy/PP 基线由 Realm 字段提供，不在此 DTO 中注入。
                     long maniaUpdatedAt = reader.IsDBNull(7) ? 0 : reader.GetInt64(7);
-                    double? xxySr = beatmap.XxyStarRating >= 0 ? beatmap.XxyStarRating : null;
 
                     string columnCountsJson = reader.IsDBNull(8) ? "{}" : reader.GetString(8);
                     string holdNoteCountsJson = reader.IsDBNull(9) ? "{}" : reader.GetString(9);
@@ -406,10 +407,10 @@ LIMIT 1;
                     var kpsList = JsonSerializer.Deserialize<List<double>>(kpsListJson) ?? new List<double>();
 
                     EzManiaSummary? maniaSummary = storedRulesetOnlineId == 3 && maniaUpdatedAt > 0
-                        ? new EzManiaSummary(columnCounts, holdNoteCounts, xxySr)
+                        ? new EzManiaSummary(columnCounts, holdNoteCounts, xxySr: null)
                         : null;
 
-                    result = new EzAnalysisResult(new KpsSummary(averageKps, maxKps, kpsList), pp, maniaSummary);
+                    result = new EzAnalysisResult(new KpsSummary(averageKps, maxKps, kpsList), pp: null, maniaSummary);
 
                     if (pending is not null && string.Equals(pending.Beatmap.Hash, beatmap.Hash, StringComparison.Ordinal))
                         result = mergeAnalysisResult(result, pending.Analysis);
@@ -1383,9 +1384,6 @@ FROM {table_songs_branch_entry};";
             if (!Enabled || string.IsNullOrEmpty(databasePath) || !File.Exists(databasePath))
                 return false;
 
-            if (newXxySrAlgorithmVersion is not int xxyVersion && newPpAlgorithmVersion is not int ppVersion)
-                return false;
-
             try
             {
                 using var connection = openConnection(databasePath);
@@ -1426,11 +1424,11 @@ WHERE {col_beatmap_id} = $id;
 
                 transaction.Commit();
 
-                if (newXxySrAlgorithmVersion is int resolvedXxyVersion && resolvedXxyVersion > 0)
-                    setMeta(connection, meta_key_xxy_sr_version, resolvedXxyVersion.ToString(CultureInfo.InvariantCulture));
+                if (newXxySrAlgorithmVersion is > 0)
+                    setMeta(connection, meta_key_xxy_sr_version, newXxySrAlgorithmVersion.Value.ToString(CultureInfo.InvariantCulture));
 
-                if (newPpAlgorithmVersion is int resolvedPpVersion && resolvedPpVersion > 0)
-                    setMeta(connection, meta_key_pp_version, resolvedPpVersion.ToString(CultureInfo.InvariantCulture));
+                if (newPpAlgorithmVersion is > 0)
+                    setMeta(connection, meta_key_pp_version, newPpAlgorithmVersion.Value.ToString(CultureInfo.InvariantCulture));
 
                 setMeta(connection, meta_key_analysis_version, ANALYSIS_VERSION.ToString(CultureInfo.InvariantCulture));
                 return true;

--- a/osu.Game/EzOsuGame/Analysis/EzSongSelectAnalysisDisplay.cs
+++ b/osu.Game/EzOsuGame/Analysis/EzSongSelectAnalysisDisplay.cs
@@ -1,0 +1,64 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.Beatmaps;
+using osu.Game.EzOsuGame.Beatmaps;
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.EzOsuGame.Analysis
+{
+    /// <summary>
+    /// 选歌面板分析显示合成：对齐官方星级缓存（BeatmapDifficultyCache）与 <see cref="BeatmapInfo.StarRating"/> 的分工。
+    /// L1 Realm 提供 NoMod xxy/PP 基线；L2/L3 的 <see cref="EzAnalysisResult"/> 仅提供 kps/KPC 与 mod 动态指标。
+    /// </summary>
+    public static class EzSongSelectAnalysisDisplay
+    {
+        public readonly record struct PanelMetrics(
+            double? PerformancePoints,
+            double AverageKps,
+            double MaxKps,
+            IReadOnlyList<double> KpsList,
+            EzManiaSummary? ManiaSummary);
+
+        public static bool HasActiveMods(IReadOnlyList<Mod>? mods) => mods != null && mods.Count > 0;
+
+        public static PanelMetrics Resolve(BeatmapInfo beatmap, EzAnalysisResult? dynamic, IReadOnlyList<Mod>? mods)
+        {
+            bool hasMods = HasActiveMods(mods);
+            bool useDynamicMetrics = hasMods && dynamicHasDisplayMetrics(dynamic);
+
+            double? pp = useDynamicMetrics && dynamic!.Value.Pp is double dynamicPp
+                ? dynamicPp
+                : beatmap.PerformancePoints >= 0
+                    ? beatmap.PerformancePoints
+                    : dynamic?.Pp;
+
+            double avgKps = dynamic?.AverageKps ?? 0;
+            double maxKps = dynamic?.MaxKps ?? 0;
+            var kpsList = dynamic?.KpsList ?? System.Array.Empty<double>();
+
+            EzManiaSummary? maniaSummary = beatmap.ToEzManiaSummaryForDisplay(
+                dynamic?.ManiaSummary,
+                preferAnalysisValues: useDynamicMetrics);
+
+            return new PanelMetrics(pp, avgKps, maxKps, kpsList, maniaSummary);
+        }
+
+        private static bool dynamicHasDisplayMetrics(EzAnalysisResult? dynamic)
+        {
+            if (!dynamic.HasValue)
+                return false;
+
+            var result = dynamic.Value;
+
+            if (result.Pp != null)
+                return true;
+
+            if (result.ManiaSummary?.XxySr != null)
+                return true;
+
+            return result.AverageKps > 0 || result.MaxKps > 0 || result.KpsList.Count > 0;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Analysis/EzSongSelectAnalysisDisplay.cs
+++ b/osu.Game/EzOsuGame/Analysis/EzSongSelectAnalysisDisplay.cs
@@ -23,29 +23,45 @@ namespace osu.Game.EzOsuGame.Analysis
 
         public static bool HasActiveMods(IReadOnlyList<Mod>? mods) => mods != null && mods.Count > 0;
 
+        public static bool HasDisplayableKps(in EzAnalysisResult result)
+            => result.KpsList.Count > 0 || result.AverageKps > 0 || result.MaxKps > 0;
+
+        /// <summary>
+        /// 避免 bindable 在异步重算完成前用空占位结果清空折线（尤其有 Mod 时）。
+        /// </summary>
+        public static bool ShouldApplyPanelUpdate(in EzAnalysisResult result, IReadOnlyList<Mod>? mods)
+            => HasDisplayableKps(result) || !HasActiveMods(mods);
+
         public static PanelMetrics Resolve(BeatmapInfo beatmap, EzAnalysisResult? dynamic, IReadOnlyList<Mod>? mods)
         {
             bool hasMods = HasActiveMods(mods);
-            bool useDynamicMetrics = hasMods && dynamicHasDisplayMetrics(dynamic);
+            bool useDynamicStarMetrics = hasMods && dynamicHasStarMetrics(dynamic);
 
-            double? pp = useDynamicMetrics && dynamic!.Value.Pp is double dynamicPp
+            double? pp = useDynamicStarMetrics && dynamic!.Value.Pp is double dynamicPp
                 ? dynamicPp
                 : beatmap.PerformancePoints >= 0
                     ? beatmap.PerformancePoints
                     : dynamic?.Pp;
 
-            double avgKps = dynamic?.AverageKps ?? 0;
-            double maxKps = dynamic?.MaxKps ?? 0;
-            var kpsList = dynamic?.KpsList ?? System.Array.Empty<double>();
+            double avgKps = 0;
+            double maxKps = 0;
+            IReadOnlyList<double> kpsList = System.Array.Empty<double>();
+
+            if (dynamic is { } analysis && HasDisplayableKps(analysis))
+            {
+                avgKps = analysis.AverageKps;
+                maxKps = analysis.MaxKps;
+                kpsList = analysis.KpsList;
+            }
 
             EzManiaSummary? maniaSummary = beatmap.ToEzManiaSummaryForDisplay(
                 dynamic?.ManiaSummary,
-                preferAnalysisValues: useDynamicMetrics);
+                preferAnalysisValues: useDynamicStarMetrics);
 
             return new PanelMetrics(pp, avgKps, maxKps, kpsList, maniaSummary);
         }
 
-        private static bool dynamicHasDisplayMetrics(EzAnalysisResult? dynamic)
+        private static bool dynamicHasStarMetrics(EzAnalysisResult? dynamic)
         {
             if (!dynamic.HasValue)
                 return false;
@@ -55,10 +71,7 @@ namespace osu.Game.EzOsuGame.Analysis
             if (result.Pp != null)
                 return true;
 
-            if (result.ManiaSummary?.XxySr != null)
-                return true;
-
-            return result.AverageKps > 0 || result.MaxKps > 0 || result.KpsList.Count > 0;
+            return result.ManiaSummary?.XxySr != null;
         }
     }
 }

--- a/osu.Game/EzOsuGame/Beatmaps/EzBeatmapXxyExtensions.cs
+++ b/osu.Game/EzOsuGame/Beatmaps/EzBeatmapXxyExtensions.cs
@@ -16,9 +16,11 @@ namespace osu.Game.EzOsuGame.Beatmaps
         public static double? GetPersistedXxyStarRating(this BeatmapInfo beatmap)
             => beatmap.HasPersistedXxyStarRating() ? beatmap.XxyStarRating : null;
 
-        public static EzManiaSummary ToEzManiaSummaryForDisplay(this BeatmapInfo beatmap, EzManiaSummary? analysisSummary = null)
+        public static EzManiaSummary ToEzManiaSummaryForDisplay(this BeatmapInfo beatmap, EzManiaSummary? analysisSummary = null, bool preferAnalysisValues = false)
         {
-            double? xxy = beatmap.GetPersistedXxyStarRating() ?? analysisSummary?.XxySr;
+            double? xxy = preferAnalysisValues && analysisSummary?.XxySr is double analysisXxy
+                ? analysisXxy
+                : beatmap.GetPersistedXxyStarRating() ?? analysisSummary?.XxySr;
 
             return new EzManiaSummary(
                 analysisSummary?.ColumnCounts,

--- a/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
@@ -91,21 +91,19 @@ namespace osu.Game.EzOsuGame.Localization
             new EzLocalizationManager.EzLocalisableString("启用 Ez 分析重算", "Enable Ez analysis recomputation");
 
         public static readonly EzLocalizationManager.EzLocalisableString EZ_ANALYSIS_REC_ENABLED_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
-            "开启后允许选歌界面进行实时分析并刷新显示，纳入Mod转换结果的分析。"
-            + "\n注意：该开关不控制 SQLite 本地读取与预热（由下方 SQLite 开关单独控制）。",
-            "When enabled, allows real-time analysis and display refresh in the song selection screen, including analysis of Mod conversion results."
-            + "\nNote: This switch does not control SQLite local reading and warmup (which is controlled separately by the SQLite switch below).");
+            "开启后，选歌界面会像官方星级一样按当前 Mod 按需重算 xxy/PP/KPS 并刷新面板。"
+            + "\n关闭时，有 Mod 仍显示 Realm 无 Mod 基线。不控制 SQLite 与 Realm 回填。",
+            "When enabled, song select recomputes xxy/PP/KPS for the current mods on demand (like official star rating) and refreshes panels."
+            + "\nWhen disabled, mods still show the NoMod Realm baseline. Does not control SQLite or Realm backfill.");
 
         public static readonly EzLocalizationManager.EzLocalisableString EZ_ANALYSIS_SQLITE_ENABLED =
             new EzLocalizationManager.EzLocalisableString("启用 Ez 分析本地数据（SQLite）", "Enable Ez analysis local data (SQLite)");
 
         public static readonly EzLocalizationManager.EzLocalisableString EZ_ANALYSIS_SQLITE_ENABLED_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
-            "启用独立控制的 SQLite 本地储存，启动时预热器。（No-Mod）"
-            + "\n开启：面板直读本地数据，在exe启动时执行预热列队分析加载（进入游戏中会暂停进度），但不会考虑Mod转换结果。"
-            + "\n关闭：不读取 SQLite 本地数据，也不执行预热。",
-            "Enable independently controlled SQLite local storage and warmup on startup (No-Mod)"
-            + "\nWhen enabled: Panels read local data directly, and perform warmup queue analysis loading on exe startup (progress will pause when entering gameplay), but Mod conversion results will not be considered."
-            + "\nWhen disabled: Do not read SQLite local data, and do not perform warmup.");
+            "控制主 analysis SQLite（kps/KPC 缓存、启动预热）与分支曲库（预生成 Mod 快照）的读写。"
+            + "\n不影响 Realm 中的 xxy/PP 基线；Mod 下面板动态重算由上方「分析重算」开关控制。",
+            "Controls main analysis SQLite (kps/KPC cache, startup warmup) and songs branch libraries (precomputed mod snapshots)."
+            + "\nDoes not affect Realm xxy/PP baselines; mod-aware panel recompute is controlled by the recompute switch above.");
 
         public static readonly EzLocalizationManager.EzLocalisableString EZ_REALM_METADATA_BACKFILL =
             new EzLocalizationManager.EzLocalisableString("补算 Realm 元数据（Tag / XxySR / PP）", "Backfill Realm metadata (Tag / XxySR / PP)");

--- a/osu.Game/Screens/Select/BeatmapTitleWedge.DifficultyDisplay.cs
+++ b/osu.Game/Screens/Select/BeatmapTitleWedge.DifficultyDisplay.cs
@@ -48,6 +48,9 @@ namespace osu.Game.Screens.Select
             [Resolved]
             private EzAnalysisDatabase analysisDatabase { get; set; } = null!;
 
+            [Resolved]
+            private EzAnalysisCache ezAnalysisCache { get; set; } = null!;
+
             private EzDisplayKpc ezDisplayKpc = null!;
 
             private ModSettingChangeTracker? settingChangeTracker;
@@ -295,23 +298,39 @@ namespace osu.Game.Screens.Select
                     bool hasMods = selectedMods.Length > 0;
                     EzManiaSummary? maniaSummary = null;
 
-                    if (!hasMods
-                        && selectedRuleset != null
-                        && EzAnalysisProviderBridge.HasAnalysisProvider(selectedRuleset)
-                        && analysisDatabase.TryGetStoredAnalysis(selectedBeatmap.BeatmapInfo, selectedRuleset, out var storedAnalysis))
+                    EzAnalysisResult? dynamicAnalysis = null;
+
+                    if (selectedBeatmap.BeatmapInfo is BeatmapInfo beatmapInfo
+                        && selectedRuleset is RulesetInfo rulesetInfo
+                        && EzAnalysisProviderBridge.HasAnalysisProvider(selectedRuleset))
                     {
-                        maniaSummary = storedAnalysis.ManiaSummary;
+                        if (hasMods)
+                        {
+                            dynamicAnalysis = ezAnalysisCache
+                                              .GetAnalysisAsync(beatmapInfo, rulesetInfo, selectedMods, cancellationToken)
+                                              .GetAwaiter()
+                                              .GetResult();
+                        }
+                        else if (analysisDatabase.TryGetStoredSqliteSlice(beatmapInfo, selectedRuleset, out var storedSlice))
+                        {
+                            dynamicAnalysis = storedSlice;
+                        }
                     }
 
                     // This can take time as it is a synchronous task.
                     // 使用可取消重载，避免快速切歌时后台任务继续持有旧谱面对象。
-                    var playableBeatmap = selectedBeatmap.GetPlayableBeatmap(selectedRuleset, Array.Empty<Mod>(), cancellationToken);
+                    var playableBeatmap = selectedBeatmap.GetPlayableBeatmap(selectedRuleset, selectedMods, cancellationToken);
 
                     cancellationToken.ThrowIfCancellationRequested();
 
                     var statistics = playableBeatmap.GetStatistics()
                                                     .Select(s => new StatisticDifficulty.Data(s.Name, s.BarDisplayLength ?? 0, s.BarDisplayLength ?? 0, 1, s.Content))
                                                     .ToList();
+
+                    if (selectedBeatmap.BeatmapInfo is BeatmapInfo localBeatmapInfo)
+                    {
+                        maniaSummary = EzSongSelectAnalysisDisplay.Resolve(localBeatmapInfo, dynamicAnalysis, selectedMods).ManiaSummary;
+                    }
 
                     maniaSummary ??= OptimizedBeatmapCalculator.GetEzManiaSummary(playableBeatmap);
 

--- a/osu.Game/Screens/Select/BeatmapTitleWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapTitleWedge.cs
@@ -347,7 +347,7 @@ namespace osu.Game.Screens.Select
                 IReadOnlyList<double> kpsList;
 
                 if (selectedMods.Count == 0
-                    && analysisDatabase.TryGetStoredAnalysis(beatmapInfo, selectedRuleset, out var storedAnalysis)
+                    && analysisDatabase.TryGetStoredSqliteSlice(beatmapInfo, selectedRuleset, out var storedAnalysis)
                     && storedAnalysis.KpsList is { Count: > 0 } storedKpsList)
                 {
                     kpsList = storedKpsList;

--- a/osu.Game/Screens/Select/PanelBeatmap.cs
+++ b/osu.Game/Screens/Select/PanelBeatmap.cs
@@ -273,6 +273,7 @@ namespace osu.Game.Screens.Select
             {
                 resetEzDisplay();
                 updateKeyCount();
+                computeEzAnalysis();
             }, true);
 
             mods.BindValueChanged(_ =>
@@ -387,6 +388,7 @@ namespace osu.Game.Screens.Select
 
             displaySR.Current.Value = EzManiaSummary.EMPTY;
             ezDisplayKpc.ManiaSummary = null;
+            ezDisplayKpsGraph.SetPoints(Array.Empty<double>());
         }
 
         private void updateKPS(EzAnalysisResult ezAnalysisResult)
@@ -432,15 +434,22 @@ namespace osu.Game.Screens.Select
                 return;
 
             ezAnalysisBindable = ezAnalysisCache.GetBindableAnalysis(beatmap, ezAnalysisCancellationSource.Token, SongSelect.DIFFICULTY_CALCULATION_DEBOUNCE);
+
+            if (EzSongSelectAnalysisDisplay.ShouldApplyPanelUpdate(ezAnalysisBindable.Value, mods.Value))
+                updateKPS(ezAnalysisBindable.Value);
+
             ezAnalysisBindable.BindValueChanged(result =>
             {
+                if (!EzSongSelectAnalysisDisplay.ShouldApplyPanelUpdate(result.NewValue, mods.Value))
+                    return;
+
                 scheduledEzAnalysisUpdate?.Cancel();
                 scheduledEzAnalysisUpdate = Scheduler.AddDelayed(() =>
                 {
                     updateKPS(result.NewValue);
                     scheduledEzAnalysisUpdate = null;
                 }, mania_ui_update_throttle_ms);
-            }, true);
+            });
         }
 
         private void computeStarRating()

--- a/osu.Game/Screens/Select/PanelBeatmap.cs
+++ b/osu.Game/Screens/Select/PanelBeatmap.cs
@@ -394,24 +394,20 @@ namespace osu.Game.Screens.Select
             if (Item?.IsVisible != true)
                 return;
 
-            double avgKPS = ezAnalysisResult.AverageKps;
-            double maxKps = ezAnalysisResult.MaxKps;
-            var kpsList = ezAnalysisResult.KpsList;
-            double? baselinePp = beatmap.PerformancePoints >= 0
-                ? beatmap.PerformancePoints
-                : ezAnalysisResult.Pp;
-            ezDisplayKps.SetKps(baselinePp, avgKPS, maxKps);
-            ezDisplayKpsGraph.SetPoints(kpsList);
+            var metrics = EzSongSelectAnalysisDisplay.Resolve(beatmap, ezAnalysisResult, mods.Value);
+
+            ezDisplayKps.SetKps(metrics.PerformancePoints, metrics.AverageKps, metrics.MaxKps);
+            ezDisplayKpsGraph.SetPoints(metrics.KpsList);
 
             if (supportsEzAnalysis && beatmap.SupportsXxyStarRating())
             {
-                var maniaSummary = ezAnalysisResult.ManiaSummary;
+                var maniaSummary = metrics.ManiaSummary;
                 var columnCounts = maniaSummary?.ColumnCounts ?? new Dictionary<int, int>();
 
-                scratchText = EzBeatmapCalculator.GetScratchFromPrecomputed(columnCounts, maxKps, kpsList);
+                scratchText = EzBeatmapCalculator.GetScratchFromPrecomputed(columnCounts, metrics.MaxKps, metrics.KpsList);
                 updateKeyCount();
                 ezDisplayKpc.ManiaSummary = maniaSummary;
-                displaySR.Current.Value = beatmap.ToEzManiaSummaryForDisplay(maniaSummary);
+                displaySR.Current.Value = maniaSummary ?? EzManiaSummary.EMPTY;
             }
         }
 

--- a/osu.Game/Screens/Select/PanelBeatmapStandalone.cs
+++ b/osu.Game/Screens/Select/PanelBeatmapStandalone.cs
@@ -392,24 +392,20 @@ namespace osu.Game.Screens.Select
             if (Item?.IsVisible != true)
                 return;
 
-            double avgKPS = ezAnalysisResult.AverageKps;
-            double maxKps = ezAnalysisResult.MaxKps;
-            IReadOnlyList<double> kpsList = ezAnalysisResult.KpsList;
-            double? baselinePp = beatmap.PerformancePoints >= 0
-                ? beatmap.PerformancePoints
-                : ezAnalysisResult.Pp;
-            ezDisplayKps.SetKps(baselinePp, avgKPS, maxKps);
-            ezDisplayKpsGraph.SetPoints(kpsList);
+            var metrics = EzSongSelectAnalysisDisplay.Resolve(beatmap, ezAnalysisResult, mods.Value);
+
+            ezDisplayKps.SetKps(metrics.PerformancePoints, metrics.AverageKps, metrics.MaxKps);
+            ezDisplayKpsGraph.SetPoints(metrics.KpsList);
 
             if (supportsEzAnalysis && beatmap.SupportsXxyStarRating())
             {
-                var maniaSummary = ezAnalysisResult.ManiaSummary;
+                var maniaSummary = metrics.ManiaSummary;
                 var columnCounts = maniaSummary?.ColumnCounts ?? new Dictionary<int, int>();
 
-                scratchText = EzBeatmapCalculator.GetScratchFromPrecomputed(columnCounts, maxKps, kpsList);
+                scratchText = EzBeatmapCalculator.GetScratchFromPrecomputed(columnCounts, metrics.MaxKps, metrics.KpsList);
                 updateKeyCount();
                 ezDisplayKpc.ManiaSummary = maniaSummary;
-                displaySR.Current.Value = beatmap.ToEzManiaSummaryForDisplay(maniaSummary);
+                displaySR.Current.Value = maniaSummary ?? EzManiaSummary.EMPTY;
             }
         }
 

--- a/osu.Game/Screens/Select/PanelBeatmapStandalone.cs
+++ b/osu.Game/Screens/Select/PanelBeatmapStandalone.cs
@@ -281,6 +281,7 @@ namespace osu.Game.Screens.Select
             {
                 resetEzDisplay();
                 updateKeyCount();
+                computeEzAnalysis();
             }, true);
 
             mods.BindValueChanged(_ => updateKeyCount(), true);
@@ -385,6 +386,7 @@ namespace osu.Game.Screens.Select
 
             displaySR.Current.Value = EzManiaSummary.EMPTY;
             ezDisplayKpc.ManiaSummary = null;
+            ezDisplayKpsGraph.SetPoints(Array.Empty<double>());
         }
 
         private void updateKPS(EzAnalysisResult ezAnalysisResult)
@@ -432,15 +434,22 @@ namespace osu.Game.Screens.Select
             resetEzDisplay();
 
             ezAnalysisBindable = ezAnalysisCache.GetBindableAnalysis(beatmap, ezAnalysisCancellationSource.Token, SongSelect.DIFFICULTY_CALCULATION_DEBOUNCE);
+
+            if (EzSongSelectAnalysisDisplay.ShouldApplyPanelUpdate(ezAnalysisBindable.Value, mods.Value))
+                updateKPS(ezAnalysisBindable.Value);
+
             ezAnalysisBindable.BindValueChanged(result =>
             {
+                if (!EzSongSelectAnalysisDisplay.ShouldApplyPanelUpdate(result.NewValue, mods.Value))
+                    return;
+
                 scheduledEzAnalysisUpdate?.Cancel();
                 scheduledEzAnalysisUpdate = Scheduler.AddDelayed(() =>
                 {
                     updateKPS(result.NewValue);
                     scheduledEzAnalysisUpdate = null;
                 }, mania_ui_update_throttle_ms);
-            }, true);
+            });
         }
 
         private void computeStarRating()


### PR DESCRIPTION
改进realm中的分析加载路线

架构对应
Realm 基线（XxyStarRating / PerformancePoints）：直读 BeatmapInfo，不走 BeatmapDifficultyCache。
官方星：BeatmapDifficultyCache + BeatmapInfo.StarRating。
Ez mod 按需：EzAnalysisCache + EzSongSelectAnalysisDisplay 合成面板。