### PR TITLE
EzSkinEditor M4: top-bar preview controls and beatmap scene

### DIFF
--- a/osu.Game.Tests/NonVisual/EzSkinEditorBeatmapPickerTest.cs
+++ b/osu.Game.Tests/NonVisual/EzSkinEditorBeatmapPickerTest.cs
@@ -1,0 +1,71 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Edit;
+using osu.Game.Rulesets.Mania;
+
+namespace osu.Game.Tests.NonVisual
+{
+    [TestFixture]
+    public class EzSkinEditorBeatmapPickerTest
+    {
+        [Test]
+        public void TestMetadataCandidateRequiresObjects()
+        {
+            var ruleset = new ManiaRuleset().RulesetInfo;
+
+            var withObjects = new BeatmapInfo
+            {
+                Ruleset = ruleset,
+                TotalObjectCount = 42,
+                BeatmapSet = new BeatmapSetInfo(),
+            };
+
+            var empty = new BeatmapInfo
+            {
+                Ruleset = ruleset,
+                TotalObjectCount = 0,
+                BeatmapSet = new BeatmapSetInfo(),
+            };
+
+            var unknown = new BeatmapInfo
+            {
+                Ruleset = ruleset,
+                TotalObjectCount = -1,
+                BeatmapSet = new BeatmapSetInfo(),
+            };
+
+            Assert.That(EzSkinEditorBeatmapPicker.IsMetadataCandidate(withObjects, ruleset.OnlineID), Is.True);
+            Assert.That(EzSkinEditorBeatmapPicker.IsMetadataCandidate(empty, ruleset.OnlineID), Is.False);
+            Assert.That(EzSkinEditorBeatmapPicker.IsMetadataCandidate(unknown, ruleset.OnlineID), Is.True);
+        }
+
+        [Test]
+        public void TestMetadataCandidateRejectsProtectedSet()
+        {
+            var ruleset = new ManiaRuleset().RulesetInfo;
+
+            var protectedBeatmap = new BeatmapInfo
+            {
+                Ruleset = ruleset,
+                TotalObjectCount = 10,
+                BeatmapSet = new BeatmapSetInfo { Protected = true },
+            };
+
+            Assert.That(EzSkinEditorBeatmapPicker.IsMetadataCandidate(protectedBeatmap, ruleset.OnlineID), Is.False);
+        }
+
+        [Test]
+        public void TestPreviewModesForManiaAndStandard()
+        {
+            var mania = new ManiaRuleset().RulesetInfo;
+
+            Assert.That(EzSkinEditorPreviewModes.GetAvailableModes(mania), Has.Count.EqualTo(4));
+            Assert.That(EzSkinEditorPreviewModes.ValidateMode(EzBeatmapPreviewMode.StaticScroll, mania), Is.EqualTo(EzBeatmapPreviewMode.StaticScroll));
+            Assert.That(EzSkinEditorPreviewModes.ValidateMode(EzBeatmapPreviewMode.StaticFullMap, mania), Is.EqualTo(EzBeatmapPreviewMode.StaticFullMap));
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Edit/TestSceneEzSkinEditorScreen.cs
+++ b/osu.Game.Tests/Visual/Edit/TestSceneEzSkinEditorScreen.cs
@@ -355,5 +355,28 @@ namespace osu.Game.Tests.Visual.Edit
             AddStep("collapse sidebar", () => editorScreen.ChildrenOfType<EzSkinEditorSidebar>().Single().ExpandedState.Value = false);
             AddUntilStep("sidebar contracted", () => editorScreen.ChildrenOfType<EzSkinEditorSidebar>().Single().DrawWidth <= EzSkinEditorSidebar.CONTRACTED_WIDTH + 1);
         }
+
+        [Test]
+        public void TestTopToolbarControls()
+        {
+            AddStep("load screen", loadScreen);
+            waitForScreenLoaded();
+
+            AddUntilStep("top toolbar visible", () => editorScreen.ChildrenOfType<EzSkinEditorTopToolbar>().Any());
+            AddUntilStep("skin dropdown visible", () => editorScreen.ChildrenOfType<EzSkinEditorSkinDropdown>().Any());
+            AddUntilStep("beatmap menu button visible", () => editorScreen.ChildrenOfType<EzSkinEditorBeatmapMenuButton>().Any());
+            AddAssert("default static preview", () => editorScreen.PreviewSource.Value == EzSkinEditorPreviewSource.Static);
+        }
+
+        [Test]
+        public void TestStaticPreviewAfterSkinSwitch()
+        {
+            AddStep("load screen", loadScreen);
+            waitForScreenLoaded();
+            importLegacySkin();
+
+            AddUntilStep("preview host visible", () => editorScreen.ChildrenOfType<EzSkinEditorPreviewHost>().Any());
+            AddAssert("still static preview", () => editorScreen.PreviewSource.Value == EzSkinEditorPreviewSource.Static);
+        }
     }
 }

--- a/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorBeatmapMenuButton.cs
+++ b/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorBeatmapMenuButton.cs
@@ -1,0 +1,171 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Localisation;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Overlays;
+using osu.Game.Overlays.SkinEditor;
+using osu.Game.Rulesets;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.EzOsuGame.Edit.Components
+{
+    public partial class EzSkinEditorBeatmapMenuButton : SkinEditorSceneLibrary.SceneButton, IHasPopover
+    {
+        public Action<RulesetInfo, EzBeatmapPreviewMode>? BeatmapPreviewRequested;
+
+        private bool active;
+
+        public bool Active
+        {
+            get => active;
+            set
+            {
+                active = value;
+                if (IsLoaded)
+                    updateColours();
+            }
+        }
+
+        private OsuColour colours = null!;
+        private OverlayColourProvider? colourProvider;
+
+        [Resolved]
+        private IRulesetStore rulesets { get; set; } = null!;
+
+        public EzSkinEditorBeatmapMenuButton()
+        {
+            Text = "实际谱面";
+            Width = 110;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours, OverlayColourProvider? overlayColourProvider)
+        {
+            this.colours = colours;
+            colourProvider = overlayColourProvider;
+            Action = this.ShowPopover;
+            updateColours();
+        }
+
+        public Popover GetPopover() => new BeatmapPreviewPopover(rulesets, BeatmapPreviewRequested);
+
+        private void updateColours()
+        {
+            BackgroundColour = active
+                ? colours.YellowDark
+                : colourProvider?.Background3 ?? colours.Blue3;
+        }
+    }
+
+    public partial class BeatmapPreviewPopover : OsuPopover
+    {
+        private readonly IRulesetStore rulesets;
+        private readonly Action<RulesetInfo, EzBeatmapPreviewMode>? onSelected;
+
+        public BeatmapPreviewPopover(IRulesetStore rulesets, Action<RulesetInfo, EzBeatmapPreviewMode>? onSelected)
+        {
+            this.rulesets = rulesets;
+            this.onSelected = onSelected;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Child = new OsuScrollContainer
+            {
+                Width = 280,
+                Height = 360,
+                Child = new FillFlowContainer
+                {
+                    AutoSizeAxes = Axes.Y,
+                    Width = 260,
+                    Direction = FillDirection.Vertical,
+                    Spacing = new Vector2(0, 6),
+                    Padding = new MarginPadding(10),
+                    Children = buildSections().ToArray(),
+                },
+            };
+        }
+
+        private IEnumerable<Drawable> buildSections()
+        {
+            foreach (var ruleset in rulesets.AvailableRulesets.OfType<RulesetInfo>())
+            {
+                yield return new OsuSpriteText
+                {
+                    Text = ruleset.Name,
+                    Font = OsuFont.Default.With(weight: FontWeight.Bold, size: 14),
+                    Margin = new MarginPadding { Top = 4 },
+                };
+
+                if (!EzSkinEditorPreviewModes.SupportsBeatmapPreview(ruleset))
+                {
+                    yield return new OsuSpriteText
+                    {
+                        Text = "预览尚未支持",
+                        Font = OsuFont.Default.With(size: 12),
+                        Colour = Color4.Gray,
+                        Margin = new MarginPadding { Bottom = 4 },
+                    };
+
+                    continue;
+                }
+
+                foreach (var mode in EzSkinEditorPreviewModes.GetAvailableModes(ruleset))
+                {
+                    var capturedRuleset = ruleset;
+                    var capturedMode = mode;
+
+                    yield return new ModeSelectButton(getModeLabel(mode), () =>
+                    {
+                        onSelected?.Invoke(capturedRuleset, capturedMode);
+                        this.HidePopover();
+                    });
+                }
+            }
+        }
+
+        private static LocalisableString getModeLabel(EzBeatmapPreviewMode mode) => mode switch
+        {
+            EzBeatmapPreviewMode.Dynamic => EzEnumStrings.DYNAMIC,
+            EzBeatmapPreviewMode.Static => EzEnumStrings.STATIC,
+            EzBeatmapPreviewMode.StaticFullMap => EzEnumStrings.STATIC_FULL_MAP,
+            EzBeatmapPreviewMode.StaticScroll => EzEnumStrings.STATIC_SCROLL,
+            _ => mode.ToString(),
+        };
+
+        private partial class ModeSelectButton : OsuButton
+        {
+            public ModeSelectButton(LocalisableString text, Action action)
+            {
+                Text = text;
+                Action = action;
+                RelativeSizeAxes = Axes.X;
+                Height = 32;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider? overlayColourProvider, OsuColour colours)
+            {
+                BackgroundColour = overlayColourProvider?.Background4 ?? colours.Blue3;
+            }
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorBeatmapPreviewHost.cs
+++ b/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorBeatmapPreviewHost.cs
@@ -1,0 +1,316 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Timing;
+using osu.Game.Beatmaps;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Overlays.Preview;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.UI;
+using osu.Game.Skinning;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.EzOsuGame.Edit.Components
+{
+    /// <summary>
+    /// In-editor beatmap preview using the same renderers as <see cref="Overlays.EzBeatmapPreviewOverlay"/>.
+    /// </summary>
+    public partial class EzSkinEditorBeatmapPreviewHost : Container
+    {
+        private const double dynamic_preview_duration = 10000;
+        private const double dynamic_preview_repeat_delay = 500;
+
+        private readonly EzSkinEditorSceneContext context;
+
+        private readonly StopwatchClock previewClock = new StopwatchClock();
+        private readonly FramedClock framedPreviewClock;
+
+        private Container stageScaleContainer = null!;
+        private Container stageViewport = null!;
+
+        private DrawableRuleset? drawableRuleset;
+        private IManiaStaticPreviewRenderer? maniaStaticRenderer;
+        private CancellationTokenSource? loadCancellation;
+
+        private IBeatmap? playableBeatmap;
+        private RulesetInfo? rulesetInfo;
+        private EzBeatmapPreviewMode previewMode;
+        private double playbackStartTime;
+        private double beatmapMinTime;
+        private double beatmapMaxTime;
+        private double nextDynamicLoopStartTime;
+
+        public EzSkinEditorBeatmapPreviewHost(EzSkinEditorSceneContext context)
+        {
+            this.context = context;
+            RelativeSizeAxes = Axes.Both;
+            framedPreviewClock = new FramedClock(previewClock);
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            InternalChild = stageViewport = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Padding = new MarginPadding(10),
+                Child = stageScaleContainer = new Container
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.Both,
+                },
+            };
+
+            if (context.PreviewBeatmap == null || context.PreviewRuleset == null)
+            {
+                stageScaleContainer.Child = createPlaceholder("未加载谱面");
+                return;
+            }
+
+            if (!EzSkinEditorPreviewModes.SupportsBeatmapPreview(context.PreviewRuleset))
+            {
+                stageScaleContainer.Child = createPlaceholder("该规则集预览尚未支持");
+                return;
+            }
+
+            rulesetInfo = context.PreviewRuleset;
+            previewMode = EzSkinEditorPreviewModes.ValidateMode(context.PreviewMode, context.PreviewRuleset);
+            beginLoad();
+        }
+
+        private void beginLoad()
+        {
+            loadCancellation?.Cancel();
+            loadCancellation = new CancellationTokenSource();
+            var token = loadCancellation.Token;
+
+            Task.Run(() =>
+            {
+                token.ThrowIfCancellationRequested();
+
+                var ruleset = rulesetInfo!;
+                var beatmap = context.PreviewBeatmap!.GetPlayableBeatmap(ruleset);
+                double startTime = computeDefaultStartTime(beatmap, ruleset, beatmap.HitObjects.Count > 0 ? beatmap.HitObjects[0].StartTime : 0);
+                return (beatmap, startTime);
+            }, token).ContinueWith(task =>
+            {
+                Schedule(() =>
+                {
+                    if (token.IsCancellationRequested || task.IsCanceled)
+                        return;
+
+                    if (task.IsFaulted)
+                    {
+                        stageScaleContainer.Child = createPlaceholder("谱面加载失败");
+                        return;
+                    }
+
+                    var (beatmap, startTime) = task.GetResultSafely();
+                    playableBeatmap = beatmap;
+                    playbackStartTime = startTime;
+                    beatmapMinTime = 0;
+                    beatmapMaxTime = Math.Max(beatmap.BeatmapInfo.Length, beatmapMinTime + 1);
+
+                    mountPreview(token);
+                    previewClock.Seek(playbackStartTime);
+
+                    if (previewMode == EzBeatmapPreviewMode.Dynamic)
+                    {
+                        nextDynamicLoopStartTime = Time.Current;
+                        previewClock.Start();
+                    }
+                });
+            }, CancellationToken.None);
+        }
+
+        private void mountPreview(CancellationToken token)
+        {
+            disposePreviewResources();
+
+            if (playableBeatmap == null || rulesetInfo == null)
+                return;
+
+            if (EzSkinEditorPreviewModes.IsManiaRuleset(rulesetInfo)
+                && previewMode is EzBeatmapPreviewMode.StaticFullMap or EzBeatmapPreviewMode.StaticScroll)
+            {
+                setupManiaStaticPreview(playableBeatmap);
+                return;
+            }
+
+            var ruleset = rulesetInfo.CreateInstance();
+            var newDrawableRuleset = ruleset.CreateDrawableRulesetWith(playableBeatmap);
+
+            stageScaleContainer.RelativeSizeAxes = Axes.None;
+            stageScaleContainer.Size = new Vector2(640, 480);
+
+            newDrawableRuleset.Clock = framedPreviewClock;
+            newDrawableRuleset.FrameStablePlayback = false;
+            newDrawableRuleset.Playfield.DisplayJudgements.Value = false;
+
+            var previewRoot = new RulesetSkinProvidingContainer(ruleset, playableBeatmap, context.EditorSkin)
+            {
+                RelativeSizeAxes = Axes.Both,
+                Child = new NonHandleContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = newDrawableRuleset,
+                },
+            };
+
+            LoadComponentAsync(previewRoot, loaded =>
+            {
+                if (token.IsCancellationRequested)
+                {
+                    loaded.Dispose();
+                    return;
+                }
+
+                stageScaleContainer.Child = loaded;
+                drawableRuleset = newDrawableRuleset;
+                maniaStaticRenderer = null;
+            }, token);
+        }
+
+        private void setupManiaStaticPreview(IBeatmap beatmap)
+        {
+            ManiaPreviewData data = ManiaPreviewGeometryBuilder.Build(beatmap);
+
+            var renderer = previewMode switch
+            {
+                EzBeatmapPreviewMode.StaticFullMap => (IManiaStaticPreviewRenderer)new StaticFullMapPreviewRenderer(),
+                EzBeatmapPreviewMode.StaticScroll => new StaticScrollPreviewRenderer(),
+                _ => null,
+            };
+
+            if (renderer == null)
+                return;
+
+            renderer.SetData(data);
+            renderer.SetCurrentTime(previewClock.CurrentTime);
+
+            stageScaleContainer.RelativeSizeAxes = Axes.Both;
+            stageScaleContainer.Scale = Vector2.One;
+            stageScaleContainer.Size = Vector2.One;
+            stageScaleContainer.Child = (Drawable)renderer;
+
+            maniaStaticRenderer = renderer;
+            drawableRuleset = null;
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (previewMode != EzBeatmapPreviewMode.Dynamic || drawableRuleset == null)
+                return;
+
+            if (previewClock.IsRunning)
+            {
+                double elapsed = previewClock.CurrentTime - playbackStartTime;
+
+                if (elapsed >= dynamic_preview_duration)
+                {
+                    previewClock.Stop();
+                    previewClock.Seek(playbackStartTime);
+                    nextDynamicLoopStartTime = Time.Current + dynamic_preview_repeat_delay;
+                }
+            }
+            else if (Time.Current >= nextDynamicLoopStartTime)
+            {
+                previewClock.Seek(playbackStartTime);
+                previewClock.Start();
+            }
+        }
+
+        protected override void UpdateAfterChildren()
+        {
+            base.UpdateAfterChildren();
+
+            if (drawableRuleset == null || maniaStaticRenderer != null)
+                return;
+
+            float viewportWidth = stageViewport.DrawWidth;
+            float viewportHeight = stageViewport.DrawHeight;
+
+            if (viewportWidth <= 1 || viewportHeight <= 1)
+                return;
+
+            float scale = Math.Min(viewportWidth / stageScaleContainer.Width, viewportHeight / stageScaleContainer.Height);
+            stageScaleContainer.Scale = new Vector2(Math.Max(0.05f, scale));
+        }
+
+        private void disposePreviewResources()
+        {
+            drawableRuleset = null;
+            maniaStaticRenderer = null;
+
+            if (stageScaleContainer.Count > 0)
+                stageScaleContainer.Clear(true);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (isDisposing)
+            {
+                loadCancellation?.Cancel();
+                disposePreviewResources();
+            }
+
+            base.Dispose(isDisposing);
+        }
+
+        private static OsuSpriteText createPlaceholder(string text) => new OsuSpriteText
+        {
+            Anchor = Anchor.Centre,
+            Origin = Anchor.Centre,
+            Text = text,
+            Colour = Color4.White,
+        };
+
+        private static double computeDefaultStartTime(IBeatmap playableBeatmap, RulesetInfo ruleset, double fallback)
+        {
+            if (ruleset.OnlineID == 3)
+            {
+                int previewTime = playableBeatmap.Metadata.PreviewTime;
+                if (previewTime > 0)
+                    return previewTime;
+            }
+            else
+            {
+                double kiaiStart = getKiaiStartTime(playableBeatmap);
+                if (!double.IsNaN(kiaiStart))
+                    return kiaiStart;
+            }
+
+            return fallback;
+        }
+
+        private static double getKiaiStartTime(IBeatmap beatmap)
+        {
+            try
+            {
+                foreach (var effectPoint in beatmap.ControlPointInfo.EffectPoints)
+                {
+                    if (effectPoint.KiaiMode)
+                        return effectPoint.Time;
+                }
+            }
+            catch
+            {
+                // ignored
+            }
+
+            return double.NaN;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorPreviewHost.cs
+++ b/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorPreviewHost.cs
@@ -62,6 +62,15 @@ namespace osu.Game.EzOsuGame.Edit.Components
 
         private void populatePlayback()
         {
+            if (context.PreviewSource == EzSkinEditorPreviewSource.Beatmap)
+            {
+                playbackContainer.Child = new EzSkinEditorBeatmapPreviewHost(context).With(d =>
+                {
+                    d.RelativeSizeAxes = Axes.Both;
+                });
+                return;
+            }
+
             if (context.Provider != null)
             {
                 playbackContainer.Child = context.Provider.CreateDynamicPart(context.EditorSkin).With(d =>
@@ -73,13 +82,7 @@ namespace osu.Game.EzOsuGame.Edit.Components
             }
             else
             {
-                playbackContainer.Child = new OsuSpriteText
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Text = "Virtual playfield not supported",
-                    Colour = Color4.White,
-                };
+                playbackContainer.Child = createPlaceholder("Virtual playfield not supported");
             }
         }
 
@@ -96,14 +99,16 @@ namespace osu.Game.EzOsuGame.Edit.Components
             }
             else
             {
-                comparisonContainer.Child = new OsuSpriteText
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Text = "Comparison preview not supported",
-                    Colour = Color4.White,
-                };
+                comparisonContainer.Child = createPlaceholder("Comparison preview not supported");
             }
         }
+
+        private static OsuSpriteText createPlaceholder(string text) => new OsuSpriteText
+        {
+            Anchor = Anchor.Centre,
+            Origin = Anchor.Centre,
+            Text = text,
+            Colour = Color4.White,
+        };
     }
 }

--- a/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorSkinDropdown.cs
+++ b/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorSkinDropdown.cs
@@ -1,0 +1,94 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Localisation;
+using osu.Game.Database;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Skinning;
+using Realms;
+
+namespace osu.Game.EzOsuGame.Edit.Components
+{
+    public partial class EzSkinEditorSkinDropdown : OsuDropdown<Live<SkinInfo>>
+    {
+        public const float DEFAULT_WIDTH = 200;
+
+        private readonly List<Live<SkinInfo>> dropdownItems = new List<Live<SkinInfo>>();
+
+        [Resolved]
+        private SkinManager skins { get; set; } = null!;
+
+        [Resolved]
+        private RealmAccess realm { get; set; } = null!;
+
+        private IDisposable? realmSubscription;
+
+        public EzSkinEditorSkinDropdown()
+        {
+            RelativeSizeAxes = Axes.None;
+            Width = DEFAULT_WIDTH;
+            AlwaysShowSearchBar = true;
+            AllowNonContiguousMatching = true;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Current = skins.CurrentSkinInfo;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            realmSubscription = realm.RegisterForNotifications(_ => realm.Realm.All<SkinInfo>()
+                                                                         .Where(s => !s.DeletePending)
+                                                                         .OrderBy(s => s.Name, StringComparer.OrdinalIgnoreCase), skinsChanged);
+
+            Current.BindValueChanged(skin =>
+            {
+                if (skin.NewValue.ID == SkinInfo.RANDOM_SKIN)
+                {
+                    skins.CurrentSkinInfo.Value = skin.OldValue;
+                    skins.SelectRandomSkin();
+                }
+            });
+
+            skins.ScriptedSkinsCatalogUpdated += refreshSkinsList;
+            refreshSkinsList();
+        }
+
+        protected override LocalisableString GenerateItemText(Live<SkinInfo> item) => item.ToString() ?? "";
+
+        private void skinsChanged(IRealmCollection<SkinInfo> sender, ChangeSet? changes)
+        {
+            if (!sender.Any())
+                return;
+
+            refreshSkinsList();
+        }
+
+        private void refreshSkinsList()
+        {
+            dropdownItems.Clear();
+            dropdownItems.AddRange(skins.GetAllUsableSkins());
+            Schedule(() => Items = dropdownItems);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (isDisposing)
+            {
+                skins.ScriptedSkinsCatalogUpdated -= refreshSkinsList;
+                realmSubscription?.Dispose();
+            }
+
+            base.Dispose(isDisposing);
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorTopToolbar.cs
+++ b/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorTopToolbar.cs
@@ -1,0 +1,129 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Overlays;
+using osu.Game.Overlays.SkinEditor;
+using osu.Game.Rulesets;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.Edit.Components
+{
+    public partial class EzSkinEditorTopToolbar : FillFlowContainer
+    {
+        public Action? StaticPreviewRequested { get; set; }
+
+        public Action<RulesetInfo, EzBeatmapPreviewMode>? BeatmapPreviewRequested { get; set; }
+
+        public Bindable<EzSkinEditorPreviewSource>? PreviewSource { get; set; }
+
+        private StaticPreviewButton staticButton = null!;
+        private EzSkinEditorBeatmapMenuButton beatmapButton = null!;
+
+        public EzSkinEditorTopToolbar()
+        {
+            AutoSizeAxes = Axes.Both;
+            Anchor = Anchor.CentreRight;
+            Origin = Anchor.CentreRight;
+            Direction = FillDirection.Horizontal;
+            Spacing = new Vector2(8);
+            Padding = new MarginPadding { Horizontal = 10, Vertical = 5 };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            Children = new Drawable[]
+            {
+                staticButton = new StaticPreviewButton
+                {
+                    Action = () => StaticPreviewRequested?.Invoke(),
+                },
+                beatmapButton = new EzSkinEditorBeatmapMenuButton
+                {
+                    BeatmapPreviewRequested = (ruleset, mode) => BeatmapPreviewRequested?.Invoke(ruleset, mode),
+                },
+                new EzSkinEditorSkinDropdown(),
+                new OsuTextFlowContainer
+                {
+                    TextAnchor = Anchor.CentreLeft,
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    AutoSizeAxes = Axes.Both,
+                    Margin = new MarginPadding { Left = 6 },
+                }.With(t =>
+                {
+                    t.AddText(@"Ez ", cp => cp.Font = OsuFont.TorusAlternate);
+                    t.AddText(@"Skin Editor", cp =>
+                    {
+                        cp.Font = OsuFont.TorusAlternate;
+                        cp.Colour = colourProvider.Highlight1;
+                    });
+                }),
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            PreviewSource?.BindValueChanged(_ => updateActiveState(), true);
+        }
+
+        private void updateActiveState()
+        {
+            if (PreviewSource == null)
+                return;
+
+            staticButton.Active = PreviewSource.Value == EzSkinEditorPreviewSource.Static;
+            beatmapButton.Active = PreviewSource.Value == EzSkinEditorPreviewSource.Beatmap;
+        }
+
+        private partial class StaticPreviewButton : SkinEditorSceneLibrary.SceneButton
+        {
+            private bool active;
+
+            public bool Active
+            {
+                get => active;
+                set
+                {
+                    active = value;
+                    if (IsLoaded)
+                        updateColours();
+                }
+            }
+
+            private OsuColour colours = null!;
+            private OverlayColourProvider? colourProvider;
+
+            public StaticPreviewButton()
+            {
+                Text = "静态皮肤";
+                Width = 100;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OsuColour colours, OverlayColourProvider? overlayColourProvider)
+            {
+                this.colours = colours;
+                colourProvider = overlayColourProvider;
+                updateColours();
+            }
+
+            private void updateColours()
+            {
+                BackgroundColour = active
+                    ? colours.YellowDark
+                    : colourProvider?.Background3 ?? colours.Blue3;
+            }
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Edit/EzSkinEditorBeatmapPicker.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinEditorBeatmapPicker.cs
@@ -1,0 +1,95 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Utils;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+using osu.Game.Rulesets;
+using Realms;
+
+namespace osu.Game.EzOsuGame.Edit
+{
+    public sealed class EzSkinEditorBeatmapPicker
+    {
+        private readonly RealmAccess realm;
+        private readonly BeatmapManager beatmaps;
+
+        public EzSkinEditorBeatmapPicker(RealmAccess realm, BeatmapManager beatmaps)
+        {
+            this.realm = realm;
+            this.beatmaps = beatmaps;
+        }
+
+        public bool TryPickRandom(RulesetInfo ruleset, out IWorkingBeatmap? workingBeatmap)
+        {
+            workingBeatmap = null;
+
+            var candidates = queryCandidates(ruleset.OnlineID);
+
+            if (candidates.Count == 0)
+                return false;
+
+            var chosen = candidates[RNG.Next(candidates.Count)];
+            workingBeatmap = beatmaps.GetWorkingBeatmap(chosen);
+            return true;
+        }
+
+        internal static bool IsMetadataCandidate(BeatmapInfo beatmapInfo, int rulesetOnlineId)
+        {
+            if (beatmapInfo.Ruleset.OnlineID != rulesetOnlineId)
+                return false;
+
+            if (beatmapInfo.BeatmapSet?.Protected == true)
+                return false;
+
+            if (beatmapInfo.TotalObjectCount == 0)
+                return false;
+
+            return beatmapInfo.TotalObjectCount > 0 || beatmapInfo.TotalObjectCount == -1;
+        }
+
+        private List<BeatmapInfo> queryCandidates(int rulesetOnlineId)
+        {
+            var metadataMatches = realm.Run(r => r.All<BeatmapInfo>()
+                                                  .Filter($@"{nameof(BeatmapInfo.BeatmapSet)}.{nameof(BeatmapSetInfo.DeletePending)} == false")
+                                                  .Filter($@"{nameof(BeatmapInfo.BeatmapSet)}.{nameof(BeatmapSetInfo.Protected)} == false")
+                                                  .Filter($@"{nameof(BeatmapInfo.Ruleset)}.{nameof(RulesetInfo.OnlineID)} == $0", rulesetOnlineId)
+                                                  .AsEnumerable()
+                                                  .Select(i => i.Detach())
+                                                  .Where(b => IsMetadataCandidate(b, rulesetOnlineId))
+                                                  .ToList());
+
+            var playable = new List<BeatmapInfo>(metadataMatches.Count);
+
+            foreach (var beatmapInfo in metadataMatches)
+            {
+                if (beatmapInfo.TotalObjectCount > 0)
+                {
+                    playable.Add(beatmapInfo);
+                    continue;
+                }
+
+                if (hasPlayableObjects(beatmapInfo))
+                    playable.Add(beatmapInfo);
+            }
+
+            return playable;
+        }
+
+        private bool hasPlayableObjects(BeatmapInfo beatmapInfo)
+        {
+            try
+            {
+                var working = beatmaps.GetWorkingBeatmap(beatmapInfo);
+                var playable = working.GetPlayableBeatmap(beatmapInfo.Ruleset);
+                return playable.HitObjects.Count > 0;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Edit/EzSkinEditorPreviewModes.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinEditorPreviewModes.cs
@@ -1,0 +1,51 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.Rulesets;
+
+namespace osu.Game.EzOsuGame.Edit
+{
+    public static class EzSkinEditorPreviewModes
+    {
+        private const int mania_ruleset_online_id = 3;
+
+        private static readonly EzBeatmapPreviewMode[] shared_modes =
+        {
+            EzBeatmapPreviewMode.Dynamic,
+            EzBeatmapPreviewMode.Static,
+        };
+
+        private static readonly EzBeatmapPreviewMode[] mania_modes =
+        {
+            EzBeatmapPreviewMode.Dynamic,
+            EzBeatmapPreviewMode.Static,
+            EzBeatmapPreviewMode.StaticFullMap,
+            EzBeatmapPreviewMode.StaticScroll,
+        };
+
+        public static bool SupportsBeatmapPreview(RulesetInfo ruleset) => ruleset.OnlineID is >= 0 and <= mania_ruleset_online_id;
+
+        public static IReadOnlyList<EzBeatmapPreviewMode> GetAvailableModes(RulesetInfo ruleset) =>
+            IsManiaRuleset(ruleset) ? mania_modes : shared_modes;
+
+        public static EzBeatmapPreviewMode GetDefaultMode(RulesetInfo ruleset) =>
+            IsManiaRuleset(ruleset) ? EzBeatmapPreviewMode.StaticFullMap : EzBeatmapPreviewMode.Static;
+
+        public static EzBeatmapPreviewMode ValidateMode(EzBeatmapPreviewMode mode, RulesetInfo ruleset)
+        {
+            var available = GetAvailableModes(ruleset);
+
+            foreach (var candidate in available)
+            {
+                if (candidate == mode)
+                    return mode;
+            }
+
+            return GetDefaultMode(ruleset);
+        }
+
+        public static bool IsManiaRuleset(RulesetInfo? ruleset) => ruleset?.OnlineID == mania_ruleset_online_id;
+    }
+}

--- a/osu.Game/EzOsuGame/Edit/EzSkinEditorPreviewSource.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinEditorPreviewSource.cs
@@ -1,0 +1,11 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.EzOsuGame.Edit
+{
+    public enum EzSkinEditorPreviewSource
+    {
+        Static,
+        Beatmap,
+    }
+}

--- a/osu.Game/EzOsuGame/Edit/EzSkinEditorPreviewState.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinEditorPreviewState.cs
@@ -1,0 +1,39 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Game.Beatmaps;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.Rulesets;
+
+namespace osu.Game.EzOsuGame.Edit
+{
+    /// <summary>
+    /// Local preview state for Ez skin editor. Does not mutate global <see cref="OsuGame.Beatmap"/> / <see cref="OsuGame.Ruleset"/>.
+    /// </summary>
+    public sealed class EzSkinEditorPreviewState
+    {
+        public Bindable<EzSkinEditorPreviewSource> Source { get; } = new Bindable<EzSkinEditorPreviewSource>(EzSkinEditorPreviewSource.Static);
+
+        public Bindable<EzBeatmapPreviewMode> Mode { get; } = new Bindable<EzBeatmapPreviewMode>(EzBeatmapPreviewMode.Static);
+
+        public Bindable<RulesetInfo?> Ruleset { get; } = new Bindable<RulesetInfo?>();
+
+        public IWorkingBeatmap? PreviewBeatmap { get; private set; }
+
+        public void SetStatic()
+        {
+            Source.Value = EzSkinEditorPreviewSource.Static;
+            PreviewBeatmap = null;
+            Ruleset.Value = null;
+        }
+
+        public void SetBeatmap(IWorkingBeatmap workingBeatmap, RulesetInfo ruleset, EzBeatmapPreviewMode mode)
+        {
+            PreviewBeatmap = workingBeatmap;
+            Ruleset.Value = ruleset;
+            Mode.Value = mode;
+            Source.Value = EzSkinEditorPreviewSource.Beatmap;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Edit/EzSkinEditorSceneContext.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinEditorSceneContext.cs
@@ -2,6 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Game.Beatmaps;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.Rulesets;
 using osu.Game.Skinning;
 
 namespace osu.Game.EzOsuGame.Edit
@@ -20,5 +23,13 @@ namespace osu.Game.EzOsuGame.Edit
         public Action? RequestSceneRefresh { get; init; }
 
         public Action? CommitSkinIni { get; init; }
+
+        public EzSkinEditorPreviewSource PreviewSource { get; init; } = EzSkinEditorPreviewSource.Static;
+
+        public IWorkingBeatmap? PreviewBeatmap { get; init; }
+
+        public RulesetInfo? PreviewRuleset { get; init; }
+
+        public EzBeatmapPreviewMode PreviewMode { get; init; } = EzBeatmapPreviewMode.Static;
     }
 }

--- a/osu.Game/EzOsuGame/Edit/EzSkinEditorScreen.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinEditorScreen.cs
@@ -7,15 +7,16 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Screens;
+using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.Edit.Components;
-using osu.Game.Graphics;
-using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Dialog;
+using osu.Game.Overlays.Notifications;
 using osu.Game.Overlays.SkinEditor;
+using osu.Game.Rulesets;
 using osu.Game.Screens;
 using osu.Game.Skinning;
 
@@ -25,7 +26,8 @@ namespace osu.Game.EzOsuGame.Edit
     // M1: layout shell + scene strategies + sidebar groups
     // M2: Saved/Draft session + Note/LN comparison preview
     // M3: Skin.ini editor + backup + save footer
-    // M4: export, EzSkin.json, advanced colouring
+    // M4: top-bar preview controls + static/beatmap scene backends
+    // M5: export, EzSkin.json, advanced colouring
 
     /// <summary>
     /// Ez skin editor screen with menu bar, scene bar, scene content and toolbox-style settings sidebar.
@@ -42,20 +44,34 @@ namespace osu.Game.EzOsuGame.Edit
         [Resolved]
         private Ez2ConfigManager ezSkinConfig { get; set; } = null!;
 
+        [Resolved]
+        private BeatmapManager beatmapManager { get; set; } = null!;
+
+        [Resolved]
+        private RealmAccess realm { get; set; } = null!;
+
         [Resolved(canBeNull: true)]
         private IDialogOverlay? dialogOverlay { get; set; }
+
+        [Resolved(canBeNull: true)]
+        private INotificationOverlay? notifications { get; set; }
 
         private Container? backgroundContainer;
         private Container sceneContentHost = null!;
         private EzSkinEditorMenuBar menuBar = null!;
         private EzSkinEditorSceneBar sceneBar = null!;
         private EzSkinEditorSidebar sidebar = null!;
-        private OsuTextFlowContainer headerText = null!;
+        private EzSkinEditorTopToolbar topToolbar = null!;
+
+        private readonly EzSkinEditorPreviewState previewState = new EzSkinEditorPreviewState();
+        private EzSkinEditorBeatmapPicker? beatmapPicker;
 
         private ISkinEditorVirtualProvider? provider;
         private EzSkinEditorSceneContext? sceneContext;
 
         public Bindable<EzSkinEditorSceneType> CurrentScene => sceneBar.CurrentScene;
+
+        internal Bindable<EzSkinEditorPreviewSource> PreviewSource => previewState.Source;
 
         /// <summary>
         /// Per-skin skin.ini session. Skin-layer only.
@@ -123,14 +139,11 @@ namespace osu.Game.EzOsuGame.Edit
                                             ApplyAction = applySettings,
                                             ExitAction = tryExit,
                                         },
-                                        headerText = new OsuTextFlowContainer
+                                        topToolbar = new EzSkinEditorTopToolbar
                                         {
-                                            TextAnchor = Anchor.TopRight,
-                                            Padding = new MarginPadding(5),
-                                            Anchor = Anchor.TopRight,
-                                            Origin = Anchor.TopRight,
-                                            AutoSizeAxes = Axes.X,
-                                            RelativeSizeAxes = Axes.Y,
+                                            PreviewSource = previewState.Source,
+                                            StaticPreviewRequested = selectStaticPreview,
+                                            BeatmapPreviewRequested = selectBeatmapPreview,
                                         },
                                     },
                                 },
@@ -171,9 +184,9 @@ namespace osu.Game.EzOsuGame.Edit
         protected override void LoadComplete()
         {
             base.LoadComplete();
+            beatmapPicker = new EzSkinEditorBeatmapPicker(realm, beatmapManager);
             sceneBar.CurrentScene.BindValueChanged(onSceneChanged, true);
             skinManager.CurrentSkinInfo.BindValueChanged(onCurrentSkinInfoChanged);
-            updateHeaderText();
         }
 
         private void onSceneChanged(ValueChangedEvent<EzSkinEditorSceneType> change)
@@ -196,16 +209,43 @@ namespace osu.Game.EzOsuGame.Edit
             backgroundContainer!.Child = createManiaStageBackgroundOrNull() ?? new Container { RelativeSizeAxes = Axes.Both };
             backgroundContainer.Child.RelativeSizeAxes = Axes.Both;
 
-            updateHeaderText();
             ensureSkinIniSession();
 
             sceneContext = buildSceneContext();
             applyCurrentScene();
         }
 
+        private void selectStaticPreview()
+        {
+            previewState.SetStatic();
+            refreshScene();
+        }
+
+        private void selectBeatmapPreview(RulesetInfo ruleset, EzBeatmapPreviewMode mode)
+        {
+            if (beatmapPicker == null)
+                return;
+
+            if (!beatmapPicker.TryPickRandom(ruleset, out var workingBeatmap))
+            {
+                notifications?.Post(new SimpleNotification
+                {
+                    Text = "未找到可用谱面",
+                });
+                return;
+            }
+
+            previewState.SetBeatmap(workingBeatmap!, ruleset, EzSkinEditorPreviewModes.ValidateMode(mode, ruleset));
+            refreshScene();
+        }
+
         private EzSkinEditorSceneContext buildSceneContext()
         {
-            provider = SkinEditorProviderResolver.Resolve(Beatmap.Value?.Beatmap);
+            var previewBeatmap = previewState.Source.Value == EzSkinEditorPreviewSource.Beatmap
+                ? previewState.PreviewBeatmap?.Beatmap
+                : null;
+
+            provider = SkinEditorProviderResolver.Resolve(previewBeatmap);
 
             return new EzSkinEditorSceneContext
             {
@@ -214,6 +254,10 @@ namespace osu.Game.EzOsuGame.Edit
                 SkinIniSession = SkinIniSession,
                 RequestSceneRefresh = refreshScene,
                 CommitSkinIni = commitSkinIni,
+                PreviewSource = previewState.Source.Value,
+                PreviewBeatmap = previewState.PreviewBeatmap,
+                PreviewRuleset = previewState.Ruleset.Value,
+                PreviewMode = previewState.Mode.Value,
             };
         }
 
@@ -291,17 +335,6 @@ namespace osu.Game.EzOsuGame.Edit
             return currentSkin is EzStyleProSkin or Ez2Skin or SbISkin
                 ? currentSkin
                 : new EzStyleProSkin(skinManager);
-        }
-
-        private void updateHeaderText()
-        {
-            headerText.Clear();
-            headerText.AddText(@"Ez ", t => t.Font = OsuFont.TorusAlternate);
-            headerText.AddText(@"Skin Editor", t =>
-            {
-                t.Font = OsuFont.TorusAlternate;
-                t.Colour = colourProvider.Highlight1;
-            });
         }
 
         private void tryExit()


### PR DESCRIPTION
## Summary

- 顶栏右侧加入 **静态皮肤**、**实际谱面**（规则集 → 预览模式 → 随机有 note 谱面）、**皮肤下拉** 三个控件。
- 场景预览区支持 **Static / Beatmap** 双后端：静态走现有 virtual provider 合成预览；谱面模式复用选歌预览渲染器（Mania 四模式 + 其他规则集 Dynamic/Static）。
- 预览状态仅保存在编辑器本地，**不写入**全局 `Beatmap` / `Ruleset`。

## Test plan

- [ ] `dotnet test osu.Game.Tests --filter "FullyQualifiedName~EzSkinEditorBeatmapPickerTest|FullyQualifiedName~TestSceneEzSkinEditorScreen"`
- [ ] 进入 Ez Skin Editor：默认静态预览，顶栏三控件可见
- [ ] 点「实际谱面」→ Mania → 全图预览：随机谱面加载并显示
- [ ] 顶栏切换皮肤：预览刷新，Legacy 皮肤 skin.ini Tab 仍正常
- [ ] Size 场景 + 谱面模式：左侧谱面预览，右侧仍为 Note/LN 合成对比


Made with [Cursor](https://cursor.com)