### PR TITLE
Ez skin editor M9: config snapshot comparison and session UX

### DIFF
--- a/osu.Game.Tests/NonVisual/EzSkinEditorComparisonSnapshotTest.cs
+++ b/osu.Game.Tests/NonVisual/EzSkinEditorComparisonSnapshotTest.cs
@@ -1,0 +1,42 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Edit;
+
+namespace osu.Game.Tests.NonVisual
+{
+    [TestFixture]
+    public class EzSkinEditorComparisonSnapshotTest
+    {
+        [Test]
+        public void TestCaptureApplyAndDefaultSync()
+        {
+            using var host = new CleanRunHeadlessGameHost();
+            var config = new Ez2ConfigManager(host.Storage);
+
+            double originalWidth = config.Get<double>(Ez2Setting.ColumnWidth);
+            double originalDefault = config.GetBindable<double>(Ez2Setting.ColumnWidth).Default;
+
+            try
+            {
+                var snapshot = new EzSkinEditorComparisonSnapshot();
+                snapshot.CaptureFrom(config);
+
+                config.GetBindable<double>(Ez2Setting.ColumnWidth).Value = originalWidth + 25;
+                snapshot.SyncBindableDefaults(config);
+
+                Assert.That(config.GetBindable<double>(Ez2Setting.ColumnWidth).Default, Is.EqualTo(originalWidth));
+
+                snapshot.ApplyTo(config);
+                Assert.That(config.Get<double>(Ez2Setting.ColumnWidth), Is.EqualTo(originalWidth));
+            }
+            finally
+            {
+                config.GetBindable<double>(Ez2Setting.ColumnWidth).Value = originalWidth;
+                config.GetBindable<double>(Ez2Setting.ColumnWidth).Default = originalDefault;
+            }
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Edit/TestSceneEzSkinEditorScreen.cs
+++ b/osu.Game.Tests/Visual/Edit/TestSceneEzSkinEditorScreen.cs
@@ -103,7 +103,7 @@ namespace osu.Game.Tests.Visual.Edit
             waitForScreenLoaded();
             switchScene(EzSkinEditorSceneType.Appearance);
 
-            AddUntilStep("two sidebar groups", () => editorScreen.ChildrenOfType<EzSkinEditorSettingsGroup>().Count() == 2);
+            AddUntilStep("three sidebar groups", () => editorScreen.ChildrenOfType<EzSkinEditorSettingsGroup>().Count() == 3);
             AddAssert("texture group present", () => editorScreen.ChildrenOfType<Dropdown<string>>().Any());
             AddAssert("no comparison placeholder", () => editorScreen.ChildrenOfType<OsuSpriteText>().All(t => t.Text.ToString().Contains("对比区") != true));
         }
@@ -371,7 +371,42 @@ namespace osu.Game.Tests.Visual.Edit
             AddUntilStep("top toolbar visible", () => editorScreen.ChildrenOfType<EzSkinEditorTopToolbar>().Any());
             AddUntilStep("skin dropdown visible", () => editorScreen.ChildrenOfType<EzSkinEditorSkinDropdown>().Any());
             AddUntilStep("beatmap menu button visible", () => editorScreen.ChildrenOfType<EzSkinEditorBeatmapMenuButton>().Any());
-            AddAssert("default static preview", () => editorScreen.PreviewSource.Value == EzSkinEditorPreviewSource.Static);
+            AddAssert("preview source resolved", () => editorScreen.PreviewSource.Value is EzSkinEditorPreviewSource.Static or EzSkinEditorPreviewSource.Beatmap);
+        }
+
+        [Test]
+        public void TestConfigSnapshotRestore()
+        {
+            AddStep("load screen", loadScreen);
+            waitForScreenLoaded();
+
+            double baseline = 0;
+            AddStep("read baseline", () => baseline = ezConfig.Get<double>(Ez2Setting.ColumnWidth));
+
+            AddStep("change column width", () => ezConfig.GetBindable<double>(Ez2Setting.ColumnWidth).Value = baseline + 30);
+            AddAssert("width changed", () => ezConfig.Get<double>(Ez2Setting.ColumnWidth) == baseline + 30);
+
+            AddStep("restore snapshot", () => editorScreen.RestoreConfigSnapshotForTesting());
+            AddAssert("width restored", () => ezConfig.Get<double>(Ez2Setting.ColumnWidth) == baseline);
+        }
+
+        [Test]
+        public void TestCreateConfigSnapshotUpdatesBaseline()
+        {
+            AddStep("load screen", loadScreen);
+            waitForScreenLoaded();
+
+            double updated = 0;
+            AddStep("change and capture", () =>
+            {
+                updated = ezConfig.Get<double>(Ez2Setting.ColumnWidth) + 15;
+                ezConfig.GetBindable<double>(Ez2Setting.ColumnWidth).Value = updated;
+                editorScreen.CreateConfigSnapshotForTesting();
+            });
+
+            AddStep("change again", () => ezConfig.GetBindable<double>(Ez2Setting.ColumnWidth).Value = updated + 20);
+            AddStep("restore snapshot", () => editorScreen.RestoreConfigSnapshotForTesting());
+            AddAssert("restored to captured value", () => ezConfig.Get<double>(Ez2Setting.ColumnWidth) == updated);
         }
 
         [Test]

--- a/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorBeatmapMenuButton.cs
+++ b/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorBeatmapMenuButton.cs
@@ -60,7 +60,9 @@ namespace osu.Game.EzOsuGame.Edit.Components
             updateColours();
         }
 
-        public Popover GetPopover() => new BeatmapPreviewPopover(rulesets, BeatmapPreviewRequested);
+        public Action? ClearBeatmapPreviewRequested { get; set; }
+
+        public Popover GetPopover() => new BeatmapPreviewPopover(rulesets, BeatmapPreviewRequested, ClearBeatmapPreviewRequested);
 
         private void updateColours()
         {
@@ -74,23 +76,36 @@ namespace osu.Game.EzOsuGame.Edit.Components
     {
         private readonly IRulesetStore rulesets;
         private readonly Action<RulesetInfo>? onSelected;
+        private readonly Action? onClear;
 
-        public BeatmapPreviewPopover(IRulesetStore rulesets, Action<RulesetInfo>? onSelected)
+        public BeatmapPreviewPopover(IRulesetStore rulesets, Action<RulesetInfo>? onSelected, Action? onClear = null)
         {
             this.rulesets = rulesets;
             this.onSelected = onSelected;
+            this.onClear = onClear;
         }
 
         [BackgroundDependencyLoader]
         private void load()
         {
+            var children = new List<Drawable>(buildRulesetButtons());
+
+            if (onClear != null)
+            {
+                children.Add(new ModeSelectButton(EzEditorStrings.TOOLBAR_CLEAR_BEATMAP_PREVIEW, () =>
+                {
+                    onClear.Invoke();
+                    this.HidePopover();
+                }));
+            }
+
             Child = new FillFlowContainer
             {
                 Width = 220,
                 AutoSizeAxes = Axes.Y,
                 Direction = FillDirection.Vertical,
                 Spacing = new Vector2(0, 6),
-                Children = buildRulesetButtons().ToArray(),
+                Children = children.ToArray(),
             };
         }
 

--- a/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorConfigSnapshotScope.cs
+++ b/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorConfigSnapshotScope.cs
@@ -1,0 +1,48 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.EzOsuGame.Configuration;
+
+namespace osu.Game.EzOsuGame.Edit.Components
+{
+    /// <summary>
+    /// Temporarily applies a configuration snapshot while building preview drawables, then restores live values on dispose.
+    /// </summary>
+    public partial class EzSkinEditorConfigSnapshotScope : Container
+    {
+        private readonly EzSkinJsonDocument snapshot;
+        private readonly Func<Drawable> createChild;
+
+        private EzSkinJsonDocument? savedDocument;
+
+        [Resolved]
+        private Ez2ConfigManager config { get; set; } = null!;
+
+        public EzSkinEditorConfigSnapshotScope(EzSkinJsonDocument snapshot, Func<Drawable> createChild)
+        {
+            this.snapshot = snapshot;
+            this.createChild = createChild;
+            RelativeSizeAxes = Axes.Both;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            savedDocument = EzSkinJsonBridge.Capture(config);
+            EzSkinJsonBridge.Apply(snapshot, config);
+            Child = createChild();
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (isDisposing && savedDocument != null)
+                EzSkinJsonBridge.Apply(savedDocument, config);
+
+            base.Dispose(isDisposing);
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorMenuBar.cs
+++ b/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorMenuBar.cs
@@ -41,6 +41,12 @@ namespace osu.Game.EzOsuGame.Edit.Components
 
         public Action? ExportOskAction { get; set; }
 
+        public Action? CreateConfigSnapshotAction { get; set; }
+
+        public Action? RestoreConfigSnapshotAction { get; set; }
+
+        public Action? ExportPreviewImageAction { get; set; }
+
         public Func<bool>? CanCreateEzSkinJson { get; set; }
 
         public Func<bool>? CanUpdateEzSkinJsonSnapshot { get; set; }
@@ -55,6 +61,11 @@ namespace osu.Game.EzOsuGame.Edit.Components
 
         public Func<bool>? CanExportOsk { get; set; }
 
+        public Func<bool>? CanExportPreviewImage { get; set; }
+
+        private readonly EditorMenuItem createConfigSnapshotItem;
+        private readonly EditorMenuItem restoreConfigSnapshotItem;
+        private readonly EditorMenuItem exportPreviewImageItem;
         private readonly EditorMenuItem createJsonItem;
         private readonly EditorMenuItem updateSnapshotItem;
         private readonly EditorMenuItem removeJsonItem;
@@ -88,6 +99,11 @@ namespace osu.Game.EzOsuGame.Edit.Components
                 {
                     Items = new OsuMenuItem[]
                     {
+                        createConfigSnapshotItem = new EditorMenuItem(EzEditorStrings.MENU_CREATE_CONFIG_SNAPSHOT, MenuItemType.Standard, () => CreateConfigSnapshotAction?.Invoke()),
+                        restoreConfigSnapshotItem = new EditorMenuItem(EzEditorStrings.MENU_RESTORE_CONFIG_SNAPSHOT, MenuItemType.Standard, () => RestoreConfigSnapshotAction?.Invoke()),
+                        new OsuMenuItemSpacer(),
+                        exportPreviewImageItem = new EditorMenuItem(EzEditorStrings.MENU_EXPORT_PREVIEW_IMAGE, MenuItemType.Standard, () => ExportPreviewImageAction?.Invoke()),
+                        new OsuMenuItemSpacer(),
                         createJsonItem = new EditorMenuItem(EzEditorStrings.MENU_CREATE_EZSKIN_JSON, MenuItemType.Standard, () => CreateEzSkinJsonAction?.Invoke()),
                         updateSnapshotItem = new EditorMenuItem(EzEditorStrings.MENU_UPDATE_EZSKIN_JSON_SNAPSHOT, MenuItemType.Standard, () => UpdateEzSkinJsonSnapshotAction?.Invoke()),
                         removeJsonItem = new EditorMenuItem(EzEditorStrings.MENU_REMOVE_EZSKIN_JSON, MenuItemType.Standard, () => RemoveEzSkinJsonAction?.Invoke()),
@@ -105,6 +121,9 @@ namespace osu.Game.EzOsuGame.Edit.Components
 
         public void RefreshMenuState()
         {
+            createConfigSnapshotItem.Action.Disabled = false;
+            restoreConfigSnapshotItem.Action.Disabled = false;
+            exportPreviewImageItem.Action.Disabled = !(CanExportPreviewImage?.Invoke() ?? false);
             createJsonItem.Action.Disabled = !(CanCreateEzSkinJson?.Invoke() ?? false);
             updateSnapshotItem.Action.Disabled = !(CanUpdateEzSkinJsonSnapshot?.Invoke() ?? false);
             removeJsonItem.Action.Disabled = !(CanRemoveEzSkinJson?.Invoke() ?? false);

--- a/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorPreviewHost.cs
+++ b/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorPreviewHost.cs
@@ -88,19 +88,21 @@ namespace osu.Game.EzOsuGame.Edit.Components
 
         private void populateComparison()
         {
-            if (context.Provider != null)
+            if (context.Provider == null)
             {
-                comparisonContainer.Child = context.Provider.CreateStaticPart(context.EditorSkin).With(d =>
+                comparisonContainer.Child = createPlaceholder(EzEditorStrings.PLACEHOLDER_COMPARISON_NOT_SUPPORTED);
+                return;
+            }
+
+            var snapshotDocument = context.ComparisonSnapshot?.Document ?? new EzSkinJsonDocument();
+
+            comparisonContainer.Child = new EzSkinEditorConfigSnapshotScope(snapshotDocument, () =>
+                context.Provider!.CreateStaticPart(context.EditorSkin).With(d =>
                 {
                     d.RelativeSizeAxes = Axes.Both;
                     d.Anchor = Anchor.Centre;
                     d.Origin = Anchor.Centre;
-                });
-            }
-            else
-            {
-                comparisonContainer.Child = createPlaceholder(EzEditorStrings.PLACEHOLDER_COMPARISON_NOT_SUPPORTED);
-            }
+                }));
         }
 
         private static OsuSpriteText createPlaceholder(LocalisableString text) => new OsuSpriteText

--- a/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorTopToolbar.cs
+++ b/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorTopToolbar.cs
@@ -23,6 +23,8 @@ namespace osu.Game.EzOsuGame.Edit.Components
 
         public Action<RulesetInfo>? BeatmapPreviewRequested { get; set; }
 
+        public Action? ClearBeatmapPreviewRequested { get; set; }
+
         public Bindable<EzSkinEditorPreviewSource>? PreviewSource { get; set; }
 
         public Bindable<EzBeatmapPreviewMode>? PreviewMode { get; set; }
@@ -49,6 +51,7 @@ namespace osu.Game.EzOsuGame.Edit.Components
                 beatmapButton = new EzSkinEditorBeatmapMenuButton
                 {
                     BeatmapPreviewRequested = ruleset => BeatmapPreviewRequested?.Invoke(ruleset),
+                    ClearBeatmapPreviewRequested = () => ClearBeatmapPreviewRequested?.Invoke(),
                 },
                 new OsuTextFlowContainer
                 {

--- a/osu.Game/EzOsuGame/Edit/EzSkinEditorComparisonSnapshot.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinEditorComparisonSnapshot.cs
@@ -1,0 +1,22 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.EzOsuGame.Configuration;
+
+namespace osu.Game.EzOsuGame.Edit
+{
+    /// <summary>
+    /// In-memory Ez skin editor configuration snapshot for preview comparison and control reset baselines.
+    /// Not persisted to disk — navigation triggers <see cref="Ez2ConfigManager"/> save separately.
+    /// </summary>
+    public sealed class EzSkinEditorComparisonSnapshot
+    {
+        public EzSkinJsonDocument Document { get; private set; } = new EzSkinJsonDocument();
+
+        public void CaptureFrom(Ez2ConfigManager config) => Document = EzSkinJsonBridge.Capture(config);
+
+        public void ApplyTo(Ez2ConfigManager config) => EzSkinJsonBridge.Apply(Document, config);
+
+        public void SyncBindableDefaults(Ez2ConfigManager config) => EzSkinJsonBridge.SyncBindableDefaults(config, Document);
+    }
+}

--- a/osu.Game/EzOsuGame/Edit/EzSkinEditorSceneContext.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinEditorSceneContext.cs
@@ -45,5 +45,10 @@ namespace osu.Game.EzOsuGame.Edit
         public RulesetInfo? PreviewRuleset { get; init; }
 
         public EzBeatmapPreviewMode PreviewMode { get; init; } = EzBeatmapPreviewMode.Static;
+
+        /// <summary>
+        /// Configuration snapshot used for comparison preview (right pane) and control reset baselines.
+        /// </summary>
+        public EzSkinEditorComparisonSnapshot? ComparisonSnapshot { get; init; }
     }
 }

--- a/osu.Game/EzOsuGame/Edit/EzSkinEditorScreen.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinEditorScreen.cs
@@ -3,6 +3,10 @@
 
 using System;
 using System.IO;
+using System.Threading.Tasks;
+using osu.Framework.Extensions;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
 using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -31,12 +35,14 @@ namespace osu.Game.EzOsuGame.Edit
 {
     // Milestone index — see EzSkinEditor refactor plan:
     // M1: layout shell + scene strategies + sidebar groups
-    // M2: Saved/Draft session + Note/LN comparison preview
+    // M2: live vs snapshot comparison + Note/LN preview (skin.ini keeps Saved/Draft)
     // M3: Skin.ini editor + backup + save footer
     // M4: top-bar preview controls + static/beatmap scene backends
     // M5: EzSkin.json + advanced colouring + config menu (json/colour→ini)
     // M6: size→ini, .osk export
     // M7: preview toolbar + skin popover + virtual comparison on size/colour scenes
+    // M8: size/colour virtual provider registration fix
+    // M9: config snapshot comparison + create/restore snapshot + auto-save on navigate
 
     /// <summary>
     /// Ez skin editor screen with menu bar, scene bar, scene content and toolbox-style settings sidebar.
@@ -84,6 +90,8 @@ namespace osu.Game.EzOsuGame.Edit
         private EzSkinEditorBeatmapPicker? beatmapPicker;
 
         private bool attemptedGlobalBeatmapPreview;
+        private bool comparisonSnapshotInitialized;
+        private bool configPreviewRefreshBound;
 
         private ISkinEditorVirtualProvider? provider;
         private EzSkinEditorSceneContext? sceneContext;
@@ -126,6 +134,7 @@ namespace osu.Game.EzOsuGame.Edit
 
         public override bool OnExiting(ScreenExitEvent e)
         {
+            persistEditorConfig();
             this.FadeOut(200, Easing.OutQuint);
             return base.OnExiting(e);
         }
@@ -176,7 +185,11 @@ namespace osu.Game.EzOsuGame.Edit
                                                 WriteColoursToSkinIniAction = writeColoursToSkinIni,
                                                 WriteSizesToSkinIniAction = writeSizesToSkinIni,
                                                 ExportOskAction = exportOsk,
+                                                CreateConfigSnapshotAction = createConfigSnapshot,
+                                                RestoreConfigSnapshotAction = restoreConfigSnapshot,
+                                                ExportPreviewImageAction = exportPreviewImage,
                                                 CanCreateEzSkinJson = () => SkinJsonSession is { IsSupported: true, HasFile: false },
+                                                CanExportPreviewImage = () => RuntimeInfo.IsDesktop,
                                                 CanUpdateEzSkinJsonSnapshot = () => SkinJsonSession is { IsSupported: true, HasFile: true }
                                                                                     && SkinJsonSession.IsDirty(ezSkinConfig),
                                                 CanRemoveEzSkinJson = () => SkinJsonSession is { IsSupported: true, HasFile: true },
@@ -191,6 +204,7 @@ namespace osu.Game.EzOsuGame.Edit
                                                 PreviewMode = PreviewState.Mode,
                                                 ToggleBeatmapPlaybackRequested = toggleBeatmapPlayback,
                                                 BeatmapPreviewRequested = selectBeatmapPreview,
+                                                ClearBeatmapPreviewRequested = clearBeatmapPreview,
                                             },
                                         },
                                     },
@@ -236,6 +250,7 @@ namespace osu.Game.EzOsuGame.Edit
             beatmapPicker = new EzSkinEditorBeatmapPicker(realm, beatmapManager);
             sceneBar.CurrentScene.BindValueChanged(onSceneChanged, true);
             skinManager.CurrentSkinInfo.BindValueChanged(onCurrentSkinInfoChanged);
+            bindConfigPreviewRefresh();
         }
 
         private void onSceneChanged(ValueChangedEvent<EzSkinEditorSceneType> change)
@@ -245,6 +260,9 @@ namespace osu.Game.EzOsuGame.Edit
                 sceneBar.CurrentScene.Value = EzSkinEditorSceneType.Appearance;
                 return;
             }
+
+            if (change.OldValue != change.NewValue)
+                persistEditorConfig();
 
             Schedule(applyCurrentScene);
         }
@@ -257,8 +275,15 @@ namespace osu.Game.EzOsuGame.Edit
 
         internal void WriteSizesToSkinIniForTesting() => writeSizesToSkinIni();
 
+        internal void CreateConfigSnapshotForTesting() => createConfigSnapshot();
+
+        internal void RestoreConfigSnapshotForTesting() => restoreConfigSnapshot();
+
+        internal EzSkinEditorComparisonSnapshot ComparisonSnapshotForTesting { get; } = new EzSkinEditorComparisonSnapshot();
+
         private void refreshScene()
         {
+            ensureComparisonSnapshot();
             ensureGlobalBeatmapPreview();
 
             backgroundContainer!.Child = createManiaStageBackgroundOrNull() ?? new Container { RelativeSizeAxes = Axes.Both };
@@ -317,6 +342,12 @@ namespace osu.Game.EzOsuGame.Edit
             refreshScene();
         }
 
+        private void clearBeatmapPreview()
+        {
+            PreviewState.SetStatic();
+            refreshScene();
+        }
+
         private EzSkinEditorSceneContext buildSceneContext()
         {
             var currentScene = sceneBar.CurrentScene.Value;
@@ -349,6 +380,7 @@ namespace osu.Game.EzOsuGame.Edit
                 PreviewBeatmap = PreviewState.PreviewBeatmap,
                 PreviewRuleset = PreviewState.Ruleset.Value,
                 PreviewMode = PreviewState.Mode.Value,
+                ComparisonSnapshot = ComparisonSnapshotForTesting,
             };
         }
 
@@ -624,14 +656,111 @@ namespace osu.Game.EzOsuGame.Edit
 
         private void onCurrentSkinInfoChanged(ValueChangedEvent<Live<SkinInfo>> skin)
         {
+            if (skin.OldValue?.ID != skin.NewValue?.ID)
+            {
+                persistEditorConfig();
+                recaptureComparisonSnapshot();
+            }
+
             Schedule(refreshScene);
+        }
+
+        private void ensureComparisonSnapshot()
+        {
+            if (comparisonSnapshotInitialized)
+                return;
+
+            recaptureComparisonSnapshot();
+            comparisonSnapshotInitialized = true;
+        }
+
+        private void recaptureComparisonSnapshot()
+        {
+            ComparisonSnapshotForTesting.CaptureFrom(ezSkinConfig);
+            ComparisonSnapshotForTesting.SyncBindableDefaults(ezSkinConfig);
+        }
+
+        private void createConfigSnapshot()
+        {
+            recaptureComparisonSnapshot();
+            postNotification(EzEditorStrings.NOTIFY_CREATED_CONFIG_SNAPSHOT);
+            refreshScene();
+        }
+
+        private void restoreConfigSnapshot()
+        {
+            ComparisonSnapshotForTesting.ApplyTo(ezSkinConfig);
+            postNotification(EzEditorStrings.NOTIFY_RESTORED_CONFIG_SNAPSHOT);
+            refreshScene();
+        }
+
+        private void persistEditorConfig()
+        {
+            ezSkinConfig.Save();
+            skinManager.CurrentSkinInfo.TriggerChange();
+        }
+
+        private void bindConfigPreviewRefresh()
+        {
+            if (configPreviewRefreshBound)
+                return;
+
+            configPreviewRefreshBound = true;
+
+            foreach (var setting in EzSkinJsonSettingCatalog.All)
+                EzSkinJsonBridge.BindSettingValueChanged(ezSkinConfig, setting, () => Schedule(refreshPreviewContent));
+        }
+
+        private void refreshPreviewContent()
+        {
+            if (!IsLoaded)
+                return;
+
+            sceneContext = buildSceneContext();
+
+            var strategy = EzSkinEditorSceneRegistry.Get(sceneBar.CurrentScene.Value);
+            sceneContentHost.Child = strategy.CreateSceneContent(sceneContext);
+        }
+
+        private void exportPreviewImage()
+        {
+            if (!RuntimeInfo.IsDesktop)
+                return;
+
+            host.TakeScreenshotAsync().ContinueWith(task =>
+            {
+                if (task.IsFaulted)
+                {
+                    Schedule(() => postNotification(LocalisableString.Format(EzEditorStrings.NOTIFY_EXPORT_FAILED, task.Exception?.GetBaseException().Message ?? "unknown error")));
+                    return;
+                }
+
+                Schedule(() =>
+                {
+                    try
+                    {
+                        using Image<Rgba32> image = task.GetResultSafely();
+                        string filename = $"ez-skin-editor-preview-{DateTimeOffset.Now:yyyyMMdd-HHmmss}.png";
+                        var exportStorage = (storage as OsuStorage)?.GetExportStorage() ?? storage.GetStorageForDirectory(@"exports");
+
+                        using (var stream = exportStorage.CreateFileSafely(filename))
+                            image.SaveAsPng(stream);
+
+                        postNotification(LocalisableString.Format(EzEditorStrings.NOTIFY_EXPORTED_TO, filename));
+                    }
+                    catch (Exception e)
+                    {
+                        postNotification(LocalisableString.Format(EzEditorStrings.NOTIFY_EXPORT_FAILED, e.Message));
+                    }
+                });
+            }, TaskScheduler.Default);
         }
 
         private ISkin getEditorSkin()
         {
             var currentSkin = skinManager.CurrentSkin.Value;
 
-            return currentSkin is EzStyleProSkin or Ez2Skin or SbISkin
+            return currentSkin is EzStyleProSkin or Ez2Skin or SbISkin or ScriptedSkinWrapper
                 ? currentSkin
                 : new EzStyleProSkin(skinManager);
         }

--- a/osu.Game/EzOsuGame/Edit/EzSkinJsonBridge.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinJsonBridge.cs
@@ -48,6 +48,46 @@ namespace osu.Game.EzOsuGame.Edit
         public static string CreateNormalizedSnapshot(Ez2ConfigManager config) =>
             EzSkinJsonDocument.SerializeNormalized(Capture(config));
 
+        /// <summary>
+        /// Sets bindable defaults to the values stored in <paramref name="document"/> so settings controls reset to the snapshot baseline.
+        /// </summary>
+        public static void SyncBindableDefaults(Ez2ConfigManager config, EzSkinJsonDocument document)
+        {
+            foreach (var pair in document.Settings)
+            {
+                if (!Enum.TryParse(pair.Key, out Ez2Setting setting))
+                    continue;
+
+                if (!EzSkinJsonSettingCatalog.Contains(setting))
+                    continue;
+
+                syncBindableDefault(config, setting, pair.Value);
+            }
+        }
+
+        private static void syncBindableDefault(Ez2ConfigManager config, Ez2Setting setting, string value)
+        {
+            var bindable = getTypedBindable(config, setting);
+
+            if (bindable == null)
+                return;
+
+            var valueProperty = bindable.GetType().GetProperty("Value");
+            var defaultProperty = bindable.GetType().GetProperty("Default");
+
+            if (valueProperty == null || defaultProperty == null)
+                return;
+
+            object? previousValue = valueProperty.GetValue(bindable);
+
+            if (bindable is IParseable parseable)
+                parseable.Parse(value, CultureInfo.InvariantCulture);
+
+            object? snapshotValue = valueProperty.GetValue(bindable);
+            defaultProperty.SetValue(bindable, snapshotValue);
+            valueProperty.SetValue(bindable, previousValue);
+        }
+
         private static bool tryCaptureSetting(Ez2ConfigManager config, Ez2Setting setting, out string value)
         {
             value = string.Empty;
@@ -79,7 +119,7 @@ namespace osu.Game.EzOsuGame.Edit
 
         private static IBindable? getTypedBindable(Ez2ConfigManager config, Ez2Setting setting)
         {
-            Type? valueType = getBindableValueType(config, setting);
+            Type? valueType = getBindableValueType(setting);
 
             if (valueType == null)
                 return null;
@@ -87,7 +127,28 @@ namespace osu.Game.EzOsuGame.Edit
             return (IBindable?)get_bindable_method.MakeGenericMethod(valueType).Invoke(config, new object[] { setting });
         }
 
-        private static Type? getBindableValueType(Ez2ConfigManager config, Ez2Setting setting)
+        public static Type? GetBindableValueType(Ez2Setting setting) => getBindableValueType(setting);
+
+        public static void BindSettingValueChanged(Ez2ConfigManager config, Ez2Setting setting, Action onChanged)
+        {
+            var valueType = getBindableValueType(setting);
+
+            if (valueType == null)
+                return;
+
+            var method = typeof(EzSkinJsonBridge).GetMethod(nameof(bindSettingValueChangedGeneric), BindingFlags.Static | BindingFlags.NonPublic)!
+                                                 .MakeGenericMethod(valueType);
+
+            method.Invoke(null, new object[] { config, setting, onChanged });
+        }
+
+        private static void bindSettingValueChangedGeneric<T>(Ez2ConfigManager config, Ez2Setting setting, Action onChanged)
+            where T : notnull
+        {
+            config.GetBindable<T>(setting).BindValueChanged(_ => onChanged());
+        }
+
+        private static Type? getBindableValueType(Ez2Setting setting)
         {
             // Access default type via a temporary bindable lookup through public getters for known settings.
             return setting switch

--- a/osu.Game/EzOsuGame/Edit/Scenes/AppearanceSceneStrategy.cs
+++ b/osu.Game/EzOsuGame/Edit/Scenes/AppearanceSceneStrategy.cs
@@ -32,6 +32,11 @@ namespace osu.Game.EzOsuGame.Edit.Scenes
                     Title = EzEditorStrings.GROUP_STAGE,
                     CreateContent = () => new EzSkinEditorStageSettingsSection(),
                 },
+                new EzSkinEditorSidebarGroupDefinition
+                {
+                    Title = EzEditorStrings.GROUP_SCRIPTED_SKIN,
+                    CreateContent = () => new EzSkinEditorScriptedSkinSettingsSection(),
+                },
             };
     }
 }

--- a/osu.Game/EzOsuGame/Edit/Settings/Sections/EzSkinEditorScriptedSkinSettingsSection.cs
+++ b/osu.Game/EzOsuGame/Edit/Settings/Sections/EzSkinEditorScriptedSkinSettingsSection.cs
@@ -1,0 +1,37 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.EzOsuGame.ScriptedSkin;
+using osu.Game.Skinning;
+
+namespace osu.Game.EzOsuGame.Edit.Settings.Sections
+{
+    public partial class EzSkinEditorScriptedSkinSettingsSection : FillFlowContainer
+    {
+        [Resolved]
+        private SkinManager skins { get; set; } = null!;
+
+        public EzSkinEditorScriptedSkinSettingsSection()
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            Direction = FillDirection.Vertical;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            if (skins.CurrentSkin.Value is not ScriptedSkinWrapper wrapper)
+            {
+                Alpha = 0;
+                return;
+            }
+
+            Child = new ScriptedSkinConfigEditor();
+            ((ScriptedSkinConfigEditor)Child).SetSkin(wrapper.GetScriptedSkin());
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Localization/EzEditorStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzEditorStrings.cs
@@ -77,9 +77,37 @@ namespace osu.Game.EzOsuGame.Localization
             "将 EzSkin 尺寸写入 Skin.ini",
             "Write EzSkin sizes to skin.ini");
 
+        public static readonly LocalisableString MENU_CREATE_CONFIG_SNAPSHOT = new EzLocalizationManager.EzLocalisableString(
+            "创建配置快照",
+            "Create config snapshot");
+
+        public static readonly LocalisableString MENU_RESTORE_CONFIG_SNAPSHOT = new EzLocalizationManager.EzLocalisableString(
+            "回到上一个快照",
+            "Restore previous snapshot");
+
+        public static readonly LocalisableString MENU_EXPORT_PREVIEW_IMAGE = new EzLocalizationManager.EzLocalisableString(
+            "导出预览图片",
+            "Export preview image");
+
+        public static readonly LocalisableString TOOLBAR_CLEAR_BEATMAP_PREVIEW = new EzLocalizationManager.EzLocalisableString(
+            "清除谱面预览",
+            "Clear beatmap preview");
+
         #endregion
 
         #region Notifications
+
+        public static readonly LocalisableString NOTIFY_CREATED_CONFIG_SNAPSHOT = new EzLocalizationManager.EzLocalisableString(
+            "已创建配置快照",
+            "Created config snapshot");
+
+        public static readonly LocalisableString NOTIFY_RESTORED_CONFIG_SNAPSHOT = new EzLocalizationManager.EzLocalisableString(
+            "已恢复到上一个配置快照",
+            "Restored previous config snapshot");
+
+        public static readonly LocalisableString NOTIFY_EXPORTED_PREVIEW_IMAGE = new EzLocalizationManager.EzLocalisableString(
+            "已导出预览图片",
+            "Exported preview image");
 
         public static readonly LocalisableString NOTIFY_BEATMAP_NOT_FOUND = new EzLocalizationManager.EzLocalisableString(
             "未找到可用谱面",
@@ -198,6 +226,8 @@ namespace osu.Game.EzOsuGame.Localization
         public static readonly LocalisableString GROUP_SIZE = new EzLocalizationManager.EzLocalisableString("尺寸", "Size");
 
         public static readonly LocalisableString GROUP_SKIN_SPECIFIC = new EzLocalizationManager.EzLocalisableString("皮肤专用", "Skin-specific");
+
+        public static readonly LocalisableString GROUP_SCRIPTED_SKIN = new EzLocalizationManager.EzLocalisableString("脚本皮肤", "Scripted skin");
 
         public static readonly LocalisableString GROUP_BASE_COLOURS = new EzLocalizationManager.EzLocalisableString("基础颜色", "Base colours");
 


### PR DESCRIPTION
## Summary
- Add in-memory config snapshot (capture/apply/sync bindable defaults) for live-vs-previous comparison on size/colour scenes; right pane renders snapshot, left pane stays live.
- Enter editor / create config snapshot resets control defaults to snapshot baseline; restore previous snapshot menu reverts all catalog settings; per-control reset still works for single fields.
- Auto-save Ez2Config on scene tab change, skin switch, and screen exit (no Apply required).
- Appearance scene: scripted skin settings group; beatmap popover clear preview; desktop preview PNG export.

## Test plan
- [x] \EzSkinEditorComparisonSnapshotTest\ (non-visual)
- [ ] \TestSceneEzSkinEditorScreen\ snapshot restore/create tests
- [ ] Manual: size scene — tweak slider, right comparison unchanged; create snapshot updates right pane; restore reverts all
- [ ] Manual: switch scene / skin — settings persist without Apply
- [ ] Manual: appearance — clear beatmap preview returns static virtual playfield


Made with [Cursor](https://cursor.com)