### PR TITLE
M10: Note scene with independent edit snapshot comparison

### DIFF
--- a/osu.Game.Rulesets.Mania/EzMania/Editor/EzSkinLNEditorProvider.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/Editor/EzSkinLNEditorProvider.cs
@@ -5,6 +5,7 @@ using osu.Framework.Audio;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.EzOsuGame.Edit;
+using osu.Game.EzOsuGame.Edit.Note;
 using osu.Game.Rulesets.Mania.Beatmaps;
 using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Rulesets.UI.Scrolling.Algorithms;
@@ -35,6 +36,7 @@ namespace osu.Game.Rulesets.Mania.EzMania.Editor
         {
             // Mania ruleset online ID is stable across osu! releases.
             SkinEditorProviderRegistry.Register(3, () => new EzSkinLNEditorProvider());
+            EzSkinEditorNoteRulesetProfileRegistry.Register(new ManiaEzSkinEditorNoteRulesetProfile());
         }
 
         protected sealed class PreviewScrollingInfo : IScrollingInfo

--- a/osu.Game.Rulesets.Mania/EzMania/Editor/EzSkinLNEditorProvider_NotePreview.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/Editor/EzSkinLNEditorProvider_NotePreview.cs
@@ -1,0 +1,40 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Game.EzOsuGame.Edit.Note;
+using osu.Game.Skinning;
+
+namespace osu.Game.Rulesets.Mania.EzMania.Editor
+{
+    public partial class EzSkinLNEditorProvider
+    {
+        public Drawable CreateNotePreview(ISkin skin, EzSkinEditorNotePreviewRequest request)
+        {
+            bool isHold = request.Part != EzSkinEditorNotePart.Note;
+            string label = request.Part switch
+            {
+                EzSkinEditorNotePart.HoldHead => "LN Head",
+                EzSkinEditorNotePart.HoldBody => "LN Body",
+                EzSkinEditorNotePart.HoldTail => "LN Tail",
+                _ => "Note",
+            };
+
+            var (columnIndex, isSpecial) = mapVariantToColumn(request.VariantId);
+
+            return createPreviewRow(skin, label, isHold, columnIndex, isSpecial).With(d =>
+            {
+                d.RelativeSizeAxes = Axes.Both;
+                d.Height = 0;
+            });
+        }
+
+        private static (int columnIndex, bool isSpecial) mapVariantToColumn(string variantId) =>
+            variantId switch
+            {
+                "S" or "P" => (0, true),
+                "2" or "B" => (1, false),
+                _ => (0, false),
+            };
+    }
+}

--- a/osu.Game.Rulesets.Mania/EzMania/Editor/EzSkinLNEditorProvider_Static.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/Editor/EzSkinLNEditorProvider_Static.cs
@@ -53,13 +53,13 @@ namespace osu.Game.Rulesets.Mania.EzMania.Editor
             };
         }
 
-        private Drawable createPreviewRow(ISkin skin, string label, bool isHold)
+        private Drawable createPreviewRow(ISkin skin, string label, bool isHold, int columnIndex = 0, bool isSpecial = false)
         {
             var transformedSkin = createTransformedSkin(skin);
 
             ManiaHitObject hitObject = isHold
-                ? new HoldNote { StartTime = 0, Duration = 500, Column = 0 }
-                : new Note { StartTime = 0, Column = 0 };
+                ? new HoldNote { StartTime = 0, Duration = 500, Column = columnIndex }
+                : new Note { StartTime = 0, Column = columnIndex };
 
             hitObject.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
 
@@ -71,7 +71,7 @@ namespace osu.Game.Rulesets.Mania.EzMania.Editor
             {
                 RelativeSizeAxes = Axes.X,
                 Height = 260,
-                Child = new PreviewDependencyContainer(preview_key_count, 0, ManiaAction.Key1)
+                Child = new PreviewDependencyContainer(preview_key_count, columnIndex, ManiaAction.Key1, isSpecial)
                 {
                     Child = new EzNoteContainer(ScrollingDirection.Down, label)
                     {
@@ -181,14 +181,14 @@ namespace osu.Game.Rulesets.Mania.EzMania.Editor
             private readonly PreviewGameplayClock gameplayClockDependency = new PreviewGameplayClock();
             private readonly ManualClock previewClock = new ManualClock();
 
-            public PreviewDependencyContainer(int keyCount, int column, ManiaAction action)
+            public PreviewDependencyContainer(int keyCount, int column, ManiaAction action, bool isSpecial = false)
             {
                 RelativeSizeAxes = Axes.Both;
                 Clock = new FramedClock(previewClock);
 
                 stageDefinition = new StageDefinition(keyCount);
                 beatmapDependency = new ManiaBeatmap(stageDefinition);
-                columnDependency = new Column(column, isSpecial: false);
+                columnDependency = new Column(column, isSpecial: isSpecial);
                 columnDependency.Action.Value = action;
 
                 InternalChildren = new Drawable[]

--- a/osu.Game.Rulesets.Mania/EzMania/Editor/ManiaEzSkinEditorNoteRulesetProfile.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/Editor/ManiaEzSkinEditorNoteRulesetProfile.cs
@@ -1,0 +1,91 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Edit.Note;
+using osu.Game.Localisation;
+using osu.Game.Overlays.Settings;
+using osu.Game.Rulesets.Mania.Configuration;
+using osu.Game.Skinning;
+
+namespace osu.Game.Rulesets.Mania.EzMania.Editor
+{
+    public partial class ManiaEzSkinEditorNoteRulesetProfile : IEzSkinEditorNoteRulesetProfile
+    {
+        private static readonly EzSkinEditorNotePart[] supported_parts =
+        {
+            EzSkinEditorNotePart.Note,
+            EzSkinEditorNotePart.HoldHead,
+            EzSkinEditorNotePart.HoldBody,
+            EzSkinEditorNotePart.HoldTail,
+        };
+
+        private static readonly EzSkinEditorNoteVariant[] legacy_variants =
+        {
+            new EzSkinEditorNoteVariant("1", "1"),
+            new EzSkinEditorNoteVariant("2", "2"),
+            new EzSkinEditorNoteVariant("S", "S"),
+        };
+
+        private static readonly EzSkinEditorNoteVariant[] ez_variants =
+        {
+            new EzSkinEditorNoteVariant(nameof(EzColumnType.A), "A"),
+            new EzSkinEditorNoteVariant(nameof(EzColumnType.B), "B"),
+            new EzSkinEditorNoteVariant(nameof(EzColumnType.S), "S"),
+            new EzSkinEditorNoteVariant(nameof(EzColumnType.E), "E"),
+            new EzSkinEditorNoteVariant(nameof(EzColumnType.P), "P"),
+        };
+
+        private readonly EzSkinLNEditorProvider previewProvider = new EzSkinLNEditorProvider();
+
+        public int RulesetOnlineId => new ManiaRuleset().RulesetInfo.OnlineID;
+
+        public RulesetInfo RulesetInfo => new ManiaRuleset().RulesetInfo;
+
+        public IReadOnlyList<EzSkinEditorNotePart> SupportedParts => supported_parts;
+
+        public IReadOnlyList<EzSkinEditorNoteVariant> GetVariants(ISkin skin, EzSkinEditorNotePart part) =>
+            isEzSkin(skin) ? ez_variants : legacy_variants;
+
+        public string GetDefaultVariantId(ISkin skin, EzSkinEditorNotePart part) =>
+            isEzSkin(skin) ? nameof(EzColumnType.A) : "1";
+
+        public Drawable CreateNotePreview(ISkin skin, EzSkinEditorNotePreviewRequest request) =>
+            previewProvider.CreateNotePreview(skin, request);
+
+        public Drawable CreateRulesetSettingsContent() => new ManiaNoteRulesetSettingsSection();
+
+        private static bool isEzSkin(ISkin skin) =>
+            skin is EzStyleProSkin or Ez2Skin or SbISkin;
+
+        private partial class ManiaNoteRulesetSettingsSection : FillFlowContainer
+        {
+            [Resolved]
+            private IRulesetConfigCache rulesetConfigCache { get; set; } = null!;
+
+            public ManiaNoteRulesetSettingsSection()
+            {
+                RelativeSizeAxes = Axes.X;
+                AutoSizeAxes = Axes.Y;
+                Direction = FillDirection.Vertical;
+                Spacing = new osuTK.Vector2(8);
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                var config = (ManiaRulesetConfigManager)rulesetConfigCache.GetConfigFor(new ManiaRuleset())!;
+
+                Add(new SettingsCheckbox
+                {
+                    LabelText = RulesetSettingsStrings.TimingBasedColouring,
+                    Current = config.GetBindable<bool>(ManiaRulesetSetting.TimingBasedNoteColouring),
+                });
+            }
+        }
+    }
+}

--- a/osu.Game.Tests/NonVisual/EzSkinEditorNoteEditSnapshotTest.cs
+++ b/osu.Game.Tests/NonVisual/EzSkinEditorNoteEditSnapshotTest.cs
@@ -1,0 +1,66 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Game.EzOsuGame.Edit.Note;
+using osu.Game.Rulesets.Mania;
+
+namespace osu.Game.Tests.NonVisual
+{
+    [TestFixture]
+    public class EzSkinEditorNoteEditSnapshotTest
+    {
+        [Test]
+        public void TestCaptureApplyRoundTrip()
+        {
+            var session = new EzSkinEditorNoteEditSession
+            {
+                Ruleset = { Value = new ManiaRuleset().RulesetInfo },
+                Part =
+                {
+                    Value = EzSkinEditorNotePart.HoldBody
+                },
+                VariantId =
+                {
+                    Value = "2"
+                },
+                NoteColour =
+                {
+                    Value = Colour4.Cyan
+                },
+                Width =
+                {
+                    Value = 120
+                },
+                Height =
+                {
+                    Value = 80
+                },
+                ExportName =
+                {
+                    Value = "test-note"
+                }
+            };
+
+            var snapshot = new EzSkinEditorNoteEditSnapshot();
+            snapshot.CaptureFrom(session);
+
+            session.Part.Value = EzSkinEditorNotePart.Note;
+            session.VariantId.Value = "1";
+            session.NoteColour.Value = Colour4.Red;
+            session.Width.Value = 50;
+            session.Height.Value = 40;
+            session.ExportName.Value = "changed";
+
+            snapshot.ApplyTo(session);
+
+            Assert.That(session.Part.Value, Is.EqualTo(EzSkinEditorNotePart.HoldBody));
+            Assert.That(session.VariantId.Value, Is.EqualTo("2"));
+            Assert.That(session.NoteColour.Value, Is.EqualTo(Colour4.Cyan));
+            Assert.That(session.Width.Value, Is.EqualTo(120));
+            Assert.That(session.Height.Value, Is.EqualTo(80));
+            Assert.That(session.ExportName.Value, Is.EqualTo("test-note"));
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Edit/TestSceneEzSkinEditorScreen.cs
+++ b/osu.Game.Tests/Visual/Edit/TestSceneEzSkinEditorScreen.cs
@@ -14,6 +14,7 @@ using osu.Game.Database;
 using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.Edit;
 using osu.Game.EzOsuGame.Edit.Components;
+using osu.Game.EzOsuGame.Edit.Note;
 using osu.Game.EzOsuGame.Localization;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
@@ -445,6 +446,34 @@ namespace osu.Game.Tests.Visual.Edit
                 var document = editorScreen.SkinIniSession!.ParseDraftDocument();
                 return (document.GetValue(EzSkinIniDocument.GENERAL_SECTION, "Name") ?? string.Empty) == baselineName;
             });
+        }
+
+        [Test]
+        public void TestNoteSceneComparisonHost()
+        {
+            AddStep("load screen", loadScreen);
+            waitForScreenLoaded();
+            switchScene(EzSkinEditorSceneType.Note);
+
+            AddUntilStep("note comparison host visible", () => editorScreen.ChildrenOfType<EzSkinEditorNoteComparisonHost>().Any());
+            AddUntilStep("two sidebar groups", () => editorScreen.ChildrenOfType<EzSkinEditorSettingsGroup>().Count() == 2);
+            AddAssert("mania note profile registered", () => EzSkinEditorNoteRulesetProfileRegistry.Get(3) != null);
+        }
+
+        [Test]
+        public void TestNoteSnapshotRestore()
+        {
+            AddStep("load screen", loadScreen);
+            waitForScreenLoaded();
+            switchScene(EzSkinEditorSceneType.Note);
+
+            AddUntilStep("note host visible", () => editorScreen.ChildrenOfType<EzSkinEditorNoteComparisonHost>().Any());
+
+            AddStep("change variant", () => editorScreen.NoteSessionForTesting.VariantId.Value = "2");
+            AddStep("create note snapshot", () => editorScreen.CreateNoteSnapshotForTesting());
+            AddStep("change variant again", () => editorScreen.NoteSessionForTesting.VariantId.Value = "S");
+            AddStep("restore note snapshot", () => editorScreen.RestoreNoteSnapshotForTesting());
+            AddAssert("variant restored", () => editorScreen.NoteSessionForTesting.VariantId.Value == "2");
         }
 
         [Test]

--- a/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorMenuBar.cs
+++ b/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorMenuBar.cs
@@ -63,6 +63,8 @@ namespace osu.Game.EzOsuGame.Edit.Components
 
         public Func<bool>? CanExportPreviewImage { get; set; }
 
+        public Func<bool>? CanUseConfigSnapshot { get; set; }
+
         private readonly EditorMenuItem createConfigSnapshotItem;
         private readonly EditorMenuItem restoreConfigSnapshotItem;
         private readonly EditorMenuItem exportPreviewImageItem;
@@ -121,8 +123,9 @@ namespace osu.Game.EzOsuGame.Edit.Components
 
         public void RefreshMenuState()
         {
-            createConfigSnapshotItem.Action.Disabled = false;
-            restoreConfigSnapshotItem.Action.Disabled = false;
+            bool canUseConfigSnapshot = CanUseConfigSnapshot?.Invoke() ?? true;
+            createConfigSnapshotItem.Action.Disabled = !canUseConfigSnapshot;
+            restoreConfigSnapshotItem.Action.Disabled = !canUseConfigSnapshot;
             exportPreviewImageItem.Action.Disabled = !(CanExportPreviewImage?.Invoke() ?? false);
             createJsonItem.Action.Disabled = !(CanCreateEzSkinJson?.Invoke() ?? false);
             updateSnapshotItem.Action.Disabled = !(CanUpdateEzSkinJsonSnapshot?.Invoke() ?? false);

--- a/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorNoteComparisonHost.cs
+++ b/osu.Game/EzOsuGame/Edit/Components/EzSkinEditorNoteComparisonHost.cs
@@ -1,0 +1,87 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Localisation;
+using osu.Game.EzOsuGame.Edit.Note;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.Graphics.Sprites;
+using osuTK.Graphics;
+
+namespace osu.Game.EzOsuGame.Edit.Components
+{
+    /// <summary>
+    /// Full-width live vs note-edit-snapshot comparison for the Note scene.
+    /// </summary>
+    public partial class EzSkinEditorNoteComparisonHost : Container
+    {
+        private readonly EzSkinEditorSceneContext context;
+
+        private Container liveContainer = null!;
+        private Container snapshotContainer = null!;
+
+        public EzSkinEditorNoteComparisonHost(EzSkinEditorSceneContext context)
+        {
+            this.context = context;
+            RelativeSizeAxes = Axes.Both;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            InternalChild = new GridContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                ColumnDimensions = new[]
+                {
+                    new Dimension(GridSizeMode.Relative, 0.5f),
+                    new Dimension(GridSizeMode.Relative, 0.5f),
+                },
+                Content = new[]
+                {
+                    new Drawable[]
+                    {
+                        liveContainer = new Container { RelativeSizeAxes = Axes.Both },
+                        snapshotContainer = new Container { RelativeSizeAxes = Axes.Both },
+                    },
+                },
+            };
+
+            populate();
+        }
+
+        public void RefreshPreviews() => populate();
+
+        private void populate()
+        {
+            if (context.NoteSession == null || context.NoteSnapshot == null)
+            {
+                liveContainer.Child = createPlaceholder(EzEditorStrings.PLACEHOLDER_NOTE_PREVIEW_NOT_AVAILABLE);
+                snapshotContainer.Child = createPlaceholder(EzEditorStrings.PLACEHOLDER_NOTE_PREVIEW_NOT_AVAILABLE);
+                return;
+            }
+
+            var profile = EzSkinEditorNoteRulesetProfileRegistry.Get(context.NoteSession.Ruleset.Value);
+
+            if (profile == null)
+            {
+                liveContainer.Child = createPlaceholder(EzEditorStrings.PLACEHOLDER_NOTE_RULESET_NOT_SUPPORTED);
+                snapshotContainer.Child = createPlaceholder(EzEditorStrings.PLACEHOLDER_NOTE_RULESET_NOT_SUPPORTED);
+                return;
+            }
+
+            liveContainer.Child = profile.CreateNotePreview(context.EditorSkin, context.NoteSession.ToPreviewRequest());
+            snapshotContainer.Child = profile.CreateNotePreview(context.EditorSkin, context.NoteSnapshot.ToPreviewRequest());
+        }
+
+        private static OsuSpriteText createPlaceholder(LocalisableString text) => new OsuSpriteText
+        {
+            Anchor = Anchor.Centre,
+            Origin = Anchor.Centre,
+            Text = text,
+            Colour = Color4.White,
+        };
+    }
+}

--- a/osu.Game/EzOsuGame/Edit/EzSkinEditorSceneContext.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinEditorSceneContext.cs
@@ -4,6 +4,7 @@
 using System;
 using osu.Game.Beatmaps;
 using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Edit.Note;
 using osu.Game.Rulesets;
 using osu.Game.Skinning;
 
@@ -39,6 +40,21 @@ namespace osu.Game.EzOsuGame.Edit
         /// Size/colour scenes use the virtual playfield on the left and Note/LN comparison on the right.
         /// </summary>
         public bool UseVirtualComparisonPreview { get; init; }
+
+        /// <summary>
+        /// Note scene uses full-width live vs note-edit-snapshot comparison only.
+        /// </summary>
+        public bool UseNoteComparisonOnly { get; init; }
+
+        public EzSkinEditorNoteEditSession? NoteSession { get; init; }
+
+        public EzSkinEditorNoteEditSnapshot? NoteSnapshot { get; init; }
+
+        public Action? CreateNoteSnapshot { get; init; }
+
+        public Action? RestoreNoteSnapshot { get; init; }
+
+        public Action? ExportNotePreview { get; init; }
 
         public IWorkingBeatmap? PreviewBeatmap { get; init; }
 

--- a/osu.Game/EzOsuGame/Edit/EzSkinEditorSceneRegistry.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinEditorSceneRegistry.cs
@@ -15,6 +15,7 @@ namespace osu.Game.EzOsuGame.Edit
             new SizeSceneStrategy(),
             new ColourSceneStrategy(),
             new SkinIniSceneStrategy(),
+            new NoteSceneStrategy(),
         };
 
         public static IEzSkinEditorSceneStrategy Get(EzSkinEditorSceneType sceneType) =>

--- a/osu.Game/EzOsuGame/Edit/EzSkinEditorSceneType.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinEditorSceneType.cs
@@ -12,5 +12,6 @@ namespace osu.Game.EzOsuGame.Edit
         Size,
         Colour,
         SkinIni,
+        Note,
     }
 }

--- a/osu.Game/EzOsuGame/Edit/EzSkinEditorScreen.cs
+++ b/osu.Game/EzOsuGame/Edit/EzSkinEditorScreen.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using osu.Framework.Extensions;
 using SixLabors.ImageSharp;
@@ -20,6 +21,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.Edit.Components;
+using osu.Game.EzOsuGame.Edit.Note;
 using osu.Game.EzOsuGame.Localization;
 using osu.Game.Graphics.Cursor;
 using osu.Game.IO;
@@ -43,6 +45,7 @@ namespace osu.Game.EzOsuGame.Edit
     // M7: preview toolbar + skin popover + virtual comparison on size/colour scenes
     // M8: size/colour virtual provider registration fix
     // M9: config snapshot comparison + create/restore snapshot + auto-save on navigate
+    // M10: Note scene with independent note-edit snapshot comparison + export
 
     /// <summary>
     /// Ez skin editor screen with menu bar, scene bar, scene content and toolbox-style settings sidebar.
@@ -92,6 +95,8 @@ namespace osu.Game.EzOsuGame.Edit
         private bool attemptedGlobalBeatmapPreview;
         private bool comparisonSnapshotInitialized;
         private Guid comparisonSnapshotSkinId;
+        private bool noteSnapshotInitialized;
+        private Guid noteSnapshotSkinId;
         private bool configPreviewRefreshBound;
 
         private ISkinEditorVirtualProvider? provider;
@@ -198,6 +203,7 @@ namespace osu.Game.EzOsuGame.Edit
                                                 CanWriteColoursToSkinIni = () => SkinIniSession is { IsSupported: true } && getCurrentKeyMode() > 0,
                                                 CanWriteSizesToSkinIni = () => SkinIniSession is { IsSupported: true } && getCurrentKeyMode() > 0,
                                                 CanExportOsk = canExportOsk,
+                                                CanUseConfigSnapshot = () => sceneBar.CurrentScene.Value != EzSkinEditorSceneType.Note,
                                             },
                                             topToolbar = new EzSkinEditorTopToolbar
                                             {
@@ -282,6 +288,14 @@ namespace osu.Game.EzOsuGame.Edit
 
         internal EzSkinEditorComparisonSnapshot ComparisonSnapshotForTesting { get; } = new EzSkinEditorComparisonSnapshot();
 
+        internal EzSkinEditorNoteEditSession NoteSessionForTesting { get; } = new EzSkinEditorNoteEditSession();
+
+        internal EzSkinEditorNoteEditSnapshot NoteSnapshotForTesting { get; } = new EzSkinEditorNoteEditSnapshot();
+
+        internal void CreateNoteSnapshotForTesting() => createNoteSnapshot();
+
+        internal void RestoreNoteSnapshotForTesting() => restoreNoteSnapshot();
+
         private void refreshScene()
         {
             ensureGlobalBeatmapPreview();
@@ -292,6 +306,7 @@ namespace osu.Game.EzOsuGame.Edit
             ensureSkinIniSession();
             ensureSkinJsonSession();
             ensureComparisonSnapshotForCurrentSkin();
+            ensureNoteSnapshotForCurrentSkin();
 
             sceneContext = buildSceneContext();
             applyCurrentScene();
@@ -357,6 +372,7 @@ namespace osu.Game.EzOsuGame.Edit
                                        && PreviewState.Source.Value == EzSkinEditorPreviewSource.Beatmap;
 
             bool useVirtualComparisonPreview = currentScene is EzSkinEditorSceneType.Size or EzSkinEditorSceneType.Colour;
+            bool useNoteComparisonOnly = currentScene == EzSkinEditorSceneType.Note;
 
             // Size/colour scenes always use the mania LN virtual provider, not the loaded beatmap ruleset.
             var previewBeatmap = allowBeatmapPreview
@@ -377,11 +393,17 @@ namespace osu.Game.EzOsuGame.Edit
                 CommitSkinIni = commitSkinIni,
                 AllowBeatmapPreview = allowBeatmapPreview,
                 UseVirtualComparisonPreview = useVirtualComparisonPreview,
+                UseNoteComparisonOnly = useNoteComparisonOnly,
                 PreviewSource = PreviewState.Source.Value,
                 PreviewBeatmap = PreviewState.PreviewBeatmap,
                 PreviewRuleset = PreviewState.Ruleset.Value,
                 PreviewMode = PreviewState.Mode.Value,
-                ComparisonSnapshot = ComparisonSnapshotForTesting,
+                ComparisonSnapshot = useNoteComparisonOnly ? null : ComparisonSnapshotForTesting,
+                NoteSession = NoteSessionForTesting,
+                NoteSnapshot = NoteSnapshotForTesting,
+                CreateNoteSnapshot = createNoteSnapshot,
+                RestoreNoteSnapshot = restoreNoteSnapshot,
+                ExportNotePreview = exportNotePreview,
             };
         }
 
@@ -693,6 +715,105 @@ namespace osu.Game.EzOsuGame.Edit
             ComparisonSnapshotForTesting.ApplyTo(ezSkinConfig, SkinIniSession);
             postNotification(EzEditorStrings.NOTIFY_RESTORED_CONFIG_SNAPSHOT);
             refreshScene();
+        }
+
+        private void ensureNoteSnapshotForCurrentSkin()
+        {
+            var currentSkinId = skinManager.CurrentSkinInfo.Value.ID;
+
+            if (noteSnapshotInitialized && noteSnapshotSkinId == currentSkinId)
+                return;
+
+            initializeNoteSessionDefaults();
+            recaptureNoteSnapshot();
+            noteSnapshotInitialized = true;
+            noteSnapshotSkinId = currentSkinId;
+        }
+
+        private void initializeNoteSessionDefaults()
+        {
+            if (NoteSessionForTesting.Ruleset.Value is not null)
+                return;
+
+            var profile = EzSkinEditorNoteRulesetProfileRegistry.All.FirstOrDefault();
+
+            if (profile == null)
+                return;
+
+            NoteSessionForTesting.Ruleset.Value = profile.RulesetInfo;
+            NoteSessionForTesting.VariantId.Value = profile.GetDefaultVariantId(getEditorSkin(), NoteSessionForTesting.Part.Value);
+        }
+
+        private void recaptureNoteSnapshot()
+        {
+            NoteSnapshotForTesting.CaptureFrom(NoteSessionForTesting);
+        }
+
+        private void createNoteSnapshot()
+        {
+            recaptureNoteSnapshot();
+            postNotification(EzEditorStrings.NOTIFY_CREATED_NOTE_SNAPSHOT);
+            refreshScene();
+        }
+
+        private void restoreNoteSnapshot()
+        {
+            NoteSnapshotForTesting.ApplyTo(NoteSessionForTesting);
+            postNotification(EzEditorStrings.NOTIFY_RESTORED_NOTE_SNAPSHOT);
+            refreshScene();
+        }
+
+        private void exportNotePreview()
+        {
+            if (!RuntimeInfo.IsDesktop)
+                return;
+
+            var skinInfo = skinManager.CurrentSkinInfo.Value;
+
+            if (skinInfo.PerformRead(s => s.Protected))
+            {
+                postNotification(EzEditorStrings.NOTIFY_CANNOT_EXPORT_NOTE_PREVIEW);
+                return;
+            }
+
+            string exportName = string.IsNullOrWhiteSpace(NoteSessionForTesting.ExportName.Value)
+                ? "note-preview"
+                : NoteSessionForTesting.ExportName.Value.Trim();
+
+            foreach (char invalid in Path.GetInvalidFileNameChars())
+                exportName = exportName.Replace(invalid, '_');
+
+            host.TakeScreenshotAsync().ContinueWith(async task =>
+            {
+                if (task.IsFaulted)
+                {
+                    Schedule(() => postNotification(LocalisableString.Format(EzEditorStrings.NOTIFY_EXPORT_FAILED, task.Exception?.GetBaseException().Message ?? "unknown error")));
+                    return;
+                }
+
+                try
+                {
+                    using Image<Rgba32> image = task.GetResultSafely();
+                    var detached = skinInfo.PerformRead(s => s.Detach());
+                    var edit = await skinManager.BeginExternalEditing(detached).ConfigureAwait(false);
+                    string directory = Path.Combine(edit.MountedPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), "_ez_note_edit");
+                    Directory.CreateDirectory(directory);
+                    string filePath = Path.Combine(directory, $"{exportName}.png");
+                    image.SaveAsPng(filePath);
+
+                    Schedule(() =>
+                    {
+                        host.OpenFileExternally(directory + Path.DirectorySeparatorChar);
+                        postNotification(EzEditorStrings.NOTIFY_NOTE_EXPORTED);
+                    });
+
+                    await edit.Finish().ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    Schedule(() => postNotification(LocalisableString.Format(EzEditorStrings.NOTIFY_EXPORT_FAILED, e.Message)));
+                }
+            }, TaskScheduler.Default);
         }
 
         private void persistEditorConfig()

--- a/osu.Game/EzOsuGame/Edit/Note/EzSkinEditorNoteEditSession.cs
+++ b/osu.Game/EzOsuGame/Edit/Note/EzSkinEditorNoteEditSession.cs
@@ -1,0 +1,42 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Game.Rulesets;
+
+namespace osu.Game.EzOsuGame.Edit.Note
+{
+    /// <summary>
+    /// In-memory note edit state for the Note scene. Not persisted to Ez2Config or skin.ini.
+    /// </summary>
+    public sealed class EzSkinEditorNoteEditSession
+    {
+        public Bindable<RulesetInfo> Ruleset { get; } = new Bindable<RulesetInfo>();
+
+        public Bindable<EzSkinEditorNotePart> Part { get; } = new Bindable<EzSkinEditorNotePart>(EzSkinEditorNotePart.Note);
+
+        public Bindable<string> VariantId { get; } = new Bindable<string>(string.Empty);
+
+        public Bindable<Colour4> NoteColour { get; } = new Bindable<Colour4>(Colour4.White);
+
+        public Bindable<bool> TrueColouring { get; } = new Bindable<bool>();
+
+        public Bindable<double> Width { get; } = new Bindable<double>(100);
+
+        public Bindable<double> Height { get; } = new Bindable<double>(100);
+
+        public Bindable<string> ExportName { get; } = new Bindable<string>("note-preview");
+
+        public EzSkinEditorNotePreviewRequest ToPreviewRequest() => new EzSkinEditorNotePreviewRequest
+        {
+            Ruleset = Ruleset.Value,
+            Part = Part.Value,
+            VariantId = VariantId.Value,
+            NoteColour = NoteColour.Value,
+            Width = Width.Value,
+            Height = Height.Value,
+            ExportName = ExportName.Value,
+        };
+    }
+}

--- a/osu.Game/EzOsuGame/Edit/Note/EzSkinEditorNoteEditSnapshot.cs
+++ b/osu.Game/EzOsuGame/Edit/Note/EzSkinEditorNoteEditSnapshot.cs
@@ -1,0 +1,61 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Game.Rulesets;
+
+namespace osu.Game.EzOsuGame.Edit.Note
+{
+    /// <summary>
+    /// In-memory note edit comparison snapshot. Independent from <see cref="EzSkinEditorComparisonSnapshot"/>.
+    /// </summary>
+    public sealed class EzSkinEditorNoteEditSnapshot
+    {
+        public RulesetInfo Ruleset { get; private set; } = null!;
+
+        public EzSkinEditorNotePart Part { get; private set; }
+
+        public string VariantId { get; private set; } = string.Empty;
+
+        public Colour4 NoteColour { get; private set; }
+
+        public double Width { get; private set; }
+
+        public double Height { get; private set; }
+
+        public string ExportName { get; private set; } = string.Empty;
+
+        public void CaptureFrom(EzSkinEditorNoteEditSession session)
+        {
+            Ruleset = session.Ruleset.Value;
+            Part = session.Part.Value;
+            VariantId = session.VariantId.Value;
+            NoteColour = session.NoteColour.Value;
+            Width = session.Width.Value;
+            Height = session.Height.Value;
+            ExportName = session.ExportName.Value;
+        }
+
+        public void ApplyTo(EzSkinEditorNoteEditSession session)
+        {
+            session.Ruleset.Value = Ruleset;
+            session.Part.Value = Part;
+            session.VariantId.Value = VariantId;
+            session.NoteColour.Value = NoteColour;
+            session.Width.Value = Width;
+            session.Height.Value = Height;
+            session.ExportName.Value = ExportName;
+        }
+
+        public EzSkinEditorNotePreviewRequest ToPreviewRequest() => new EzSkinEditorNotePreviewRequest
+        {
+            Ruleset = Ruleset,
+            Part = Part,
+            VariantId = VariantId,
+            NoteColour = NoteColour,
+            Width = Width,
+            Height = Height,
+            ExportName = ExportName,
+        };
+    }
+}

--- a/osu.Game/EzOsuGame/Edit/Note/EzSkinEditorNotePart.cs
+++ b/osu.Game/EzOsuGame/Edit/Note/EzSkinEditorNotePart.cs
@@ -1,0 +1,13 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.EzOsuGame.Edit.Note
+{
+    public enum EzSkinEditorNotePart
+    {
+        Note,
+        HoldHead,
+        HoldBody,
+        HoldTail,
+    }
+}

--- a/osu.Game/EzOsuGame/Edit/Note/EzSkinEditorNotePreviewRequest.cs
+++ b/osu.Game/EzOsuGame/Edit/Note/EzSkinEditorNotePreviewRequest.cs
@@ -1,0 +1,28 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Game.Rulesets;
+
+namespace osu.Game.EzOsuGame.Edit.Note
+{
+    /// <summary>
+    /// Immutable note preview parameters for a single comparison pane.
+    /// </summary>
+    public readonly struct EzSkinEditorNotePreviewRequest
+    {
+        public RulesetInfo Ruleset { get; init; }
+
+        public EzSkinEditorNotePart Part { get; init; }
+
+        public string VariantId { get; init; }
+
+        public Colour4 NoteColour { get; init; }
+
+        public double Width { get; init; }
+
+        public double Height { get; init; }
+
+        public string ExportName { get; init; }
+    }
+}

--- a/osu.Game/EzOsuGame/Edit/Note/EzSkinEditorNoteRulesetProfileRegistry.cs
+++ b/osu.Game/EzOsuGame/Edit/Note/EzSkinEditorNoteRulesetProfileRegistry.cs
@@ -1,0 +1,28 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Game.Rulesets;
+
+namespace osu.Game.EzOsuGame.Edit.Note
+{
+    public static class EzSkinEditorNoteRulesetProfileRegistry
+    {
+        private static readonly List<IEzSkinEditorNoteRulesetProfile> profiles = new List<IEzSkinEditorNoteRulesetProfile>();
+
+        public static IReadOnlyList<IEzSkinEditorNoteRulesetProfile> All => profiles;
+
+        public static void Register(IEzSkinEditorNoteRulesetProfile profile)
+        {
+            profiles.RemoveAll(p => p.RulesetOnlineId == profile.RulesetOnlineId);
+            profiles.Add(profile);
+        }
+
+        public static IEzSkinEditorNoteRulesetProfile? Get(RulesetInfo? ruleset) =>
+            ruleset == null ? null : profiles.FirstOrDefault(p => p.RulesetOnlineId == ruleset.OnlineID);
+
+        public static IEzSkinEditorNoteRulesetProfile? Get(int rulesetOnlineId) =>
+            profiles.FirstOrDefault(p => p.RulesetOnlineId == rulesetOnlineId);
+    }
+}

--- a/osu.Game/EzOsuGame/Edit/Note/EzSkinEditorNoteVariant.cs
+++ b/osu.Game/EzOsuGame/Edit/Note/EzSkinEditorNoteVariant.cs
@@ -1,0 +1,18 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.EzOsuGame.Edit.Note
+{
+    public readonly struct EzSkinEditorNoteVariant
+    {
+        public string Id { get; init; }
+
+        public string Label { get; init; }
+
+        public EzSkinEditorNoteVariant(string id, string label)
+        {
+            Id = id;
+            Label = label;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Edit/Note/IEzSkinEditorNoteRulesetProfile.cs
+++ b/osu.Game/EzOsuGame/Edit/Note/IEzSkinEditorNoteRulesetProfile.cs
@@ -1,0 +1,27 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Graphics;
+using osu.Game.Rulesets;
+using osu.Game.Skinning;
+
+namespace osu.Game.EzOsuGame.Edit.Note
+{
+    public interface IEzSkinEditorNoteRulesetProfile
+    {
+        int RulesetOnlineId { get; }
+
+        RulesetInfo RulesetInfo { get; }
+
+        IReadOnlyList<EzSkinEditorNotePart> SupportedParts { get; }
+
+        IReadOnlyList<EzSkinEditorNoteVariant> GetVariants(ISkin skin, EzSkinEditorNotePart part);
+
+        string GetDefaultVariantId(ISkin skin, EzSkinEditorNotePart part);
+
+        Drawable CreateNotePreview(ISkin skin, EzSkinEditorNotePreviewRequest request);
+
+        Drawable CreateRulesetSettingsContent();
+    }
+}

--- a/osu.Game/EzOsuGame/Edit/Scenes/NoteSceneStrategy.cs
+++ b/osu.Game/EzOsuGame/Edit/Scenes/NoteSceneStrategy.cs
@@ -1,0 +1,51 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Graphics;
+using osu.Framework.Localisation;
+using osu.Game.EzOsuGame.Edit.Components;
+using osu.Game.EzOsuGame.Edit.Settings.Sections;
+using osu.Game.EzOsuGame.Localization;
+
+namespace osu.Game.EzOsuGame.Edit.Scenes
+{
+    public class NoteSceneStrategy : IEzSkinEditorSceneStrategy
+    {
+        public EzSkinEditorSceneType SceneType => EzSkinEditorSceneType.Note;
+
+        public LocalisableString TabTitle => EzEditorStrings.TAB_NOTE;
+
+        public Drawable CreateSceneContent(EzSkinEditorSceneContext context) =>
+            new EzSkinEditorNoteComparisonHost(context);
+
+        public IReadOnlyList<EzSkinEditorSidebarGroupDefinition> CreateSidebarGroups(EzSkinEditorSceneContext context)
+        {
+            if (context.NoteSession == null)
+                return Array.Empty<EzSkinEditorSidebarGroupDefinition>();
+
+            return new[]
+            {
+                new EzSkinEditorSidebarGroupDefinition
+                {
+                    Title = EzEditorStrings.GROUP_NOTE_RULESET,
+                    CreateContent = () => new EzSkinEditorNoteRulesetSettingsSection(
+                        context.NoteSession,
+                        () => context.RequestSceneRefresh?.Invoke()),
+                },
+                new EzSkinEditorSidebarGroupDefinition
+                {
+                    Title = EzEditorStrings.GROUP_NOTE_EDIT,
+                    CreateContent = () => new EzSkinEditorNoteEditSettingsSection(
+                        context.NoteSession,
+                        context.EditorSkin,
+                        () => context.CreateNoteSnapshot?.Invoke(),
+                        () => context.RestoreNoteSnapshot?.Invoke(),
+                        () => context.ExportNotePreview?.Invoke(),
+                        () => context.RequestSceneRefresh?.Invoke()),
+                },
+            };
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Edit/Settings/Sections/EzSkinEditorNoteEditSettingsSection.cs
+++ b/osu.Game/EzOsuGame/Edit/Settings/Sections/EzSkinEditorNoteEditSettingsSection.cs
@@ -1,0 +1,135 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.EzOsuGame.Edit.Note;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.Overlays.Settings;
+using osu.Game.Skinning;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.Edit.Settings.Sections
+{
+    public partial class EzSkinEditorNoteEditSettingsSection : FillFlowContainer
+    {
+        private readonly EzSkinEditorNoteEditSession session;
+        private readonly Action createNoteSnapshot;
+        private readonly Action restoreNoteSnapshot;
+        private readonly Action exportNotePreview;
+        private readonly Action requestRefresh;
+        private readonly ISkin editorSkin;
+
+        private readonly BindableList<string> variantItems = new BindableList<string>();
+        private SettingsDropdown<string> variantDropdown = null!;
+
+        public EzSkinEditorNoteEditSettingsSection(
+            EzSkinEditorNoteEditSession session,
+            ISkin editorSkin,
+            Action createNoteSnapshot,
+            Action restoreNoteSnapshot,
+            Action exportNotePreview,
+            Action requestRefresh)
+        {
+            this.session = session;
+            this.editorSkin = editorSkin;
+            this.createNoteSnapshot = createNoteSnapshot;
+            this.restoreNoteSnapshot = restoreNoteSnapshot;
+            this.exportNotePreview = exportNotePreview;
+            this.requestRefresh = requestRefresh;
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            Direction = FillDirection.Vertical;
+            Spacing = new Vector2(8);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            variantDropdown = new SettingsDropdown<string>
+            {
+                LabelText = EzEditorStrings.NOTE_VARIANT_LABEL,
+                Current = session.VariantId,
+                ItemSource = variantItems,
+            };
+
+            Children = new Drawable[]
+            {
+                variantDropdown,
+                new SettingsColour
+                {
+                    LabelText = EzEditorStrings.NOTE_COLOUR_LABEL,
+                    Current = session.NoteColour,
+                },
+                new SettingsCheckbox
+                {
+                    LabelText = EzEditorStrings.NOTE_TRUE_COLOURING_LABEL,
+                    TooltipText = EzEditorStrings.NOTE_TRUE_COLOURING_TOOLTIP,
+                    Current = session.TrueColouring,
+                },
+                new SettingsSlider<double>
+                {
+                    LabelText = EzEditorStrings.NOTE_WIDTH_LABEL,
+                    Current = session.Width,
+                    KeyboardStep = 1,
+                },
+                new SettingsSlider<double>
+                {
+                    LabelText = EzEditorStrings.NOTE_HEIGHT_LABEL,
+                    Current = session.Height,
+                    KeyboardStep = 1,
+                },
+                new SettingsTextBox
+                {
+                    LabelText = EzEditorStrings.NOTE_EXPORT_NAME_LABEL,
+                    Current = session.ExportName,
+                },
+                new SettingsButton
+                {
+                    Text = EzEditorStrings.NOTE_CREATE_SNAPSHOT,
+                    Action = createNoteSnapshot,
+                },
+                new SettingsButton
+                {
+                    Text = EzEditorStrings.NOTE_RESTORE_SNAPSHOT,
+                    Action = restoreNoteSnapshot,
+                },
+                new SettingsButton
+                {
+                    Text = EzEditorStrings.NOTE_EXPORT_BUTTON,
+                    Action = exportNotePreview,
+                },
+            };
+
+            session.TrueColouring.Disabled = true;
+            refreshVariants();
+
+            session.VariantId.BindValueChanged(_ => requestRefresh());
+            session.NoteColour.BindValueChanged(_ => requestRefresh());
+            session.Width.BindValueChanged(_ => requestRefresh());
+            session.Height.BindValueChanged(_ => requestRefresh());
+        }
+
+        private void refreshVariants()
+        {
+            var profile = EzSkinEditorNoteRulesetProfileRegistry.Get(session.Ruleset.Value);
+
+            variantItems.Clear();
+
+            if (profile == null)
+                return;
+
+            foreach (var variant in profile.GetVariants(editorSkin, session.Part.Value))
+                variantItems.Add(variant.Id);
+
+            if (variantItems.Count == 0)
+                return;
+
+            if (!variantItems.Contains(session.VariantId.Value))
+                session.VariantId.Value = profile.GetDefaultVariantId(editorSkin, session.Part.Value);
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Edit/Settings/Sections/EzSkinEditorNoteRulesetSettingsSection.cs
+++ b/osu.Game/EzOsuGame/Edit/Settings/Sections/EzSkinEditorNoteRulesetSettingsSection.cs
@@ -1,0 +1,84 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.EzOsuGame.Edit.Note;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.Overlays.Settings;
+using osu.Game.Rulesets;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.Edit.Settings.Sections
+{
+    public partial class EzSkinEditorNoteRulesetSettingsSection : FillFlowContainer
+    {
+        private readonly EzSkinEditorNoteEditSession session;
+        private readonly Action requestRefresh;
+
+        private readonly BindableList<RulesetInfo> rulesets = new BindableList<RulesetInfo>();
+
+        private FillFlowContainer rulesetSettingsContainer = null!;
+
+        public EzSkinEditorNoteRulesetSettingsSection(EzSkinEditorNoteEditSession session, Action requestRefresh)
+        {
+            this.session = session;
+            this.requestRefresh = requestRefresh;
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            Direction = FillDirection.Vertical;
+            Spacing = new Vector2(8);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            rulesets.AddRange(EzSkinEditorNoteRulesetProfileRegistry.All.Select(p => p.RulesetInfo));
+
+            if (session.Ruleset.Value is null && rulesets.Count > 0)
+                session.Ruleset.Value = rulesets[0];
+
+            Add(new SettingsDropdown<RulesetInfo>
+            {
+                LabelText = EzEditorStrings.NOTE_RULESET_LABEL,
+                Current = session.Ruleset,
+                ItemSource = rulesets,
+            });
+
+            Add(new SettingsEnumDropdown<EzSkinEditorNotePart>
+            {
+                LabelText = EzEditorStrings.NOTE_PART_LABEL,
+                Current = session.Part,
+            });
+
+            Add(rulesetSettingsContainer = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(8),
+            });
+
+            session.Ruleset.BindValueChanged(_ =>
+            {
+                refreshRulesetSettings();
+                requestRefresh();
+            }, true);
+            session.Part.BindValueChanged(_ => requestRefresh());
+        }
+
+        private void refreshRulesetSettings()
+        {
+            rulesetSettingsContainer.Clear();
+
+            var profile = EzSkinEditorNoteRulesetProfileRegistry.Get(session.Ruleset.Value);
+
+            if (profile != null)
+                rulesetSettingsContainer.Add(profile.CreateRulesetSettingsContent());
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Localization/EzEditorStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzEditorStrings.cs
@@ -215,6 +215,8 @@ namespace osu.Game.EzOsuGame.Localization
 
         public static readonly LocalisableString TAB_SKIN_INI = new EzLocalizationManager.EzLocalisableString("skin.ini", "skin.ini");
 
+        public static readonly LocalisableString TAB_NOTE = new EzLocalizationManager.EzLocalisableString("Note", "Note");
+
         #endregion
 
         #region Sidebar groups
@@ -239,6 +241,56 @@ namespace osu.Game.EzOsuGame.Localization
 
         public static readonly LocalisableString GROUP_MODE = new EzLocalizationManager.EzLocalisableString("模式", "Mode");
 
+        public static readonly LocalisableString GROUP_NOTE_RULESET = new EzLocalizationManager.EzLocalisableString("规则集", "Ruleset");
+
+        public static readonly LocalisableString GROUP_NOTE_EDIT = new EzLocalizationManager.EzLocalisableString("Note 编辑", "Note edit");
+
+        #endregion
+
+        #region Note scene
+
+        public static readonly LocalisableString NOTE_RULESET_LABEL = new EzLocalizationManager.EzLocalisableString("规则集", "Ruleset");
+
+        public static readonly LocalisableString NOTE_PART_LABEL = new EzLocalizationManager.EzLocalisableString("部件类型", "Part type");
+
+        public static readonly LocalisableString NOTE_VARIANT_LABEL = new EzLocalizationManager.EzLocalisableString("变体", "Variant");
+
+        public static readonly LocalisableString NOTE_COLOUR_LABEL = new EzLocalizationManager.EzLocalisableString("颜色", "Colour");
+
+        public static readonly LocalisableString NOTE_TRUE_COLOURING_LABEL = new EzLocalizationManager.EzLocalisableString("真着色", "True colouring");
+
+        public static readonly LocalisableString NOTE_TRUE_COLOURING_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "TODO: EzNoteTrueColourProcessor",
+            "TODO: EzNoteTrueColourProcessor");
+
+        public static readonly LocalisableString NOTE_WIDTH_LABEL = new EzLocalizationManager.EzLocalisableString("宽度", "Width");
+
+        public static readonly LocalisableString NOTE_HEIGHT_LABEL = new EzLocalizationManager.EzLocalisableString("高度", "Height");
+
+        public static readonly LocalisableString NOTE_EXPORT_NAME_LABEL = new EzLocalizationManager.EzLocalisableString("导出名称", "Export name");
+
+        public static readonly LocalisableString NOTE_CREATE_SNAPSHOT = new EzLocalizationManager.EzLocalisableString("创建 Note 对比快照", "Create note comparison snapshot");
+
+        public static readonly LocalisableString NOTE_RESTORE_SNAPSHOT = new EzLocalizationManager.EzLocalisableString("恢复 Note 对比快照", "Restore note comparison snapshot");
+
+        public static readonly LocalisableString NOTE_EXPORT_BUTTON = new EzLocalizationManager.EzLocalisableString("导出 PNG", "Export PNG");
+
+        public static readonly LocalisableString NOTIFY_CREATED_NOTE_SNAPSHOT = new EzLocalizationManager.EzLocalisableString(
+            "已创建 Note 对比快照",
+            "Created note comparison snapshot");
+
+        public static readonly LocalisableString NOTIFY_RESTORED_NOTE_SNAPSHOT = new EzLocalizationManager.EzLocalisableString(
+            "已恢复 Note 对比快照",
+            "Restored note comparison snapshot");
+
+        public static readonly LocalisableString NOTIFY_NOTE_EXPORTED = new EzLocalizationManager.EzLocalisableString(
+            "已导出 Note 预览到皮肤 _ez_note_edit 目录",
+            "Exported note preview to skin _ez_note_edit folder");
+
+        public static readonly LocalisableString NOTIFY_CANNOT_EXPORT_NOTE_PREVIEW = new EzLocalizationManager.EzLocalisableString(
+            "当前皮肤无法导出 Note 预览",
+            "Cannot export note preview for the current skin");
+
         #endregion
 
         #region Toolbar and preview
@@ -256,6 +308,14 @@ namespace osu.Game.EzOsuGame.Localization
         public static readonly LocalisableString PLACEHOLDER_VIRTUAL_PLAYFIELD_NOT_SUPPORTED = new EzLocalizationManager.EzLocalisableString(
             "Virtual playfield not supported",
             "Virtual playfield not supported");
+
+        public static readonly LocalisableString PLACEHOLDER_NOTE_PREVIEW_NOT_AVAILABLE = new EzLocalizationManager.EzLocalisableString(
+            "Note 预览不可用",
+            "Note preview not available");
+
+        public static readonly LocalisableString PLACEHOLDER_NOTE_RULESET_NOT_SUPPORTED = new EzLocalizationManager.EzLocalisableString(
+            "当前规则集暂不支持 Note 预览",
+            "Note preview is not supported for the selected ruleset");
 
         public static readonly LocalisableString PLACEHOLDER_COMPARISON_NOT_SUPPORTED = new EzLocalizationManager.EzLocalisableString(
             "Comparison preview not supported",


### PR DESCRIPTION
## Summary

- Add **Note** skin editor scene with 50/50 live vs note-edit-snapshot comparison (`EzSkinEditorNoteEditSnapshot`), independent from M9 Ez2Config/skin.ini config snapshot.
- Mania ruleset profile: part types (Note / LN head/body/tail), variant resolution (Legacy 1|2|S, Ez A|B|S|E|P), `TimingBasedNoteColouring` in sidebar.
- Note edit sidebar: variant, colour, width/height, export name, create/restore note snapshot, PNG export to skin `_ez_note_edit/` with folder open.
- Hide global config snapshot menu items on Note scene; true colouring placeholder disabled.

## Commits

1. Add note edit session and snapshot types for the Note scene
2. Add Note scene strategy and live vs snapshot comparison host
3. Add Mania note ruleset profile and LN provider note preview
4. Add Note scene sidebar sections and hide config snapshot menu on Note tab
5. Wire Note scene session lifecycle, snapshot actions, and PNG export
6. Add tests for Note scene comparison host and note edit snapshot restore

## Test plan

- [x] `dotnet test osu.Game.Tests/osu.Game.Tests.csproj --filter FullyQualifiedName~EzSkinEditorNoteEditSnapshotTest`
- [ ] `TestSceneEzSkinEditorScreen.TestNoteSceneComparisonHost` (visual)
- [ ] `TestSceneEzSkinEditorScreen.TestNoteSnapshotRestore` (visual)
- [ ] Manual: Note tab → change variant → left changes / right stays until create snapshot
- [ ] Manual: Export PNG → `_ez_note_edit` folder opens in file manager
