### PR TITLE
Ez skin editor M8: virtual comparison on size/colour scenes

### DIFF
--- a/osu.Game.Tests/Visual/Edit/TestSceneEzSkinEditorScreen.cs
+++ b/osu.Game.Tests/Visual/Edit/TestSceneEzSkinEditorScreen.cs
@@ -134,13 +134,18 @@ namespace osu.Game.Tests.Visual.Edit
         }
 
         [Test]
-        public void TestColourSceneGroups()
+        public void TestColourSceneComparisonDrawables()
         {
             AddStep("load screen", loadScreen);
             waitForScreenLoaded();
+            AddAssert("mania preview provider registered", () => SkinEditorProviderRegistry.Get(3) != null);
             switchScene(EzSkinEditorSceneType.Colour);
 
+            AddUntilStep("comparison grid visible", () => editorScreen.ChildrenOfType<EzSkinEditorPreviewHost>().Single().ChildrenOfType<GridContainer>().Any());
             AddUntilStep("two sidebar groups", () => editorScreen.ChildrenOfType<EzSkinEditorSettingsGroup>().Count() == 2);
+            AddAssert("comparison preview supported", () => editorScreen.ChildrenOfType<OsuSpriteText>().All(t => t.Text.ToString().Contains(EzEditorStrings.PLACEHOLDER_COMPARISON_NOT_SUPPORTED.ToString()) != true));
+            AddUntilStep("static note label visible", () => editorScreen.ChildrenOfType<OsuSpriteText>().Any(t => t.Text.ToString() == "Note"));
+            AddUntilStep("static ln label visible", () => editorScreen.ChildrenOfType<OsuSpriteText>().Any(t => t.Text.ToString() == "LN"));
         }
 
         [Test]

--- a/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorPreviewHost.cs
+++ b/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorPreviewHost.cs
@@ -12,28 +12,26 @@ using osuTK.Graphics;
 namespace osu.Game.EzOsuGame.Edit.Components
 {
     /// <summary>
-    /// Hosts the virtual playback scene. With comparison enabled (size scene only),
+    /// Hosts the virtual playback scene. With comparison enabled (size/colour scenes),
     /// playback is on the left and Note/LN static preview is on the right.
     /// </summary>
     public partial class EzSkinEditorPreviewHost : Container
     {
         private readonly EzSkinEditorSceneContext context;
-        private readonly bool showComparison;
 
         private Container playbackContainer = null!;
         private Container comparisonContainer = null!;
 
-        public EzSkinEditorPreviewHost(EzSkinEditorSceneContext context, bool showComparison = false)
+        public EzSkinEditorPreviewHost(EzSkinEditorSceneContext context)
         {
             this.context = context;
-            this.showComparison = showComparison;
             RelativeSizeAxes = Axes.Both;
         }
 
         [BackgroundDependencyLoader]
         private void load()
         {
-            if (!showComparison)
+            if (!context.UseVirtualComparisonPreview)
             {
                 InternalChild = playbackContainer = new Container { RelativeSizeAxes = Axes.Both };
                 populatePlayback();

--- a/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorSkinDropdown.cs
+++ b/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorSkinDropdown.cs
@@ -27,13 +27,11 @@ namespace osu.Game.EzOsuGame.Edit.Components
     /// <summary>
     /// Skin selector anchored to the scene bar. Uses a popover so the list does not expand inline over the editor.
     /// </summary>
-    public partial class EzSkinEditorSkinDropdown : CompositeDrawable, IHasPopover
+    public partial class EzSkinEditorSkinDropdown : SkinEditorSceneLibrary.SceneButton, IHasPopover
     {
         public const float DEFAULT_WIDTH = 200;
 
         private readonly List<Live<SkinInfo>> dropdownItems = new List<Live<SkinInfo>>();
-
-        private SkinPickerButton pickerButton = null!;
 
         [Resolved]
         private SkinManager skins { get; set; } = null!;
@@ -45,19 +43,14 @@ namespace osu.Game.EzOsuGame.Edit.Components
 
         public EzSkinEditorSkinDropdown()
         {
-            RelativeSizeAxes = Axes.None;
             Width = DEFAULT_WIDTH;
-            Height = SkinEditorSceneLibrary.BUTTON_HEIGHT;
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(OverlayColourProvider? colourProvider, OsuColour colours)
         {
-            InternalChild = pickerButton = new SkinPickerButton
-            {
-                RelativeSizeAxes = Axes.Both,
-                Action = this.ShowPopover,
-            };
+            BackgroundColour = colourProvider?.Background3 ?? colours.Blue3;
+            Action = this.ShowPopover;
         }
 
         protected override void LoadComplete()
@@ -68,7 +61,7 @@ namespace osu.Game.EzOsuGame.Edit.Components
                                                                          .Where(s => !s.DeletePending)
                                                                          .OrderBy(s => s.Name, StringComparer.OrdinalIgnoreCase), skinsChanged);
 
-            skins.CurrentSkinInfo.BindValueChanged(e => pickerButton.Text = e.NewValue.ToString() ?? string.Empty, true);
+            skins.CurrentSkinInfo.BindValueChanged(e => Text = e.NewValue.ToString() ?? string.Empty, true);
 
             skins.ScriptedSkinsCatalogUpdated += refreshSkinsList;
             refreshSkinsList();
@@ -99,16 +92,6 @@ namespace osu.Game.EzOsuGame.Edit.Components
             }
 
             base.Dispose(isDisposing);
-        }
-
-        private partial class SkinPickerButton : OsuButton
-        {
-            [BackgroundDependencyLoader]
-            private void load(OverlayColourProvider? colourProvider, OsuColour colours)
-            {
-                BackgroundColour = colourProvider?.Background3 ?? colours.Blue3;
-                Content.CornerRadius = 5;
-            }
         }
 
         private partial class SkinListPopover : OsuPopover

--- a/osu.Game/EzOsuGame/Edit/EzSkinEditorSceneContext.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinEditorSceneContext.cs
@@ -35,6 +35,11 @@ namespace osu.Game.EzOsuGame.Edit
         /// </summary>
         public bool AllowBeatmapPreview { get; init; }
 
+        /// <summary>
+        /// Size/colour scenes use the virtual playfield on the left and Note/LN comparison on the right.
+        /// </summary>
+        public bool UseVirtualComparisonPreview { get; init; }
+
         public IWorkingBeatmap? PreviewBeatmap { get; init; }
 
         public RulesetInfo? PreviewRuleset { get; init; }

--- a/osu.Game/EzOsuGame/Edit/EzSkinEditorScreen.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinEditorScreen.cs
@@ -36,6 +36,7 @@ namespace osu.Game.EzOsuGame.Edit
     // M4: top-bar preview controls + static/beatmap scene backends
     // M5: EzSkin.json + advanced colouring + config menu (json/colour→ini)
     // M6: size→ini, .osk export
+    // M7: preview toolbar + skin popover + virtual comparison on size/colour scenes
 
     /// <summary>
     /// Ez skin editor screen with menu bar, scene bar, scene content and toolbox-style settings sidebar.
@@ -231,6 +232,7 @@ namespace osu.Game.EzOsuGame.Edit
         protected override void LoadComplete()
         {
             base.LoadComplete();
+            SkinEditorProviderResolver.EnsureDefaultProviderRegistered();
             beatmapPicker = new EzSkinEditorBeatmapPicker(realm, beatmapManager);
             sceneBar.CurrentScene.BindValueChanged(onSceneChanged, true);
             skinManager.CurrentSkinInfo.BindValueChanged(onCurrentSkinInfoChanged);
@@ -317,13 +319,19 @@ namespace osu.Game.EzOsuGame.Edit
 
         private EzSkinEditorSceneContext buildSceneContext()
         {
-            bool allowBeatmapPreview = sceneBar.CurrentScene.Value == EzSkinEditorSceneType.Appearance
+            var currentScene = sceneBar.CurrentScene.Value;
+
+            bool allowBeatmapPreview = currentScene == EzSkinEditorSceneType.Appearance
                                        && PreviewState.Source.Value == EzSkinEditorPreviewSource.Beatmap;
 
+            bool useVirtualComparisonPreview = currentScene is EzSkinEditorSceneType.Size or EzSkinEditorSceneType.Colour;
+
+            // Size/colour scenes always use the mania LN virtual provider, not the loaded beatmap ruleset.
             var previewBeatmap = allowBeatmapPreview
                 ? PreviewState.PreviewBeatmap?.Beatmap
                 : null;
 
+            SkinEditorProviderResolver.EnsureDefaultProviderRegistered();
             provider = SkinEditorProviderResolver.Resolve(previewBeatmap);
 
             return new EzSkinEditorSceneContext
@@ -336,6 +344,7 @@ namespace osu.Game.EzOsuGame.Edit
                 RequestSceneRefresh = refreshScene,
                 CommitSkinIni = commitSkinIni,
                 AllowBeatmapPreview = allowBeatmapPreview,
+                UseVirtualComparisonPreview = useVirtualComparisonPreview,
                 PreviewSource = PreviewState.Source.Value,
                 PreviewBeatmap = PreviewState.PreviewBeatmap,
                 PreviewRuleset = PreviewState.Ruleset.Value,

--- a/osu.Game/EzOsuGame/Edit/Scenes/ColourSceneStrategy.cs
+++ b/osu.Game/EzOsuGame/Edit/Scenes/ColourSceneStrategy.cs
@@ -16,7 +16,8 @@ namespace osu.Game.EzOsuGame.Edit.Scenes
 
         public LocalisableString TabTitle => EzEditorStrings.TAB_COLOUR;
 
-        public Drawable CreateSceneContent(EzSkinEditorSceneContext context) => new EzSkinEditorPreviewHost(context);
+        public Drawable CreateSceneContent(EzSkinEditorSceneContext context) =>
+            new EzSkinEditorPreviewHost(context);
 
         public IReadOnlyList<EzSkinEditorSidebarGroupDefinition> CreateSidebarGroups(EzSkinEditorSceneContext context) => new[]
         {

--- a/osu.Game/EzOsuGame/Edit/Scenes/SizeSceneStrategy.cs
+++ b/osu.Game/EzOsuGame/Edit/Scenes/SizeSceneStrategy.cs
@@ -18,7 +18,7 @@ namespace osu.Game.EzOsuGame.Edit.Scenes
         public LocalisableString TabTitle => EzEditorStrings.TAB_SIZE;
 
         public Drawable CreateSceneContent(EzSkinEditorSceneContext context) =>
-            new EzSkinEditorPreviewHost(context, showComparison: true);
+            new EzSkinEditorPreviewHost(context);
 
         public IReadOnlyList<EzSkinEditorSidebarGroupDefinition> CreateSidebarGroups(EzSkinEditorSceneContext context)
         {

--- a/osu.Game/EzOsuGame/Edit/SkinEditorProviderResolver.cs
+++ b/osu.Game/EzOsuGame/Edit/SkinEditorProviderResolver.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using osu.Game.Beatmaps;
 
 namespace osu.Game.EzOsuGame.Edit
@@ -13,6 +14,17 @@ namespace osu.Game.EzOsuGame.Edit
         private const int mania_ruleset_online_id = 3;
 
         private const string mania_provider_type_name = "osu.Game.Rulesets.Mania.EzMania.Editor.EzSkinLNEditorProvider, osu.Game.Rulesets.Mania";
+
+        /// <summary>
+        /// Ensures the default mania virtual preview provider is registered.
+        /// </summary>
+        public static void EnsureDefaultProviderRegistered()
+        {
+            if (SkinEditorProviderRegistry.Get(mania_ruleset_online_id) != null)
+                return;
+
+            ensureManiaProviderRegistered();
+        }
 
         public static ISkinEditorVirtualProvider? Resolve(IBeatmap? beatmap)
         {
@@ -33,11 +45,19 @@ namespace osu.Game.EzOsuGame.Edit
         {
             try
             {
-                var assembly = AppDomain.CurrentDomain.GetAssemblies()
-                                        .FirstOrDefault(a => a.GetName().Name == "osu.Game.Rulesets.Mania")
-                               ?? Assembly.Load(new AssemblyName("osu.Game.Rulesets.Mania"));
+                var type = Type.GetType(mania_provider_type_name, throwOnError: false);
 
-                _ = assembly.GetType("osu.Game.Rulesets.Mania.EzMania.Editor.EzSkinLNEditorProvider", throwOnError: false);
+                if (type == null)
+                {
+                    var assembly = AppDomain.CurrentDomain.GetAssemblies()
+                                            .FirstOrDefault(a => a.GetName().Name == "osu.Game.Rulesets.Mania")
+                                   ?? Assembly.Load(new AssemblyName("osu.Game.Rulesets.Mania"));
+
+                    type = assembly.GetType("osu.Game.Rulesets.Mania.EzMania.Editor.EzSkinLNEditorProvider", throwOnError: false);
+                }
+
+                if (type != null)
+                    RuntimeHelpers.RunClassConstructor(type.TypeHandle);
             }
             catch
             {


### PR DESCRIPTION
## Summary
- Restore left playfield + right Note/LN comparison preview on **Size** and **Colour** scenes via \UseVirtualComparisonPreview\ in scene context.
- Fix mania virtual preview provider registration (\RuntimeHelpers.RunClassConstructor\) so scenes no longer fall back to placeholder text.
- Cherry-pick missed skin selector button layout fix (direct \SceneButton\, no clipping in scene bar).

## Test plan
- [ ] Open Ez Skin Editor, switch to **Size**: left scrolling mania preview + right Note/LN static comparison visible.
- [ ] Switch to **Colour**: same comparison layout, sidebar colour groups still work.
- [ ] **Appearance** still uses beatmap preview when loaded; **skin.ini** stays single-column virtual preview.
- [ ] Scene bar skin button shows full label and rounded rect, not clipped.


Made with [Cursor](https://cursor.com)