### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -23,6 +23,10 @@ on:
         required: false
         default: ''
 
+permissions:
+  contents: write
+  packages: read
+
 jobs:
   prepare:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/SK-la/Ez2Lazer/security/code-scanning/2](https://github.com/SK-la/Ez2Lazer/security/code-scanning/2)

Add an explicit workflow-level `permissions` block near the top of `.github/workflows/auto-release.yml` (after `on:` section, before `jobs:`) so every job gets a defined baseline instead of inheriting repository defaults.

Best single fix with minimal functional risk:
- Set:
  - `contents: write` (needed for release/tag publishing flows and compatible with checkout/API usage),
  - `packages: read` (safe minimal read for package access if needed during build).
- This preserves existing functionality better than setting `contents: read`, which could break release creation in the `release` job (partially omitted in snippet).

No imports/dependencies/method definitions are needed; this is YAML-only configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
