### PR TITLE
M9.5: align config snapshot scope to Ez2Config and skin.ini

### DIFF
--- a/osu.Game.Tests/NonVisual/EzSkinEditorComparisonSnapshotTest.cs
+++ b/osu.Game.Tests/NonVisual/EzSkinEditorComparisonSnapshotTest.cs
@@ -2,13 +2,18 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions;
+using osu.Game.Database;
 using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.Edit;
+using osu.Game.Skinning;
+using osu.Game.Tests.Resources;
 
 namespace osu.Game.Tests.NonVisual
 {
     [TestFixture]
-    public class EzSkinEditorComparisonSnapshotTest
+    public class EzSkinEditorComparisonSnapshotTest : ImportTest
     {
         [Test]
         public void TestCaptureApplyAndDefaultSync()
@@ -36,6 +41,66 @@ namespace osu.Game.Tests.NonVisual
             {
                 config.GetBindable<double>(Ez2Setting.ColumnWidth).Value = originalWidth;
                 config.GetBindable<double>(Ez2Setting.ColumnWidth).Default = originalDefault;
+            }
+        }
+
+        [Test]
+        public void TestSkinIniDraftCaptureApplyWhenUnsupported()
+        {
+            using var host = new CleanRunHeadlessGameHost();
+
+            try
+            {
+                var osu = LoadOsuIntoHost(host);
+                var config = new Ez2ConfigManager(host.Storage);
+                var session = new EzSkinIniSession(osu.Dependencies.Get<SkinManager>());
+
+                var snapshot = new EzSkinEditorComparisonSnapshot();
+                snapshot.CaptureFrom(config, session);
+
+                Assert.That(snapshot.SkinIniDraftText, Is.Null);
+            }
+            finally
+            {
+                host.Exit();
+            }
+        }
+
+        [Test]
+        public void TestSkinIniDraftCaptureApplyRoundTrip()
+        {
+            using var host = new CleanRunHeadlessGameHost();
+
+            try
+            {
+                var osu = LoadOsuIntoHost(host);
+                var config = new Ez2ConfigManager(host.Storage);
+                var skinManager = osu.Dependencies.Get<SkinManager>();
+                var session = new EzSkinIniSession(skinManager);
+
+                const string modified = "[General]\nName: Modified Skin\n";
+
+                var imported = skinManager.Import(new ImportTask(TestResources.OpenResource(@"Archives/modified-ezSkin.osk"), "modified-ezSkin.osk")).GetResultSafely();
+                skinManager.CurrentSkinInfo.Value = imported;
+                session.LoadFromSkin(imported);
+
+                Assert.That(session.IsSupported, Is.True);
+
+                string originalDraft = session.DraftText;
+                var snapshot = new EzSkinEditorComparisonSnapshot();
+                snapshot.CaptureFrom(config, session);
+
+                Assert.That(snapshot.SkinIniDraftText, Is.EqualTo(originalDraft));
+
+                session.SetDraftText(modified);
+                Assert.That(session.DraftText, Is.EqualTo(modified));
+
+                snapshot.ApplyTo(config, session);
+                Assert.That(session.DraftText, Is.EqualTo(originalDraft));
+            }
+            finally
+            {
+                host.Exit();
             }
         }
     }

--- a/osu.Game.Tests/Visual/Edit/TestSceneEzSkinEditorScreen.cs
+++ b/osu.Game.Tests/Visual/Edit/TestSceneEzSkinEditorScreen.cs
@@ -410,6 +410,44 @@ namespace osu.Game.Tests.Visual.Edit
         }
 
         [Test]
+        public void TestSkinIniConfigSnapshotRestore()
+        {
+            importLegacySkin();
+            AddStep("load screen", loadScreen);
+            waitForScreenLoaded();
+            switchScene(EzSkinEditorSceneType.SkinIni);
+
+            AddUntilStep("session loaded", () => editorScreen.SkinIniSession != null);
+
+            string baselineName = null!;
+            AddStep("read baseline name", () =>
+            {
+                var document = editorScreen.SkinIniSession!.ParseDraftDocument();
+                baselineName = document.GetValue(EzSkinIniDocument.GENERAL_SECTION, "Name") ?? string.Empty;
+            });
+
+            AddStep("change name", () =>
+            {
+                var document = editorScreen.SkinIniSession!.ParseDraftDocument();
+                document.SetValue(EzSkinIniDocument.GENERAL_SECTION, "Name", "Snapshot Test Name");
+                editorScreen.SkinIniSession.ApplyDocument(document);
+            });
+
+            AddAssert("name changed", () =>
+            {
+                var document = editorScreen.SkinIniSession!.ParseDraftDocument();
+                return (document.GetValue(EzSkinIniDocument.GENERAL_SECTION, "Name") ?? string.Empty) == "Snapshot Test Name";
+            });
+
+            AddStep("restore snapshot", () => editorScreen.RestoreConfigSnapshotForTesting());
+            AddAssert("name restored", () =>
+            {
+                var document = editorScreen.SkinIniSession!.ParseDraftDocument();
+                return (document.GetValue(EzSkinIniDocument.GENERAL_SECTION, "Name") ?? string.Empty) == baselineName;
+            });
+        }
+
+        [Test]
         public void TestStaticPreviewAfterSkinSwitch()
         {
             AddStep("load screen", loadScreen);

--- a/osu.Game/EzOsuGame/Edit/EzSkinEditorComparisonSnapshot.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinEditorComparisonSnapshot.cs
@@ -6,16 +6,33 @@ using osu.Game.EzOsuGame.Configuration;
 namespace osu.Game.EzOsuGame.Edit
 {
     /// <summary>
-    /// In-memory Ez skin editor configuration snapshot for preview comparison and control reset baselines.
+    /// In-memory skin editor configuration snapshot for preview comparison and control reset baselines.
+    /// Covers <see cref="EzSkinJsonSettingCatalog"/> (Ez2Config) and <see cref="EzSkinIniFieldCatalog"/> (skin.ini draft).
+    /// Does not include RulesetConfig, ScriptedSkin, or Note edit session state.
     /// Not persisted to disk — navigation triggers <see cref="Ez2ConfigManager"/> save separately.
     /// </summary>
     public sealed class EzSkinEditorComparisonSnapshot
     {
         public EzSkinJsonDocument Document { get; private set; } = new EzSkinJsonDocument();
 
-        public void CaptureFrom(Ez2ConfigManager config) => Document = EzSkinJsonBridge.Capture(config);
+        /// <summary>
+        /// Captured <see cref="EzSkinIniSession.DraftText"/> when the session is supported; otherwise <c>null</c>.
+        /// </summary>
+        public string? SkinIniDraftText { get; private set; }
 
-        public void ApplyTo(Ez2ConfigManager config) => EzSkinJsonBridge.Apply(Document, config);
+        public void CaptureFrom(Ez2ConfigManager config, EzSkinIniSession? skinIniSession = null)
+        {
+            Document = EzSkinJsonBridge.Capture(config);
+            SkinIniDraftText = skinIniSession is { IsSupported: true } ? skinIniSession.DraftText : null;
+        }
+
+        public void ApplyTo(Ez2ConfigManager config, EzSkinIniSession? skinIniSession = null)
+        {
+            EzSkinJsonBridge.Apply(Document, config);
+
+            if (SkinIniDraftText != null && skinIniSession is { IsSupported: true })
+                skinIniSession.SetDraftText(SkinIniDraftText);
+        }
 
         public void SyncBindableDefaults(Ez2ConfigManager config) => EzSkinJsonBridge.SyncBindableDefaults(config, Document);
     }

--- a/osu.Game/EzOsuGame/Edit/EzSkinEditorSceneContext.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinEditorSceneContext.cs
@@ -48,6 +48,7 @@ namespace osu.Game.EzOsuGame.Edit
 
         /// <summary>
         /// Configuration snapshot used for comparison preview (right pane) and control reset baselines.
+        /// Covers Ez2Config and skin.ini only — not RulesetConfig, ScriptedSkin, or Note edit state.
         /// </summary>
         public EzSkinEditorComparisonSnapshot? ComparisonSnapshot { get; init; }
     }

--- a/osu.Game/EzOsuGame/Edit/EzSkinEditorScreen.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinEditorScreen.cs
@@ -91,6 +91,7 @@ namespace osu.Game.EzOsuGame.Edit
 
         private bool attemptedGlobalBeatmapPreview;
         private bool comparisonSnapshotInitialized;
+        private Guid comparisonSnapshotSkinId;
         private bool configPreviewRefreshBound;
 
         private ISkinEditorVirtualProvider? provider;
@@ -283,7 +284,6 @@ namespace osu.Game.EzOsuGame.Edit
 
         private void refreshScene()
         {
-            ensureComparisonSnapshot();
             ensureGlobalBeatmapPreview();
 
             backgroundContainer!.Child = createManiaStageBackgroundOrNull() ?? new Container { RelativeSizeAxes = Axes.Both };
@@ -291,6 +291,7 @@ namespace osu.Game.EzOsuGame.Edit
 
             ensureSkinIniSession();
             ensureSkinJsonSession();
+            ensureComparisonSnapshotForCurrentSkin();
 
             sceneContext = buildSceneContext();
             applyCurrentScene();
@@ -656,27 +657,27 @@ namespace osu.Game.EzOsuGame.Edit
 
         private void onCurrentSkinInfoChanged(ValueChangedEvent<Live<SkinInfo>> skin)
         {
-            if (skin.OldValue?.ID != skin.NewValue?.ID)
-            {
+            if (skin.OldValue.ID != skin.NewValue.ID)
                 persistEditorConfig();
-                recaptureComparisonSnapshot();
-            }
 
             Schedule(refreshScene);
         }
 
-        private void ensureComparisonSnapshot()
+        private void ensureComparisonSnapshotForCurrentSkin()
         {
-            if (comparisonSnapshotInitialized)
+            var currentSkinId = skinManager.CurrentSkinInfo.Value.ID;
+
+            if (comparisonSnapshotInitialized && comparisonSnapshotSkinId == currentSkinId)
                 return;
 
             recaptureComparisonSnapshot();
             comparisonSnapshotInitialized = true;
+            comparisonSnapshotSkinId = currentSkinId;
         }
 
         private void recaptureComparisonSnapshot()
         {
-            ComparisonSnapshotForTesting.CaptureFrom(ezSkinConfig);
+            ComparisonSnapshotForTesting.CaptureFrom(ezSkinConfig, SkinIniSession);
             ComparisonSnapshotForTesting.SyncBindableDefaults(ezSkinConfig);
         }
 
@@ -689,7 +690,7 @@ namespace osu.Game.EzOsuGame.Edit
 
         private void restoreConfigSnapshot()
         {
-            ComparisonSnapshotForTesting.ApplyTo(ezSkinConfig);
+            ComparisonSnapshotForTesting.ApplyTo(ezSkinConfig, SkinIniSession);
             postNotification(EzEditorStrings.NOTIFY_RESTORED_CONFIG_SNAPSHOT);
             refreshScene();
         }

--- a/osu.Game/EzOsuGame/Edit/EzSkinIniBridge.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinIniBridge.cs
@@ -1,0 +1,26 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+
+namespace osu.Game.EzOsuGame.Edit
+{
+    /// <summary>
+    /// Helpers for skin.ini fields participating in <see cref="EzSkinEditorComparisonSnapshot"/> default baselines.
+    /// </summary>
+    public static class EzSkinIniBridge
+    {
+        public static EzSkinIniDocument? TryParseSnapshotDocument(string? skinIniDraftText) =>
+            string.IsNullOrEmpty(skinIniDraftText) ? null : EzSkinIniDocument.Parse(skinIniDraftText);
+
+        public static void SyncTextDefault(Bindable<string> bindable, string? snapshotValue, string currentValue) =>
+            bindable.Default = snapshotValue ?? currentValue;
+
+        public static void SyncBoolDefault(Bindable<bool> bindable, string? snapshotRaw, bool currentValue) =>
+            bindable.Default = snapshotRaw != null ? snapshotRaw == "1" : currentValue;
+
+        public static void SyncColourDefault(Bindable<Colour4> bindable, Colour4? snapshotColour, Colour4 currentValue) =>
+            bindable.Default = snapshotColour ?? currentValue;
+    }
+}

--- a/osu.Game/EzOsuGame/Edit/EzSkinIniFieldCatalog.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinIniFieldCatalog.cs
@@ -23,6 +23,7 @@ namespace osu.Game.EzOsuGame.Edit
 
     /// <summary>
     /// Known editable <c>skin.ini</c> keys aligned with legacy decoders.
+    /// Fields exposed in the skin editor sidebar participate in <see cref="EzSkinEditorComparisonSnapshot"/> default baselines.
     /// </summary>
     public static class EzSkinIniFieldCatalog
     {

--- a/osu.Game/EzOsuGame/Edit/EzSkinJsonSettingCatalog.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinJsonSettingCatalog.cs
@@ -8,6 +8,7 @@ namespace osu.Game.EzOsuGame.Edit
 {
     /// <summary>
     /// Ez settings persisted in per-skin <see cref="EzSkinJsonDocument"/> (editor catalog only).
+    /// This is the Ez2Config subset that participates in <see cref="EzSkinEditorComparisonSnapshot"/> default baselines.
     /// </summary>
     public static class EzSkinJsonSettingCatalog
     {

--- a/osu.Game/EzOsuGame/Edit/Scenes/SkinIniSceneStrategy.cs
+++ b/osu.Game/EzOsuGame/Edit/Scenes/SkinIniSceneStrategy.cs
@@ -33,17 +33,17 @@ namespace osu.Game.EzOsuGame.Edit.Scenes
                 new EzSkinEditorSidebarGroupDefinition
                 {
                     Title = EzEditorStrings.GROUP_GENERAL,
-                    CreateContent = () => new EzSkinEditorSkinIniGeneralSection(context.SkinIniSession),
+                    CreateContent = () => new EzSkinEditorSkinIniGeneralSection(context.SkinIniSession, context.ComparisonSnapshot),
                 },
                 new EzSkinEditorSidebarGroupDefinition
                 {
                     Title = EzEditorStrings.GROUP_COLOURS,
-                    CreateContent = () => new EzSkinEditorSkinIniColoursSection(context.SkinIniSession),
+                    CreateContent = () => new EzSkinEditorSkinIniColoursSection(context.SkinIniSession, context.ComparisonSnapshot),
                 },
                 new EzSkinEditorSidebarGroupDefinition
                 {
                     Title = EzEditorStrings.GROUP_MODE,
-                    CreateContent = () => new EzSkinEditorSkinIniManiaSection(context.SkinIniSession),
+                    CreateContent = () => new EzSkinEditorSkinIniManiaSection(context.SkinIniSession, context.ComparisonSnapshot),
                 },
             };
         }

--- a/osu.Game/EzOsuGame/Edit/Settings/Sections/EzSkinEditorSkinIniColoursSection.cs
+++ b/osu.Game/EzOsuGame/Edit/Settings/Sections/EzSkinEditorSkinIniColoursSection.cs
@@ -18,8 +18,8 @@ namespace osu.Game.EzOsuGame.Edit.Settings.Sections
     {
         private readonly Dictionary<string, Bindable<Colour4>> colourFields = new Dictionary<string, Bindable<Colour4>>();
 
-        public EzSkinEditorSkinIniColoursSection(EzSkinIniSession? session)
-            : base(session)
+        public EzSkinEditorSkinIniColoursSection(EzSkinIniSession? session, EzSkinEditorComparisonSnapshot? comparisonSnapshot = null)
+            : base(session, comparisonSnapshot)
         {
         }
 
@@ -50,13 +50,24 @@ namespace osu.Game.EzOsuGame.Edit.Settings.Sections
             WithApplying(() =>
             {
                 var document = ParseDocument();
+                var snapshotDocument = ParseSnapshotDocument();
 
                 foreach (var (key, bindable) in colourFields)
                 {
+                    Colour4 value;
+
                     if (document != null && document.TryGetColourValue(key, out var colour))
-                        bindable.Value = colour;
+                        value = colour;
                     else
-                        bindable.Value = Colour4.White;
+                        value = Colour4.White;
+
+                    bindable.Value = value;
+
+                    Colour4? snapshotColour = snapshotDocument != null && snapshotDocument.TryGetColourValue(key, out var parsedSnapshotColour)
+                        ? parsedSnapshotColour
+                        : null;
+
+                    EzSkinIniBridge.SyncColourDefault(bindable, snapshotColour, value);
                 }
             });
         }

--- a/osu.Game/EzOsuGame/Edit/Settings/Sections/EzSkinEditorSkinIniGeneralSection.cs
+++ b/osu.Game/EzOsuGame/Edit/Settings/Sections/EzSkinEditorSkinIniGeneralSection.cs
@@ -18,8 +18,8 @@ namespace osu.Game.EzOsuGame.Edit.Settings.Sections
         private readonly Dictionary<string, Bindable<string>> textFields = new Dictionary<string, Bindable<string>>();
         private readonly Dictionary<string, Bindable<bool>> boolFields = new Dictionary<string, Bindable<bool>>();
 
-        public EzSkinEditorSkinIniGeneralSection(EzSkinIniSession? session)
-            : base(session)
+        public EzSkinEditorSkinIniGeneralSection(EzSkinIniSession? session, EzSkinEditorComparisonSnapshot? comparisonSnapshot = null)
+            : base(session, comparisonSnapshot)
         {
         }
 
@@ -70,12 +70,21 @@ namespace osu.Game.EzOsuGame.Edit.Settings.Sections
             WithApplying(() =>
             {
                 var document = ParseDocument();
+                var snapshotDocument = ParseSnapshotDocument();
 
                 foreach (var (key, bindable) in textFields)
-                    bindable.Value = document?.GetValue(EzSkinIniDocument.GENERAL_SECTION, key) ?? string.Empty;
+                {
+                    string value = document?.GetValue(EzSkinIniDocument.GENERAL_SECTION, key) ?? string.Empty;
+                    bindable.Value = value;
+                    EzSkinIniBridge.SyncTextDefault(bindable, snapshotDocument?.GetValue(EzSkinIniDocument.GENERAL_SECTION, key), value);
+                }
 
                 foreach (var (key, bindable) in boolFields)
-                    bindable.Value = document?.GetValue(EzSkinIniDocument.GENERAL_SECTION, key) == "1";
+                {
+                    bool value = document?.GetValue(EzSkinIniDocument.GENERAL_SECTION, key) == "1";
+                    bindable.Value = value;
+                    EzSkinIniBridge.SyncBoolDefault(bindable, snapshotDocument?.GetValue(EzSkinIniDocument.GENERAL_SECTION, key), value);
+                }
             });
         }
 

--- a/osu.Game/EzOsuGame/Edit/Settings/Sections/EzSkinEditorSkinIniManiaSection.cs
+++ b/osu.Game/EzOsuGame/Edit/Settings/Sections/EzSkinEditorSkinIniManiaSection.cs
@@ -29,8 +29,8 @@ namespace osu.Game.EzOsuGame.Edit.Settings.Sections
         private FillFlowContainer staticFields = null!;
         private FillFlowContainer perKeyFields = null!;
 
-        public EzSkinEditorSkinIniManiaSection(EzSkinIniSession? session)
-            : base(session)
+        public EzSkinEditorSkinIniManiaSection(EzSkinIniSession? session, EzSkinEditorComparisonSnapshot? comparisonSnapshot = null)
+            : base(session, comparisonSnapshot)
         {
         }
 
@@ -110,6 +110,7 @@ namespace osu.Game.EzOsuGame.Edit.Settings.Sections
             WithApplying(() =>
             {
                 var document = ParseDocument();
+                var snapshotDocument = ParseSnapshotDocument();
                 var keysList = document?.GetManiaKeys().ToList() ?? new List<int>();
 
                 if (keysList.Count == 0)
@@ -127,15 +128,31 @@ namespace osu.Game.EzOsuGame.Edit.Settings.Sections
                 rebuildPerKeyFields(keys);
 
                 foreach (var (key, bindable) in textFields)
-                    bindable.Value = document?.GetManiaValue(keys, key) ?? string.Empty;
+                {
+                    string value = document?.GetManiaValue(keys, key) ?? string.Empty;
+                    bindable.Value = value;
+                    EzSkinIniBridge.SyncTextDefault(bindable, snapshotDocument?.GetManiaValue(keys, key), value);
+                }
 
                 foreach (var (key, bindable) in boolFields)
-                    bindable.Value = document?.GetManiaValue(keys, key) == "1";
+                {
+                    bool value = document?.GetManiaValue(keys, key) == "1";
+                    bindable.Value = value;
+                    EzSkinIniBridge.SyncBoolDefault(bindable, snapshotDocument?.GetManiaValue(keys, key), value);
+                }
 
                 foreach (var (key, bindable) in colourFields)
                 {
                     string? raw = document?.GetManiaValue(keys, key);
-                    bindable.Value = raw != null && EzSkinIniColourFormat.TryParse(raw, out var colour) ? colour : Colour4.White;
+                    Colour4 value = raw != null && EzSkinIniColourFormat.TryParse(raw, out var colour) ? colour : Colour4.White;
+                    bindable.Value = value;
+
+                    string? snapshotRaw = snapshotDocument?.GetManiaValue(keys, key);
+                    Colour4? snapshotColour = snapshotRaw != null && EzSkinIniColourFormat.TryParse(snapshotRaw, out var snapshotParsedColour)
+                        ? snapshotParsedColour
+                        : null;
+
+                    EzSkinIniBridge.SyncColourDefault(bindable, snapshotColour, value);
                 }
             });
         }

--- a/osu.Game/EzOsuGame/Edit/Settings/Sections/EzSkinEditorSkinIniSectionBase.cs
+++ b/osu.Game/EzOsuGame/Edit/Settings/Sections/EzSkinEditorSkinIniSectionBase.cs
@@ -17,11 +17,14 @@ namespace osu.Game.EzOsuGame.Edit.Settings.Sections
     {
         protected readonly EzSkinIniSession? Session;
 
+        protected readonly EzSkinEditorComparisonSnapshot? ComparisonSnapshot;
+
         protected bool Applying { get; private set; }
 
-        protected EzSkinEditorSkinIniSectionBase(EzSkinIniSession? session)
+        protected EzSkinEditorSkinIniSectionBase(EzSkinIniSession? session, EzSkinEditorComparisonSnapshot? comparisonSnapshot = null)
         {
             Session = session;
+            ComparisonSnapshot = comparisonSnapshot;
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
             Direction = FillDirection.Vertical;
@@ -121,5 +124,8 @@ namespace osu.Game.EzOsuGame.Edit.Settings.Sections
         }
 
         protected EzSkinIniDocument? ParseDocument() => Session?.ParseDraftDocument();
+
+        protected EzSkinIniDocument? ParseSnapshotDocument() =>
+            EzSkinIniBridge.TryParseSnapshotDocument(ComparisonSnapshot?.SkinIniDraftText);
     }
 }


### PR DESCRIPTION
## Summary

- Extend `EzSkinEditorComparisonSnapshot` to capture/restore `skin.ini` draft text alongside Ez2Config (`EzSkinJsonSettingCatalog`).
- Fix snapshot capture timing: run after `ensureSkinIniSession`, and recapture on skin change only after session reload.
- Sync skin.ini sidebar bindable defaults from the comparison snapshot via `EzSkinIniBridge`.
- Document that only Ez2Config and skin.ini participate in snapshot default baselines (not RulesetConfig, ScriptedSkin, or Note edit state).

## Commits

1. Extend editor config snapshot to cover skin.ini draft text
2. Fix config snapshot capture order after skin.ini session load
3. Sync skin.ini sidebar bindable defaults from comparison snapshot
4. Add tests for skin.ini config snapshot capture and restore

## Test plan

- [x] `dotnet test osu.Game.Tests/osu.Game.Tests.csproj --filter FullyQualifiedName~EzSkinEditorComparisonSnapshotTest`
- [ ] `TestSceneEzSkinEditorScreen.TestSkinIniConfigSnapshotRestore` (visual)
- [ ] Manual: legacy skin → Skin.ini scene → edit Name → 回到上一个快照 → draft restored
- [ ] Manual: 创建配置快照 updates baseline for both Size slider and skin.ini field
