### PR TITLE
EzSkinEditor M2: skin.ini session and comparison preview

### DIFF
--- a/osu.Game.Rulesets.Mania/EzMania/Editor/EzSkinLNEditorProvider.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/Editor/EzSkinLNEditorProvider.cs
@@ -33,16 +33,8 @@ namespace osu.Game.Rulesets.Mania.EzMania.Editor
 
         static EzSkinLNEditorProvider()
         {
-            // Register this provider for the Mania ruleset in the global registry.
-            try
-            {
-                int rulesetId = new ManiaRuleset().RulesetInfo.OnlineID;
-                SkinEditorProviderRegistry.Register(rulesetId, () => new EzSkinLNEditorProvider());
-            }
-            catch
-            {
-                // swallow - registration is best-effort (assembly load ordering may vary)
-            }
+            // Mania ruleset online ID is stable across osu! releases.
+            SkinEditorProviderRegistry.Register(3, () => new EzSkinLNEditorProvider());
         }
 
         protected sealed class PreviewScrollingInfo : IScrollingInfo

--- a/osu.Game.Rulesets.Mania/EzMania/Editor/EzSkinLNEditorProvider_Static.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/Editor/EzSkinLNEditorProvider_Static.cs
@@ -38,47 +38,44 @@ namespace osu.Game.Rulesets.Mania.EzMania.Editor
                 RelativeSizeAxes = Axes.Both,
                 Child = new FillFlowContainer
                 {
-                    RelativeSizeAxes = Axes.Y,
-                    AutoSizeAxes = Axes.X,
+                    RelativeSizeAxes = Axes.Both,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Direction = FillDirection.Horizontal,
-                    Spacing = new Vector2(15, 0),
+                    Direction = FillDirection.Vertical,
+                    Spacing = new Vector2(0, 10),
                     Padding = new MarginPadding(10),
                     Children = new[]
                     {
-                        createColumn(skin, useTransformed: false, "Before"),
-                        createColumn(skin, useTransformed: true, "After"),
+                        createPreviewRow(skin, "Note", isHold: false),
+                        createPreviewRow(skin, "LN", isHold: true),
                     }
                 }
             };
         }
 
-        private SkinProvidingContainer createColumn(ISkin skin, bool useTransformed, string label)
+        private Drawable createPreviewRow(ISkin skin, string label, bool isHold)
         {
-            var skinToProvide = useTransformed ? createTransformedSkin(skin) : skin;
-            var hold = new HoldNote { StartTime = 0, Duration = 500, Column = 0 };
-            hold.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+            var transformedSkin = createTransformedSkin(skin);
 
-            return new SkinProvidingContainer(skinToProvide)
+            ManiaHitObject hitObject = isHold
+                ? new HoldNote { StartTime = 0, Duration = 500, Column = 0 }
+                : new Note { StartTime = 0, Column = 0 };
+
+            hitObject.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+
+            DrawableHitObject drawable = isHold
+                ? new DrawableHoldNote((HoldNote)hitObject)
+                : new DrawableNote((Note)hitObject);
+
+            return new SkinProvidingContainer(transformedSkin)
             {
-                RelativeSizeAxes = Axes.Y,
-                Width = preview_column_width + 10,
-                Child = new Container
+                RelativeSizeAxes = Axes.X,
+                Height = 260,
+                Child = new PreviewDependencyContainer(preview_key_count, 0, ManiaAction.Key1)
                 {
-                    RelativeSizeAxes = Axes.Both,
-                    Children = new Drawable[]
+                    Child = new EzNoteContainer(ScrollingDirection.Down, label)
                     {
-                        new PreviewDependencyContainer(preview_key_count, 0, ManiaAction.Key1)
-                        {
-                            Child = new EzNoteContainer(ScrollingDirection.Down, label)
-                            {
-                                Child = new DrawableHoldNote(hold)
-                                {
-                                    RelativeSizeAxes = Axes.Both,
-                                }
-                            }
-                        },
+                        Child = drawable,
                     }
                 }
             };

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -15,6 +15,7 @@ using osu.Game.Graphics;
 using osu.Game.EzOsuGame.Analysis;
 using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.Extensions;
+using osu.Game.Rulesets.Mania.EzMania.Editor;
 using osu.Game.Localisation;
 using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Configuration;
@@ -56,6 +57,12 @@ namespace osu.Game.Rulesets.Mania
 {
     public class ManiaRuleset : Ruleset, ILegacyRuleset
     {
+        static ManiaRuleset()
+        {
+            // Ensure Mania skin editor provider is registered when the ruleset assembly is used.
+            _ = typeof(EzSkinLNEditorProvider);
+        }
+
         /// <summary>
         /// The maximum number of supported keys in a single stage.
         /// </summary>

--- a/osu.Game.Rulesets.Mania/Skinning/EzStylePro/EzHoldNoteHead.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/EzStylePro/EzHoldNoteHead.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Animations;
@@ -59,6 +60,9 @@ namespace osu.Game.Rulesets.Mania.Skinning.EzStylePro
         protected override void UpdateDrawable()
         {
             Height = NoteHeight;
+
+            if (!MainContainer.Children.Any())
+                return;
 
             if (MainContainer.Child is Container c)
             {

--- a/osu.Game.Tests/Visual/Edit/TestSceneEzSkinEditorScreen.cs
+++ b/osu.Game.Tests/Visual/Edit/TestSceneEzSkinEditorScreen.cs
@@ -1,27 +1,46 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Platform;
 using osu.Framework.Testing;
-using osu.Game.Graphics.Sprites;
+using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.Edit;
 using osu.Game.EzOsuGame.Edit.Components;
+using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays.Dialog;
 using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Mania.EzMania.Editor;
 using osu.Game.Screens.Edit.Components.Menus;
+using osu.Game.Skinning;
+using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Edit
 {
     public partial class TestSceneEzSkinEditorScreen : ScreenTestScene
     {
+        [Resolved]
+        private SkinManager skinManager { get; set; } = null!;
+
+        [Resolved]
+        private Ez2ConfigManager ezConfig { get; set; } = null!;
+
+        [Resolved]
+        private Storage storage { get; set; } = null!;
+
         private EzSkinEditorScreen editorScreen = null!;
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
             Ruleset.Value = new ManiaRuleset().RulesetInfo;
+            SkinEditorProviderRegistry.Register(3, () => new EzSkinLNEditorProvider());
         }
 
         protected override void BackButtonPressed()
@@ -46,6 +65,9 @@ namespace osu.Game.Tests.Visual.Edit
 
         private void switchScene(EzSkinEditorSceneType scene) =>
             AddStep($"switch to {scene}", () => editorScreen.CurrentScene.Value = scene);
+
+        private void ensureMutableSkin() =>
+            AddStep("ensure mutable skin", () => skinManager.EnsureMutableSkin());
 
         [Test]
         public void TestLayoutShell()
@@ -81,23 +103,27 @@ namespace osu.Game.Tests.Visual.Edit
         }
 
         [Test]
-        public void TestSizeSceneGroups()
+        public void TestSizeSceneComparisonDrawables()
         {
             AddStep("load screen", loadScreen);
             waitForScreenLoaded();
+            AddAssert("mania preview provider registered", () => SkinEditorProviderRegistry.Get(3) != null);
             switchScene(EzSkinEditorSceneType.Size);
 
+            AddUntilStep("comparison grid visible", () => editorScreen.ChildrenOfType<EzSkinEditorPreviewHost>().Single().ChildrenOfType<GridContainer>().Any());
             AddUntilStep("at least one sidebar group", () => editorScreen.ChildrenOfType<EzSkinEditorSettingsGroup>().Any());
-            AddUntilStep("comparison area visible", () => editorScreen.ChildrenOfType<OsuSpriteText>().Any(t => t.Text.ToString().Contains("对比区")));
+            AddAssert("no comparison placeholder", () => editorScreen.ChildrenOfType<OsuSpriteText>().All(t => t.Text.ToString().Contains("对比区") != true));
+            AddAssert("comparison preview supported", () => editorScreen.ChildrenOfType<OsuSpriteText>().All(t => t.Text.ToString().Contains("Comparison preview not supported") != true));
+            AddUntilStep("static note label visible", () => editorScreen.ChildrenOfType<OsuSpriteText>().Any(t => t.Text.ToString() == "Note"));
+            AddUntilStep("static ln label visible", () => editorScreen.ChildrenOfType<OsuSpriteText>().Any(t => t.Text.ToString() == "LN"));
             AddUntilStep("playback and comparison are horizontal", () =>
             {
                 var preview = editorScreen.ChildrenOfType<EzSkinEditorPreviewHost>().SingleOrDefault();
-                var comparisonText = editorScreen.ChildrenOfType<OsuSpriteText>()
-                                                 .SingleOrDefault(t => t.Text.ToString().Contains("对比区"));
+                var comparisonLabel = editorScreen.ChildrenOfType<OsuSpriteText>().FirstOrDefault(t => t.Text.ToString() == "LN");
 
                 return preview != null
-                       && comparisonText != null
-                       && comparisonText.ScreenSpaceDrawQuad.Centre.X > preview.ScreenSpaceDrawQuad.Centre.X;
+                       && comparisonLabel != null
+                       && comparisonLabel.ScreenSpaceDrawQuad.Centre.X > preview.ScreenSpaceDrawQuad.Centre.X;
             });
         }
 
@@ -120,6 +146,101 @@ namespace osu.Game.Tests.Visual.Edit
 
             AddUntilStep("playback only host", () => editorScreen.ChildrenOfType<EzSkinEditorPreviewHost>().Any());
             AddUntilStep("save footer button", () => editorScreen.ChildrenOfType<OsuButton>().Any(b => b.Text.ToString() == "保存 Skin.ini"));
+        }
+
+        [Test]
+        public void TestApplySavesEzConfig()
+        {
+            const double target_alpha = 0.42;
+
+            AddStep("load screen", loadScreen);
+            waitForScreenLoaded();
+
+            AddStep("change hit target alpha", () => ezConfig.GetBindable<double>(Ez2Setting.HitTargetAlpha).Value = target_alpha);
+            AddStep("apply settings", () => editorScreen.ApplySettings());
+
+            AddAssert("bindable retained", () => ezConfig.GetBindable<double>(Ez2Setting.HitTargetAlpha).Value, () => Is.EqualTo(target_alpha));
+            AddAssert("EzSkinSettings.ini written", () => storage.Exists("EzSkinSettings.ini"));
+        }
+
+        [Test]
+        public void TestSkinIniSessionLoadSave()
+        {
+            AddStep("load screen", loadScreen);
+            waitForScreenLoaded();
+            switchScene(EzSkinEditorSceneType.SkinIni);
+
+            AddUntilStep("session loaded", () => editorScreen.SkinIniSession != null);
+
+            string savedText = null!;
+            string dirtyText = null!;
+
+            AddStep("capture saved text", () =>
+            {
+                savedText = editorScreen.SkinIniSession!.SavedText;
+                dirtyText = savedText + "\n; m2 test marker";
+            });
+
+            AddStep("set dirty draft", () => editorScreen.SkinIniSession!.SetDraftText(dirtyText));
+            AddAssert("session dirty", () => editorScreen.SkinIniSession!.IsDirty);
+
+            AddStep("discard draft", () => editorScreen.SkinIniSession!.Discard());
+            AddAssert("session clean after discard", () => !editorScreen.SkinIniSession!.IsDirty);
+            AddAssert("draft restored", () => editorScreen.SkinIniSession!.DraftText, () => Is.EqualTo(savedText));
+
+            ensureMutableSkin();
+            AddUntilStep("session reloaded for mutable skin", () => editorScreen.SkinIniSession!.SkinId == skinManager.CurrentSkinInfo.Value.ID);
+
+            AddStep("set dirty draft again", () => editorScreen.SkinIniSession!.SetDraftText(dirtyText));
+            AddStep("commit draft", () => editorScreen.SkinIniSession!.Commit());
+            AddAssert("session clean after commit", () => !editorScreen.SkinIniSession!.IsDirty);
+            AddAssert("saved text updated", () => editorScreen.SkinIniSession!.SavedText, () => Is.EqualTo(dirtyText));
+        }
+
+        [Test]
+        public void TestSkinIniSessionPerSkin()
+        {
+            AddStep("load screen", loadScreen);
+            waitForScreenLoaded();
+            switchScene(EzSkinEditorSceneType.SkinIni);
+
+            AddUntilStep("session loaded", () => editorScreen.SkinIniSession != null);
+
+            System.Guid originalSkinId = Guid.Empty;
+
+            AddStep("capture skin id and dirty draft", () =>
+            {
+                originalSkinId = editorScreen.SkinIniSession!.SkinId;
+                editorScreen.SkinIniSession.SetDraftText(editorScreen.SkinIniSession.SavedText + "\n; per-skin leak test");
+            });
+
+            AddStep("switch skin", () => skinManager.SetSkinFromConfiguration(SkinInfo.TRIANGLES_SKIN.ToString()));
+            AddUntilStep("session bound to new skin", () => editorScreen.SkinIniSession!.SkinId != originalSkinId);
+            AddAssert("draft not dirty after switch", () => !editorScreen.SkinIniSession!.IsDirty);
+            AddAssert("draft matches saved for new skin", () => editorScreen.SkinIniSession!.DraftText == editorScreen.SkinIniSession!.SavedText);
+        }
+
+        [Test]
+        public void TestExitDialogSkinIniDirty()
+        {
+            AddStep("load screen", loadScreen);
+            waitForScreenLoaded();
+            switchScene(EzSkinEditorSceneType.SkinIni);
+
+            AddUntilStep("session loaded", () => editorScreen.SkinIniSession != null);
+
+            AddStep("set dirty draft", () => editorScreen.SkinIniSession!.SetDraftText(editorScreen.SkinIniSession.SavedText + "\n; exit test"));
+            AddStep("show exit dialog", () => editorScreen.ShowExitDialog());
+            AddUntilStep("dialog visible", () => DialogOverlay.CurrentDialog is ConfirmDialog);
+
+            AddStep("discard via cancel", () =>
+            {
+                InputManager.MoveMouseTo(DialogOverlay.CurrentDialog!.ChildrenOfType<PopupDialogButton>().Last());
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddUntilStep("screen exited", () => Stack.CurrentScreen == null);
+            AddAssert("session clean after discard exit", () => !editorScreen.SkinIniSession!.IsDirty);
         }
 
         [Test]

--- a/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorPreviewHost.cs
+++ b/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorPreviewHost.cs
@@ -2,11 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
-using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osuTK.Graphics;
 
@@ -14,7 +11,7 @@ namespace osu.Game.EzOsuGame.Edit.Components
 {
     /// <summary>
     /// Hosts the virtual playback scene. With comparison enabled (size scene only),
-    /// playback is on the left and the before/after comparison placeholder is on the right.
+    /// playback is on the left and Note/LN static preview is on the right.
     /// </summary>
     public partial class EzSkinEditorPreviewHost : Container
     {
@@ -60,7 +57,7 @@ namespace osu.Game.EzOsuGame.Edit.Components
             };
 
             populatePlayback();
-            populateComparisonPlaceholder();
+            populateComparison();
         }
 
         private void populatePlayback()
@@ -86,24 +83,27 @@ namespace osu.Game.EzOsuGame.Edit.Components
             }
         }
 
-        private void populateComparisonPlaceholder()
+        private void populateComparison()
         {
-            comparisonContainer.Children = new Drawable[]
+            if (context.Provider != null)
             {
-                new Box
+                comparisonContainer.Child = context.Provider.CreateStaticPart(context.EditorSkin).With(d =>
                 {
-                    RelativeSizeAxes = Axes.Both,
-                    Colour = Color4.Black.Opacity(0.35f),
-                },
-                new OsuSpriteText
+                    d.RelativeSizeAxes = Axes.Both;
+                    d.Anchor = Anchor.Centre;
+                    d.Origin = Anchor.Centre;
+                });
+            }
+            else
+            {
+                comparisonContainer.Child = new OsuSpriteText
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Text = "Note/LN 对比区（里程碑 2）",
-                    Font = OsuFont.Default.With(size: 18, weight: FontWeight.Bold),
+                    Text = "Comparison preview not supported",
                     Colour = Color4.White,
-                },
-            };
+                };
+            }
         }
     }
 }

--- a/osu.Game/EzOsuGame/Edit/EzSkinEditorSceneContext.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinEditorSceneContext.cs
@@ -15,6 +15,10 @@ namespace osu.Game.EzOsuGame.Edit
 
         public ISkin EditorSkin { get; init; } = null!;
 
+        public EzSkinIniSession? SkinIniSession { get; init; }
+
         public Action? RequestSceneRefresh { get; init; }
+
+        public Action? CommitSkinIni { get; init; }
     }
 }

--- a/osu.Game/EzOsuGame/Edit/EzSkinEditorScreen.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinEditorScreen.cs
@@ -7,6 +7,8 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Screens;
+using osu.Game.Database;
+using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.Edit.Components;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
@@ -37,6 +39,9 @@ namespace osu.Game.EzOsuGame.Edit
         [Resolved]
         private SkinManager skinManager { get; set; } = null!;
 
+        [Resolved]
+        private Ez2ConfigManager ezSkinConfig { get; set; } = null!;
+
         [Resolved(canBeNull: true)]
         private IDialogOverlay? dialogOverlay { get; set; }
 
@@ -51,6 +56,11 @@ namespace osu.Game.EzOsuGame.Edit
         private EzSkinEditorSceneContext? sceneContext;
 
         public Bindable<EzSkinEditorSceneType> CurrentScene => sceneBar.CurrentScene;
+
+        /// <summary>
+        /// Per-skin skin.ini session. Skin-layer only.
+        /// </summary>
+        public EzSkinIniSession? SkinIniSession { get; private set; }
 
         public EzSkinEditorScreen()
         {
@@ -162,10 +172,13 @@ namespace osu.Game.EzOsuGame.Edit
         {
             base.LoadComplete();
             sceneBar.CurrentScene.BindValueChanged(_ => Schedule(applyCurrentScene), true);
+            skinManager.CurrentSkinInfo.BindValueChanged(onCurrentSkinInfoChanged);
             updateHeaderText();
         }
 
         public void PopulateSettings() => refreshScene();
+
+        public void ApplySettings() => applySettings();
 
         private void refreshScene()
         {
@@ -173,23 +186,29 @@ namespace osu.Game.EzOsuGame.Edit
             backgroundContainer.Child.RelativeSizeAxes = Axes.Both;
 
             updateHeaderText();
+            ensureSkinIniSession();
 
+            sceneContext = buildSceneContext();
+            applyCurrentScene();
+        }
+
+        private EzSkinEditorSceneContext buildSceneContext()
+        {
             provider = SkinEditorProviderResolver.Resolve(Beatmap.Value?.Beatmap);
 
-            sceneContext = new EzSkinEditorSceneContext
+            return new EzSkinEditorSceneContext
             {
                 Provider = provider,
                 EditorSkin = getEditorSkin(),
+                SkinIniSession = SkinIniSession,
                 RequestSceneRefresh = refreshScene,
+                CommitSkinIni = commitSkinIni,
             };
-
-            applyCurrentScene();
         }
 
         private void applyCurrentScene()
         {
-            if (sceneContext == null)
-                return;
+            sceneContext = buildSceneContext();
 
             var strategy = EzSkinEditorSceneRegistry.Get(sceneBar.CurrentScene.Value);
             sceneContentHost.Child = strategy.CreateSceneContent(sceneContext);
@@ -198,8 +217,52 @@ namespace osu.Game.EzOsuGame.Edit
 
         private void applySettings()
         {
-            // Milestone 2: commit draft to config and refresh preview.
-            applyCurrentScene();
+            ezSkinConfig.Save();
+
+            if (SkinIniSession?.IsDirty == true)
+                SkinIniSession.Commit();
+
+            refreshScene();
+        }
+
+        private void commitSkinIni()
+        {
+            if (SkinIniSession?.IsDirty != true)
+                return;
+
+            SkinIniSession.Commit();
+            refreshScene();
+        }
+
+        private void ensureSkinIniSession()
+        {
+            var currentSkin = skinManager.CurrentSkinInfo.Value;
+            Guid currentSkinId = currentSkin.ID;
+
+            SkinIniSession ??= new EzSkinIniSession(skinManager);
+
+            if (SkinIniSession.SkinId == currentSkinId)
+                return;
+
+            if (SkinIniSession.IsDirty)
+                SkinIniSession.Discard();
+
+            SkinIniSession.LoadFromSkin(currentSkin);
+        }
+
+        private void onCurrentSkinInfoChanged(ValueChangedEvent<Live<SkinInfo>> skin)
+        {
+            if (SkinIniSession == null)
+                return;
+
+            if (SkinIniSession.SkinId == skin.NewValue.ID)
+                return;
+
+            if (SkinIniSession.IsDirty)
+                SkinIniSession.Discard();
+
+            SkinIniSession.LoadFromSkin(skin.NewValue);
+            Schedule(refreshScene);
         }
 
         private ISkin getEditorSkin()
@@ -239,6 +302,12 @@ namespace osu.Game.EzOsuGame.Edit
                 return;
             }
 
+            if (SkinIniSession?.IsDirty != true)
+            {
+                this.Exit();
+                return;
+            }
+
             dialogOverlay.Push(new ConfirmDialog("应用更改到皮肤？", () =>
             {
                 applySettings();
@@ -247,6 +316,8 @@ namespace osu.Game.EzOsuGame.Edit
                     this.Exit();
             }, () =>
             {
+                SkinIniSession?.Discard();
+
                 if (this.IsCurrentScreen())
                     this.Exit();
             }));

--- a/osu.Game/EzOsuGame/Edit/EzSkinIniSession.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinIniSession.cs
@@ -1,0 +1,104 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.IO;
+using System.Text;
+using osu.Framework.IO.Stores;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+using osu.Game.IO;
+using osu.Game.Extensions;
+using osu.Game.Skinning;
+
+namespace osu.Game.EzOsuGame.Edit
+{
+    /// <summary>
+    /// Per-skin <c>skin.ini</c> saved/draft text session. Skin-layer only — not related to <see cref="Configuration.Ez2ConfigManager"/>.
+    /// </summary>
+    public sealed class EzSkinIniSession
+    {
+        private readonly SkinManager skinManager;
+        private readonly IResourceStore<byte[]> skinFiles;
+
+        public Guid SkinId { get; private set; }
+
+        public string SavedText { get; private set; } = string.Empty;
+
+        public string DraftText { get; private set; } = string.Empty;
+
+        public bool IsDirty => DraftText != SavedText;
+
+        public EzSkinIniSession(SkinManager skinManager)
+        {
+            this.skinManager = skinManager;
+            skinFiles = ((IStorageResourceProvider)skinManager).Files;
+        }
+
+        public void LoadFromSkin(Live<SkinInfo> skinInfo)
+        {
+            string text = skinInfo.PerformRead(readSkinIniText);
+            SkinId = skinInfo.ID;
+            SavedText = text;
+            DraftText = text;
+        }
+
+        public void SetDraftText(string text) => DraftText = text;
+
+        public void Discard() => DraftText = SavedText;
+
+        public bool Commit()
+        {
+            if (!IsDirty)
+                return false;
+
+            var live = skinManager.CurrentSkinInfo.Value;
+
+            if (live.ID != SkinId)
+                throw new InvalidOperationException("Cannot commit skin.ini for a skin that is no longer current.");
+
+            live.PerformWrite(skin => writeSkinIniText(skin, DraftText));
+            skinManager.CurrentSkinInfo.TriggerChange();
+            SavedText = DraftText;
+            return true;
+        }
+
+        private string readSkinIniText(SkinInfo skin)
+        {
+            var existingFile = skin.GetFile(@"skin.ini");
+
+            if (existingFile == null)
+                return createDefaultSkinIniText(skin);
+
+            using (var stream = skinFiles.GetStream(existingFile.File.GetStoragePath()))
+            {
+                if (stream == null)
+                    return createDefaultSkinIniText(skin);
+
+                using (var reader = new StreamReader(stream, Encoding.UTF8))
+                    return reader.ReadToEnd();
+            }
+        }
+
+        private void writeSkinIniText(SkinInfo skin, string text)
+        {
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(text));
+            var existingFile = skin.GetFile(@"skin.ini");
+
+            if (existingFile != null)
+                skinManager.ReplaceFile(skin, existingFile, stream);
+            else
+                skinManager.AddFile(skin, stream, @"skin.ini");
+        }
+
+        private static string createDefaultSkinIniText(SkinInfo skin)
+        {
+            var builder = new StringBuilder();
+            builder.AppendLine(@"[General]");
+            builder.AppendLine($@"Name: {skin.Name}");
+            builder.AppendLine($@"Author: {skin.Creator}");
+            builder.AppendLine(FormattableString.Invariant($"Version: {SkinConfiguration.LATEST_VERSION}"));
+            return builder.ToString();
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Edit/Scenes/SkinIniSceneStrategy.cs
+++ b/osu.Game/EzOsuGame/Edit/Scenes/SkinIniSceneStrategy.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -33,16 +34,16 @@ namespace osu.Game.EzOsuGame.Edit.Scenes
             };
 
         public Drawable CreateSidebarFooter(EzSkinEditorSceneContext context) =>
-            new SkinIniSaveFooter(context);
+            new SkinIniSaveFooter(context.CommitSkinIni);
     }
 
     internal partial class SkinIniSaveFooter : Container
     {
-        private readonly EzSkinEditorSceneContext context;
+        private readonly Action? commitSkinIni;
 
-        public SkinIniSaveFooter(EzSkinEditorSceneContext context)
+        public SkinIniSaveFooter(Action? commitSkinIni)
         {
-            this.context = context;
+            this.commitSkinIni = commitSkinIni;
             RelativeSizeAxes = Axes.X;
             Height = 40;
         }
@@ -55,7 +56,7 @@ namespace osu.Game.EzOsuGame.Edit.Scenes
                 Text = "保存 Skin.ini",
                 RelativeSizeAxes = Axes.X,
                 Height = 40,
-                Action = () => context.RequestSceneRefresh?.Invoke(),
+                Action = () => commitSkinIni?.Invoke(),
             };
         }
 

--- a/osu.Game/EzOsuGame/Edit/Settings/Sections/EzSkinEditorSkinIniPlaceholderSection.cs
+++ b/osu.Game/EzOsuGame/Edit/Settings/Sections/EzSkinEditorSkinIniPlaceholderSection.cs
@@ -30,7 +30,7 @@ namespace osu.Game.EzOsuGame.Edit.Settings.Sections
                 },
                 new OsuSpriteText
                 {
-                    Text = "里程碑 3：将在此显示 Skin.ini 各项设置。",
+                    Text = "编辑当前皮肤的 skin.ini（General + 规则集段）。M3 将在此提供完整表单；请使用底部按钮保存。",
                     Font = OsuFont.Default.With(size: 14),
                     Colour = Color4.Gray,
                 },

--- a/osu.Game/EzOsuGame/Edit/SkinEditorProviderResolver.cs
+++ b/osu.Game/EzOsuGame/Edit/SkinEditorProviderResolver.cs
@@ -1,6 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Linq;
+using System.Reflection;
 using osu.Game.Beatmaps;
 
 namespace osu.Game.EzOsuGame.Edit
@@ -8,6 +11,8 @@ namespace osu.Game.EzOsuGame.Edit
     public static class SkinEditorProviderResolver
     {
         private const int mania_ruleset_online_id = 3;
+
+        private const string mania_provider_type_name = "osu.Game.Rulesets.Mania.EzMania.Editor.EzSkinLNEditorProvider, osu.Game.Rulesets.Mania";
 
         public static ISkinEditorVirtualProvider? Resolve(IBeatmap? beatmap)
         {
@@ -21,6 +26,24 @@ namespace osu.Game.EzOsuGame.Edit
             }
 
             // Default to mania for editor previews when no beatmap ruleset is available.
+            return SkinEditorProviderRegistry.Get(mania_ruleset_online_id) ?? ensureManiaProviderRegistered();
+        }
+
+        private static ISkinEditorVirtualProvider? ensureManiaProviderRegistered()
+        {
+            try
+            {
+                var assembly = AppDomain.CurrentDomain.GetAssemblies()
+                                        .FirstOrDefault(a => a.GetName().Name == "osu.Game.Rulesets.Mania")
+                               ?? Assembly.Load(new AssemblyName("osu.Game.Rulesets.Mania"));
+
+                _ = assembly.GetType("osu.Game.Rulesets.Mania.EzMania.Editor.EzSkinLNEditorProvider", throwOnError: false);
+            }
+            catch
+            {
+                // best-effort: ruleset assembly may not be present in trimmed/test hosts
+            }
+
             return SkinEditorProviderRegistry.Get(mania_ruleset_online_id);
         }
     }


### PR DESCRIPTION
## Summary

- Add per-skin EzSkinIniSession (saved/draft text) with load, commit, and discard; wire skin.ini footer and skin-switch reload.
- Split apply/exit flows: Ez2ConfigManager.Save() for process-layer settings; skin.ini commit + TriggerChange() only when skin layer is dirty.
- Size scene comparison area now uses CreateStaticPart with live Note/LN static preview rows.
- Extend TestSceneEzSkinEditorScreen for comparison preview, apply save, ini session, per-skin isolation, and exit dialog.

## Test plan

- [x] dotnet build
- [x] dotnet test --filter FullyQualifiedName~TestSceneEzSkinEditorScreen
- [ ] Manual: open Ez Skin Editor, edit size sliders, apply, verify EzSkinSettings.ini
- [ ] Manual: skin.ini scene dirty draft, save footer, switch skins

Made with [Cursor](https://cursor.com)