### PR TITLE
feat(pixiv): Pixiv follow-feed menu background (P0)

### DIFF
--- a/osu.Game/Configuration/BackgroundSource.cs
+++ b/osu.Game/Configuration/BackgroundSource.cs
@@ -23,5 +23,8 @@ namespace osu.Game.Configuration
 
         [Description("'EzResources/BG/*' from osu data folder")]
         Picture = 4,
+
+        [Description("Pixiv follow feed (requires pixiv_auth.json)")]
+        PixivFollow = 5,
     }
 }

--- a/osu.Game/EzOsuGame/Background/Pixiv/PixivApiClient.cs
+++ b/osu.Game/EzOsuGame/Background/Pixiv/PixivApiClient.cs
@@ -1,0 +1,199 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using Newtonsoft.Json.Linq;
+using osu.Framework.Utils;
+
+namespace osu.Game.EzOsuGame.Background.Pixiv
+{
+    public class PixivApiClient
+    {
+        private readonly PixivAuthService authService;
+
+        public PixivApiClient(PixivAuthService authService)
+        {
+            this.authService = authService;
+        }
+
+        public bool TryGetRandomFollowIllust(out PixivIllustInfo illust, out string? error)
+        {
+            illust = default;
+            error = null;
+
+            if (!authService.TryRefreshAccessToken(out string? accessToken, out error))
+                return false;
+
+            var candidates = new List<PixivIllustInfo>();
+            string? nextUrl = $"{PixivConstants.ApiBaseUrl}/v1/illust/follow?restrict=public";
+
+            for (int page = 0; page < 3 && nextUrl != null; page++)
+            {
+                if (!tryFetchIllusts(nextUrl, accessToken!, candidates, out nextUrl, out error))
+                    return false;
+
+                if (candidates.Count >= 30)
+                    break;
+            }
+
+            if (candidates.Count == 0)
+            {
+                error = "No suitable illustrations found in Pixiv follow feed.";
+                return false;
+            }
+
+            illust = candidates[RNG.Next(candidates.Count)];
+            return true;
+        }
+
+        public bool TryGetUserAccount(out string? account, out string? error)
+        {
+            account = null;
+            error = null;
+
+            if (!authService.TryRefreshAccessToken(out string? accessToken, out error))
+                return false;
+
+            try
+            {
+                using var request = createApiRequest($"{PixivConstants.ApiBaseUrl}/v2/user/account", accessToken!);
+                request.Perform();
+
+                if (request.ResponseStatusCode != HttpStatusCode.OK)
+                {
+                    error = request.GetResponseString() ?? "Failed to load Pixiv account.";
+                    return false;
+                }
+
+                account = JObject.Parse(request.GetResponseString() ?? string.Empty)["user"]?["account"]?.ToString();
+                return !string.IsNullOrWhiteSpace(account);
+            }
+            catch (Exception ex)
+            {
+                error = ex.Message;
+                return false;
+            }
+        }
+
+        private bool tryFetchIllusts(string url, string accessToken, List<PixivIllustInfo> output, out string? nextUrl, out string? error)
+        {
+            nextUrl = null;
+            error = null;
+
+            try
+            {
+                using var request = createApiRequest(url, accessToken);
+                request.Perform();
+
+                if (request.ResponseStatusCode != HttpStatusCode.OK)
+                {
+                    error = request.GetResponseString() ?? "Failed to load Pixiv follow feed.";
+                    return false;
+                }
+
+                var json = JObject.Parse(request.GetResponseString() ?? string.Empty);
+                nextUrl = json["next_url"]?.ToString();
+
+                var illusts = json["illusts"] as JArray;
+                if (illusts == null)
+                    return true;
+
+                foreach (var token in illusts)
+                {
+                    if (!tryParseIllust(token, out PixivIllustInfo info))
+                        continue;
+
+                    if (isRestricted(token))
+                        continue;
+
+                    output.Add(info);
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                error = ex.Message;
+                return false;
+            }
+        }
+
+        private static bool tryParseIllust(JToken token, out PixivIllustInfo info)
+        {
+            info = default;
+
+            string? account = token["user"]?["account"]?.ToString();
+            long illustId = token["id"]?.Value<long>() ?? 0;
+            if (string.IsNullOrWhiteSpace(account) || illustId <= 0)
+                return false;
+
+            int pageCount = token["page_count"]?.Value<int>() ?? 1;
+            int page = pageCount <= 1 ? 0 : RNG.Next(0, pageCount);
+
+            string? imageUrl = getImageUrl(token, page);
+            if (string.IsNullOrWhiteSpace(imageUrl))
+                return false;
+
+            info = new PixivIllustInfo(account, illustId, page, imageUrl);
+            return true;
+        }
+
+        private static string? getImageUrl(JToken token, int page)
+        {
+            if (page == 0)
+            {
+                string? original = token["meta_single_page"]?["original_image_url"]?.ToString();
+                if (!string.IsNullOrWhiteSpace(original))
+                    return original;
+
+                return token["image_urls"]?["large"]?.ToString()
+                       ?? token["image_urls"]?["square_medium"]?.ToString();
+            }
+
+            var pages = token["meta_pages"] as JArray;
+            if (pages == null || page >= pages.Count)
+                return null;
+
+            return pages[page]["image_urls"]?["large"]?.ToString()
+                   ?? pages[page]["image_urls"]?["square_medium"]?.ToString();
+        }
+
+        private static bool isRestricted(JToken token)
+        {
+            int sanityLevel = token["sanity_level"]?.Value<int>() ?? 0;
+            if (sanityLevel >= 4)
+                return true;
+
+            var tags = token["tags"] as JArray;
+            if (tags == null)
+                return false;
+
+            return tags.Any(t =>
+            {
+                string? name = t["name"]?.ToString() ?? t.ToString();
+                return name != null && name.Contains("R-18", StringComparison.OrdinalIgnoreCase);
+            });
+        }
+
+        private static Framework.IO.Network.WebRequest createApiRequest(string url, string accessToken)
+        {
+            var request = new Framework.IO.Network.WebRequest(url)
+            {
+                Method = HttpMethod.Get,
+            };
+
+            request.AddHeader("Authorization", $"Bearer {accessToken}");
+            request.AddHeader("User-Agent", PixivConstants.UserAgent);
+            request.AddHeader("App-OS", PixivConstants.AppOs);
+            request.AddHeader("App-OS-Version", PixivConstants.AppOsVersion);
+            request.AddHeader("App-Version", PixivConstants.AppVersion);
+            request.AddHeader("Accept-Language", "zh-CN");
+
+            return request;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Background/Pixiv/PixivAuthFile.cs
+++ b/osu.Game/EzOsuGame/Background/Pixiv/PixivAuthFile.cs
@@ -1,0 +1,13 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Newtonsoft.Json;
+
+namespace osu.Game.EzOsuGame.Background.Pixiv
+{
+    public class PixivAuthFile
+    {
+        [JsonProperty("refresh_token")]
+        public string? RefreshToken { get; set; }
+    }
+}

--- a/osu.Game/EzOsuGame/Background/Pixiv/PixivAuthService.cs
+++ b/osu.Game/EzOsuGame/Background/Pixiv/PixivAuthService.cs
@@ -1,0 +1,198 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using Newtonsoft.Json.Linq;
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using osu.Game.EzOsuGame;
+
+namespace osu.Game.EzOsuGame.Background.Pixiv
+{
+    public class PixivAuthService
+    {
+        private readonly Storage storage;
+
+        private string? cachedAccessToken;
+        private DateTimeOffset accessTokenExpiresAt = DateTimeOffset.MinValue;
+        private readonly object tokenLock = new object();
+
+        public PixivAuthService(Storage storage)
+        {
+            this.storage = storage;
+        }
+
+        public bool HasRefreshToken => !string.IsNullOrWhiteSpace(LoadRefreshToken());
+
+        public string? LoadRefreshToken() => loadRefreshTokenFromFile();
+
+        public void SaveRefreshToken(string refreshToken)
+        {
+            if (string.IsNullOrWhiteSpace(refreshToken))
+                throw new ArgumentException("Refresh token cannot be empty.", nameof(refreshToken));
+
+            writeRefreshTokenToFile(refreshToken);
+            invalidateAccessToken();
+        }
+
+        public void ClearRefreshToken()
+        {
+            invalidateAccessToken();
+
+            try
+            {
+                if (storage.Exists(EzModifyPath.PIXIV_AUTH_FILE))
+                    storage.Delete(EzModifyPath.PIXIV_AUTH_FILE);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"Failed to delete Pixiv auth file: {ex.Message}", LoggingTarget.Network, LogLevel.Important);
+            }
+        }
+
+        public bool TryRefreshAccessToken(out string? accessToken, out string? error)
+        {
+            lock (tokenLock)
+            {
+                if (!string.IsNullOrEmpty(cachedAccessToken) && DateTimeOffset.UtcNow < accessTokenExpiresAt.AddMinutes(-1))
+                {
+                    accessToken = cachedAccessToken;
+                    error = null;
+                    return true;
+                }
+
+                string? refreshToken = LoadRefreshToken();
+
+                if (string.IsNullOrWhiteSpace(refreshToken))
+                {
+                    accessToken = null;
+                    error = "Pixiv refresh token is not configured. Run tools/GetPixivRefreshToken.ps1 or paste a token in settings.";
+                    return false;
+                }
+
+                try
+                {
+                    using var request = createTokenRequest(new Dictionary<string, string>
+                    {
+                        ["grant_type"] = "refresh_token",
+                        ["refresh_token"] = refreshToken,
+                        ["include_policy"] = "true",
+                    });
+
+                    request.Perform();
+
+                    if (request.ResponseStatusCode != HttpStatusCode.OK)
+                    {
+                        accessToken = null;
+                        error = request.GetResponseString() ?? "Pixiv token refresh failed.";
+                        invalidateAccessToken();
+                        return false;
+                    }
+
+                    var json = JObject.Parse(request.GetResponseString() ?? string.Empty);
+                    cachedAccessToken = json["access_token"]?.ToString();
+                    string? newRefresh = json["refresh_token"]?.ToString();
+
+                    if (!string.IsNullOrWhiteSpace(newRefresh) && newRefresh != refreshToken)
+                        SaveRefreshToken(newRefresh);
+
+                    int expiresIn = json["expires_in"]?.Value<int>() ?? 3600;
+                    accessTokenExpiresAt = DateTimeOffset.UtcNow.AddSeconds(expiresIn);
+
+                    if (string.IsNullOrWhiteSpace(cachedAccessToken))
+                    {
+                        accessToken = null;
+                        error = "Pixiv token refresh returned an empty access token.";
+                        invalidateAccessToken();
+                        return false;
+                    }
+
+                    accessToken = cachedAccessToken;
+                    error = null;
+                    return true;
+                }
+                catch (Exception ex)
+                {
+                    accessToken = null;
+                    error = ex.Message;
+                    invalidateAccessToken();
+                    return false;
+                }
+            }
+        }
+
+        public string? GetAccessToken()
+        {
+            return TryRefreshAccessToken(out string? accessToken, out _) ? accessToken : null;
+        }
+
+        private void invalidateAccessToken()
+        {
+            cachedAccessToken = null;
+            accessTokenExpiresAt = DateTimeOffset.MinValue;
+        }
+
+        private string? loadRefreshTokenFromFile()
+        {
+            try
+            {
+                if (!storage.Exists(EzModifyPath.PIXIV_AUTH_FILE))
+                    return null;
+
+                using var stream = storage.GetStream(EzModifyPath.PIXIV_AUTH_FILE);
+                using var reader = new StreamReader(stream);
+                string content = reader.ReadToEnd();
+
+                if (string.IsNullOrWhiteSpace(content))
+                    return null;
+
+                var auth = Newtonsoft.Json.JsonConvert.DeserializeObject<PixivAuthFile>(content);
+                return string.IsNullOrWhiteSpace(auth?.RefreshToken) ? null : auth.RefreshToken;
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"Failed to read Pixiv auth file: {ex.Message}", LoggingTarget.Network, LogLevel.Important);
+                return null;
+            }
+        }
+
+        private void writeRefreshTokenToFile(string refreshToken)
+        {
+            try
+            {
+                string json = Newtonsoft.Json.JsonConvert.SerializeObject(new PixivAuthFile { RefreshToken = refreshToken }, Newtonsoft.Json.Formatting.Indented);
+                using var stream = storage.CreateFileSafely(EzModifyPath.PIXIV_AUTH_FILE);
+                using var writer = new StreamWriter(stream);
+                writer.Write(json);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"Failed to write Pixiv auth file: {ex.Message}", LoggingTarget.Network, LogLevel.Important);
+            }
+        }
+
+        private static Framework.IO.Network.WebRequest createTokenRequest(Dictionary<string, string> formData)
+        {
+            var request = new Framework.IO.Network.WebRequest(PixivConstants.AuthTokenUrl)
+            {
+                Method = HttpMethod.Post,
+            };
+
+            request.AddHeader("User-Agent", PixivConstants.UserAgent);
+            request.AddHeader("App-OS", PixivConstants.AppOs);
+            request.AddHeader("App-OS-Version", PixivConstants.AppOsVersion);
+            request.AddHeader("App-Version", PixivConstants.AppVersion);
+            request.AddParameter("client_id", PixivConstants.ClientId);
+            request.AddParameter("client_secret", PixivConstants.ClientSecret);
+
+            foreach (var pair in formData)
+                request.AddParameter(pair.Key, pair.Value);
+
+            return request;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Background/Pixiv/PixivBackground.cs
+++ b/osu.Game/EzOsuGame/Background/Pixiv/PixivBackground.cs
@@ -1,0 +1,114 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.Input.Events;
+using osu.Framework.Utils;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.EzOsuGame.Background.Pixiv
+{
+    public partial class PixivBackground : Graphics.Backgrounds.Background
+    {
+        private PixivIllustInfo illustInfo;
+        private string loadedTexturePath = string.Empty;
+
+        public PixivBackground()
+            : base(string.Empty)
+        {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(PixivBackgroundCoordinator coordinator, LargeTextureStore textures, OsuGame? game)
+        {
+            if (coordinator.TryResolveBackground(out illustInfo, out string resourcePath, out string? error))
+            {
+                loadedTexturePath = resourcePath;
+                Sprite.Texture = textures.Get(resourcePath);
+                addAttribution(game);
+            }
+            else
+            {
+                coordinator.LogFailure("Background load", error);
+                loadedTexturePath = $@"Backgrounds/bg{RNG.Next(1, 6)}";
+                Sprite.Texture = textures.Get(loadedTexturePath);
+            }
+        }
+
+        private void addAttribution(OsuGame? game)
+        {
+            if (illustInfo.IllustId <= 0)
+                return;
+
+            string label = illustInfo.AttributionLabel;
+            string artworkUrl = $"https://www.pixiv.net/artworks/{illustInfo.IllustId}";
+
+            var attribution = new PixivAttributionBadge(label, () => game?.OpenUrlExternally(artworkUrl));
+            AddInternal(attribution);
+        }
+
+        public override bool Equals(Graphics.Backgrounds.Background other)
+        {
+            if (other is PixivBackground pixiv)
+                return pixiv.loadedTexturePath == loadedTexturePath;
+
+            return base.Equals(other);
+        }
+
+        private partial class PixivAttributionBadge : OsuClickableContainer
+        {
+            private readonly OsuSpriteText label;
+
+            public PixivAttributionBadge(string text, System.Action? onClick)
+            {
+                Anchor = Anchor.BottomLeft;
+                Origin = Anchor.BottomLeft;
+                Position = new Vector2(30, 30);
+                AutoSizeAxes = Axes.Both;
+                Action = onClick;
+                TooltipText = "Open on Pixiv";
+
+                Child = new Container
+                {
+                    AutoSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Alpha = 0.65f,
+                            Colour = Color4.Black,
+                        },
+                        label = new OsuSpriteText
+                        {
+                            Margin = new MarginPadding { Horizontal = 14, Vertical = 8 },
+                            Font = OsuFont.GetFont(weight: FontWeight.Bold, size: 18),
+                            Text = text,
+                            Colour = Color4.White,
+                        },
+                    },
+                };
+            }
+
+            protected override bool OnHover(HoverEvent e)
+            {
+                label.FadeColour(Colour4.FromHex(@"B0D4FF"), 150, Easing.OutQuint);
+                return base.OnHover(e);
+            }
+
+            protected override void OnHoverLost(HoverLostEvent e)
+            {
+                label.FadeColour(Color4.White, 150, Easing.OutQuint);
+                base.OnHoverLost(e);
+            }
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Background/Pixiv/PixivBackgroundCoordinator.cs
+++ b/osu.Game/EzOsuGame/Background/Pixiv/PixivBackgroundCoordinator.cs
@@ -1,0 +1,55 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using osu.Game.EzOsuGame.Configuration;
+
+namespace osu.Game.EzOsuGame.Background.Pixiv
+{
+    public class PixivBackgroundCoordinator
+    {
+        public PixivAuthService Auth { get; }
+        public PixivApiClient Api { get; }
+        public PixivImageStore Images { get; }
+
+        public PixivBackgroundCoordinator(Storage storage)
+        {
+            Auth = new PixivAuthService(storage);
+            Api = new PixivApiClient(Auth);
+            Images = new PixivImageStore(storage);
+        }
+
+        public bool TryResolveBackground(out PixivIllustInfo illust, out string resourcePath, out string? error)
+        {
+            illust = default;
+            resourcePath = string.Empty;
+            error = null;
+
+            if (!Auth.HasRefreshToken)
+            {
+                error = "Pixiv refresh token is not configured.";
+                return false;
+            }
+
+            if (Images.TryGetRandomCachedIllust(out illust, out resourcePath))
+                return true;
+
+            if (!Api.TryGetRandomFollowIllust(out illust, out error))
+                return false;
+
+            if (!Images.TryEnsureCached(illust, out resourcePath, out error))
+                return false;
+
+            return true;
+        }
+
+        public void LogFailure(string context, string? error)
+        {
+            if (string.IsNullOrWhiteSpace(error))
+                return;
+
+            Logger.Log($"[Pixiv] {context}: {error}", Ez2ConfigManager.LOGGER_NAME, LogLevel.Important);
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Background/Pixiv/PixivConstants.cs
+++ b/osu.Game/EzOsuGame/Background/Pixiv/PixivConstants.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.EzOsuGame.Background.Pixiv
+{
+    internal static class PixivConstants
+    {
+        public const string ClientId = "MOBrBDS8blbauo1uch9Z4AXbbf";
+        public const string ClientSecret = "ttIDt8NdJJMxTCWRMTtPArt";
+
+        public const string AuthTokenUrl = "https://oauth.secure.pixiv.net/auth/token";
+        public const string ApiBaseUrl = "https://app-api.pixiv.net";
+        public const string ImageReferer = "https://www.pixiv.net/";
+
+        public const string UserAgent = "PixivAndroidApp/5.0.234 (Android 11; Pixel 5)";
+        public const string AppOs = "android";
+        public const string AppOsVersion = "11";
+        public const string AppVersion = "5.0.234";
+    }
+}

--- a/osu.Game/EzOsuGame/Background/Pixiv/PixivFileNamer.cs
+++ b/osu.Game/EzOsuGame/Background/Pixiv/PixivFileNamer.cs
@@ -1,0 +1,84 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace osu.Game.EzOsuGame.Background.Pixiv
+{
+    public static class PixivFileNamer
+    {
+        private static readonly Regex invalid_chars = new Regex(@"[\\/:*?""<>|]", RegexOptions.Compiled);
+
+        public static string SanitizeAccount(string account)
+        {
+            if (string.IsNullOrWhiteSpace(account))
+                return "unknown";
+
+            string sanitized = invalid_chars.Replace(account.Trim(), "_");
+            return string.IsNullOrWhiteSpace(sanitized) ? "unknown" : sanitized;
+        }
+
+        public static string BuildFileName(string account, long illustId, int page, string extension = ".png")
+        {
+            if (!extension.StartsWith('.'))
+                extension = "." + extension;
+
+            return $"{SanitizeAccount(account)}_{illustId}_p{page}{extension}";
+        }
+
+        public static string BuildRelativePath(string account, long illustId, int page, string extension = ".png")
+            => Path.Combine(EzModifyPath.BG_PIXIV_PATH, BuildFileName(account, illustId, page, extension)).Replace('\\', '/');
+
+        public static bool TryParseFileName(string fileName, out string account, out long illustId, out int page)
+        {
+            account = string.Empty;
+            illustId = 0;
+            page = 0;
+
+            string name = Path.GetFileNameWithoutExtension(fileName);
+            if (string.IsNullOrEmpty(name))
+                return false;
+
+            int pageIndex = name.LastIndexOf("_p", StringComparison.Ordinal);
+            if (pageIndex < 0)
+                return false;
+
+            if (!int.TryParse(name.AsSpan(pageIndex + 2), out page))
+                return false;
+
+            string prefix = name.Substring(0, pageIndex);
+            int idIndex = prefix.LastIndexOf('_');
+            if (idIndex < 0)
+                return false;
+
+            if (!long.TryParse(prefix.AsSpan(idIndex + 1), out illustId))
+                return false;
+
+            account = prefix.Substring(0, idIndex);
+            return !string.IsNullOrEmpty(account);
+        }
+
+        public static bool IsSupportedImageExtension(string fileName)
+        {
+            string ext = Path.GetExtension(fileName);
+            return ext.Equals(".png", StringComparison.OrdinalIgnoreCase)
+                   || ext.Equals(".jpg", StringComparison.OrdinalIgnoreCase)
+                   || ext.Equals(".jpeg", StringComparison.OrdinalIgnoreCase)
+                   || ext.Equals(".webp", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static string GetExtensionFromUrl(string url)
+        {
+            if (string.IsNullOrEmpty(url))
+                return ".png";
+
+            string path = url.Split('?').First();
+            string ext = Path.GetExtension(path);
+
+            return string.IsNullOrEmpty(ext) ? ".png" : ext.ToLowerInvariant();
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Background/Pixiv/PixivIllustInfo.cs
+++ b/osu.Game/EzOsuGame/Background/Pixiv/PixivIllustInfo.cs
@@ -1,0 +1,22 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.EzOsuGame.Background.Pixiv
+{
+    public readonly struct PixivIllustInfo
+    {
+        public string Account { get; }
+        public long IllustId { get; }
+        public int Page { get; }
+        public string ImageUrl { get; }
+        public string AttributionLabel => $"{Account}_{IllustId}";
+
+        public PixivIllustInfo(string account, long illustId, int page, string imageUrl)
+        {
+            Account = account;
+            IllustId = illustId;
+            Page = page;
+            ImageUrl = imageUrl;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Background/Pixiv/PixivImageStore.cs
+++ b/osu.Game/EzOsuGame/Background/Pixiv/PixivImageStore.cs
@@ -1,0 +1,123 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using osu.Framework.Utils;
+
+namespace osu.Game.EzOsuGame.Background.Pixiv
+{
+    public class PixivImageStore
+    {
+        private readonly Storage storage;
+
+        public PixivImageStore(Storage storage)
+        {
+            this.storage = storage;
+        }
+
+        public bool TryGetRandomCachedIllust(out PixivIllustInfo illust, out string resourcePath)
+        {
+            illust = default;
+            resourcePath = string.Empty;
+
+            try
+            {
+                ensureCacheDirectory();
+
+                string[] files = storage.GetFiles(EzModifyPath.BG_PIXIV_PATH)
+                                        .Where(PixivFileNamer.IsSupportedImageExtension)
+                                        .ToArray();
+
+                if (files.Length == 0)
+                    return false;
+
+                string file = files[RNG.Next(files.Length)];
+                resourcePath = file.Replace('\\', '/');
+
+                if (!PixivFileNamer.TryParseFileName(Path.GetFileName(file), out string account, out long illustId, out int page))
+                    return false;
+
+                illust = new PixivIllustInfo(account, illustId, page, string.Empty);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"Failed to enumerate Pixiv cache: {ex.Message}", LoggingTarget.Network, LogLevel.Important);
+                return false;
+            }
+        }
+
+        public bool TryEnsureCached(PixivIllustInfo illust, out string resourcePath, out string? error)
+        {
+            resourcePath = PixivFileNamer.BuildRelativePath(
+                illust.Account,
+                illust.IllustId,
+                illust.Page,
+                PixivFileNamer.GetExtensionFromUrl(illust.ImageUrl));
+
+            if (storage.Exists(resourcePath))
+            {
+                error = null;
+                return true;
+            }
+
+            return tryDownload(illust, resourcePath, out error);
+        }
+
+        private bool tryDownload(PixivIllustInfo illust, string resourcePath, out string? error)
+        {
+            error = null;
+
+            try
+            {
+                ensureCacheDirectory();
+
+                using var request = new Framework.IO.Network.WebRequest(illust.ImageUrl)
+                {
+                    Method = HttpMethod.Get,
+                };
+
+                request.AddHeader("Referer", PixivConstants.ImageReferer);
+                request.AddHeader("User-Agent", PixivConstants.UserAgent);
+
+                request.Perform();
+
+                if (request.ResponseStatusCode != HttpStatusCode.OK)
+                {
+                    error = request.GetResponseString() ?? "Failed to download Pixiv image.";
+                    return false;
+                }
+
+                byte[] data = request.GetResponseData();
+
+                if (data.Length == 0)
+                {
+                    error = "Downloaded Pixiv image was empty.";
+                    return false;
+                }
+
+                using var stream = storage.CreateFileSafely(resourcePath);
+                stream.Write(data, 0, data.Length);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                error = ex.Message;
+                return false;
+            }
+        }
+
+        private void ensureCacheDirectory()
+        {
+            string fullPath = storage.GetFullPath(EzModifyPath.BG_PIXIV_PATH);
+            if (!Directory.Exists(fullPath))
+                Directory.CreateDirectory(fullPath);
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/EzModifyPath.cs
+++ b/osu.Game/EzOsuGame/EzModifyPath.cs
@@ -16,5 +16,11 @@ namespace osu.Game.EzOsuGame
 
         public const string VIDEO_PATH = @"EzResources/Video";
         public const string BG_PATH = @"EzResources/BG";
+        public const string BG_PIXIV_PATH = @"EzResources/BG_PIXIV";
+
+        /// <summary>
+        /// Pixiv OAuth refresh token (same directory as client.realm / framework.ini).
+        /// </summary>
+        public const string PIXIV_AUTH_FILE = @"pixiv_auth.json";
     }
 }

--- a/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
@@ -363,6 +363,37 @@ namespace osu.Game.EzOsuGame.Localization
 
         #endregion
 
+        #region Pixiv 背景
+
+        public static readonly EzLocalizationManager.EzLocalisableString PIXIV_REFRESH_TOKEN = new EzLocalizationManager.EzLocalisableString(
+            "Pixiv refresh token", "Pixiv refresh token");
+
+        public static readonly EzLocalizationManager.EzLocalisableString PIXIV_REFRESH_TOKEN_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "首次使用请运行仓库 tools/GetPixivRefreshToken.ps1 完成官方 OAuth，或在下方粘贴 refresh_token 后点保存。"
+            + "\n凭证仅写入数据目录 pixiv_auth.json（与 client.realm 同级），不写入 framework.ini。",
+            "Run tools/GetPixivRefreshToken.ps1 once for official OAuth, or paste a refresh_token below and save."
+            + "\nCredentials are stored only in pixiv_auth.json (osu data folder), not in framework.ini.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString PIXIV_SAVE_TOKEN = new EzLocalizationManager.EzLocalisableString("保存 Pixiv 凭证", "Save Pixiv credentials");
+        public static readonly EzLocalizationManager.EzLocalisableString PIXIV_SAVE_TOKEN_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "写入 pixiv_auth.json。", "Writes to pixiv_auth.json.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString PIXIV_VERIFY_TOKEN = new EzLocalizationManager.EzLocalisableString("验证 Pixiv 登录", "Verify Pixiv login");
+        public static readonly EzLocalizationManager.EzLocalisableString PIXIV_VERIFY_TOKEN_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "使用 refresh_token 换取 access_token 并显示 Pixiv 账号。", "Exchanges the refresh token and shows the Pixiv account name.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString PIXIV_CLEAR_TOKEN = new EzLocalizationManager.EzLocalisableString("清除 Pixiv 凭证", "Clear Pixiv credentials");
+        public static readonly EzLocalizationManager.EzLocalisableString PIXIV_CLEAR_TOKEN_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "删除 pixiv_auth.json。", "Deletes pixiv_auth.json.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString PIXIV_TOKEN_SAVED = new EzLocalizationManager.EzLocalisableString("Pixiv 凭证已保存。", "Pixiv credentials saved.");
+        public static readonly EzLocalizationManager.EzLocalisableString PIXIV_TOKEN_CLEARED = new EzLocalizationManager.EzLocalisableString("Pixiv 凭证已清除。", "Pixiv credentials cleared.");
+        public static readonly EzLocalizationManager.EzLocalisableString PIXIV_TOKEN_EMPTY = new EzLocalizationManager.EzLocalisableString("refresh_token 不能为空。", "refresh_token cannot be empty.");
+        public static readonly EzLocalizationManager.EzLocalisableString PIXIV_VERIFY_SUCCESS = new EzLocalizationManager.EzLocalisableString("Pixiv 登录成功：@{0}", "Pixiv login OK: @{0}");
+        public static readonly EzLocalizationManager.EzLocalisableString PIXIV_VERIFY_FAILED = new EzLocalizationManager.EzLocalisableString("Pixiv 登录验证失败。", "Pixiv login verification failed.");
+
+        #endregion
+
         #region 实验性功能
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_ACCOUNT = new EzLocalizationManager.EzLocalisableString(

--- a/osu.Game/EzOsuGame/Overlays/EzPixivBackgroundSettings.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzPixivBackgroundSettings.cs
@@ -1,0 +1,101 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Framework.Localisation;
+using osu.Game.EzOsuGame.Background.Pixiv;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Notifications;
+using osu.Game.Overlays.Settings;
+
+namespace osu.Game.EzOsuGame.Overlays
+{
+    public static partial class EzPixivBackgroundSettings
+    {
+        public static void AddTo(SettingsSubsection subsection, PixivBackgroundCoordinator coordinator, INotificationOverlay? notifications)
+        {
+            var tokenInput = new Bindable<string>(coordinator.Auth.LoadRefreshToken() ?? string.Empty);
+
+            var tokenTextBox = new FormTextBox
+            {
+                Caption = EzSettingsStrings.PIXIV_REFRESH_TOKEN,
+                HintText = EzSettingsStrings.PIXIV_REFRESH_TOKEN_TOOLTIP,
+                Current = tokenInput,
+            };
+
+            subsection.Add(new SettingsItemV2(tokenTextBox)
+            {
+                Keywords = new[] { "pixiv", "background", "refresh", "token", "oauth", "auth" }
+            });
+
+            var saveButton = new SettingsButton
+            {
+                Text = EzSettingsStrings.PIXIV_SAVE_TOKEN,
+                TooltipText = EzSettingsStrings.PIXIV_SAVE_TOKEN_TOOLTIP,
+                Keywords = new[] { "pixiv", "save", "token" },
+            };
+            saveButton.Action = () =>
+            {
+                string token = tokenInput.Value?.Trim() ?? string.Empty;
+
+                if (string.IsNullOrWhiteSpace(token))
+                {
+                    post(notifications, EzSettingsStrings.PIXIV_TOKEN_EMPTY);
+                    return;
+                }
+
+                coordinator.Auth.SaveRefreshToken(token);
+                post(notifications, EzSettingsStrings.PIXIV_TOKEN_SAVED);
+            };
+
+            var verifyButton = new SettingsButton
+            {
+                Text = EzSettingsStrings.PIXIV_VERIFY_TOKEN,
+                TooltipText = EzSettingsStrings.PIXIV_VERIFY_TOKEN_TOOLTIP,
+                Keywords = new[] { "pixiv", "verify", "token", "login" },
+            };
+            verifyButton.Action = () =>
+            {
+                string token = tokenInput.Value?.Trim() ?? string.Empty;
+
+                if (!string.IsNullOrWhiteSpace(token))
+                    coordinator.Auth.SaveRefreshToken(token);
+
+                if (!coordinator.Auth.TryRefreshAccessToken(out _, out string? error))
+                {
+                    post(notifications, error ?? EzSettingsStrings.PIXIV_VERIFY_FAILED);
+                    return;
+                }
+
+                if (coordinator.Api.TryGetUserAccount(out string? account, out error))
+                    post(notifications, EzSettingsStrings.PIXIV_VERIFY_SUCCESS.Format(account ?? "?"));
+                else
+                    post(notifications, error ?? EzSettingsStrings.PIXIV_VERIFY_FAILED);
+            };
+
+            var clearButton = new SettingsButton
+            {
+                Text = EzSettingsStrings.PIXIV_CLEAR_TOKEN,
+                TooltipText = EzSettingsStrings.PIXIV_CLEAR_TOKEN_TOOLTIP,
+                Keywords = new[] { "pixiv", "clear", "logout", "token" },
+            };
+            clearButton.Action = () =>
+            {
+                coordinator.Auth.ClearRefreshToken();
+                tokenInput.Value = string.Empty;
+                post(notifications, EzSettingsStrings.PIXIV_TOKEN_CLEARED);
+            };
+
+            subsection.Add(saveButton);
+            subsection.Add(verifyButton);
+            subsection.Add(clearButton);
+        }
+
+        private static void post(INotificationOverlay? notifications, LocalisableString text)
+        {
+            notifications?.Post(new SimpleNotification { Text = text });
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Overlays/EzUISettings.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzUISettings.cs
@@ -6,6 +6,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Database;
 using osu.Game.EzOsuGame.Analysis;
+using osu.Game.EzOsuGame.Background.Pixiv;
 using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.Localization;
 using osu.Game.Graphics.UserInterfaceV2;
@@ -21,11 +22,14 @@ namespace osu.Game.EzOsuGame.Overlays
         [BackgroundDependencyLoader]
         private void load(
             Ez2ConfigManager ezConfig,
+            PixivBackgroundCoordinator pixivBackgroundCoordinator,
             BackgroundDataStoreProcessor? backgroundDataStoreProcessor,
             EzAnalysisWarmupProcessor? analysisWarmupProcessor,
             IDialogOverlay? dialogOverlay,
             INotificationOverlay? notifications)
         {
+            EzPixivBackgroundSettings.AddTo(this, pixivBackgroundCoordinator, notifications);
+
             AddRange(new Drawable[]
             {
                 new SettingsItemV2(new FormCheckBox

--- a/osu.Game/Online/TrustedDomainOnlineStore.cs
+++ b/osu.Game/Online/TrustedDomainOnlineStore.cs
@@ -13,6 +13,9 @@ namespace osu.Game.Online
     {
         protected override string GetLookupUrl(string url)
         {
+            if (Uri.TryCreate(url, UriKind.Absolute, out Uri? uri) && isPixivTrustedHost(uri))
+                return url;
+
             ServerPreset customApiUrl = GlobalConfigStore.EzConfig.Get<ServerPreset>(Ez2Setting.ServerPreset);
 
             switch (customApiUrl)
@@ -21,7 +24,7 @@ namespace osu.Game.Online
                 case ServerPreset.Gu:
                     #if DEBUG
                     // 任何从服务器获取资源的事件都会引发这个日志输出
-                    if (!Uri.TryCreate(url, UriKind.Absolute, out Uri? uri1) || !uri1.Host.EndsWith(@".ppy.sh", StringComparison.OrdinalIgnoreCase))
+                    if (!Uri.TryCreate(url, UriKind.Absolute, out Uri? customUri) || !customUri.Host.EndsWith(@".ppy.sh", StringComparison.OrdinalIgnoreCase))
                     {
                         Logger.Log($@"[Ez2Lazer] Using Custom ApiUrl {url}", Ez2ConfigManager.LOGGER_NAME, LogLevel.Important);
                     }
@@ -30,14 +33,28 @@ namespace osu.Game.Online
                     return url;
 
                 default:
-                    if (!Uri.TryCreate(url, UriKind.Absolute, out Uri? uri) || !uri.Host.EndsWith(@".ppy.sh", StringComparison.OrdinalIgnoreCase))
+                    if (!Uri.TryCreate(url, UriKind.Absolute, out uri))
                     {
                         Logger.Log($@"Blocking resource lookup from external website: {url}", LoggingTarget.Network, LogLevel.Important);
                         return string.Empty;
                     }
 
-                    return url;
+                    if (uri.Host.EndsWith(@".ppy.sh", StringComparison.OrdinalIgnoreCase))
+                        return url;
+
+                    Logger.Log($@"Blocking resource lookup from external website: {url}", LoggingTarget.Network, LogLevel.Important);
+                    return string.Empty;
             }
+        }
+
+        private static bool isPixivTrustedHost(Uri uri)
+        {
+            string host = uri.Host;
+
+            return host.Equals(@"pixiv.net", StringComparison.OrdinalIgnoreCase)
+                   || host.EndsWith(@".pixiv.net", StringComparison.OrdinalIgnoreCase)
+                   || host.Equals(@"pximg.net", StringComparison.OrdinalIgnoreCase)
+                   || host.EndsWith(@".pximg.net", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -335,6 +335,7 @@ namespace osu.Game
             GlobalConfigStore.Config = LocalConfig;
             GlobalConfigStore.EzConfig = Ez2ConfigManager;
             dependencies.Cache(Ez2ConfigManager);
+            dependencies.Cache(new EzOsuGame.Background.Pixiv.PixivBackgroundCoordinator(Storage));
 
             bindFrameLimiter(Ez2ConfigManager, frameworkConfig);
             EzSkinInfo = new EzSkinInfo(Ez2ConfigManager);

--- a/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
@@ -23,6 +23,7 @@ using osu.Game.Configuration;
 using osu.Game.EzOsuGame;
 using osu.Game.Graphics.Backgrounds;
 using osu.Game.EzOsuGame.Background;
+using osu.Game.EzOsuGame.Background.Pixiv;
 using osu.Game.EzOsuGame.Localization;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
@@ -266,6 +267,12 @@ namespace osu.Game.Screens.Backgrounds
                     }
 
                     return new Background($@"Backgrounds/bg{RNG.Next(0, 5) % 5 + 1}");
+                }
+
+                case BackgroundSource.PixivFollow:
+                {
+                    ensureStorageTextureSource();
+                    return new PixivBackground();
                 }
             }
 

--- a/tools/GetPixivRefreshToken.ps1
+++ b/tools/GetPixivRefreshToken.ps1
@@ -1,0 +1,118 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    One-time Pixiv OAuth helper for Ez2Lazer. Writes refresh_token to pixiv_auth.json.
+
+.DESCRIPTION
+    Opens the official Pixiv login page in your system browser (PKCE).
+    After login, copy the "code" query parameter from the pixiv:// redirect URL
+    and paste it here. The script exchanges it for a refresh_token via Pixiv's
+    official oauth.secure.pixiv.net endpoint.
+
+.PARAMETER DataPath
+    osu data directory (same folder as client.realm). Defaults to %AppData%\osu.
+
+.EXAMPLE
+    .\GetPixivRefreshToken.ps1
+    .\GetPixivRefreshToken.ps1 -DataPath "D:\osu"
+#>
+[CmdletBinding()]
+param(
+    [string]$DataPath = (Join-Path $env:APPDATA 'osu')
+)
+
+$ErrorActionPreference = 'Stop'
+
+$clientId = 'MOBrBDS8blbauo1uch9Z4AXbbf'
+$clientSecret = 'ttIDt8NdJJMxTCWRMTtPArt'
+$redirectUri = 'https://app-api.pixiv.net/web/v1/users/auth/pixiv/callback'
+$tokenUrl = 'https://oauth.secure.pixiv.net/auth/token'
+$userAgent = 'PixivAndroidApp/5.0.234 (Android 11; Pixel 5)'
+
+function New-RandomUrlSafeString {
+    param([int]$ByteCount = 32)
+    $bytes = New-Object byte[] $ByteCount
+    [System.Security.Cryptography.RandomNumberGenerator]::Create().GetBytes($bytes)
+    [Convert]::ToBase64String($bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_')
+}
+
+function Get-Sha256Base64Url {
+    param([string]$Text)
+    $bytes = [System.Text.Encoding]::ASCII.GetBytes($Text)
+    $hash = [System.Security.Cryptography.SHA256]::Create().ComputeHash($bytes)
+    [Convert]::ToBase64String($hash).TrimEnd('=').Replace('+', '-').Replace('/', '_')
+}
+
+function Invoke-PixivTokenRequest {
+    param([hashtable]$Body)
+
+    $pairs = foreach ($key in $Body.Keys) {
+        '{0}={1}' -f [uri]::EscapeDataString($key), [uri]::EscapeDataString([string]$Body[$key])
+    }
+    $payload = $pairs -join '&'
+
+    return Invoke-RestMethod -Uri $tokenUrl -Method Post -ContentType 'application/x-www-form-urlencoded' `
+        -Headers @{ 'User-Agent' = $userAgent } -Body $payload
+}
+
+Write-Host 'Ez2Lazer Pixiv OAuth helper' -ForegroundColor Cyan
+Write-Host "Data path: $DataPath"
+Write-Host ''
+
+if (-not (Test-Path -LiteralPath $DataPath)) {
+    New-Item -ItemType Directory -Path $DataPath | Out-Null
+    Write-Host "Created data directory: $DataPath"
+}
+
+$codeVerifier = New-RandomUrlSafeString
+$codeChallenge = Get-Sha256Base64Url -Text $codeVerifier
+
+$loginUrl = 'https://app-api.pixiv.net/web/v1/login?code_challenge={0}&code_challenge_method=S256&client=pixiv-android' -f $codeChallenge
+
+Write-Host 'Step 1: Opening official Pixiv login page in your browser...' -ForegroundColor Yellow
+Start-Process $loginUrl
+
+Write-Host ''
+Write-Host 'Step 2: After login, the browser may show a blank page or fail to open pixiv://'
+Write-Host 'Copy the full redirect URL (or just the code= value) from the address bar.'
+Write-Host 'Example: pixiv://account/login?code=XXXXXXXX&via=login'
+Write-Host ''
+
+$rawInput = Read-Host 'Paste redirect URL or authorization code'
+if ([string]::IsNullOrWhiteSpace($rawInput)) {
+    throw 'No code provided.'
+}
+
+$code = $rawInput.Trim()
+if ($code -match '(?:\?|&)code=([^&]+)') {
+    $code = [uri]::UnescapeDataString($Matches[1])
+}
+
+Write-Host ''
+Write-Host 'Step 3: Exchanging code for refresh_token...' -ForegroundColor Yellow
+
+$response = Invoke-PixivTokenRequest -Body @{
+    client_id     = $clientId
+    client_secret = $clientSecret
+    grant_type    = 'authorization_code'
+    code          = $code
+    code_verifier = $codeVerifier
+    redirect_uri  = $redirectUri
+    include_policy = 'true'
+}
+
+if (-not $response.refresh_token) {
+    throw "Token response did not include refresh_token.`n$($response | ConvertTo-Json -Depth 4)"
+}
+
+$authFile = Join-Path $DataPath 'pixiv_auth.json'
+$json = @{ refresh_token = $response.refresh_token } | ConvertTo-Json
+Set-Content -LiteralPath $authFile -Value $json -Encoding UTF8
+
+Write-Host ''
+Write-Host "Success! Wrote: $authFile" -ForegroundColor Green
+if ($response.user) {
+    Write-Host ("Logged in as: @{0}" -f $response.user.account)
+}
+Write-Host ''
+Write-Host 'You can now select "Pixiv follow feed" as the menu background source in Ez2Lazer.'


### PR DESCRIPTION
## Summary

- Add **Pixiv follow feed** as a menu background source (BackgroundSource.PixivFollow), with images cached under EzResources/BG_PIXIV/ as {account}_{illustId}_p{page}.png.
- **TrustedDomainOnlineStore** always allows *.pixiv.net / *.pximg.net on every osu server preset (Official / Gu / Manual).
- OAuth uses a single credential file **pixiv_auth.json** in the osu data folder (same level as client.realm); settings UI can save/verify/clear it. Ships **	ools/GetPixivRefreshToken.ps1** for one-time official PKCE login.
- Menu background shows an attribution badge (ccount_illustId); click opens the artwork on Pixiv. R-18 works filtered by default.

## Test plan

- [ ] Run 	ools/GetPixivRefreshToken.ps1, confirm %AppData%/osu/pixiv_auth.json is created
- [ ] Settings → Ez UI → paste token / Verify shows Pixiv @account
- [ ] Settings → Main menu background → Pixiv follow feed; return to main menu shows cached or newly downloaded art
- [ ] Badge click opens pixiv.net/artworks/{id} in system browser
- [ ] Switch server preset (Official / Gu / Manual); Pixiv background still loads
- [ ] Without token, source falls back to built-in g* backgrounds

## Notes

P2 (auto-download every 3 min) and P3 (content/naming filters) are out of scope for this PR.

Made with [Cursor](https://cursor.com)