### PR TITLE
Ez skin editor M7: preview toolbar, playback fixes, skin popover

### DIFF
--- a/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorBeatmapMenuButton.cs
+++ b/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorBeatmapMenuButton.cs
@@ -11,24 +11,20 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Localisation;
 using osu.Framework.Graphics.UserInterface;
-using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.Localization;
 using osu.Game.Graphics;
-using osu.Game.Graphics.Containers;
-using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Overlays;
 using osu.Game.Overlays.SkinEditor;
 using osu.Game.Rulesets;
 using osuTK;
-using osuTK.Graphics;
 
 namespace osu.Game.EzOsuGame.Edit.Components
 {
     public partial class EzSkinEditorBeatmapMenuButton : SkinEditorSceneLibrary.SceneButton, IHasPopover
     {
-        public Action<RulesetInfo, EzBeatmapPreviewMode>? BeatmapPreviewRequested;
+        public Action<RulesetInfo>? BeatmapPreviewRequested;
 
         private bool active;
 
@@ -51,8 +47,8 @@ namespace osu.Game.EzOsuGame.Edit.Components
 
         public EzSkinEditorBeatmapMenuButton()
         {
-            Text = EzEditorStrings.TOOLBAR_REAL_BEATMAP;
-            Width = 110;
+            Text = EzEditorStrings.TOOLBAR_SELECT_MODE;
+            Width = 100;
         }
 
         [BackgroundDependencyLoader]
@@ -77,9 +73,9 @@ namespace osu.Game.EzOsuGame.Edit.Components
     public partial class BeatmapPreviewPopover : OsuPopover
     {
         private readonly IRulesetStore rulesets;
-        private readonly Action<RulesetInfo, EzBeatmapPreviewMode>? onSelected;
+        private readonly Action<RulesetInfo>? onSelected;
 
-        public BeatmapPreviewPopover(IRulesetStore rulesets, Action<RulesetInfo, EzBeatmapPreviewMode>? onSelected)
+        public BeatmapPreviewPopover(IRulesetStore rulesets, Action<RulesetInfo>? onSelected)
         {
             this.rulesets = rulesets;
             this.onSelected = onSelected;
@@ -88,68 +84,32 @@ namespace osu.Game.EzOsuGame.Edit.Components
         [BackgroundDependencyLoader]
         private void load()
         {
-            Child = new OsuScrollContainer
+            Child = new FillFlowContainer
             {
-                Width = 280,
-                Height = 360,
-                Child = new FillFlowContainer
-                {
-                    AutoSizeAxes = Axes.Y,
-                    Width = 260,
-                    Direction = FillDirection.Vertical,
-                    Spacing = new Vector2(0, 6),
-                    Padding = new MarginPadding(10),
-                    Children = buildSections().ToArray(),
-                },
+                Width = 220,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(0, 6),
+                Children = buildRulesetButtons().ToArray(),
             };
         }
 
-        private IEnumerable<Drawable> buildSections()
+        private IEnumerable<Drawable> buildRulesetButtons()
         {
             foreach (var ruleset in rulesets.AvailableRulesets.OfType<RulesetInfo>())
             {
-                yield return new OsuSpriteText
-                {
-                    Text = ruleset.Name,
-                    Font = OsuFont.Default.With(weight: FontWeight.Bold, size: 14),
-                    Margin = new MarginPadding { Top = 4 },
-                };
-
                 if (!EzSkinEditorPreviewModes.SupportsBeatmapPreview(ruleset))
-                {
-                    yield return new OsuSpriteText
-                    {
-                        Text = EzEditorStrings.TOOLBAR_PREVIEW_NOT_SUPPORTED,
-                        Font = OsuFont.Default.With(size: 12),
-                        Colour = Color4.Gray,
-                        Margin = new MarginPadding { Bottom = 4 },
-                    };
-
                     continue;
-                }
 
-                foreach (var mode in EzSkinEditorPreviewModes.GetAvailableModes(ruleset))
+                var capturedRuleset = ruleset;
+
+                yield return new ModeSelectButton(ruleset.Name, () =>
                 {
-                    var capturedRuleset = ruleset;
-                    var capturedMode = mode;
-
-                    yield return new ModeSelectButton(getModeLabel(mode), () =>
-                    {
-                        onSelected?.Invoke(capturedRuleset, capturedMode);
-                        this.HidePopover();
-                    });
-                }
+                    onSelected?.Invoke(capturedRuleset);
+                    this.HidePopover();
+                });
             }
         }
-
-        private static LocalisableString getModeLabel(EzBeatmapPreviewMode mode) => mode switch
-        {
-            EzBeatmapPreviewMode.Dynamic => EzEnumStrings.DYNAMIC,
-            EzBeatmapPreviewMode.Static => EzEnumStrings.STATIC,
-            EzBeatmapPreviewMode.StaticFullMap => EzEnumStrings.STATIC_FULL_MAP,
-            EzBeatmapPreviewMode.StaticScroll => EzEnumStrings.STATIC_SCROLL,
-            _ => mode.ToString(),
-        };
 
         private partial class ModeSelectButton : OsuButton
         {

--- a/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorBeatmapPreviewHost.cs
+++ b/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorBeatmapPreviewHost.cs
@@ -3,15 +3,14 @@
 
 using System;
 using System.Threading;
-using System.Threading.Tasks;
 using osu.Framework.Allocation;
-using osu.Framework.Extensions;
+using osu.Framework.Bindables;
+using osu.Game.EzOsuGame.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Timing;
 using osu.Game.Beatmaps;
 using osu.Framework.Localisation;
-using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.Localization;
 using osu.Game.EzOsuGame.Overlays.Preview;
 using osu.Game.Graphics.Sprites;
@@ -51,6 +50,8 @@ namespace osu.Game.EzOsuGame.Edit.Components
         private double beatmapMaxTime;
         private double nextDynamicLoopStartTime;
 
+        private Bindable<EzBeatmapPreviewMode>? previewModeBindable;
+
         public EzSkinEditorBeatmapPreviewHost(EzSkinEditorSceneContext context)
         {
             this.context = context;
@@ -61,6 +62,12 @@ namespace osu.Game.EzOsuGame.Edit.Components
         [BackgroundDependencyLoader]
         private void load()
         {
+            if (context.PreviewState != null)
+            {
+                previewModeBindable = context.PreviewState.Mode.GetBoundCopy();
+                previewModeBindable.BindValueChanged(onPreviewModeChanged, true);
+            }
+
             InternalChild = stageViewport = new Container
             {
                 RelativeSizeAxes = Axes.Both,
@@ -96,43 +103,37 @@ namespace osu.Game.EzOsuGame.Edit.Components
             loadCancellation = new CancellationTokenSource();
             var token = loadCancellation.Token;
 
-            Task.Run(() =>
-            {
-                token.ThrowIfCancellationRequested();
+            IBeatmap beatmap;
+            double startTime;
 
+            try
+            {
                 var ruleset = rulesetInfo!;
-                var beatmap = context.PreviewBeatmap!.GetPlayableBeatmap(ruleset);
-                double startTime = computeDefaultStartTime(beatmap, ruleset, beatmap.HitObjects.Count > 0 ? beatmap.HitObjects[0].StartTime : 0);
-                return (beatmap, startTime);
-            }, token).ContinueWith(task =>
+                beatmap = context.PreviewBeatmap!.GetPlayableBeatmap(ruleset);
+                startTime = computeDefaultStartTime(beatmap, ruleset, beatmap.HitObjects.Count > 0 ? beatmap.HitObjects[0].StartTime : 0);
+            }
+            catch
             {
-                Schedule(() =>
-                {
-                    if (token.IsCancellationRequested || task.IsCanceled)
-                        return;
+                stageScaleContainer.Child = createPlaceholder(EzEditorStrings.PLACEHOLDER_BEATMAP_LOAD_FAILED);
+                return;
+            }
 
-                    if (task.IsFaulted)
-                    {
-                        stageScaleContainer.Child = createPlaceholder(EzEditorStrings.PLACEHOLDER_BEATMAP_LOAD_FAILED);
-                        return;
-                    }
+            if (token.IsCancellationRequested)
+                return;
 
-                    var (beatmap, startTime) = task.GetResultSafely();
-                    playableBeatmap = beatmap;
-                    playbackStartTime = startTime;
-                    beatmapMinTime = 0;
-                    beatmapMaxTime = Math.Max(beatmap.BeatmapInfo.Length, beatmapMinTime + 1);
+            playableBeatmap = beatmap;
+            playbackStartTime = startTime;
+            beatmapMinTime = 0;
+            beatmapMaxTime = Math.Max(beatmap.BeatmapInfo.Length, beatmapMinTime + 1);
 
-                    mountPreview(token);
-                    previewClock.Seek(playbackStartTime);
+            mountPreview(token);
+            previewClock.Seek(playbackStartTime);
 
-                    if (previewMode == EzBeatmapPreviewMode.Dynamic)
-                    {
-                        nextDynamicLoopStartTime = Time.Current;
-                        previewClock.Start();
-                    }
-                });
-            }, CancellationToken.None);
+            if (previewMode == EzBeatmapPreviewMode.Dynamic)
+            {
+                nextDynamicLoopStartTime = Time.Current;
+                previewClock.Start();
+            }
         }
 
         private void mountPreview(CancellationToken token)
@@ -171,15 +172,18 @@ namespace osu.Game.EzOsuGame.Edit.Components
 
             LoadComponentAsync(previewRoot, loaded =>
             {
-                if (token.IsCancellationRequested)
+                Schedule(() =>
                 {
-                    loaded.Dispose();
-                    return;
-                }
+                    if (token.IsCancellationRequested || !IsLoaded || IsDisposed)
+                    {
+                        loaded.Dispose();
+                        return;
+                    }
 
-                stageScaleContainer.Child = loaded;
-                drawableRuleset = newDrawableRuleset;
-                maniaStaticRenderer = null;
+                    stageScaleContainer.Child = loaded;
+                    drawableRuleset = newDrawableRuleset;
+                    maniaStaticRenderer = null;
+                });
             }, token);
         }
 
@@ -209,11 +213,14 @@ namespace osu.Game.EzOsuGame.Edit.Components
             drawableRuleset = null;
         }
 
+        private bool isDynamicPlayback =>
+            (previewModeBindable?.Value ?? previewMode) == EzBeatmapPreviewMode.Dynamic;
+
         protected override void Update()
         {
             base.Update();
 
-            if (previewMode != EzBeatmapPreviewMode.Dynamic || drawableRuleset == null)
+            if (!isDynamicPlayback || drawableRuleset == null)
                 return;
 
             if (previewClock.IsRunning)
@@ -260,12 +267,32 @@ namespace osu.Game.EzOsuGame.Edit.Components
                 stageScaleContainer.Clear(true);
         }
 
+        private void onPreviewModeChanged(ValueChangedEvent<EzBeatmapPreviewMode> change)
+        {
+            previewMode = change.NewValue;
+
+            if (change.NewValue == EzBeatmapPreviewMode.Dynamic)
+            {
+                nextDynamicLoopStartTime = Time.Current;
+                previewClock.Start();
+            }
+            else
+            {
+                nextDynamicLoopStartTime = double.PositiveInfinity;
+                previewClock.Stop();
+            }
+        }
+
         protected override void Dispose(bool isDisposing)
         {
             if (isDisposing)
             {
+                previewModeBindable?.UnbindAll();
                 loadCancellation?.Cancel();
-                disposePreviewResources();
+                loadCancellation?.Dispose();
+                loadCancellation = null;
+                drawableRuleset = null;
+                maniaStaticRenderer = null;
             }
 
             base.Dispose(isDisposing);

--- a/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorPreviewHost.cs
+++ b/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorPreviewHost.cs
@@ -64,7 +64,7 @@ namespace osu.Game.EzOsuGame.Edit.Components
 
         private void populatePlayback()
         {
-            if (context.PreviewSource == EzSkinEditorPreviewSource.Beatmap)
+            if (context.AllowBeatmapPreview && context.PreviewSource == EzSkinEditorPreviewSource.Beatmap)
             {
                 playbackContainer.Child = new EzSkinEditorBeatmapPreviewHost(context).With(d =>
                 {

--- a/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorSceneBar.cs
+++ b/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorSceneBar.cs
@@ -33,11 +33,14 @@ namespace osu.Game.EzOsuGame.Edit.Components
         {
             RelativeSizeAxes = Axes.X;
             Height = HEIGHT;
+            Masking = true;
         }
 
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider overlayColourProvider)
         {
+            const float skin_dropdown_area_width = EzSkinEditorSkinDropdown.DEFAULT_WIDTH + padding * 2;
+
             InternalChildren = new Drawable[]
             {
                 new Box
@@ -48,6 +51,7 @@ namespace osu.Game.EzOsuGame.Edit.Components
                 new OsuScrollContainer(Direction.Horizontal)
                 {
                     RelativeSizeAxes = Axes.Both,
+                    Padding = new MarginPadding { Right = skin_dropdown_area_width },
                     Child = new FillFlowContainer
                     {
                         Name = @"Ez scene library",
@@ -64,6 +68,12 @@ namespace osu.Game.EzOsuGame.Edit.Components
                             Margin = new MarginPadding(10),
                         }).ToArray(),
                     },
+                },
+                new EzSkinEditorSkinDropdown
+                {
+                    Anchor = Anchor.CentreRight,
+                    Origin = Anchor.CentreRight,
+                    Margin = new MarginPadding { Right = padding },
                 },
             };
         }

--- a/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorSkinDropdown.cs
+++ b/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorSkinDropdown.cs
@@ -5,20 +5,35 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
 using osu.Game.Database;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Overlays;
+using osu.Game.Overlays.SkinEditor;
 using osu.Game.Skinning;
+using osuTK;
 using Realms;
 
 namespace osu.Game.EzOsuGame.Edit.Components
 {
-    public partial class EzSkinEditorSkinDropdown : OsuDropdown<Live<SkinInfo>>
+    /// <summary>
+    /// Skin selector anchored to the scene bar. Uses a popover so the list does not expand inline over the editor.
+    /// </summary>
+    public partial class EzSkinEditorSkinDropdown : CompositeDrawable, IHasPopover
     {
         public const float DEFAULT_WIDTH = 200;
 
         private readonly List<Live<SkinInfo>> dropdownItems = new List<Live<SkinInfo>>();
+
+        private SkinPickerButton pickerButton = null!;
 
         [Resolved]
         private SkinManager skins { get; set; } = null!;
@@ -32,14 +47,17 @@ namespace osu.Game.EzOsuGame.Edit.Components
         {
             RelativeSizeAxes = Axes.None;
             Width = DEFAULT_WIDTH;
-            AlwaysShowSearchBar = true;
-            AllowNonContiguousMatching = true;
+            Height = SkinEditorSceneLibrary.BUTTON_HEIGHT;
         }
 
         [BackgroundDependencyLoader]
         private void load()
         {
-            Current = skins.CurrentSkinInfo;
+            InternalChild = pickerButton = new SkinPickerButton
+            {
+                RelativeSizeAxes = Axes.Both,
+                Action = this.ShowPopover,
+            };
         }
 
         protected override void LoadComplete()
@@ -50,20 +68,13 @@ namespace osu.Game.EzOsuGame.Edit.Components
                                                                          .Where(s => !s.DeletePending)
                                                                          .OrderBy(s => s.Name, StringComparer.OrdinalIgnoreCase), skinsChanged);
 
-            Current.BindValueChanged(skin =>
-            {
-                if (skin.NewValue.ID == SkinInfo.RANDOM_SKIN)
-                {
-                    skins.CurrentSkinInfo.Value = skin.OldValue;
-                    skins.SelectRandomSkin();
-                }
-            });
+            skins.CurrentSkinInfo.BindValueChanged(e => pickerButton.Text = e.NewValue.ToString() ?? string.Empty, true);
 
             skins.ScriptedSkinsCatalogUpdated += refreshSkinsList;
             refreshSkinsList();
         }
 
-        protected override LocalisableString GenerateItemText(Live<SkinInfo> item) => item.ToString() ?? "";
+        public Popover GetPopover() => new SkinListPopover(dropdownItems, skins);
 
         private void skinsChanged(IRealmCollection<SkinInfo> sender, ChangeSet? changes)
         {
@@ -77,7 +88,6 @@ namespace osu.Game.EzOsuGame.Edit.Components
         {
             dropdownItems.Clear();
             dropdownItems.AddRange(skins.GetAllUsableSkins());
-            Schedule(() => Items = dropdownItems);
         }
 
         protected override void Dispose(bool isDisposing)
@@ -89,6 +99,136 @@ namespace osu.Game.EzOsuGame.Edit.Components
             }
 
             base.Dispose(isDisposing);
+        }
+
+        private partial class SkinPickerButton : OsuButton
+        {
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider? colourProvider, OsuColour colours)
+            {
+                BackgroundColour = colourProvider?.Background3 ?? colours.Blue3;
+                Content.CornerRadius = 5;
+            }
+        }
+
+        private partial class SkinListPopover : OsuPopover
+        {
+            private const float body_width = 280;
+            private const float body_padding = 10;
+            private const float search_height = 32;
+            private const float list_height = 200;
+            private const float content_spacing = 8;
+            private const float body_height = body_padding * 2 + search_height + content_spacing + list_height;
+
+            private readonly IReadOnlyList<Live<SkinInfo>> items;
+            private readonly SkinManager skins;
+
+            private OsuTextBox searchBox = null!;
+            private FillFlowContainer listFlow = null!;
+
+            public SkinListPopover(IReadOnlyList<Live<SkinInfo>> items, SkinManager skins)
+                : base(withPadding: false)
+            {
+                this.items = items;
+                this.skins = skins;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                // Popover.Body defaults to AutoSize and grows with every skin row — lock body size here.
+                Width = body_width;
+                Height = body_height;
+
+                Content.AutoSizeAxes = Axes.None;
+                Content.RelativeSizeAxes = Axes.Both;
+
+                AllowableAnchors = new[]
+                {
+                    Anchor.BottomRight,
+                    Anchor.BottomLeft,
+                    Anchor.TopRight,
+                    Anchor.TopLeft,
+                };
+
+                Child = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Direction = FillDirection.Vertical,
+                    Spacing = new Vector2(content_spacing),
+                    Padding = new MarginPadding(body_padding),
+                    Children = new Drawable[]
+                    {
+                        searchBox = new OsuTextBox
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            Height = search_height,
+                            PlaceholderText = @"Search skins",
+                        },
+                        new OsuScrollContainer
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            Height = list_height,
+                            ScrollbarOverlapsContent = false,
+                            Child = listFlow = new FillFlowContainer
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y,
+                                Direction = FillDirection.Vertical,
+                                Spacing = new Vector2(4),
+                            },
+                        },
+                    },
+                };
+
+                searchBox.Current.BindValueChanged(_ => rebuildList(searchBox.Text), true);
+                rebuildList(string.Empty);
+            }
+
+            private void rebuildList(string query)
+            {
+                listFlow.Clear(false);
+
+                foreach (var skin in items)
+                {
+                    string name = skin.ToString() ?? string.Empty;
+
+                    if (!string.IsNullOrWhiteSpace(query)
+                        && name.IndexOf(query, StringComparison.OrdinalIgnoreCase) < 0)
+                    {
+                        continue;
+                    }
+
+                    var captured = skin;
+
+                    listFlow.Add(new SkinSelectButton(name, () =>
+                    {
+                        if (captured.ID == SkinInfo.RANDOM_SKIN)
+                            skins.SelectRandomSkin();
+                        else
+                            skins.CurrentSkinInfo.Value = captured;
+
+                        this.HidePopover();
+                    }));
+                }
+            }
+
+            private partial class SkinSelectButton : OsuButton
+            {
+                public SkinSelectButton(LocalisableString text, Action action)
+                {
+                    Text = text;
+                    Action = action;
+                    RelativeSizeAxes = Axes.X;
+                    Height = 32;
+                }
+
+                [BackgroundDependencyLoader]
+                private void load(OverlayColourProvider? colourProvider, OsuColour colours)
+                {
+                    BackgroundColour = colourProvider?.Background4 ?? colours.Blue3;
+                }
+            }
         }
     }
 }

--- a/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorTopToolbar.cs
+++ b/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorTopToolbar.cs
@@ -19,13 +19,15 @@ namespace osu.Game.EzOsuGame.Edit.Components
 {
     public partial class EzSkinEditorTopToolbar : FillFlowContainer
     {
-        public Action? StaticPreviewRequested { get; set; }
+        public Action? ToggleBeatmapPlaybackRequested { get; set; }
 
-        public Action<RulesetInfo, EzBeatmapPreviewMode>? BeatmapPreviewRequested { get; set; }
+        public Action<RulesetInfo>? BeatmapPreviewRequested { get; set; }
 
         public Bindable<EzSkinEditorPreviewSource>? PreviewSource { get; set; }
 
-        private StaticPreviewButton staticButton = null!;
+        public Bindable<EzBeatmapPreviewMode>? PreviewMode { get; set; }
+
+        private BeatmapPlaybackButton playbackButton = null!;
         private EzSkinEditorBeatmapMenuButton beatmapButton = null!;
 
         public EzSkinEditorTopToolbar()
@@ -43,15 +45,11 @@ namespace osu.Game.EzOsuGame.Edit.Components
         {
             Children = new Drawable[]
             {
-                staticButton = new StaticPreviewButton
-                {
-                    Action = () => StaticPreviewRequested?.Invoke(),
-                },
+                playbackButton = new BeatmapPlaybackButton(),
                 beatmapButton = new EzSkinEditorBeatmapMenuButton
                 {
-                    BeatmapPreviewRequested = (ruleset, mode) => BeatmapPreviewRequested?.Invoke(ruleset, mode),
+                    BeatmapPreviewRequested = ruleset => BeatmapPreviewRequested?.Invoke(ruleset),
                 },
-                new EzSkinEditorSkinDropdown(),
                 new OsuTextFlowContainer
                 {
                     TextAnchor = Anchor.CentreLeft,
@@ -75,55 +73,41 @@ namespace osu.Game.EzOsuGame.Edit.Components
         {
             base.LoadComplete();
 
+            playbackButton.Action = () => ToggleBeatmapPlaybackRequested?.Invoke();
+
             PreviewSource?.BindValueChanged(_ => updateActiveState(), true);
+            PreviewMode?.BindValueChanged(_ => updateActiveState(), true);
         }
 
         private void updateActiveState()
         {
-            if (PreviewSource == null)
-                return;
+            bool beatmapLoaded = PreviewSource?.Value == EzSkinEditorPreviewSource.Beatmap;
+            bool playing = beatmapLoaded && PreviewMode?.Value == EzBeatmapPreviewMode.Dynamic;
 
-            staticButton.Active = PreviewSource.Value == EzSkinEditorPreviewSource.Static;
-            beatmapButton.Active = PreviewSource.Value == EzSkinEditorPreviewSource.Beatmap;
+            playbackButton.Enabled.Value = beatmapLoaded;
+            playbackButton.ShowPausedState = beatmapLoaded && !playing;
+
+            beatmapButton.Active = beatmapLoaded;
         }
 
-        private partial class StaticPreviewButton : SkinEditorSceneLibrary.SceneButton
+        private partial class BeatmapPlaybackButton : SkinEditorSceneLibrary.SceneButton
         {
-            private bool active;
-
-            public bool Active
+            public bool ShowPausedState
             {
-                get => active;
-                set
-                {
-                    active = value;
-                    if (IsLoaded)
-                        updateColours();
-                }
+                set => Text = value ? EzEditorStrings.TOOLBAR_PLAY_BEATMAP : EzEditorStrings.TOOLBAR_PAUSE_BEATMAP;
             }
 
-            private OsuColour colours = null!;
-            private OverlayColourProvider? colourProvider;
-
-            public StaticPreviewButton()
+            public BeatmapPlaybackButton()
             {
-                Text = EzEditorStrings.TOOLBAR_STATIC_SKIN;
-                Width = 100;
+                Text = EzEditorStrings.TOOLBAR_PAUSE_BEATMAP;
+                Width = 110;
             }
 
             [BackgroundDependencyLoader]
-            private void load(OsuColour colours, OverlayColourProvider? overlayColourProvider)
+            private void load(OverlayColourProvider? overlayColourProvider, OsuColour colours)
             {
-                this.colours = colours;
-                colourProvider = overlayColourProvider;
-                updateColours();
-            }
-
-            private void updateColours()
-            {
-                BackgroundColour = active
-                    ? colours.YellowDark
-                    : colourProvider?.Background3 ?? colours.Blue3;
+                BackgroundColour = overlayColourProvider?.Background3 ?? colours.Blue3;
+                Content.CornerRadius = 5;
             }
         }
     }

--- a/osu.Game/EzOsuGame/Edit/EzSkinEditorBeatmapPicker.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinEditorBeatmapPicker.cs
@@ -1,7 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
+using System;
 using System.Linq;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
@@ -13,6 +13,8 @@ namespace osu.Game.EzOsuGame.Edit
 {
     public sealed class EzSkinEditorBeatmapPicker
     {
+        private const int unknown_object_count_attempts = 8;
+
         private readonly RealmAccess realm;
         private readonly BeatmapManager beatmaps;
 
@@ -22,18 +24,99 @@ namespace osu.Game.EzOsuGame.Edit
             this.beatmaps = beatmaps;
         }
 
+        public static bool CanUseAsPreview(IWorkingBeatmap working)
+        {
+            if (working is DummyWorkingBeatmap)
+                return false;
+
+            if (working is WorkingBeatmap playable && playable.BeatmapSetInfo.Protected)
+                return false;
+
+            if (working.BeatmapInfo.Ruleset is not RulesetInfo ruleset)
+                return false;
+
+            if (!EzSkinEditorPreviewModes.SupportsBeatmapPreview(ruleset))
+                return false;
+
+            return working.BeatmapInfo.TotalObjectCount != 0;
+        }
+
         public bool TryPickRandom(RulesetInfo ruleset, out IWorkingBeatmap? workingBeatmap)
         {
             workingBeatmap = null;
 
-            var candidates = queryCandidates(ruleset.OnlineID);
+            if (tryPickRandomWithKnownObjectCount(ruleset.OnlineID, out var beatmapInfo))
+            {
+                workingBeatmap = beatmaps.GetWorkingBeatmap(beatmapInfo);
+                return true;
+            }
 
-            if (candidates.Count == 0)
+            if (tryPickRandomWithUnknownObjectCount(ruleset, out beatmapInfo))
+            {
+                workingBeatmap = beatmaps.GetWorkingBeatmap(beatmapInfo);
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool tryPickRandomWithKnownObjectCount(int rulesetOnlineId, out BeatmapInfo beatmapInfo)
+        {
+            beatmapInfo = null!;
+
+            int count = realm.Run(r => buildFastQuery(r, rulesetOnlineId).Count());
+
+            if (count == 0)
                 return false;
 
-            var chosen = candidates[RNG.Next(candidates.Count)];
-            workingBeatmap = beatmaps.GetWorkingBeatmap(chosen);
+            int index = RNG.Next(0, count);
+
+            beatmapInfo = realm.Run(r => buildFastQuery(r, rulesetOnlineId)
+                                         .AsEnumerable()
+                                         .ElementAt(index)
+                                         .Detach());
+
             return true;
+        }
+
+        private bool tryPickRandomWithUnknownObjectCount(RulesetInfo ruleset, out BeatmapInfo beatmapInfo)
+        {
+            beatmapInfo = null!;
+
+            int count = realm.Run(r => buildUnknownObjectCountQuery(r, ruleset.OnlineID).Count());
+
+            if (count == 0)
+                return false;
+
+            for (int attempt = 0; attempt < Math.Min(unknown_object_count_attempts, count); attempt++)
+            {
+                int index = RNG.Next(0, count);
+
+                var candidate = realm.Run(r => buildUnknownObjectCountQuery(r, ruleset.OnlineID)
+                                               .AsEnumerable()
+                                               .ElementAt(index)
+                                               .Detach());
+
+                if (!IsMetadataCandidate(candidate, ruleset.OnlineID))
+                    continue;
+
+                try
+                {
+                    var working = beatmaps.GetWorkingBeatmap(candidate);
+
+                    if (working.GetPlayableBeatmap(ruleset).HitObjects.Count > 0)
+                    {
+                        beatmapInfo = candidate;
+                        return true;
+                    }
+                }
+                catch
+                {
+                    // ignored
+                }
+            }
+
+            return false;
         }
 
         internal static bool IsMetadataCandidate(BeatmapInfo beatmapInfo, int rulesetOnlineId)
@@ -44,52 +127,21 @@ namespace osu.Game.EzOsuGame.Edit
             if (beatmapInfo.BeatmapSet?.Protected == true)
                 return false;
 
-            if (beatmapInfo.TotalObjectCount == 0)
-                return false;
-
-            return beatmapInfo.TotalObjectCount > 0 || beatmapInfo.TotalObjectCount == -1;
+            return beatmapInfo.TotalObjectCount != 0;
         }
 
-        private List<BeatmapInfo> queryCandidates(int rulesetOnlineId)
-        {
-            var metadataMatches = realm.Run(r => r.All<BeatmapInfo>()
-                                                  .Filter($@"{nameof(BeatmapInfo.BeatmapSet)}.{nameof(BeatmapSetInfo.DeletePending)} == false")
-                                                  .Filter($@"{nameof(BeatmapInfo.BeatmapSet)}.{nameof(BeatmapSetInfo.Protected)} == false")
-                                                  .Filter($@"{nameof(BeatmapInfo.Ruleset)}.{nameof(RulesetInfo.OnlineID)} == $0", rulesetOnlineId)
-                                                  .AsEnumerable()
-                                                  .Select(i => i.Detach())
-                                                  .Where(b => IsMetadataCandidate(b, rulesetOnlineId))
-                                                  .ToList());
+        private static IQueryable<BeatmapInfo> buildFastQuery(Realm r, int rulesetOnlineId) =>
+            r.All<BeatmapInfo>()
+             .Filter($@"{nameof(BeatmapInfo.BeatmapSet)}.{nameof(BeatmapSetInfo.DeletePending)} == false")
+             .Filter($@"{nameof(BeatmapInfo.BeatmapSet)}.{nameof(BeatmapSetInfo.Protected)} == false")
+             .Filter($@"{nameof(BeatmapInfo.Ruleset)}.{nameof(RulesetInfo.OnlineID)} == $0", rulesetOnlineId)
+             .Filter($@"{nameof(BeatmapInfo.TotalObjectCount)} > 0");
 
-            var playable = new List<BeatmapInfo>(metadataMatches.Count);
-
-            foreach (var beatmapInfo in metadataMatches)
-            {
-                if (beatmapInfo.TotalObjectCount > 0)
-                {
-                    playable.Add(beatmapInfo);
-                    continue;
-                }
-
-                if (hasPlayableObjects(beatmapInfo))
-                    playable.Add(beatmapInfo);
-            }
-
-            return playable;
-        }
-
-        private bool hasPlayableObjects(BeatmapInfo beatmapInfo)
-        {
-            try
-            {
-                var working = beatmaps.GetWorkingBeatmap(beatmapInfo);
-                var playable = working.GetPlayableBeatmap(beatmapInfo.Ruleset);
-                return playable.HitObjects.Count > 0;
-            }
-            catch
-            {
-                return false;
-            }
-        }
+        private static IQueryable<BeatmapInfo> buildUnknownObjectCountQuery(Realm r, int rulesetOnlineId) =>
+            r.All<BeatmapInfo>()
+             .Filter($@"{nameof(BeatmapInfo.BeatmapSet)}.{nameof(BeatmapSetInfo.DeletePending)} == false")
+             .Filter($@"{nameof(BeatmapInfo.BeatmapSet)}.{nameof(BeatmapSetInfo.Protected)} == false")
+             .Filter($@"{nameof(BeatmapInfo.Ruleset)}.{nameof(RulesetInfo.OnlineID)} == $0", rulesetOnlineId)
+             .Filter($@"{nameof(BeatmapInfo.TotalObjectCount)} == -1");
     }
 }

--- a/osu.Game/EzOsuGame/Edit/EzSkinEditorPreviewModes.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinEditorPreviewModes.cs
@@ -33,6 +33,11 @@ namespace osu.Game.EzOsuGame.Edit
         public static EzBeatmapPreviewMode GetDefaultMode(RulesetInfo ruleset) =>
             IsManiaRuleset(ruleset) ? EzBeatmapPreviewMode.StaticFullMap : EzBeatmapPreviewMode.Static;
 
+        /// <summary>
+        /// Appearance scene loads a full playable beatmap preview.
+        /// </summary>
+        public static EzBeatmapPreviewMode GetAppearanceLoadMode(RulesetInfo ruleset) => EzBeatmapPreviewMode.Dynamic;
+
         public static EzBeatmapPreviewMode ValidateMode(EzBeatmapPreviewMode mode, RulesetInfo ruleset)
         {
             var available = GetAvailableModes(ruleset);

--- a/osu.Game/EzOsuGame/Edit/EzSkinEditorPreviewState.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinEditorPreviewState.cs
@@ -42,6 +42,12 @@ namespace osu.Game.EzOsuGame.Edit
             SuggestedKeyMode.Value = resolveKeyModeFromBeatmap(workingBeatmap);
         }
 
+        public bool HasBeatmapLoaded => Source.Value == EzSkinEditorPreviewSource.Beatmap && PreviewBeatmap != null;
+
+        public void PauseBeatmapPlayback() => Mode.Value = EzBeatmapPreviewMode.Static;
+
+        public void ResumeBeatmapPlayback() => Mode.Value = EzBeatmapPreviewMode.Dynamic;
+
         private static int? resolveKeyModeFromBeatmap(IWorkingBeatmap workingBeatmap)
         {
             if (workingBeatmap.BeatmapInfo.Ruleset.OnlineID != 3)

--- a/osu.Game/EzOsuGame/Edit/EzSkinEditorSceneContext.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinEditorSceneContext.cs
@@ -30,6 +30,11 @@ namespace osu.Game.EzOsuGame.Edit
 
         public EzSkinEditorPreviewSource PreviewSource { get; init; } = EzSkinEditorPreviewSource.Static;
 
+        /// <summary>
+        /// Beatmap preview is only shown in the appearance scene.
+        /// </summary>
+        public bool AllowBeatmapPreview { get; init; }
+
         public IWorkingBeatmap? PreviewBeatmap { get; init; }
 
         public RulesetInfo? PreviewRuleset { get; init; }

--- a/osu.Game/EzOsuGame/Edit/EzSkinEditorScreen.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinEditorScreen.cs
@@ -8,6 +8,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Localisation;
 using osu.Framework.Platform;
 using osu.Framework.Screens;
@@ -55,6 +56,9 @@ namespace osu.Game.EzOsuGame.Edit
         private BeatmapManager beatmapManager { get; set; } = null!;
 
         [Resolved]
+        private IBindable<WorkingBeatmap> gameBeatmap { get; set; } = null!;
+
+        [Resolved]
         private RealmAccess realm { get; set; } = null!;
 
         [Resolved]
@@ -77,6 +81,8 @@ namespace osu.Game.EzOsuGame.Edit
         private EzSkinEditorTopToolbar topToolbar = null!;
 
         private EzSkinEditorBeatmapPicker? beatmapPicker;
+
+        private bool attemptedGlobalBeatmapPreview;
 
         private ISkinEditorVirtualProvider? provider;
         private EzSkinEditorSceneContext? sceneContext;
@@ -132,81 +138,86 @@ namespace osu.Game.EzOsuGame.Edit
                 new OsuContextMenuContainer
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Child = new GridContainer
+                    Child = new PopoverContainer
                     {
                         RelativeSizeAxes = Axes.Both,
-                        RowDimensions = new[]
+                        Child = new GridContainer
                         {
-                            new Dimension(GridSizeMode.AutoSize),
-                            new Dimension(GridSizeMode.AutoSize),
-                            new Dimension(),
-                        },
-                        Content = new[]
-                        {
-                            new Drawable[]
+                            RelativeSizeAxes = Axes.Both,
+                            RowDimensions = new[]
                             {
-                                new Container
+                                new Dimension(GridSizeMode.AutoSize),
+                                new Dimension(GridSizeMode.AutoSize),
+                                new Dimension(),
+                            },
+                            Content = new[]
+                            {
+                                new Drawable[]
                                 {
-                                    Name = @"Menu container",
-                                    RelativeSizeAxes = Axes.X,
-                                    Depth = float.MinValue,
-                                    Height = SkinEditor.MENU_HEIGHT,
-                                    Children = new Drawable[]
+                                    new Container
                                     {
-                                        menuBar = new EzSkinEditorMenuBar
+                                        Name = @"Menu container",
+                                        RelativeSizeAxes = Axes.X,
+                                        Depth = float.MinValue,
+                                        Height = SkinEditor.MENU_HEIGHT,
+                                        Children = new Drawable[]
                                         {
-                                            ApplyAction = applySettings,
-                                            ExitAction = tryExit,
-                                            CreateEzSkinJsonAction = createEzSkinJson,
-                                            UpdateEzSkinJsonSnapshotAction = updateEzSkinJsonSnapshot,
-                                            RemoveEzSkinJsonAction = removeEzSkinJson,
-                                            ImportJsonAction = importJson,
-                                            ImportFromSkinJsonAction = importFromSkinJson,
-                                            ExportJsonAction = exportJson,
-                                            WriteColoursToSkinIniAction = writeColoursToSkinIni,
-                                            WriteSizesToSkinIniAction = writeSizesToSkinIni,
-                                            ExportOskAction = exportOsk,
-                                            CanCreateEzSkinJson = () => SkinJsonSession is { IsSupported: true, HasFile: false },
-                                            CanUpdateEzSkinJsonSnapshot = () => SkinJsonSession is { IsSupported: true, HasFile: true }
-                                                                                && SkinJsonSession.IsDirty(ezSkinConfig),
-                                            CanRemoveEzSkinJson = () => SkinJsonSession is { IsSupported: true, HasFile: true },
-                                            CanImportFromSkinJson = () => SkinJsonSession is { IsSupported: true, HasFile: true },
-                                            CanWriteColoursToSkinIni = () => SkinIniSession is { IsSupported: true } && getCurrentKeyMode() > 0,
-                                            CanWriteSizesToSkinIni = () => SkinIniSession is { IsSupported: true } && getCurrentKeyMode() > 0,
-                                            CanExportOsk = canExportOsk,
-                                        },
-                                        topToolbar = new EzSkinEditorTopToolbar
-                                        {
-                                            PreviewSource = PreviewState.Source,
-                                            StaticPreviewRequested = selectStaticPreview,
-                                            BeatmapPreviewRequested = selectBeatmapPreview,
+                                            menuBar = new EzSkinEditorMenuBar
+                                            {
+                                                ApplyAction = applySettings,
+                                                ExitAction = tryExit,
+                                                CreateEzSkinJsonAction = createEzSkinJson,
+                                                UpdateEzSkinJsonSnapshotAction = updateEzSkinJsonSnapshot,
+                                                RemoveEzSkinJsonAction = removeEzSkinJson,
+                                                ImportJsonAction = importJson,
+                                                ImportFromSkinJsonAction = importFromSkinJson,
+                                                ExportJsonAction = exportJson,
+                                                WriteColoursToSkinIniAction = writeColoursToSkinIni,
+                                                WriteSizesToSkinIniAction = writeSizesToSkinIni,
+                                                ExportOskAction = exportOsk,
+                                                CanCreateEzSkinJson = () => SkinJsonSession is { IsSupported: true, HasFile: false },
+                                                CanUpdateEzSkinJsonSnapshot = () => SkinJsonSession is { IsSupported: true, HasFile: true }
+                                                                                    && SkinJsonSession.IsDirty(ezSkinConfig),
+                                                CanRemoveEzSkinJson = () => SkinJsonSession is { IsSupported: true, HasFile: true },
+                                                CanImportFromSkinJson = () => SkinJsonSession is { IsSupported: true, HasFile: true },
+                                                CanWriteColoursToSkinIni = () => SkinIniSession is { IsSupported: true } && getCurrentKeyMode() > 0,
+                                                CanWriteSizesToSkinIni = () => SkinIniSession is { IsSupported: true } && getCurrentKeyMode() > 0,
+                                                CanExportOsk = canExportOsk,
+                                            },
+                                            topToolbar = new EzSkinEditorTopToolbar
+                                            {
+                                                PreviewSource = PreviewState.Source,
+                                                PreviewMode = PreviewState.Mode,
+                                                ToggleBeatmapPlaybackRequested = toggleBeatmapPlayback,
+                                                BeatmapPreviewRequested = selectBeatmapPreview,
+                                            },
                                         },
                                     },
                                 },
-                            },
-                            new Drawable[]
-                            {
-                                sceneBar = new EzSkinEditorSceneBar
+                                new Drawable[]
                                 {
-                                    RelativeSizeAxes = Axes.X,
-                                },
-                            },
-                            new Drawable[]
-                            {
-                                new GridContainer
-                                {
-                                    RelativeSizeAxes = Axes.Both,
-                                    ColumnDimensions = new[]
+                                    sceneBar = new EzSkinEditorSceneBar
                                     {
-                                        new Dimension(),
-                                        new Dimension(GridSizeMode.AutoSize),
+                                        RelativeSizeAxes = Axes.X,
                                     },
-                                    Content = new[]
+                                },
+                                new Drawable[]
+                                {
+                                    new GridContainer
                                     {
-                                        new Drawable[]
+                                        RelativeSizeAxes = Axes.Both,
+                                        ColumnDimensions = new[]
                                         {
-                                            sceneContentHost = new Container { RelativeSizeAxes = Axes.Both },
-                                            sidebar = new EzSkinEditorSidebar(),
+                                            new Dimension(),
+                                            new Dimension(GridSizeMode.AutoSize),
+                                        },
+                                        Content = new[]
+                                        {
+                                            new Drawable[]
+                                            {
+                                                sceneContentHost = new Container { RelativeSizeAxes = Axes.Both },
+                                                sidebar = new EzSkinEditorSidebar(),
+                                            },
                                         },
                                     },
                                 },
@@ -246,6 +257,8 @@ namespace osu.Game.EzOsuGame.Edit
 
         private void refreshScene()
         {
+            ensureGlobalBeatmapPreview();
+
             backgroundContainer!.Child = createManiaStageBackgroundOrNull() ?? new Container { RelativeSizeAxes = Axes.Both };
             backgroundContainer.Child.RelativeSizeAxes = Axes.Both;
 
@@ -257,13 +270,34 @@ namespace osu.Game.EzOsuGame.Edit
             menuBar.RefreshMenuState();
         }
 
-        private void selectStaticPreview()
+        private void ensureGlobalBeatmapPreview()
         {
-            PreviewState.SetStatic();
-            refreshScene();
+            if (attemptedGlobalBeatmapPreview || PreviewState.HasBeatmapLoaded)
+                return;
+
+            attemptedGlobalBeatmapPreview = true;
+
+            if (!EzSkinEditorBeatmapPicker.CanUseAsPreview(gameBeatmap.Value))
+                return;
+
+            if (gameBeatmap.Value.BeatmapInfo.Ruleset is not RulesetInfo ruleset)
+                return;
+
+            PreviewState.SetBeatmap(gameBeatmap.Value, ruleset, EzSkinEditorPreviewModes.GetAppearanceLoadMode(ruleset));
         }
 
-        private void selectBeatmapPreview(RulesetInfo ruleset, EzBeatmapPreviewMode mode)
+        private void toggleBeatmapPlayback()
+        {
+            if (!PreviewState.HasBeatmapLoaded)
+                return;
+
+            if (PreviewState.Mode.Value == EzBeatmapPreviewMode.Dynamic)
+                PreviewState.PauseBeatmapPlayback();
+            else
+                PreviewState.ResumeBeatmapPlayback();
+        }
+
+        private void selectBeatmapPreview(RulesetInfo ruleset)
         {
             if (beatmapPicker == null)
                 return;
@@ -277,13 +311,16 @@ namespace osu.Game.EzOsuGame.Edit
                 return;
             }
 
-            PreviewState.SetBeatmap(workingBeatmap!, ruleset, EzSkinEditorPreviewModes.ValidateMode(mode, ruleset));
+            PreviewState.SetBeatmap(workingBeatmap!, ruleset, EzSkinEditorPreviewModes.GetAppearanceLoadMode(ruleset));
             refreshScene();
         }
 
         private EzSkinEditorSceneContext buildSceneContext()
         {
-            var previewBeatmap = PreviewState.Source.Value == EzSkinEditorPreviewSource.Beatmap
+            bool allowBeatmapPreview = sceneBar.CurrentScene.Value == EzSkinEditorSceneType.Appearance
+                                       && PreviewState.Source.Value == EzSkinEditorPreviewSource.Beatmap;
+
+            var previewBeatmap = allowBeatmapPreview
                 ? PreviewState.PreviewBeatmap?.Beatmap
                 : null;
 
@@ -298,6 +335,7 @@ namespace osu.Game.EzOsuGame.Edit
                 PreviewState = PreviewState,
                 RequestSceneRefresh = refreshScene,
                 CommitSkinIni = commitSkinIni,
+                AllowBeatmapPreview = allowBeatmapPreview,
                 PreviewSource = PreviewState.Source.Value,
                 PreviewBeatmap = PreviewState.PreviewBeatmap,
                 PreviewRuleset = PreviewState.Ruleset.Value,

--- a/osu.Game/EzOsuGame/Localization/EzEditorStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzEditorStrings.cs
@@ -213,9 +213,11 @@ namespace osu.Game.EzOsuGame.Localization
 
         #region Toolbar and preview
 
-        public static readonly LocalisableString TOOLBAR_STATIC_SKIN = new EzLocalizationManager.EzLocalisableString("静态皮肤", "Static skin");
+        public static readonly LocalisableString TOOLBAR_PAUSE_BEATMAP = new EzLocalizationManager.EzLocalisableString("暂停谱面", "Pause beatmap");
 
-        public static readonly LocalisableString TOOLBAR_REAL_BEATMAP = new EzLocalizationManager.EzLocalisableString("实际谱面", "Beatmap");
+        public static readonly LocalisableString TOOLBAR_PLAY_BEATMAP = new EzLocalizationManager.EzLocalisableString("播放谱面", "Play beatmap");
+
+        public static readonly LocalisableString TOOLBAR_SELECT_MODE = new EzLocalizationManager.EzLocalisableString("选择模式", "Select mode");
 
         public static readonly LocalisableString TOOLBAR_PREVIEW_NOT_SUPPORTED = new EzLocalizationManager.EzLocalisableString(
             "预览尚未支持",


### PR DESCRIPTION
## Summary
- Rework top toolbar: play/pause beatmap preview, simplified mode picker, auto-load global beatmap on enter, and PopoverContainer for beatmap selection.
- Fix beatmap preview host threading on beatmap switch and pause/resume so scrolling actually stops.
- Move skin selector to scene bar as a popover button to avoid OsuDropdown painting a full-height column.

## Test plan
- [ ] Open Ez Skin Editor on Appearance scene; confirm global beatmap loads and plays.
- [ ] Click Pause/Play beatmap; preview should freeze and resume.
- [ ] Switch ruleset via Select mode; no InvalidThreadForMutationException in log.
- [ ] Open skin selector on scene bar; list pops over with fixed height, no background column when closed.
- [ ] Size/Colour scenes still use virtual preview only.


Made with [Cursor](https://cursor.com)