### PR TITLE
启动性能：SQLite 按需预热、Realm 回填互斥与维护类型定义（PR1/2）

### DIFF
--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -87,15 +87,10 @@ namespace osu.Game.Database
         /// <param name="forceAll">When true, clears persisted values first so all supported beatmaps are recomputed.</param>
         public void QueueEzRealmMetadataBackfill(bool forceAll = false)
         {
-            lock (ezRealmBackfillLock)
+            if (!tryBeginEzRealmMetadataBackfill())
             {
-                if (ezRealmBackfillQueued)
-                {
-                    Logger.Log("Ez Realm metadata backfill is already running; ignoring duplicate request.");
-                    return;
-                }
-
-                ezRealmBackfillQueued = true;
+                Logger.Log("Ez Realm metadata backfill is already running; ignoring duplicate request.");
+                return;
             }
 
             Task.Factory.StartNew(() =>
@@ -113,10 +108,27 @@ namespace osu.Game.Database
                 }
                 finally
                 {
-                    lock (ezRealmBackfillLock)
-                        ezRealmBackfillQueued = false;
+                    endEzRealmMetadataBackfill();
                 }
             }, TaskCreationOptions.LongRunning);
+        }
+
+        private bool tryBeginEzRealmMetadataBackfill()
+        {
+            lock (ezRealmBackfillLock)
+            {
+                if (ezRealmBackfillQueued)
+                    return false;
+
+                ezRealmBackfillQueued = true;
+                return true;
+            }
+        }
+
+        private void endEzRealmMetadataBackfill()
+        {
+            lock (ezRealmBackfillLock)
+                ezRealmBackfillQueued = false;
         }
 
         protected override void LoadComplete()
@@ -135,7 +147,21 @@ namespace osu.Game.Database
                     clearOutdatedXxyStarRatings();
 
                     // Run Ez Realm backfill before official star population so it is not blocked for long periods.
-                    runEzRealmMetadataBackfill();
+                    if (tryBeginEzRealmMetadataBackfill())
+                    {
+                        try
+                        {
+                            runEzRealmMetadataBackfill();
+                        }
+                        finally
+                        {
+                            endEzRealmMetadataBackfill();
+                        }
+                    }
+                    else
+                    {
+                        Logger.Log("Skipping startup Ez Realm metadata backfill because another backfill is already running.");
+                    }
 
                     populateMissingStarRatings();
                     processOnlineBeatmapSetsWithNoUpdate();

--- a/osu.Game/EzOsuGame/Analysis/EzAnalysisDatabase.cs
+++ b/osu.Game/EzOsuGame/Analysis/EzAnalysisDatabase.cs
@@ -205,7 +205,6 @@ namespace osu.Game.EzOsuGame.Analysis
             return resolvedValues.Count == 0 ? empty_xxy_sr_values : resolvedValues;
         }
 
-
         public IReadOnlyDictionary<Guid, double> GetStoredPpValues(IEnumerable<BeatmapInfo> beatmaps, IRulesetInfo? rulesetInfo, IReadOnlyList<Mod>? mods = null)
         {
             var beatmapList = beatmaps.Distinct().ToList();
@@ -519,6 +518,26 @@ namespace osu.Game.EzOsuGame.Analysis
             return persistentStore.GetBeatmapsNeedingRecompute(beatmaps);
         }
 
+        public bool TrySetForceRecompute(bool force)
+        {
+            if (!sqliteAnalysisEnabled.Value || !EzAnalysisPersistentStore.Enabled)
+                return false;
+
+            return persistentStore.TrySetForceRecompute(force);
+        }
+
+        public bool ShouldRunAutomaticSqliteWarmup()
+        {
+            if (!sqliteAnalysisEnabled.Value || !EzAnalysisPersistentStore.Enabled)
+                return false;
+
+            string databasePath = persistentStore.GetMainDatabasePath();
+            return EzAnalysisSchemaManager.ShouldRunAutomaticSqliteWarmup(databasePath);
+        }
+
+        public void EnsureInitialised()
+            => persistentStore.Initialise();
+
         /// <summary>
         /// 扫描所有分支库：v2+ legacy 库补写版本 meta；v1 迁移后标记全量 refresh；返回 xxy 或 PP 算法落后、需要重算的分支计划。
         /// </summary>
@@ -575,6 +594,40 @@ namespace osu.Game.EzOsuGame.Analysis
                         supportsXxy ? currentXxyVersion : 0,
                         supportsPp ? currentPpVersion : 0));
                 }
+            }
+
+            return plans;
+        }
+
+        /// <summary>
+        /// 为每个可用分支曲库生成强制 refresh 计划（忽略 stored 版本）。
+        /// </summary>
+        public IReadOnlyList<SongsBranchRefreshPlan> GetAllSongsBranchesForceRefreshPlans()
+        {
+            if (!sqliteAnalysisEnabled.Value || !EzAnalysisPersistentStore.Enabled)
+                return Array.Empty<SongsBranchRefreshPlan>();
+
+            var plans = new List<SongsBranchRefreshPlan>();
+
+            foreach (var branch in persistentStore.GetAvailableSongsBranches())
+            {
+                var rulesetInfo = rulesetStore.GetRuleset(branch.Metadata.RulesetOnlineId);
+
+                if (rulesetInfo is not RulesetInfo localRulesetInfo)
+                    continue;
+
+                bool supportsXxy = EzXxyStarRatingSupport.TryGetXxyStarRatingVersion(localRulesetInfo, out int currentXxyVersion);
+                bool supportsPp = tryGetOfficialPerformancePointsVersion(localRulesetInfo, out int currentPpVersion);
+
+                if (!supportsXxy && !supportsPp)
+                    continue;
+
+                plans.Add(new SongsBranchRefreshPlan(
+                    branch,
+                    RefreshXxy: supportsXxy,
+                    RefreshPp: supportsPp,
+                    CurrentXxyVersion: supportsXxy ? currentXxyVersion : 0,
+                    CurrentPpVersion: supportsPp ? currentPpVersion : 0));
             }
 
             return plans;

--- a/osu.Game/EzOsuGame/Analysis/EzAnalysisPersistentStore.cs
+++ b/osu.Game/EzOsuGame/Analysis/EzAnalysisPersistentStore.cs
@@ -88,6 +88,8 @@ namespace osu.Game.EzOsuGame.Analysis
 
         public static string DatabaseFilename => $"{LEGACY_DATABASE_FILENAME_PREFIX}{ANALYSIS_VERSION}.sqlite";
 
+        public string GetMainDatabasePath() => storage.GetFullPath(DatabaseFilename, true);
+
         /// <summary>
         /// 旧版稳定文件名（中间分支）；v7 启动时会从此文件迁移一次。
         /// </summary>

--- a/osu.Game/EzOsuGame/Analysis/EzAnalysisSchemaManager.cs
+++ b/osu.Game/EzOsuGame/Analysis/EzAnalysisSchemaManager.cs
@@ -174,6 +174,55 @@ WHERE {COL_UPDATED_AT} <> 0;
             rebuildMainDatabaseInPlace(connection);
         }
 
+        /// <summary>
+        /// 当前版本主库文件已存在且 schema / analysis 版本与代码一致。
+        /// </summary>
+        public static bool IsMainDatabaseMatching(string databasePath)
+        {
+            if (!File.Exists(databasePath))
+                return false;
+
+            try
+            {
+                using var connection = OpenConnection(databasePath);
+
+                if (!tableExists(connection, TABLE_ENTRY))
+                    return false;
+
+                if (!int.TryParse(TryGetMeta(connection, META_KEY_SCHEMA_VERSION), NumberStyles.Integer, CultureInfo.InvariantCulture, out int storedSchemaVersion)
+                    || storedSchemaVersion != MAIN_SCHEMA_VERSION)
+                    return false;
+
+                if (!int.TryParse(TryGetMeta(connection, META_KEY_ANALYSIS_VERSION), NumberStyles.Integer, CultureInfo.InvariantCulture, out int storedAnalysisVersion)
+                    || storedAnalysisVersion != ANALYSIS_VERSION)
+                    return false;
+
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// 存在可迁移的旧版主库，或当前主库需要 schema / 版本升级。
+        /// 已匹配的最新版文件不应触发启动预热。
+        /// </summary>
+        public static bool ShouldRunAutomaticSqliteWarmup(string databasePath)
+        {
+            if (IsMainDatabaseMatching(databasePath))
+                return false;
+
+            if (!File.Exists(databasePath))
+            {
+                string? directory = Path.GetDirectoryName(databasePath);
+                return !string.IsNullOrEmpty(directory) && findLatestPreviousMainDatabase(directory, databasePath) != null;
+            }
+
+            return true;
+        }
+
         public static void EnsureMetaTableExists(SqliteConnection connection)
         {
             using var cmd = connection.CreateCommand();

--- a/osu.Game/EzOsuGame/Analysis/EzAnalysisWarmupProcessor.cs
+++ b/osu.Game/EzOsuGame/Analysis/EzAnalysisWarmupProcessor.cs
@@ -22,13 +22,11 @@ using osu.Game.Screens.Play;
 namespace osu.Game.EzOsuGame.Analysis
 {
     /// <summary>
-    /// 启动阶段做一次全量扫描，补齐 analysis 主体（kps / mania 列统计）。基线 PP 由 Realm / BeatmapUpdater 负责。
-    /// 运行阶段通过单后台 worker 仅处理最新选中谱面的低优先级重算。
+    /// 启动时仅在 SQLite 主库需要版本/ schema 升级时自动补算；已匹配最新版文件时不自动预热。
+    /// 其余 SQLite 维护由设置页手动触发；Realm 基线仍由 BackgroundDataStoreProcessor 负责。
     /// </summary>
     public partial class EzAnalysisWarmupProcessor : Component
     {
-        protected Task ProcessingTask { get; private set; } = Task.CompletedTask;
-
         [Resolved]
         private BeatmapManager beatmapManager { get; set; } = null!;
 
@@ -56,10 +54,11 @@ namespace osu.Game.EzOsuGame.Analysis
         private IBindable<bool> sqliteEnabledBindable = null!;
         private bool sqliteEnabled;
         private bool backgroundWorkersStarted;
-        private readonly object processingTaskLock = new object();
+        private readonly object sqliteManualRebuildLock = new object();
+        private bool sqliteMainRebuildQueued;
+        private bool sqliteSongsBranchesRebuildQueued;
 
         protected virtual int TimeToSleepDuringGameplay => 30000;
-
         private readonly object pendingBeatmapLock = new object();
         private readonly HashSet<Guid> pendingBeatmapIds = new HashSet<Guid>();
         private readonly HashSet<Guid> inFlightBeatmapIds = new HashSet<Guid>();
@@ -104,7 +103,9 @@ namespace osu.Game.EzOsuGame.Analysis
             if (enabled)
             {
                 ensureBackgroundWorkersStarted();
-                triggerStartupWarmupScan();
+                pendingScanCompleted = true;
+                Schedule(() => queueSelectedBeatmapRecomputeIfRequired(currentBeatmap.Value));
+                tryQueueAutomaticSqliteUpgradeWarmup();
                 return;
             }
 
@@ -133,115 +134,109 @@ namespace osu.Game.EzOsuGame.Analysis
                 TaskScheduler.Default);
         }
 
-        private void triggerStartupWarmupScan()
+        private void tryQueueAutomaticSqliteUpgradeWarmup()
         {
-            if (!sqliteEnabled)
+            if (!sqliteEnabled || !analysisDatabase.ShouldRunAutomaticSqliteWarmup())
                 return;
 
-            lock (processingTaskLock)
+            Task.Factory.StartNew(() =>
             {
-                if (!ProcessingTask.IsCompleted)
-                    return;
-
-                pendingScanCompleted = false;
-
-                ProcessingTask = Task.Factory.StartNew(() =>
+                try
                 {
-                    scanBeatmapsNeedingWarmup();
-                    scanSongsBranchesNeedingRefresh();
-                }, TaskCreationOptions.LongRunning).ContinueWith(t =>
+                    Logger.Log("Automatic SQLite upgrade warmup started.", Ez2ConfigManager.LOGGER_NAME, LogLevel.Important);
+
+                    analysisDatabase.EnsureInitialised();
+                    executeSqliteMainRebuild(forceAll: false);
+                    executeSqliteSongsBranchesRebuild(forceAll: false);
+
+                    Logger.Log("Automatic SQLite upgrade warmup finished.", Ez2ConfigManager.LOGGER_NAME, LogLevel.Important);
+                }
+                catch (Exception e)
                 {
-                    if (t.Exception?.InnerException is ObjectDisposedException)
-                    {
-                        Logger.Log("Finished analysis startup scan aborted during shutdown", Ez2ConfigManager.LOGGER_NAME, LogLevel.Verbose);
-                        return;
-                    }
-
-                    if (!sqliteEnabled)
-                        return;
-
-                    pendingScanCompleted = true;
-                    Schedule(() => queueSelectedBeatmapRecomputeIfRequired(currentBeatmap.Value));
-
-                    Logger.Log("Finished background analysis startup scan.", Ez2ConfigManager.LOGGER_NAME, LogLevel.Important);
-                });
-            }
+                    Logger.Error(e, "Automatic SQLite upgrade warmup failed.", Ez2ConfigManager.LOGGER_NAME);
+                }
+            }, TaskCreationOptions.LongRunning);
         }
 
-        private void scanBeatmapsNeedingWarmup()
+        public void QueueSqliteMainRebuild(bool forceAll)
         {
             if (!sqliteEnabled)
                 return;
 
-            List<(Guid id, string hash, int rulesetOnlineId)> beatmaps = new List<(Guid id, string hash, int rulesetOnlineId)>();
-
-            realmAccess.Run(r =>
+            lock (sqliteManualRebuildLock)
             {
-                int totalBeatmaps = 0;
-                int totalWithSet = 0;
-                int maniaTotal = 0;
-                int maniaWithSet = 0;
-                int maniaHidden = 0;
-
-                Dictionary<string, int> rulesetDistribution = new Dictionary<string, int>();
-
-                // Align with official BackgroundDataStoreProcessor: don't exclude Hidden beatmaps here.
-                // Hidden beatmaps can still be attached to sets and may contribute to cache hit rates.
-                foreach (var b in r.All<BeatmapInfo>())
+                if (sqliteMainRebuildQueued)
                 {
-                    totalBeatmaps++;
-
-                    bool hasEzAnalysisProvider = EzAnalysisProviderBridge.HasAnalysisProvider(b.Ruleset);
-
-                    if (hasEzAnalysisProvider)
-                    {
-                        maniaTotal++;
-                        if (b.Hidden)
-                            maniaHidden++;
-                    }
-
-                    if (totalBeatmaps <= 2000)
-                    {
-                        string key = $"{b.Ruleset.ShortName}:{b.Ruleset.OnlineID}";
-                        rulesetDistribution.TryGetValue(key, out int count);
-                        rulesetDistribution[key] = count + 1;
-                    }
-
-                    if (b.BeatmapSet == null)
-                        continue;
-
-                    // Externally hosted libraries are volatile; skip startup sqlite backfill.
-                    if (b.BeatmapSet is { IsExternallyHosted: true })
-                        continue;
-
-                    totalWithSet++;
-
-                    if (hasEzAnalysisProvider)
-                        maniaWithSet++;
-
-                    beatmaps.Add((b.ID, b.Hash, b.Ruleset.OnlineID));
+                    Logger.Log("SQLite main rebuild is already queued; ignoring duplicate request.", Ez2ConfigManager.LOGGER_NAME, LogLevel.Important);
+                    return;
                 }
 
-                Logger.Log($"Startup scan beatmap summary: total={totalBeatmaps}, total_with_set={totalWithSet}, mania_total={maniaTotal}, mania_with_set={maniaWithSet}, mania_hidden={maniaHidden}",
-                    Ez2ConfigManager.LOGGER_NAME, LogLevel.Important);
+                sqliteMainRebuildQueued = true;
+            }
 
-                if (maniaTotal == 0)
+            Task.Factory.StartNew(() =>
+            {
+                try
                 {
-                    string dist = string.Join(", ", rulesetDistribution.OrderByDescending(kvp => kvp.Value).Take(10).Select(kvp => $"{kvp.Key}={kvp.Value}"));
-                    Logger.Log($"Startup scan ruleset distribution (first 2000): {dist}", Ez2ConfigManager.LOGGER_NAME, LogLevel.Important);
+                    executeSqliteMainRebuild(forceAll);
                 }
-            });
+                catch (Exception e)
+                {
+                    Logger.Error(e, "SQLite main rebuild failed.", Ez2ConfigManager.LOGGER_NAME);
+                }
+                finally
+                {
+                    lock (sqliteManualRebuildLock)
+                        sqliteMainRebuildQueued = false;
+                }
+            }, TaskCreationOptions.LongRunning);
+        }
 
-            if (beatmaps.Count == 0)
-                return;
-
+        public void QueueSqliteSongsBranchesRebuild(bool forceAll)
+        {
             if (!sqliteEnabled)
                 return;
 
-            var needingRecompute = analysisDatabase.GetBeatmapsNeedingRecompute(beatmaps);
+            lock (sqliteManualRebuildLock)
+            {
+                if (sqliteSongsBranchesRebuildQueued)
+                {
+                    Logger.Log("SQLite songs branch rebuild is already queued; ignoring duplicate request.", Ez2ConfigManager.LOGGER_NAME, LogLevel.Important);
+                    return;
+                }
 
+                sqliteSongsBranchesRebuildQueued = true;
+            }
+
+            Task.Factory.StartNew(() =>
+            {
+                try
+                {
+                    executeSqliteSongsBranchesRebuild(forceAll);
+                }
+                catch (Exception e)
+                {
+                    Logger.Error(e, "SQLite songs branch rebuild failed.", Ez2ConfigManager.LOGGER_NAME);
+                }
+                finally
+                {
+                    lock (sqliteManualRebuildLock)
+                        sqliteSongsBranchesRebuildQueued = false;
+                }
+            }, TaskCreationOptions.LongRunning);
+        }
+
+        private void executeSqliteMainRebuild(bool forceAll)
+        {
             if (!sqliteEnabled)
                 return;
+
+            if (forceAll)
+                analysisDatabase.TrySetForceRecompute(true);
+
+            IReadOnlyList<Guid> needingRecompute = forceAll
+                ? collectAllBeatmapIdsForSqlite()
+                : collectBeatmapsNeedingMainSqliteBackfill();
 
             if (needingRecompute.Count == 0)
             {
@@ -249,13 +244,85 @@ namespace osu.Game.EzOsuGame.Analysis
                 return;
             }
 
+            Logger.Log($"Manual SQLite main rebuild queued {needingRecompute.Count} beatmap(s) (forceAll={forceAll}).",
+                Ez2ConfigManager.LOGGER_NAME, LogLevel.Important);
+
+            queueBeatmapsForMainSqliteBackfill(needingRecompute);
+        }
+
+        private void executeSqliteSongsBranchesRebuild(bool forceAll)
+        {
+            if (!sqliteEnabled)
+                return;
+
+            var refreshPlans = forceAll
+                ? analysisDatabase.GetAllSongsBranchesForceRefreshPlans()
+                : analysisDatabase.GetSongsBranchesNeedingRefresh();
+
+            runSongsBranchRefreshPlans(refreshPlans);
+        }
+
+        private List<(Guid id, string hash, int rulesetOnlineId)> collectBeatmapDescriptorsForSqlite()
+        {
+            var beatmaps = new List<(Guid id, string hash, int rulesetOnlineId)>();
+
+            realmAccess.Run(r =>
+            {
+                foreach (var b in r.All<BeatmapInfo>())
+                {
+                    if (b.BeatmapSet == null)
+                        continue;
+
+                    if (b.BeatmapSet is { IsExternallyHosted: true })
+                        continue;
+
+                    beatmaps.Add((b.ID, b.Hash, b.Ruleset.OnlineID));
+                }
+            });
+
+            return beatmaps;
+        }
+
+        private IReadOnlyList<Guid> collectBeatmapsNeedingMainSqliteBackfill()
+        {
+            var beatmaps = collectBeatmapDescriptorsForSqlite();
+
+            if (beatmaps.Count == 0 || !sqliteEnabled)
+                return Array.Empty<Guid>();
+
+            return analysisDatabase.GetBeatmapsNeedingRecompute(beatmaps);
+        }
+
+        private IReadOnlyList<Guid> collectAllBeatmapIdsForSqlite()
+        {
+            var beatmapIds = new List<Guid>();
+
+            realmAccess.Run(r =>
+            {
+                foreach (var b in r.All<BeatmapInfo>())
+                {
+                    if (b.BeatmapSet == null)
+                        continue;
+
+                    if (b.BeatmapSet is { IsExternallyHosted: true })
+                        continue;
+
+                    beatmapIds.Add(b.ID);
+                }
+            });
+
+            return beatmapIds;
+        }
+
+        private void queueBeatmapsForMainSqliteBackfill(IReadOnlyList<Guid> beatmapIds)
+        {
             bool shouldSignalStartupWarmup = false;
 
             lock (pendingBeatmapLock)
             {
                 pendingBeatmapIds.Clear();
 
-                foreach (Guid id in needingRecompute)
+                foreach (Guid id in beatmapIds)
                     pendingBeatmapIds.Add(id);
 
                 if (!startupWarmupSignalPending)
@@ -268,15 +335,13 @@ namespace osu.Game.EzOsuGame.Analysis
             if (shouldSignalStartupWarmup)
                 startupWarmupSignal.Release();
 
-            postWarmupSummaryNotification(needingRecompute.Count);
+            postWarmupSummaryNotification(beatmapIds.Count);
         }
 
-        private void scanSongsBranchesNeedingRefresh()
+        private void runSongsBranchRefreshPlans(IReadOnlyList<EzAnalysisDatabase.SongsBranchRefreshPlan> refreshPlans)
         {
             if (!sqliteEnabled)
                 return;
-
-            var refreshPlans = analysisDatabase.GetSongsBranchesNeedingRefresh();
 
             if (refreshPlans.Count == 0)
             {
@@ -321,7 +386,6 @@ namespace osu.Game.EzOsuGame.Analysis
         }
 
         private ProgressNotification? songsBranchRefreshProgressNotification;
-        private int songsBranchRefreshTotalBeatmaps;
 
         private void postSongsBranchRefreshNotification(int branchCount, int totalBeatmaps)
         {
@@ -350,7 +414,6 @@ namespace osu.Game.EzOsuGame.Analysis
                     };
 
                     songsBranchRefreshProgressNotification = notification;
-                    songsBranchRefreshTotalBeatmaps = totalBeatmaps;
                     notificationOverlay.Post(notification);
                 }
                 catch (Exception e)
@@ -380,7 +443,6 @@ namespace osu.Game.EzOsuGame.Analysis
                         songsBranchRefreshProgressNotification.CompletionText = "Songs branch refresh complete";
                         songsBranchRefreshProgressNotification.State = ProgressNotificationState.Completed;
                         songsBranchRefreshProgressNotification = null;
-                        songsBranchRefreshTotalBeatmaps = 0;
                     }
                 }
                 catch
@@ -435,7 +497,7 @@ namespace osu.Game.EzOsuGame.Analysis
                         try
                         {
                             using var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, pendingBeatmapRecomputeCancellationSource.Token);
-                            recomputePendingBeatmap(beatmapId, skipExistingComparison: true, linkedCancellation.Token, source: "startup warmup");
+                            recomputePendingBeatmap(beatmapId, skipExistingComparison: true, linkedCancellation.Token, source: "manual sqlite rebuild");
                         }
                         catch (ObjectDisposedException)
                         {
@@ -518,7 +580,7 @@ namespace osu.Game.EzOsuGame.Analysis
                     if (startupWarmupProgressNotification != null)
                     {
                         int processed = startupWarmupTotalCount > 0 ? startupWarmupTotalCount - remaining : 0;
-                        startupWarmupProgressNotification.Text = $"Ez analysis startup scan queued {startupWarmupTotalCount} beatmaps for recompute ({processed} of {startupWarmupTotalCount})";
+                        startupWarmupProgressNotification.Text = $"Ez analysis rebuild queued {startupWarmupTotalCount} beatmaps for recompute ({processed} of {startupWarmupTotalCount})";
                         startupWarmupProgressNotification.Progress = startupWarmupTotalCount > 0 ? (float)processed / startupWarmupTotalCount : 1;
 
                         if (remaining <= 0)
@@ -613,7 +675,7 @@ namespace osu.Game.EzOsuGame.Analysis
                     {
                         notificationOverlay.Post(new SimpleNotification
                         {
-                            Text = $"Ez analysis startup scan queued {totalCount} beatmaps for recompute. Background sqlite warmup is still processing {remainingCount} remaining result(s)."
+                            Text = $"Ez analysis rebuild queued {totalCount} beatmaps for recompute. Background sqlite processing is still working through {remainingCount} remaining result(s)."
                         });
 
                         return;
@@ -621,7 +683,7 @@ namespace osu.Game.EzOsuGame.Analysis
 
                     var notification = new ProgressNotification
                     {
-                        Text = $"Ez analysis startup scan queued {totalCount} beatmaps for recompute ({totalCount - remainingCount} of {totalCount})",
+                        Text = $"Ez analysis rebuild queued {totalCount} beatmaps for recompute ({totalCount - remainingCount} of {totalCount})",
                         CompletionText = "beatmaps' analysis recompute is complete",
                         CancelRequested = () =>
                         {

--- a/osu.Game/EzOsuGame/Analysis/EzDataRebuildTarget.cs
+++ b/osu.Game/EzOsuGame/Analysis/EzDataRebuildTarget.cs
@@ -1,0 +1,29 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+using osu.Game.EzOsuGame.Localization;
+
+namespace osu.Game.EzOsuGame.Analysis
+{
+    public enum EzDataRebuildTarget
+    {
+        [LocalisableDescription(typeof(EzEnumStrings), nameof(EzEnumStrings.DATA_REBUILD_TARGET_REALM_TAGS))]
+        RealmTags = 0,
+
+        [LocalisableDescription(typeof(EzEnumStrings), nameof(EzEnumStrings.DATA_REBUILD_TARGET_REALM_XXY))]
+        RealmXxy = 1,
+
+        [LocalisableDescription(typeof(EzEnumStrings), nameof(EzEnumStrings.DATA_REBUILD_TARGET_REALM_PP))]
+        RealmPp = 2,
+
+        [LocalisableDescription(typeof(EzEnumStrings), nameof(EzEnumStrings.DATA_REBUILD_TARGET_REALM_ALL))]
+        RealmAll = 3,
+
+        [LocalisableDescription(typeof(EzEnumStrings), nameof(EzEnumStrings.DATA_REBUILD_TARGET_SQLITE_MAIN))]
+        SqliteMain = 4,
+
+        [LocalisableDescription(typeof(EzEnumStrings), nameof(EzEnumStrings.DATA_REBUILD_TARGET_SQLITE_BRANCHES))]
+        SqliteSongsBranches = 5,
+    }
+}

--- a/osu.Game/EzOsuGame/Database/EzRealmMetadataScope.cs
+++ b/osu.Game/EzOsuGame/Database/EzRealmMetadataScope.cs
@@ -1,0 +1,16 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Game.EzOsuGame.Database
+{
+    [Flags]
+    public enum EzRealmMetadataScope
+    {
+        Tags = 1,
+        Xxy = 2,
+        Pp = 4,
+        All = Tags | Xxy | Pp,
+    }
+}

--- a/osu.Game/EzOsuGame/Localization/EzEnumStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzEnumStrings.cs
@@ -40,5 +40,12 @@ namespace osu.Game.EzOsuGame.Localization
 
         public static readonly LocalisableString IGNORE_BETTER = new EzLocalizationManager.EzLocalisableString("忽略更好", "Ignore Better");
         public static readonly LocalisableString IGNORE_WORSE = new EzLocalizationManager.EzLocalisableString("忽略更差", "Ignore Worse");
+
+        public static readonly LocalisableString DATA_REBUILD_TARGET_REALM_TAGS = new EzLocalizationManager.EzLocalisableString("Realm Tag", "Realm Tag");
+        public static readonly LocalisableString DATA_REBUILD_TARGET_REALM_XXY = new EzLocalizationManager.EzLocalisableString("Realm Xxy 星级", "Realm Xxy SR");
+        public static readonly LocalisableString DATA_REBUILD_TARGET_REALM_PP = new EzLocalizationManager.EzLocalisableString("Realm PP", "Realm PP");
+        public static readonly LocalisableString DATA_REBUILD_TARGET_REALM_ALL = new EzLocalizationManager.EzLocalisableString("Realm 全部元数据", "Realm all metadata");
+        public static readonly LocalisableString DATA_REBUILD_TARGET_SQLITE_MAIN = new EzLocalizationManager.EzLocalisableString("SQLite 主库 kps/KPC", "SQLite main kps/KPC");
+        public static readonly LocalisableString DATA_REBUILD_TARGET_SQLITE_BRANCHES = new EzLocalizationManager.EzLocalisableString("SQLite 分支曲库 xxy/PP", "SQLite songs branches xxy/PP");
     }
 }


### PR DESCRIPTION
## Summary

- 添加 EzDataRebuildTarget / EzRealmMetadataScope 类型定义（无运行时行为变化，为 PR2 设置页维护功能做准备）
- BackgroundDataStoreProcessor 启动回填与手动 QueueEzRealmMetadataBackfill 共用互斥 gate，避免并发写 Realm
- EzAnalysisWarmupProcessor 移除启动全库 SQLite 扫描：已有匹配当前版本主库时不自动预热，仅在缺库、可迁移旧库或 schema 需升级时增量补算

## Test plan

- [ ] dotnet build osu.Game 通过
- [ ] 大库冷启动：主菜单前 FPS 不再因 SQLite 全库扫描长时间极低
- [ ] 已有匹配版本 ez-analysis sqlite 时，启动日志不出现全库 Startup scan
- [ ] 缺库或 schema 需升级时仍会自动增量补算
- [ ] 启动 Realm 回填进行中，手动补算应被忽略
- [ ] 本 PR 不含设置页维护 UI（见后续 PR2）

Made with [Cursor](https://cursor.com)