### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -206,6 +206,8 @@ jobs:
   build:
     needs: prepare
     if: ${{ needs.prepare.outputs.skip_release != 'true' }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/SK-la/Ez2Lazer/security/code-scanning/3](https://github.com/SK-la/Ez2Lazer/security/code-scanning/3)

Add an explicit `permissions` block to the `build` job in `.github/workflows/auto-release.yml`, directly under the job’s `if` (or before `strategy`), with least privilege needed for current behavior.

Best single fix without changing functionality:
- In `.github/workflows/auto-release.yml`, within `jobs.build`, add:
  - `permissions:`
  - `contents: read`
  
This is sufficient as a minimal safe baseline for checkout/read operations in `build` and satisfies the CodeQL finding for the highlighted job. No imports/dependencies/method changes are needed (YAML workflow only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
