### PR TITLE
设置页数据维护 UI 与 dispatch 层（PR2/2）

### DIFF
--- a/osu.Game.Tests/EzOsuGame/Analysis/EzDataRebuildDispatcherTest.cs
+++ b/osu.Game.Tests/EzOsuGame/Analysis/EzDataRebuildDispatcherTest.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
-using osu.Game.Database;
 using osu.Game.EzOsuGame.Analysis;
 using osu.Game.EzOsuGame.Database;
 
@@ -101,7 +100,7 @@ namespace osu.Game.Tests.EzOsuGame.Analysis
         [TestCase(EzDataRebuildTarget.RealmAll)]
         public void TestRealmTargetsUnavailableWhenProcessorMissing(EzDataRebuildTarget target)
         {
-            var dispatcher = new EzDataRebuildDispatcher((BackgroundDataStoreProcessor?)null, (EzAnalysisWarmupProcessor?)null);
+            var dispatcher = new EzDataRebuildDispatcher(null, null);
 
             Assert.That(dispatcher.Execute(target, forceAll: false), Is.EqualTo(EzDataRebuildDispatchResult.UnavailableProcessor));
         }
@@ -110,7 +109,7 @@ namespace osu.Game.Tests.EzOsuGame.Analysis
         [TestCase(EzDataRebuildTarget.SqliteSongsBranches)]
         public void TestSqliteTargetsUnavailableWhenProcessorMissing(EzDataRebuildTarget target)
         {
-            var dispatcher = new EzDataRebuildDispatcher((BackgroundDataStoreProcessor?)null, (EzAnalysisWarmupProcessor?)null);
+            var dispatcher = new EzDataRebuildDispatcher(null, null);
 
             Assert.That(dispatcher.Execute(target, forceAll: false), Is.EqualTo(EzDataRebuildDispatchResult.UnavailableProcessor));
         }

--- a/osu.Game.Tests/EzOsuGame/Analysis/EzDataRebuildDispatcherTest.cs
+++ b/osu.Game.Tests/EzOsuGame/Analysis/EzDataRebuildDispatcherTest.cs
@@ -1,0 +1,161 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Database;
+using osu.Game.EzOsuGame.Analysis;
+using osu.Game.EzOsuGame.Database;
+
+namespace osu.Game.Tests.EzOsuGame.Analysis
+{
+    [TestFixture]
+    public class EzDataRebuildDispatcherTest
+    {
+        [TestCase(EzDataRebuildTarget.RealmTags, EzRealmMetadataScope.Tags)]
+        [TestCase(EzDataRebuildTarget.RealmXxy, EzRealmMetadataScope.Xxy)]
+        [TestCase(EzDataRebuildTarget.RealmPp, EzRealmMetadataScope.Pp)]
+        [TestCase(EzDataRebuildTarget.RealmAll, EzRealmMetadataScope.All)]
+        public void TestRealmTargetsDispatchWithCorrectScope(EzDataRebuildTarget target, EzRealmMetadataScope expectedScope)
+        {
+            EzRealmMetadataScope? capturedScope = null;
+            bool? capturedForceAll = null;
+
+            var dispatcher = new EzDataRebuildDispatcher(
+                (scope, forceAll) =>
+                {
+                    capturedScope = scope;
+                    capturedForceAll = forceAll;
+                    return EzDataRebuildDispatchResult.Queued;
+                },
+                null,
+                null);
+
+            Assert.That(dispatcher.Execute(target, forceAll: false), Is.EqualTo(EzDataRebuildDispatchResult.Queued));
+            Assert.That(capturedScope, Is.EqualTo(expectedScope));
+            Assert.That(capturedForceAll, Is.False);
+
+            Assert.That(dispatcher.Execute(target, forceAll: true), Is.EqualTo(EzDataRebuildDispatchResult.Queued));
+            Assert.That(capturedScope, Is.EqualTo(expectedScope));
+            Assert.That(capturedForceAll, Is.True);
+        }
+
+        [Test]
+        public void TestSqliteMainDispatchPropagatesForceAll()
+        {
+            bool? capturedForceAll = null;
+
+            var dispatcher = new EzDataRebuildDispatcher(
+                null,
+                forceAll =>
+                {
+                    capturedForceAll = forceAll;
+                    return EzDataRebuildDispatchResult.Queued;
+                },
+                null);
+
+            Assert.That(dispatcher.Execute(EzDataRebuildTarget.SqliteMain, forceAll: false), Is.EqualTo(EzDataRebuildDispatchResult.Queued));
+            Assert.That(capturedForceAll, Is.False);
+
+            Assert.That(dispatcher.Execute(EzDataRebuildTarget.SqliteMain, forceAll: true), Is.EqualTo(EzDataRebuildDispatchResult.Queued));
+            Assert.That(capturedForceAll, Is.True);
+        }
+
+        [Test]
+        public void TestSqliteSongsBranchesDispatchPropagatesForceAll()
+        {
+            bool? capturedForceAll = null;
+
+            var dispatcher = new EzDataRebuildDispatcher(
+                null,
+                null,
+                forceAll =>
+                {
+                    capturedForceAll = forceAll;
+                    return EzDataRebuildDispatchResult.Queued;
+                });
+
+            Assert.That(dispatcher.Execute(EzDataRebuildTarget.SqliteSongsBranches, forceAll: false), Is.EqualTo(EzDataRebuildDispatchResult.Queued));
+            Assert.That(capturedForceAll, Is.False);
+
+            Assert.That(dispatcher.Execute(EzDataRebuildTarget.SqliteSongsBranches, forceAll: true), Is.EqualTo(EzDataRebuildDispatchResult.Queued));
+            Assert.That(capturedForceAll, Is.True);
+        }
+
+        [TestCase(EzDataRebuildDispatchResult.AlreadyRunning)]
+        [TestCase(EzDataRebuildDispatchResult.SqliteDisabled)]
+        public void TestQueueDelegateResultIsPropagated(EzDataRebuildDispatchResult delegateResult)
+        {
+            var dispatcher = new EzDataRebuildDispatcher(
+                (_, _) => delegateResult,
+                _ => delegateResult,
+                _ => delegateResult);
+
+            Assert.That(dispatcher.Execute(EzDataRebuildTarget.RealmAll, forceAll: false), Is.EqualTo(delegateResult));
+            Assert.That(dispatcher.Execute(EzDataRebuildTarget.SqliteMain, forceAll: false), Is.EqualTo(delegateResult));
+            Assert.That(dispatcher.Execute(EzDataRebuildTarget.SqliteSongsBranches, forceAll: false), Is.EqualTo(delegateResult));
+        }
+
+        [TestCase(EzDataRebuildTarget.RealmTags)]
+        [TestCase(EzDataRebuildTarget.RealmXxy)]
+        [TestCase(EzDataRebuildTarget.RealmPp)]
+        [TestCase(EzDataRebuildTarget.RealmAll)]
+        public void TestRealmTargetsUnavailableWhenProcessorMissing(EzDataRebuildTarget target)
+        {
+            var dispatcher = new EzDataRebuildDispatcher((BackgroundDataStoreProcessor?)null, (EzAnalysisWarmupProcessor?)null);
+
+            Assert.That(dispatcher.Execute(target, forceAll: false), Is.EqualTo(EzDataRebuildDispatchResult.UnavailableProcessor));
+        }
+
+        [TestCase(EzDataRebuildTarget.SqliteMain)]
+        [TestCase(EzDataRebuildTarget.SqliteSongsBranches)]
+        public void TestSqliteTargetsUnavailableWhenProcessorMissing(EzDataRebuildTarget target)
+        {
+            var dispatcher = new EzDataRebuildDispatcher((BackgroundDataStoreProcessor?)null, (EzAnalysisWarmupProcessor?)null);
+
+            Assert.That(dispatcher.Execute(target, forceAll: false), Is.EqualTo(EzDataRebuildDispatchResult.UnavailableProcessor));
+        }
+
+        [Test]
+        public void TestUnknownTargetReturnsUnknownTarget()
+        {
+            var dispatcher = new EzDataRebuildDispatcher(
+                (_, _) => EzDataRebuildDispatchResult.Queued,
+                _ => EzDataRebuildDispatchResult.Queued,
+                _ => EzDataRebuildDispatchResult.Queued);
+
+            Assert.That(dispatcher.Execute((EzDataRebuildTarget)999, forceAll: false), Is.EqualTo(EzDataRebuildDispatchResult.UnknownTarget));
+        }
+
+        [TestCase(EzDataRebuildTarget.RealmTags, true, false, false)]
+        [TestCase(EzDataRebuildTarget.RealmAll, true, false, false)]
+        [TestCase(EzDataRebuildTarget.SqliteMain, false, true, false)]
+        [TestCase(EzDataRebuildTarget.SqliteSongsBranches, false, false, true)]
+        public void TestCanDispatch(EzDataRebuildTarget target, bool hasRealm, bool hasSqliteMain, bool hasSqliteBranches)
+        {
+            var dispatcher = new EzDataRebuildDispatcher(
+                hasRealm ? (_, _) => EzDataRebuildDispatchResult.Queued : null,
+                hasSqliteMain ? _ => EzDataRebuildDispatchResult.Queued : null,
+                hasSqliteBranches ? _ => EzDataRebuildDispatchResult.Queued : null);
+
+            Assert.That(dispatcher.CanDispatch(target), Is.True);
+        }
+
+        [TestCase(EzDataRebuildTarget.RealmTags)]
+        [TestCase(EzDataRebuildTarget.RealmAll)]
+        public void TestCanDispatchFalseWhenRealmProcessorMissing(EzDataRebuildTarget target)
+        {
+            var dispatcher = new EzDataRebuildDispatcher(null, _ => EzDataRebuildDispatchResult.Queued, _ => EzDataRebuildDispatchResult.Queued);
+
+            Assert.That(dispatcher.CanDispatch(target), Is.False);
+        }
+
+        [TestCase(EzDataRebuildTarget.SqliteMain)]
+        [TestCase(EzDataRebuildTarget.SqliteSongsBranches)]
+        public void TestCanDispatchFalseWhenWarmupProcessorMissing(EzDataRebuildTarget target)
+        {
+            var dispatcher = new EzDataRebuildDispatcher((_, _) => EzDataRebuildDispatchResult.Queued, null, null);
+
+            Assert.That(dispatcher.CanDispatch(target), Is.False);
+        }
+    }
+}

--- a/osu.Game.Tests/EzOsuGame/Analysis/EzDataRebuildMaintenanceHandlerTest.cs
+++ b/osu.Game.Tests/EzOsuGame/Analysis/EzDataRebuildMaintenanceHandlerTest.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Moq;
+using NUnit.Framework;
+using osu.Game.EzOsuGame.Analysis;
+using osu.Game.Overlays;
+
+namespace osu.Game.Tests.EzOsuGame.Analysis
+{
+    [TestFixture]
+    public class EzDataRebuildMaintenanceHandlerTest
+    {
+        [TestCase(EzDataRebuildDispatchResult.UnavailableProcessor)]
+        [TestCase(EzDataRebuildDispatchResult.AlreadyRunning)]
+        [TestCase(EzDataRebuildDispatchResult.SqliteDisabled)]
+        public void TestGetErrorMessageReturnsMessageForFailureResults(EzDataRebuildDispatchResult result)
+        {
+            Assert.That(EzDataRebuildMaintenanceHandler.GetErrorMessage(result).ToString(), Is.Not.Empty);
+        }
+
+        [Test]
+        public void TestCanExecuteRequiresDialogAndDispatchAvailability()
+        {
+            var dispatcher = new EzDataRebuildDispatcher((_, _) => EzDataRebuildDispatchResult.Queued, null, null);
+            var dialogOverlay = new Mock<IDialogOverlay>().Object;
+            var handlerWithDialog = new EzDataRebuildMaintenanceHandler(dispatcher, dialogOverlay, notifications: null);
+            var handlerWithoutDialog = new EzDataRebuildMaintenanceHandler(dispatcher, dialogOverlay: null, notifications: null);
+
+            Assert.That(handlerWithDialog.CanExecute(EzDataRebuildTarget.RealmAll), Is.True);
+            Assert.That(handlerWithoutDialog.CanExecute(EzDataRebuildTarget.RealmAll), Is.False);
+            Assert.That(handlerWithDialog.CanExecute(EzDataRebuildTarget.SqliteMain), Is.False);
+        }
+    }
+}

--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -421,9 +421,19 @@ namespace osu.Game.Database
 
             realmAccess.Run(r =>
             {
-                foreach (var b in r.All<BeatmapInfo>().Where(b => b.XxyStarRating < 0 && b.BeatmapSet != null).AsEnumerable()
-                                   .Where(b => EzXxyStarRatingSupport.SupportsRuleset(b.Ruleset)))
+                foreach (var b in r.All<BeatmapInfo>())
+                {
+                    if (b.BeatmapSet == null)
+                        continue;
+
+                    if (b.XxyStarRating >= 0)
+                        continue;
+
+                    if (!EzXxyStarRatingSupport.SupportsRuleset(b.Ruleset))
+                        continue;
+
                     beatmapIds.Add(b.ID);
+                }
             });
 
             if (beatmapIds.Count == 0)
@@ -487,9 +497,16 @@ namespace osu.Game.Database
 
             realmAccess.Run(r =>
             {
-                foreach (var beatmap in r.All<BeatmapInfo>().Where(b => b.BeatmapSet != null).AsEnumerable()
-                                         .Where(b => b.HasVideo == null || b.HasStoryboard == null))
+                foreach (var beatmap in r.All<BeatmapInfo>())
+                {
+                    if (beatmap.BeatmapSet == null)
+                        continue;
+
+                    if (beatmap.HasVideo != null && beatmap.HasStoryboard != null)
+                        continue;
+
                     beatmapIds.Add(beatmap.ID);
+                }
             });
 
             if (beatmapIds.Count == 0)
@@ -557,9 +574,19 @@ namespace osu.Game.Database
 
             realmAccess.Run(r =>
             {
-                foreach (var b in r.All<BeatmapInfo>().Where(b => b.BeatmapSet != null && b.PerformancePoints < 0).AsEnumerable()
-                                   .Where(b => EzXxyStarRatingSupport.IsRulesetAvailable(b.Ruleset)))
+                foreach (var b in r.All<BeatmapInfo>())
+                {
+                    if (b.BeatmapSet == null)
+                        continue;
+
+                    if (b.PerformancePoints >= 0)
+                        continue;
+
+                    if (!EzXxyStarRatingSupport.IsRulesetAvailable(b.Ruleset))
+                        continue;
+
                     beatmapIds.Add(b.ID);
+                }
             });
 
             if (beatmapIds.Count == 0)
@@ -1240,10 +1267,23 @@ namespace osu.Game.Database
             config.SetValue(OsuSetting.LastOnlineTagsPopulation, metadataSourceFetchDate);
         }
 
+        private int lastNotificationProgressReported = -1;
+
+        private const int notification_progress_update_interval = 50;
+
         private void updateNotificationProgress(ProgressNotification? notification, int processedCount, int totalCount)
         {
             if (notification == null)
                 return;
+
+            bool shouldUpdate = processedCount == 0
+                                  || processedCount >= totalCount
+                                  || processedCount - lastNotificationProgressReported >= notification_progress_update_interval;
+
+            if (!shouldUpdate)
+                return;
+
+            lastNotificationProgressReported = processedCount;
 
             Schedule(() =>
             {
@@ -1302,6 +1342,8 @@ namespace osu.Game.Database
                 CompletionText = completed,
                 State = ProgressNotificationState.Active
             };
+
+            lastNotificationProgressReported = -1;
 
             Schedule(() => notificationOverlay?.Post(notification));
 

--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -86,18 +86,18 @@ namespace osu.Game.Database
         /// Queue Ez Realm metadata backfill (Tag / XxySR / PP) on a background thread.
         /// </summary>
         /// <param name="forceAll">When true, clears persisted values first so all supported beatmaps are recomputed.</param>
-        public void QueueEzRealmMetadataBackfill(bool forceAll = false)
+        public EzDataRebuildDispatchResult QueueEzRealmMetadataBackfill(bool forceAll = false)
             => QueueEzRealmMetadataRebuild(EzRealmMetadataScope.All, forceAll);
 
         /// <summary>
         /// Queue scoped Ez Realm metadata rebuild on a background thread.
         /// </summary>
-        public void QueueEzRealmMetadataRebuild(EzRealmMetadataScope scope, bool forceAll)
+        public EzDataRebuildDispatchResult QueueEzRealmMetadataRebuild(EzRealmMetadataScope scope, bool forceAll)
         {
             if (!tryBeginEzRealmMetadataBackfill())
             {
                 Logger.Log("Ez Realm metadata backfill is already running; ignoring duplicate request.");
-                return;
+                return EzDataRebuildDispatchResult.AlreadyRunning;
             }
 
             Task.Factory.StartNew(() =>
@@ -118,6 +118,8 @@ namespace osu.Game.Database
                     endEzRealmMetadataBackfill();
                 }
             }, TaskCreationOptions.LongRunning);
+
+            return EzDataRebuildDispatchResult.Queued;
         }
 
         private bool tryBeginEzRealmMetadataBackfill()

--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -18,6 +18,7 @@ using osu.Framework.Platform;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.EzOsuGame.Analysis;
+using osu.Game.EzOsuGame.Database;
 using osu.Game.Extensions;
 using osu.Game.Online.API;
 using osu.Game.Overlays;
@@ -86,6 +87,12 @@ namespace osu.Game.Database
         /// </summary>
         /// <param name="forceAll">When true, clears persisted values first so all supported beatmaps are recomputed.</param>
         public void QueueEzRealmMetadataBackfill(bool forceAll = false)
+            => QueueEzRealmMetadataRebuild(EzRealmMetadataScope.All, forceAll);
+
+        /// <summary>
+        /// Queue scoped Ez Realm metadata rebuild on a background thread.
+        /// </summary>
+        public void QueueEzRealmMetadataRebuild(EzRealmMetadataScope scope, bool forceAll)
         {
             if (!tryBeginEzRealmMetadataBackfill())
             {
@@ -98,9 +105,9 @@ namespace osu.Game.Database
                 try
                 {
                     if (forceAll)
-                        forceEzRealmMetadataRecalculation();
+                        clearEzRealmMetadata(scope);
 
-                    runEzRealmMetadataBackfill();
+                    runEzRealmMetadataBackfill(scope);
                 }
                 catch (Exception e)
                 {
@@ -262,15 +269,23 @@ namespace osu.Game.Database
         }
 
         private void runEzRealmMetadataBackfill()
+            => runEzRealmMetadataBackfill(EzRealmMetadataScope.All);
+
+        private void runEzRealmMetadataBackfill(EzRealmMetadataScope scope)
         {
-            populateMissingXxyStarRatings();
-            populateMissingPerformancePoints();
-            populateMissingBeatmapTagFlags();
+            if (scope.HasFlag(EzRealmMetadataScope.Xxy))
+                populateMissingXxyStarRatings();
+
+            if (scope.HasFlag(EzRealmMetadataScope.Pp))
+                populateMissingPerformancePoints();
+
+            if (scope.HasFlag(EzRealmMetadataScope.Tags))
+                populateMissingBeatmapTagFlags();
         }
 
-        private void forceEzRealmMetadataRecalculation()
+        private void clearEzRealmMetadata(EzRealmMetadataScope scope)
         {
-            Logger.Log("Forcing Ez Realm metadata recalculation (Tag / XxySR / PP)...");
+            Logger.Log($"Forcing Ez Realm metadata recalculation ({scope})...");
 
             int beatmapCount = 0;
 
@@ -281,8 +296,11 @@ namespace osu.Game.Database
                     if (beatmap.BeatmapSet == null)
                         continue;
 
-                    beatmap.HasVideo = null;
-                    beatmap.HasStoryboard = null;
+                    if (scope.HasFlag(EzRealmMetadataScope.Tags))
+                    {
+                        beatmap.HasVideo = null;
+                        beatmap.HasStoryboard = null;
+                    }
 
                     // Third-party / unavailable rulesets: keep persisted xxy/pp until the assembly is loadable again.
                     if (!EzXxyStarRatingSupport.IsRulesetAvailable(beatmap.Ruleset))
@@ -291,17 +309,21 @@ namespace osu.Game.Database
                         continue;
                     }
 
-                    beatmap.PerformancePoints = -1;
+                    if (scope.HasFlag(EzRealmMetadataScope.Pp))
+                        beatmap.PerformancePoints = -1;
 
-                    if (EzXxyStarRatingSupport.SupportsRuleset(beatmap.Ruleset))
+                    if (scope.HasFlag(EzRealmMetadataScope.Xxy) && EzXxyStarRatingSupport.SupportsRuleset(beatmap.Ruleset))
                         beatmap.XxyStarRating = -1;
 
                     beatmapCount++;
                 }
             });
 
-            Logger.Log($"Marked {beatmapCount} beatmaps for Ez Realm metadata recalculation.");
+            Logger.Log($"Marked {beatmapCount} beatmaps for Ez Realm metadata recalculation ({scope}).");
         }
+
+        private void forceEzRealmMetadataRecalculation()
+            => clearEzRealmMetadata(EzRealmMetadataScope.All);
 
         /// <remarks>
         /// This is split out from <see cref="processOnlineBeatmapSetsWithNoUpdate"/> as a separate process to prevent high server-side load

--- a/osu.Game/EzOsuGame/Analysis/EzAnalysisWarmupProcessor.cs
+++ b/osu.Game/EzOsuGame/Analysis/EzAnalysisWarmupProcessor.cs
@@ -158,17 +158,17 @@ namespace osu.Game.EzOsuGame.Analysis
             }, TaskCreationOptions.LongRunning);
         }
 
-        public void QueueSqliteMainRebuild(bool forceAll)
+        public EzDataRebuildDispatchResult QueueSqliteMainRebuild(bool forceAll)
         {
             if (!sqliteEnabled)
-                return;
+                return EzDataRebuildDispatchResult.SqliteDisabled;
 
             lock (sqliteManualRebuildLock)
             {
                 if (sqliteMainRebuildQueued)
                 {
                     Logger.Log("SQLite main rebuild is already queued; ignoring duplicate request.", Ez2ConfigManager.LOGGER_NAME, LogLevel.Important);
-                    return;
+                    return EzDataRebuildDispatchResult.AlreadyRunning;
                 }
 
                 sqliteMainRebuildQueued = true;
@@ -190,19 +190,21 @@ namespace osu.Game.EzOsuGame.Analysis
                         sqliteMainRebuildQueued = false;
                 }
             }, TaskCreationOptions.LongRunning);
+
+            return EzDataRebuildDispatchResult.Queued;
         }
 
-        public void QueueSqliteSongsBranchesRebuild(bool forceAll)
+        public EzDataRebuildDispatchResult QueueSqliteSongsBranchesRebuild(bool forceAll)
         {
             if (!sqliteEnabled)
-                return;
+                return EzDataRebuildDispatchResult.SqliteDisabled;
 
             lock (sqliteManualRebuildLock)
             {
                 if (sqliteSongsBranchesRebuildQueued)
                 {
                     Logger.Log("SQLite songs branch rebuild is already queued; ignoring duplicate request.", Ez2ConfigManager.LOGGER_NAME, LogLevel.Important);
-                    return;
+                    return EzDataRebuildDispatchResult.AlreadyRunning;
                 }
 
                 sqliteSongsBranchesRebuildQueued = true;
@@ -224,6 +226,8 @@ namespace osu.Game.EzOsuGame.Analysis
                         sqliteSongsBranchesRebuildQueued = false;
                 }
             }, TaskCreationOptions.LongRunning);
+
+            return EzDataRebuildDispatchResult.Queued;
         }
 
         private void executeSqliteMainRebuild(bool forceAll)

--- a/osu.Game/EzOsuGame/Analysis/EzAnalysisWarmupProcessor.cs
+++ b/osu.Game/EzOsuGame/Analysis/EzAnalysisWarmupProcessor.cs
@@ -60,10 +60,14 @@ namespace osu.Game.EzOsuGame.Analysis
 
         protected virtual int TimeToSleepDuringGameplay => 30000;
         private readonly object pendingBeatmapLock = new object();
-        private readonly HashSet<Guid> pendingBeatmapIds = new HashSet<Guid>();
+        private readonly Queue<Guid> pendingBeatmapQueue = new Queue<Guid>();
         private readonly HashSet<Guid> inFlightBeatmapIds = new HashSet<Guid>();
         private ProgressNotification? startupWarmupProgressNotification;
         private int startupWarmupTotalCount;
+        private int startupWarmupProcessedCount;
+        private int lastStartupWarmupProgressReported = -1;
+
+        private const int warmup_progress_update_interval = 50;
         private readonly SemaphoreSlim startupWarmupSignal = new SemaphoreSlim(0, 1);
         private readonly SemaphoreSlim selectedBeatmapRecomputeSignal = new SemaphoreSlim(0, 1);
         private readonly CancellationTokenSource startupWarmupCancellationSource = new CancellationTokenSource();
@@ -324,10 +328,12 @@ namespace osu.Game.EzOsuGame.Analysis
 
             lock (pendingBeatmapLock)
             {
-                pendingBeatmapIds.Clear();
+                pendingBeatmapQueue.Clear();
+                startupWarmupProcessedCount = 0;
+                lastStartupWarmupProgressReported = -1;
 
                 foreach (Guid id in beatmapIds)
-                    pendingBeatmapIds.Add(id);
+                    pendingBeatmapQueue.Enqueue(id);
 
                 if (!startupWarmupSignalPending)
                 {
@@ -390,6 +396,7 @@ namespace osu.Game.EzOsuGame.Analysis
         }
 
         private ProgressNotification? songsBranchRefreshProgressNotification;
+        private int lastSongsBranchBeatmapProgressReported = -1;
 
         private void postSongsBranchRefreshNotification(int branchCount, int totalBeatmaps)
         {
@@ -418,6 +425,7 @@ namespace osu.Game.EzOsuGame.Analysis
                     };
 
                     songsBranchRefreshProgressNotification = notification;
+                    lastSongsBranchBeatmapProgressReported = -1;
                     notificationOverlay.Post(notification);
                 }
                 catch (Exception e)
@@ -431,6 +439,21 @@ namespace osu.Game.EzOsuGame.Analysis
         {
             if (songsBranchRefreshProgressNotification == null)
                 return;
+
+            if (processedBeatmaps > 0 && branchBeatmapTotal > 0)
+            {
+                bool shouldUpdate = processedBeatmaps >= branchBeatmapTotal
+                                    || processedBeatmaps - lastSongsBranchBeatmapProgressReported >= warmup_progress_update_interval;
+
+                if (!shouldUpdate)
+                    return;
+
+                lastSongsBranchBeatmapProgressReported = processedBeatmaps;
+            }
+            else
+            {
+                lastSongsBranchBeatmapProgressReported = -1;
+            }
 
             Schedule(() =>
             {
@@ -565,9 +588,7 @@ namespace osu.Game.EzOsuGame.Analysis
 
                 if (beatmap == null)
                 {
-                    lock (pendingBeatmapLock)
-                        pendingBeatmapIds.Remove(beatmapId);
-
+                    updateStartupWarmupProgressNotification();
                     return;
                 }
 
@@ -575,27 +596,7 @@ namespace osu.Game.EzOsuGame.Analysis
                                 .GetAwaiter()
                                 .GetResult();
 
-                lock (pendingBeatmapLock)
-                {
-                    pendingBeatmapIds.Remove(beatmapId);
-
-                    int remaining = pendingBeatmapIds.Count;
-
-                    if (startupWarmupProgressNotification != null)
-                    {
-                        int processed = startupWarmupTotalCount > 0 ? startupWarmupTotalCount - remaining : 0;
-                        startupWarmupProgressNotification.Text = $"Ez analysis rebuild queued {startupWarmupTotalCount} beatmaps for recompute ({processed} of {startupWarmupTotalCount})";
-                        startupWarmupProgressNotification.Progress = startupWarmupTotalCount > 0 ? (float)processed / startupWarmupTotalCount : 1;
-
-                        if (remaining <= 0)
-                        {
-                            startupWarmupProgressNotification.CompletionText = $"{startupWarmupTotalCount} beatmaps' analysis recompute complete";
-                            startupWarmupProgressNotification.State = ProgressNotificationState.Completed;
-                            startupWarmupProgressNotification = null;
-                            startupWarmupTotalCount = 0;
-                        }
-                    }
-                }
+                updateStartupWarmupProgressNotification();
 
                 ((IWorkingBeatmapCache)beatmapManager).Invalidate(beatmap);
 
@@ -620,13 +621,12 @@ namespace osu.Game.EzOsuGame.Analysis
         {
             lock (pendingBeatmapLock)
             {
-                foreach (Guid pendingBeatmapId in pendingBeatmapIds)
+                while (pendingBeatmapQueue.Count > 0)
                 {
-                    if (!inFlightBeatmapIds.Add(pendingBeatmapId))
-                        continue;
+                    beatmapId = pendingBeatmapQueue.Dequeue();
 
-                    beatmapId = pendingBeatmapId;
-                    return true;
+                    if (inFlightBeatmapIds.Add(beatmapId))
+                        return true;
                 }
             }
 
@@ -637,7 +637,64 @@ namespace osu.Game.EzOsuGame.Analysis
         private int getPendingBeatmapCount()
         {
             lock (pendingBeatmapLock)
-                return pendingBeatmapIds.Count;
+                return pendingBeatmapQueue.Count + inFlightBeatmapIds.Count;
+        }
+
+        private void updateStartupWarmupProgressNotification()
+        {
+            ProgressNotification? notification;
+            int processed;
+            int total;
+
+            lock (pendingBeatmapLock)
+            {
+                startupWarmupProcessedCount++;
+                processed = startupWarmupProcessedCount;
+                total = startupWarmupTotalCount;
+                notification = startupWarmupProgressNotification;
+
+                if (notification == null)
+                    return;
+
+                bool isComplete = total > 0 && processed >= total;
+                bool shouldUpdate = total <= 10
+                                    || isComplete
+                                    || processed - lastStartupWarmupProgressReported >= warmup_progress_update_interval;
+
+                if (!shouldUpdate)
+                    return;
+
+                lastStartupWarmupProgressReported = processed;
+
+                if (isComplete)
+                {
+                    startupWarmupProgressNotification = null;
+                    startupWarmupTotalCount = 0;
+                    startupWarmupProcessedCount = 0;
+                    lastStartupWarmupProgressReported = -1;
+                }
+            }
+
+            Schedule(() =>
+            {
+                try
+                {
+                    if (notification.State == ProgressNotificationState.Cancelled)
+                        return;
+
+                    notification.Text = $"Ez analysis rebuild queued {total} beatmaps for recompute ({processed} of {total})";
+                    notification.Progress = total > 0 ? (float)processed / total : 1;
+
+                    if (processed >= total)
+                    {
+                        notification.CompletionText = $"{total} beatmaps' analysis recompute complete";
+                        notification.State = ProgressNotificationState.Completed;
+                    }
+                }
+                catch
+                {
+                }
+            });
         }
 
         private void cancelPendingBeatmapProcessing()
@@ -646,7 +703,9 @@ namespace osu.Game.EzOsuGame.Analysis
 
             lock (pendingBeatmapLock)
             {
-                pendingBeatmapIds.Clear();
+                pendingBeatmapQueue.Clear();
+                startupWarmupProcessedCount = 0;
+                lastStartupWarmupProgressReported = -1;
                 queuedSelectedBeatmapId = null;
                 startupWarmupSignalPending = false;
                 selectedBeatmapRecomputeSignalPending = false;
@@ -701,6 +760,8 @@ namespace osu.Game.EzOsuGame.Analysis
                     {
                         startupWarmupProgressNotification = notification;
                         startupWarmupTotalCount = totalCount;
+                        startupWarmupProcessedCount = 0;
+                        lastStartupWarmupProgressReported = -1;
                     }
 
                     notificationOverlay.Post(notification);

--- a/osu.Game/EzOsuGame/Analysis/EzDataRebuildDispatchResult.cs
+++ b/osu.Game/EzOsuGame/Analysis/EzDataRebuildDispatchResult.cs
@@ -1,0 +1,14 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.EzOsuGame.Analysis
+{
+    public enum EzDataRebuildDispatchResult
+    {
+        Queued,
+        UnavailableProcessor,
+        AlreadyRunning,
+        SqliteDisabled,
+        UnknownTarget,
+    }
+}

--- a/osu.Game/EzOsuGame/Analysis/EzDataRebuildDispatcher.cs
+++ b/osu.Game/EzOsuGame/Analysis/EzDataRebuildDispatcher.cs
@@ -1,0 +1,127 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Logging;
+using osu.Game.Database;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Database;
+
+namespace osu.Game.EzOsuGame.Analysis
+{
+    public class EzDataRebuildDispatcher
+    {
+        private readonly BackgroundDataStoreProcessor? backgroundDataStoreProcessor;
+        private readonly EzAnalysisWarmupProcessor? warmupProcessor;
+        private readonly Func<EzRealmMetadataScope, bool, EzDataRebuildDispatchResult>? queueRealm;
+        private readonly Func<bool, EzDataRebuildDispatchResult>? queueSqliteMain;
+        private readonly Func<bool, EzDataRebuildDispatchResult>? queueSqliteSongsBranches;
+
+        public EzDataRebuildDispatcher(
+            BackgroundDataStoreProcessor? backgroundDataStoreProcessor,
+            EzAnalysisWarmupProcessor? warmupProcessor)
+            : this(
+                backgroundDataStoreProcessor == null ? null : backgroundDataStoreProcessor.QueueEzRealmMetadataRebuild,
+                warmupProcessor == null ? null : warmupProcessor.QueueSqliteMainRebuild,
+                warmupProcessor == null ? null : warmupProcessor.QueueSqliteSongsBranchesRebuild)
+        {
+            this.backgroundDataStoreProcessor = backgroundDataStoreProcessor;
+            this.warmupProcessor = warmupProcessor;
+        }
+
+        internal EzDataRebuildDispatcher(
+            Func<EzRealmMetadataScope, bool, EzDataRebuildDispatchResult>? queueRealm,
+            Func<bool, EzDataRebuildDispatchResult>? queueSqliteMain,
+            Func<bool, EzDataRebuildDispatchResult>? queueSqliteSongsBranches)
+        {
+            this.queueRealm = queueRealm;
+            this.queueSqliteMain = queueSqliteMain;
+            this.queueSqliteSongsBranches = queueSqliteSongsBranches;
+        }
+
+        public bool CanDispatch(EzDataRebuildTarget target)
+        {
+            switch (target)
+            {
+                case EzDataRebuildTarget.RealmTags:
+                case EzDataRebuildTarget.RealmXxy:
+                case EzDataRebuildTarget.RealmPp:
+                case EzDataRebuildTarget.RealmAll:
+                    return queueRealm != null;
+
+                case EzDataRebuildTarget.SqliteMain:
+                    return queueSqliteMain != null;
+
+                case EzDataRebuildTarget.SqliteSongsBranches:
+                    return queueSqliteSongsBranches != null;
+
+                default:
+                    return false;
+            }
+        }
+
+        public EzDataRebuildDispatchResult Execute(EzDataRebuildTarget target, bool forceAll)
+        {
+            switch (target)
+            {
+                case EzDataRebuildTarget.RealmTags:
+                    return dispatchRealm(EzRealmMetadataScope.Tags, forceAll);
+
+                case EzDataRebuildTarget.RealmXxy:
+                    return dispatchRealm(EzRealmMetadataScope.Xxy, forceAll);
+
+                case EzDataRebuildTarget.RealmPp:
+                    return dispatchRealm(EzRealmMetadataScope.Pp, forceAll);
+
+                case EzDataRebuildTarget.RealmAll:
+                    return dispatchRealm(EzRealmMetadataScope.All, forceAll);
+
+                case EzDataRebuildTarget.SqliteMain:
+                    return dispatchSqliteMain(forceAll);
+
+                case EzDataRebuildTarget.SqliteSongsBranches:
+                    return dispatchSqliteSongsBranches(forceAll);
+
+                default:
+                    Logger.Log($"Unknown data rebuild target: {target}", Ez2ConfigManager.LOGGER_NAME, LogLevel.Important);
+                    return EzDataRebuildDispatchResult.UnknownTarget;
+            }
+        }
+
+        private EzDataRebuildDispatchResult dispatchRealm(EzRealmMetadataScope scope, bool forceAll)
+        {
+            if (queueRealm == null)
+            {
+                Logger.Log($"Cannot queue Realm metadata rebuild ({scope}): background data store processor is unavailable.",
+                    Ez2ConfigManager.LOGGER_NAME, LogLevel.Important);
+                return EzDataRebuildDispatchResult.UnavailableProcessor;
+            }
+
+            return queueRealm(scope, forceAll);
+        }
+
+        private EzDataRebuildDispatchResult dispatchSqliteMain(bool forceAll)
+        {
+            if (queueSqliteMain == null)
+            {
+                Logger.Log("Cannot queue SQLite main rebuild: analysis warmup processor is unavailable.",
+                    Ez2ConfigManager.LOGGER_NAME, LogLevel.Important);
+                return EzDataRebuildDispatchResult.UnavailableProcessor;
+            }
+
+            return queueSqliteMain(forceAll);
+        }
+
+        private EzDataRebuildDispatchResult dispatchSqliteSongsBranches(bool forceAll)
+        {
+            if (queueSqliteSongsBranches == null)
+            {
+                Logger.Log("Cannot queue SQLite songs branch rebuild: analysis warmup processor is unavailable.",
+                    Ez2ConfigManager.LOGGER_NAME, LogLevel.Important);
+                return EzDataRebuildDispatchResult.UnavailableProcessor;
+            }
+
+            return queueSqliteSongsBranches(forceAll);
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Analysis/EzDataRebuildMaintenanceHandler.cs
+++ b/osu.Game/EzOsuGame/Analysis/EzDataRebuildMaintenanceHandler.cs
@@ -1,0 +1,79 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+using osu.Game.Database;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.EzOsuGame.Overlays;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Notifications;
+
+namespace osu.Game.EzOsuGame.Analysis
+{
+    public class EzDataRebuildMaintenanceHandler
+    {
+        private readonly EzDataRebuildDispatcher dispatcher;
+        private readonly IDialogOverlay? dialogOverlay;
+        private readonly INotificationOverlay? notifications;
+
+        public EzDataRebuildMaintenanceHandler(
+            BackgroundDataStoreProcessor? backgroundDataStoreProcessor,
+            EzAnalysisWarmupProcessor? analysisWarmupProcessor,
+            IDialogOverlay? dialogOverlay,
+            INotificationOverlay? notifications)
+            : this(new EzDataRebuildDispatcher(backgroundDataStoreProcessor, analysisWarmupProcessor), dialogOverlay, notifications)
+        {
+        }
+
+        internal EzDataRebuildMaintenanceHandler(
+            EzDataRebuildDispatcher dispatcher,
+            IDialogOverlay? dialogOverlay,
+            INotificationOverlay? notifications)
+        {
+            this.dispatcher = dispatcher;
+            this.dialogOverlay = dialogOverlay;
+            this.notifications = notifications;
+        }
+
+        public bool CanExecute(EzDataRebuildTarget target)
+            => dialogOverlay != null && dispatcher.CanDispatch(target);
+
+        public void RequestExecute(EzDataRebuildTarget target)
+        {
+            if (dialogOverlay == null)
+            {
+                notifications?.Post(new SimpleErrorNotification { Text = EzSettingsStrings.DATA_REBUILD_DIALOG_UNAVAILABLE });
+                return;
+            }
+
+            dialogOverlay.Push(new EzDataRebuildConfirmDialog(
+                () => notifyDispatchResult(Dispatch(target, forceAll: false)),
+                () => notifyDispatchResult(Dispatch(target, forceAll: true))));
+        }
+
+        public EzDataRebuildDispatchResult Dispatch(EzDataRebuildTarget target, bool forceAll)
+            => dispatcher.Execute(target, forceAll);
+
+        public void NotifyDispatchResult(EzDataRebuildDispatchResult result)
+            => notifyDispatchResult(result);
+
+        internal static LocalisableString GetErrorMessage(EzDataRebuildDispatchResult result)
+        {
+            return result switch
+            {
+                EzDataRebuildDispatchResult.UnavailableProcessor => EzSettingsStrings.DATA_REBUILD_UNAVAILABLE,
+                EzDataRebuildDispatchResult.AlreadyRunning => EzSettingsStrings.DATA_REBUILD_ALREADY_RUNNING,
+                EzDataRebuildDispatchResult.SqliteDisabled => EzSettingsStrings.DATA_REBUILD_SQLITE_DISABLED,
+                _ => EzSettingsStrings.DATA_REBUILD_UNAVAILABLE,
+            };
+        }
+
+        private void notifyDispatchResult(EzDataRebuildDispatchResult result)
+        {
+            if (result == EzDataRebuildDispatchResult.Queued)
+                return;
+
+            notifications?.Post(new SimpleErrorNotification { Text = GetErrorMessage(result) });
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
@@ -116,8 +116,8 @@ namespace osu.Game.EzOsuGame.Localization
             new EzLocalizationManager.EzLocalisableString("执行", "Execute");
 
         public static readonly EzLocalizationManager.EzLocalisableString DATA_REBUILD_EXECUTE_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
-            "确认后可选补算缺失或完全重算。大库可能耗时较长，请留意右下角进度通知。",
-            "Choose backfill missing or force full rebuild. Large libraries may take a while; watch the progress notification.");
+            "确认后可选补算缺失或完全重算。大库可能耗时较长，请留意右上角进度通知。",
+            "Choose backfill missing or force full rebuild. Large libraries may take a while; watch the progress notification in the top-right corner.");
 
         public static readonly EzLocalizationManager.EzLocalisableString DATA_REBUILD_DIALOG_HEADER =
             new EzLocalizationManager.EzLocalisableString("数据维护", "Data maintenance");
@@ -168,9 +168,9 @@ namespace osu.Game.EzOsuGame.Localization
 
         public static readonly EzLocalizationManager.EzLocalisableString EZ_REALM_METADATA_BACKFILL_FORCE_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
             "先将所有谱面的 Tag / XxySR / PP 标记为未计算，再执行完整补算。"
-            + "\n谱面较多时耗时较长，请留意右下角进度通知。",
+            + "\n谱面较多时耗时较长，请留意右上角进度通知。",
             "Marks all beatmaps' Tag / XxySR / PP as uncomputed, then runs a full backfill."
-            + "\nMay take a long time for large libraries; watch the progress notification.");
+            + "\nMay take a long time for large libraries; watch the progress notification in the top-right corner.");
 
         #region 机制类
 

--- a/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
@@ -100,10 +100,53 @@ namespace osu.Game.EzOsuGame.Localization
             new EzLocalizationManager.EzLocalisableString("启用 Ez 分析本地数据（SQLite）", "Enable Ez analysis local data (SQLite)");
 
         public static readonly EzLocalizationManager.EzLocalisableString EZ_ANALYSIS_SQLITE_ENABLED_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
-            "控制主 analysis SQLite（kps/KPC 缓存、启动预热）与分支曲库（预生成 Mod 快照）的读写。"
-            + "\n不影响 Realm 中的 xxy/PP 基线；Mod 下面板动态重算由上方「分析重算」开关控制。",
-            "Controls main analysis SQLite (kps/KPC cache, startup warmup) and songs branch libraries (precomputed mod snapshots)."
-            + "\nDoes not affect Realm xxy/PP baselines; mod-aware panel recompute is controlled by the recompute switch above.");
+            "控制主 analysis SQLite（kps/KPC 缓存）与分支曲库（预生成 Mod 快照）的读写。"
+            + "\n仅在缺少当前版本文件或需要 schema 升级时自动预热；已有匹配文件时请在下方的维护控件手动补算/重算。",
+            "Controls main analysis SQLite (kps/KPC cache) and songs branch libraries (precomputed mod snapshots)."
+            + "\nAuto-warmup runs only when the current database is missing or needs schema upgrade; use maintenance controls below when a matching file already exists.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString DATA_REBUILD_TARGET =
+            new EzLocalizationManager.EzLocalisableString("数据维护目标", "Data maintenance target");
+
+        public static readonly EzLocalizationManager.EzLocalisableString DATA_REBUILD_TARGET_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "选择要维护的数据范围。SQLite 在已有匹配的最新版文件时不会自动预热；Realm 缺失项仍会在启动时自动补算。",
+            "Choose which data to maintain. SQLite is not auto-warmed when a matching current database exists; Realm missing values are still filled at startup.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString DATA_REBUILD_EXECUTE =
+            new EzLocalizationManager.EzLocalisableString("执行", "Execute");
+
+        public static readonly EzLocalizationManager.EzLocalisableString DATA_REBUILD_EXECUTE_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "确认后可选补算缺失或完全重算。大库可能耗时较长，请留意右下角进度通知。",
+            "Choose backfill missing or force full rebuild. Large libraries may take a while; watch the progress notification.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString DATA_REBUILD_DIALOG_HEADER =
+            new EzLocalizationManager.EzLocalisableString("数据维护", "Data maintenance");
+
+        public static readonly EzLocalizationManager.EzLocalisableString DATA_REBUILD_DIALOG_BODY = new EzLocalizationManager.EzLocalisableString(
+            "即将对所选目标执行后台维护。\n补算缺失仅处理未写入的数据；完全重算会先清除已有结果再全部重算。",
+            "Background maintenance will run for the selected target.\nBackfill missing only fills gaps; force rebuild clears existing results first.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString DATA_REBUILD_DIALOG_BACKFILL =
+            new EzLocalizationManager.EzLocalisableString("尝试补算", "Backfill missing");
+
+        public static readonly EzLocalizationManager.EzLocalisableString DATA_REBUILD_DIALOG_FORCE =
+            new EzLocalizationManager.EzLocalisableString("完全重算", "Force rebuild");
+
+        public static readonly EzLocalizationManager.EzLocalisableString DATA_REBUILD_UNAVAILABLE = new EzLocalizationManager.EzLocalisableString(
+            "无法执行数据维护：所需后台处理器不可用。",
+            "Cannot run data maintenance: the required background processor is unavailable.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString DATA_REBUILD_ALREADY_RUNNING = new EzLocalizationManager.EzLocalisableString(
+            "数据维护已在后台运行，请等待当前任务完成。",
+            "Data maintenance is already running in the background. Wait for the current task to finish.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString DATA_REBUILD_SQLITE_DISABLED = new EzLocalizationManager.EzLocalisableString(
+            "SQLite 分析缓存已关闭，请在上方启用后再执行。",
+            "SQLite analysis cache is disabled. Enable it above before running this action.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString DATA_REBUILD_DIALOG_UNAVAILABLE = new EzLocalizationManager.EzLocalisableString(
+            "无法打开确认对话框，请稍后重试。",
+            "Cannot open the confirmation dialog. Try again later.");
 
         public static readonly EzLocalizationManager.EzLocalisableString EZ_REALM_METADATA_BACKFILL =
             new EzLocalizationManager.EzLocalisableString("补算 Realm 元数据（Tag / XxySR / PP）", "Backfill Realm metadata (Tag / XxySR / PP)");

--- a/osu.Game/EzOsuGame/Overlays/EzDataRebuildConfirmDialog.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzDataRebuildConfirmDialog.cs
@@ -1,0 +1,41 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.Overlays.Dialog;
+
+namespace osu.Game.EzOsuGame.Overlays
+{
+    public partial class EzDataRebuildConfirmDialog : PopupDialog
+    {
+        public EzDataRebuildConfirmDialog(Action onBackfill, Action onForceRebuild)
+        {
+            ArgumentNullException.ThrowIfNull(onBackfill);
+            ArgumentNullException.ThrowIfNull(onForceRebuild);
+
+            Icon = FontAwesome.Solid.ExclamationTriangle;
+            HeaderText = EzSettingsStrings.DATA_REBUILD_DIALOG_HEADER;
+            BodyText = EzSettingsStrings.DATA_REBUILD_DIALOG_BODY;
+
+            Buttons = new PopupDialogButton[]
+            {
+                new PopupDialogOkButton
+                {
+                    Text = EzSettingsStrings.DATA_REBUILD_DIALOG_BACKFILL,
+                    Action = onBackfill,
+                },
+                new PopupDialogDangerousButton
+                {
+                    Text = EzSettingsStrings.DATA_REBUILD_DIALOG_FORCE,
+                    Action = onForceRebuild,
+                },
+                new PopupDialogCancelButton
+                {
+                    Text = EzSettingsStrings.CANCEL_BUTTON,
+                },
+            };
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Overlays/EzDataRebuildSettingsSection.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzDataRebuildSettingsSection.cs
@@ -1,0 +1,66 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Database;
+using osu.Game.EzOsuGame.Analysis;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Settings;
+
+namespace osu.Game.EzOsuGame.Overlays
+{
+    public partial class EzDataRebuildSettingsSection : FillFlowContainer
+    {
+        public EzDataRebuildSettingsSection()
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            Direction = FillDirection.Vertical;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(
+            BackgroundDataStoreProcessor? backgroundDataStoreProcessor,
+            EzAnalysisWarmupProcessor? analysisWarmupProcessor,
+            IDialogOverlay? dialogOverlay,
+            INotificationOverlay? notifications)
+        {
+            var rebuildTarget = new Bindable<EzDataRebuildTarget>(EzDataRebuildTarget.RealmAll);
+            var maintenanceHandler = new EzDataRebuildMaintenanceHandler(backgroundDataStoreProcessor, analysisWarmupProcessor, dialogOverlay, notifications);
+
+            var executeButton = new DangerousSettingsButton
+            {
+                Text = EzSettingsStrings.DATA_REBUILD_EXECUTE,
+                TooltipText = EzSettingsStrings.DATA_REBUILD_EXECUTE_TOOLTIP,
+                Keywords = new[] { "realm", "tag", "xxy", "pp", "metadata", "backfill", "force", "recalculate", "sqlite", "rebuild", "maintenance", "execute" },
+            };
+
+            void updateExecuteButtonState()
+            {
+                executeButton.Enabled.Value = maintenanceHandler.CanExecute(rebuildTarget.Value);
+            }
+
+            executeButton.Action = () => maintenanceHandler.RequestExecute(rebuildTarget.Value);
+            rebuildTarget.BindValueChanged(_ => updateExecuteButtonState(), true);
+
+            AddRange(new Drawable[]
+            {
+                new SettingsItemV2(new FormEnumDropdown<EzDataRebuildTarget>
+                {
+                    Caption = EzSettingsStrings.DATA_REBUILD_TARGET,
+                    HintText = EzSettingsStrings.DATA_REBUILD_TARGET_TOOLTIP,
+                    Current = rebuildTarget,
+                })
+                {
+                    Keywords = new[] { "realm", "tag", "xxy", "pp", "metadata", "backfill", "force", "recalculate", "sqlite", "rebuild", "maintenance" }
+                },
+                executeButton,
+            });
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Overlays/EzDataRebuildSettingsSection.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzDataRebuildSettingsSection.cs
@@ -1,10 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Game.Database;
 using osu.Game.EzOsuGame.Analysis;
 using osu.Game.EzOsuGame.Localization;
@@ -14,17 +11,10 @@ using osu.Game.Overlays.Settings;
 
 namespace osu.Game.EzOsuGame.Overlays
 {
-    public partial class EzDataRebuildSettingsSection : FillFlowContainer
+    public static partial class EzDataRebuildSettingsSection
     {
-        public EzDataRebuildSettingsSection()
-        {
-            RelativeSizeAxes = Axes.X;
-            AutoSizeAxes = Axes.Y;
-            Direction = FillDirection.Vertical;
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(
+        public static void AddTo(
+            SettingsSubsection subsection,
             BackgroundDataStoreProcessor? backgroundDataStoreProcessor,
             EzAnalysisWarmupProcessor? analysisWarmupProcessor,
             IDialogOverlay? dialogOverlay,
@@ -33,7 +23,7 @@ namespace osu.Game.EzOsuGame.Overlays
             var rebuildTarget = new Bindable<EzDataRebuildTarget>(EzDataRebuildTarget.RealmAll);
             var maintenanceHandler = new EzDataRebuildMaintenanceHandler(backgroundDataStoreProcessor, analysisWarmupProcessor, dialogOverlay, notifications);
 
-            var executeButton = new DangerousSettingsButton
+            var executeButton = new DangerousSettingsButtonV2
             {
                 Text = EzSettingsStrings.DATA_REBUILD_EXECUTE,
                 TooltipText = EzSettingsStrings.DATA_REBUILD_EXECUTE_TOOLTIP,
@@ -48,19 +38,17 @@ namespace osu.Game.EzOsuGame.Overlays
             executeButton.Action = () => maintenanceHandler.RequestExecute(rebuildTarget.Value);
             rebuildTarget.BindValueChanged(_ => updateExecuteButtonState(), true);
 
-            AddRange(new Drawable[]
+            subsection.Add(new SettingsItemV2(new FormEnumDropdown<EzDataRebuildTarget>
             {
-                new SettingsItemV2(new FormEnumDropdown<EzDataRebuildTarget>
-                {
-                    Caption = EzSettingsStrings.DATA_REBUILD_TARGET,
-                    HintText = EzSettingsStrings.DATA_REBUILD_TARGET_TOOLTIP,
-                    Current = rebuildTarget,
-                })
-                {
-                    Keywords = new[] { "realm", "tag", "xxy", "pp", "metadata", "backfill", "force", "recalculate", "sqlite", "rebuild", "maintenance" }
-                },
-                executeButton,
+                Caption = EzSettingsStrings.DATA_REBUILD_TARGET,
+                HintText = EzSettingsStrings.DATA_REBUILD_TARGET_TOOLTIP,
+                Current = rebuildTarget,
+            })
+            {
+                Keywords = new[] { "realm", "tag", "xxy", "pp", "metadata", "backfill", "force", "recalculate", "sqlite", "rebuild", "maintenance" }
             });
+
+            subsection.Add(executeButton);
         }
     }
 }

--- a/osu.Game/EzOsuGame/Overlays/EzUISettings.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzUISettings.cs
@@ -1,11 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Localisation;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Game.Database;
+using osu.Framework.Localisation;
 using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.Localization;
 using osu.Game.Graphics.UserInterfaceV2;
@@ -18,7 +16,7 @@ namespace osu.Game.EzOsuGame.Overlays
         protected override LocalisableString Header => EzSettingsStrings.EZ_UI_SETTINGS_HEADER;
 
         [BackgroundDependencyLoader]
-        private void load(Ez2ConfigManager ezConfig, BackgroundDataStoreProcessor? backgroundDataStoreProcessor)
+        private void load(Ez2ConfigManager ezConfig)
         {
             AddRange(new Drawable[]
             {
@@ -40,33 +38,7 @@ namespace osu.Game.EzOsuGame.Overlays
                 {
                     Keywords = new[] { "analysis", "sqlite", "cache", "warmup", "persistent" }
                 },
-                new FillFlowContainer
-                {
-                    RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y,
-                    Direction = FillDirection.Vertical,
-                    // Padding = SettingsPanel.CONTENT_PADDING,
-                    Margin = new MarginPadding { Top = 10, Bottom = 10, Left = 10 },
-                    Children = new Drawable[]
-                    {
-                        new SettingsButton
-                        {
-                            Text = EzSettingsStrings.EZ_REALM_METADATA_BACKFILL_BUTTON,
-                            TooltipText = EzSettingsStrings.EZ_REALM_METADATA_BACKFILL_TOOLTIP,
-                            Action = () => backgroundDataStoreProcessor?.QueueEzRealmMetadataBackfill(),
-                            Keywords = new[] { "realm", "tag", "xxy", "pp", "metadata", "backfill" },
-                        },
-#if DEBUG
-                        new SettingsButton
-                        {
-                            Text = EzSettingsStrings.EZ_REALM_METADATA_BACKFILL_FORCE_BUTTON,
-                            TooltipText = EzSettingsStrings.EZ_REALM_METADATA_BACKFILL_FORCE_TOOLTIP,
-                            Action = () => backgroundDataStoreProcessor?.QueueEzRealmMetadataBackfill(forceAll: true),
-                            Keywords = new[] { "realm", "tag", "xxy", "pp", "metadata", "force", "recalculate" },
-                        },
-# endif
-                    }
-                },
+                new EzDataRebuildSettingsSection(),
                 new SettingsItemV2(new FormCheckBox
                 {
                     Caption = EzSettingsStrings.HIDE_MAIN_MENU_ONLINE_BANNER,

--- a/osu.Game/EzOsuGame/Overlays/EzUISettings.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzUISettings.cs
@@ -4,9 +4,12 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
+using osu.Game.Database;
+using osu.Game.EzOsuGame.Analysis;
 using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.Localization;
 using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Overlays;
 using osu.Game.Overlays.Settings;
 
 namespace osu.Game.EzOsuGame.Overlays
@@ -16,7 +19,12 @@ namespace osu.Game.EzOsuGame.Overlays
         protected override LocalisableString Header => EzSettingsStrings.EZ_UI_SETTINGS_HEADER;
 
         [BackgroundDependencyLoader]
-        private void load(Ez2ConfigManager ezConfig)
+        private void load(
+            Ez2ConfigManager ezConfig,
+            BackgroundDataStoreProcessor? backgroundDataStoreProcessor,
+            EzAnalysisWarmupProcessor? analysisWarmupProcessor,
+            IDialogOverlay? dialogOverlay,
+            INotificationOverlay? notifications)
         {
             AddRange(new Drawable[]
             {
@@ -38,7 +46,12 @@ namespace osu.Game.EzOsuGame.Overlays
                 {
                     Keywords = new[] { "analysis", "sqlite", "cache", "warmup", "persistent" }
                 },
-                new EzDataRebuildSettingsSection(),
+            });
+
+            EzDataRebuildSettingsSection.AddTo(this, backgroundDataStoreProcessor, analysisWarmupProcessor, dialogOverlay, notifications);
+
+            AddRange(new Drawable[]
+            {
                 new SettingsItemV2(new FormCheckBox
                 {
                     Caption = EzSettingsStrings.HIDE_MAIN_MENU_ONLINE_BANNER,

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1246,7 +1246,7 @@ namespace osu.Game
             loadComponentSingleFile(new MedalOverlay(), topMostOverlayContent.Add);
 
             loadComponentSingleFile(new BackgroundDataStoreProcessor(), Add, true);
-            loadComponentSingleFile(new EzAnalysisWarmupProcessor(), Add);
+            loadComponentSingleFile(new EzAnalysisWarmupProcessor(), Add, true);
             loadComponentSingleFile<BeatmapStore>(detachedBeatmapStore = new RealmDetachedBeatmapStore(), Add, true);
             loadComponentSingleFile(new QueueController(), Add, true);
 


### PR DESCRIPTION
## Summary

- `BackgroundDataStoreProcessor` 支持按 `EzRealmMetadataScope` 分项 Realm 回填/清数据
- 新增 `EzDataRebuildDispatchResult` / `EzDataRebuildDispatcher`，queue 方法返回明确结果，避免 processor 缺失时静默 no-op
- 设置页以 `EzDataRebuildSettingsSection` 替换旧 Realm 补算按钮：目标下拉 + 确认弹窗 + 错误通知
- `EzAnalysisWarmupProcessor` 启用 DI（`OsuGame`）供维护 UI 注入

## Commits（建议按 commit 顺序 review）

1. BDP 按 scope 分项 Realm 回填 API
2. Dispatch 返回结果与路由
3. 设置页维护 UI + Handler
4. 单元测试

## Test plan

- [x] `dotnet build osu.Game` 通过
- [x] `dotnet test --filter EzDataRebuild` 通过（27 项）
- [x] 设置 → Ez UI：选择维护目标 → 执行 → 补算/完全重算 均能触发后台任务
- [ ] processor 不可用 / SQLite 关闭 / 已在运行时，按钮禁用或弹出错误通知
- [x] 依赖 PR1（#45，已合并）：启动 SQLite 按需预热 + Realm gate

## 关联

- PR1 #45（已合并）：启动性能与类型定义

Made with [Cursor](https://cursor.com)