### PR TITLE
EzSkinEditor M6: size to skin.ini and .osk export

### DIFF
--- a/osu.Game.Tests/NonVisual/EzSkinSizeSkinIniWriterTest.cs
+++ b/osu.Game.Tests/NonVisual/EzSkinSizeSkinIniWriterTest.cs
@@ -1,0 +1,90 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Globalization;
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Edit;
+using osu.Game.Skinning;
+
+namespace osu.Game.Tests.NonVisual
+{
+    [TestFixture]
+    public class EzSkinSizeSkinIniWriterTest
+    {
+        [Test]
+        public void TestFormatColumnWidthArrayUsesPerColumnWidths()
+        {
+            using var host = new CleanRunHeadlessGameHost();
+            var config = new Ez2ConfigManager(host.Storage);
+
+            const int key_mode = 4;
+            config.GetBindable<double>(Ez2Setting.ColumnWidth).Value = 40;
+            config.GetBindable<double>(Ez2Setting.SpecialFactor).Value = 2;
+            config.SetColumnType(key_mode, 1, EzColumnType.S);
+
+            string formatted = EzSkinLegacyManiaIniFormat.FormatColumnWidthArray(key_mode, config);
+            float[] parts = formatted.Split(',').Select(v => float.Parse(v, CultureInfo.InvariantCulture)).ToArray();
+
+            Assert.That(parts, Has.Length.EqualTo(key_mode));
+            Assert.That(parts[0], Is.EqualTo(40 / LegacyManiaSkinConfiguration.POSITION_SCALE_FACTOR).Within(0.001));
+            Assert.That(parts[1], Is.EqualTo(80 / LegacyManiaSkinConfiguration.POSITION_SCALE_FACTOR).Within(0.001));
+
+            host.Exit();
+        }
+
+        [Test]
+        public void TestFormatHitPositionMatchesLegacyDecoderSemantics()
+        {
+            const float ez_hit_position = 180f;
+            string legacy = EzSkinLegacyManiaIniFormat.FormatHitPosition(ez_hit_position);
+
+            float parsedLegacy = float.Parse(legacy, CultureInfo.InvariantCulture);
+            float roundTripEz = (480 - parsedLegacy) * LegacyManiaSkinConfiguration.POSITION_SCALE_FACTOR;
+
+            Assert.That(roundTripEz, Is.EqualTo(ez_hit_position).Within(0.01));
+        }
+
+        [Test]
+        public void TestFormatWidthForNoteHeightScaleUsesNoteHeightScaleToWidth()
+        {
+            using var host = new CleanRunHeadlessGameHost();
+            var config = new Ez2ConfigManager(host.Storage);
+
+            const int key_mode = 4;
+            config.GetBindable<double>(Ez2Setting.ColumnWidth).Value = 64;
+            config.GetBindable<double>(Ez2Setting.NoteHeightScaleToWidth).Value = 2;
+
+            float columnWidth = config.GetColumnWidth(key_mode, 0);
+            float expectedEzHeight = columnWidth * 0.5f * 2f;
+            string formatted = EzSkinLegacyManiaIniFormat.FormatWidthForNoteHeightScale(key_mode, config);
+
+            Assert.That(float.Parse(formatted, CultureInfo.InvariantCulture),
+                Is.EqualTo(expectedEzHeight / LegacyManiaSkinConfiguration.POSITION_SCALE_FACTOR).Within(0.001));
+
+            host.Exit();
+        }
+
+        [Test]
+        public void TestWriteManiaSizeSettingsToDocument()
+        {
+            using var host = new CleanRunHeadlessGameHost();
+            var config = new Ez2ConfigManager(host.Storage);
+
+            const int key_mode = 4;
+            config.GetBindable<double>(Ez2Setting.ColumnWidth).Value = 50;
+            config.GetBindable<double>(Ez2Setting.HitPosition).Value = 200;
+            config.GetBindable<double>(Ez2Setting.NoteHeightScaleToWidth).Value = 1.5;
+
+            var document = EzSkinIniDocument.Parse(string.Empty);
+            EzSkinSizeSkinIniWriter.WriteManiaSizeSettingsToDocument(key_mode, config, document);
+
+            Assert.That(document.GetManiaValue(key_mode, "ColumnWidth"), Is.EqualTo(EzSkinLegacyManiaIniFormat.FormatColumnWidthArray(key_mode, config)));
+            Assert.That(document.GetManiaValue(key_mode, "HitPosition"), Is.EqualTo(EzSkinLegacyManiaIniFormat.FormatHitPosition(200)));
+            Assert.That(document.GetManiaValue(key_mode, "WidthForNoteHeightScale"), Is.EqualTo(EzSkinLegacyManiaIniFormat.FormatWidthForNoteHeightScale(key_mode, config)));
+
+            host.Exit();
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Edit/TestSceneEzSkinEditorScreen.cs
+++ b/osu.Game.Tests/Visual/Edit/TestSceneEzSkinEditorScreen.cs
@@ -458,5 +458,32 @@ namespace osu.Game.Tests.Visual.Edit
                     return json != null && !json.Contains(dirty_alpha.ToString("0.##", System.Globalization.CultureInfo.InvariantCulture), StringComparison.Ordinal);
                 }));
         }
+
+        [Test]
+        public void TestWriteSizesToSkinIniUpdatesDraft()
+        {
+            importLegacySkin();
+            AddStep("load screen", loadScreen);
+            waitForScreenLoaded();
+
+            AddUntilStep("skin.ini session loaded", () => editorScreen.SkinIniSession != null);
+
+            AddStep("change column width", () => ezConfig.GetBindable<double>(Ez2Setting.ColumnWidth).Value = 99);
+            AddStep("write sizes to skin.ini draft", () => editorScreen.WriteSizesToSkinIniForTesting());
+
+            AddAssert("draft dirty", () => editorScreen.SkinIniSession!.IsDirty);
+            AddAssert("draft contains column width", () => editorScreen.SkinIniSession!.DraftText.Contains("ColumnWidth:", StringComparison.Ordinal));
+        }
+
+        [Test]
+        public void TestExportOskMenuPresent()
+        {
+            AddStep("load screen", loadScreen);
+            waitForScreenLoaded();
+
+            AddAssert("export osk menu present", () => editorScreen.ChildrenOfType<EditorMenuItem>().Any(i => i.Text.ToString() == "导出 .osk"));
+            AddAssert("export disabled on built-in skin",
+                () => editorScreen.ChildrenOfType<EditorMenuItem>().First(i => i.Text.ToString() == "导出 .osk").Action.Disabled);
+        }
     }
 }

--- a/osu.Game/EzOsuGame/Edit/EzSkinEditorScreen.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinEditorScreen.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -238,6 +239,8 @@ namespace osu.Game.EzOsuGame.Edit
         public void ApplySettings() => applySettings();
 
         internal void CreateEzSkinJsonForTesting() => createEzSkinJson();
+
+        internal void WriteSizesToSkinIniForTesting() => writeSizesToSkinIni();
 
         private void refreshScene()
         {
@@ -532,14 +535,23 @@ namespace osu.Game.EzOsuGame.Edit
         {
             if (!canExportOsk())
             {
-                postNotification("当前皮肤无法导出");
+                postNotification(RuntimeInfo.IsDesktop ? "当前皮肤无法导出" : "当前平台不支持导出");
                 return;
             }
 
             try
             {
+                bool committedSkinIni = false;
+
+                if (SkinIniSession is { IsDirty: true })
+                {
+                    SkinIniSession.Commit();
+                    committedSkinIni = true;
+                }
+
                 skinManager.ExportCurrentSkin();
-                postNotification("正在导出 .osk…");
+                postNotification(committedSkinIni ? "已保存 skin.ini 并导出 .osk…" : "正在导出 .osk…");
+                refreshScene();
             }
             catch (Exception e)
             {
@@ -555,7 +567,8 @@ namespace osu.Game.EzOsuGame.Edit
             return ezSkinConfig.Get<int>(Ez2Setting.ColumnTypeListSelect);
         }
 
-        private bool canExportOsk() => !skinManager.CurrentSkin.Disabled
+        private bool canExportOsk() => RuntimeInfo.IsDesktop
+                                       && !skinManager.CurrentSkin.Disabled
                                        && skinManager.CurrentSkinInfo.Value.PerformRead(s => !s.Protected);
 
         private void postNotification(string text) => notifications?.Post(new SimpleNotification { Text = text });

--- a/osu.Game/EzOsuGame/Edit/EzSkinLegacyManiaIniFormat.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinLegacyManiaIniFormat.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Globalization;
+using System.Linq;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.Skinning;
+
+namespace osu.Game.EzOsuGame.Edit
+{
+    /// <summary>
+    /// Inverse transforms for legacy Mania <c>skin.ini</c> values written by Ez editors.
+    /// Mirrors <see cref="LegacyManiaSkinDecoder"/> read semantics.
+    /// </summary>
+    public static class EzSkinLegacyManiaIniFormat
+    {
+        private const float min_legacy_hit_position = 240f;
+        private const float max_legacy_hit_position = 480f;
+
+        public static string FormatScaledValue(float ezValue) =>
+            (ezValue / LegacyManiaSkinConfiguration.POSITION_SCALE_FACTOR).ToString(CultureInfo.InvariantCulture);
+
+        public static string FormatHitPosition(float ezHitPosition)
+        {
+            float legacy = max_legacy_hit_position - ezHitPosition / LegacyManiaSkinConfiguration.POSITION_SCALE_FACTOR;
+            legacy = Math.Clamp(legacy, min_legacy_hit_position, max_legacy_hit_position);
+            return legacy.ToString(CultureInfo.InvariantCulture);
+        }
+
+        public static string FormatColumnWidthArray(int keyMode, Ez2ConfigManager config)
+        {
+            var values = Enumerable.Range(0, keyMode)
+                                   .Select(i => FormatScaledValue(config.GetColumnWidth(keyMode, i)));
+
+            return string.Join(',', values);
+        }
+
+        public static string FormatWidthForNoteHeightScale(int keyMode, Ez2ConfigManager config)
+        {
+            float columnWidth = config.GetColumnWidth(keyMode, 0);
+            double noteHeightScale = config.Get<double>(Ez2Setting.NoteHeightScaleToWidth);
+            float ezPixelHeight = columnWidth * 0.5f * (float)noteHeightScale;
+            return FormatScaledValue(ezPixelHeight);
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Edit/EzSkinSizeSkinIniWriter.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinSizeSkinIniWriter.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Globalization;
 using osu.Game.EzOsuGame.Configuration;
 
 namespace osu.Game.EzOsuGame.Edit
@@ -17,16 +16,18 @@ namespace osu.Game.EzOsuGame.Edit
                 return false;
 
             var document = session.ParseDraftDocument();
-            document.EnsureManiaBlock(keyMode);
-
-            document.SetManiaValue(keyMode, "ColumnWidth", format(config.Get<double>(Ez2Setting.ColumnWidth)));
-            document.SetManiaValue(keyMode, "HitPosition", format(config.Get<double>(Ez2Setting.HitPosition)));
-            document.SetManiaValue(keyMode, "WidthForNoteHeightScale", format(config.Get<double>(Ez2Setting.ColumnWidth)));
-
+            WriteManiaSizeSettingsToDocument(keyMode, config, document);
             session.ApplyDocument(document);
             return true;
         }
 
-        private static string format(double value) => value.ToString(CultureInfo.InvariantCulture);
+        internal static void WriteManiaSizeSettingsToDocument(int keyMode, Ez2ConfigManager config, EzSkinIniDocument document)
+        {
+            document.EnsureManiaBlock(keyMode);
+
+            document.SetManiaValue(keyMode, "ColumnWidth", EzSkinLegacyManiaIniFormat.FormatColumnWidthArray(keyMode, config));
+            document.SetManiaValue(keyMode, "HitPosition", EzSkinLegacyManiaIniFormat.FormatHitPosition((float)config.Get<double>(Ez2Setting.HitPosition)));
+            document.SetManiaValue(keyMode, "WidthForNoteHeightScale", EzSkinLegacyManiaIniFormat.FormatWidthForNoteHeightScale(keyMode, config));
+        }
     }
 }


### PR DESCRIPTION
## 依赖说明

**请先合并 #51（EzSkinEditor M5）再合并本 PR。**

本 PR 基于 `feature/ez-skin-editor-m5-json-colouring`（#51），当前 diff 仅含 M6 的 3 个 commit。M5 合并进 `master` 后，可将本 PR 的 base 改回 `master` 再合并。

- 前置 PR：https://github.com/SK-la/Ez2Lazer/pull/51

## Summary

- 新增 `EzSkinLegacyManiaIniFormat`，与 `LegacyManiaSkinDecoder` 对称的 Mania 尺寸逆变换。
- 完善 `EzSkinSizeSkinIniWriter`：按列 `ColumnWidth` 数组（含 `SpecialFactor`）、`HitPosition` legacy 坐标、`WidthForNoteHeightScale` ← `NoteHeightScaleToWidth`。
- `.osk` 导出：dirty `skin.ini` 先 `Commit()`（不写 `EzSkinSettings.ini`）；非桌面平台禁用；通知文案区分是否已保存 skin.ini。

## Test plan

- [x] `dotnet build osu.Game` / `osu.Game.Tests`
- [x] `dotnet test --filter FullyQualifiedName~EzSkinSize`（4 项通过）
- [ ] 配置→写尺寸→skin.ini 草稿可见；文件→应用 commit
- [ ] 导出 .osk 含最新 skin.ini；`EzSkinSettings.ini` 不被 export 改动
