### PR TITLE
feat(pixiv): background auto-download every 3 minutes (P2)

### DIFF
--- a/osu.Game/EzOsuGame/Background/Pixiv/PixivApiClient.cs
+++ b/osu.Game/EzOsuGame/Background/Pixiv/PixivApiClient.cs
@@ -25,11 +25,39 @@ namespace osu.Game.EzOsuGame.Background.Pixiv
             illust = default;
             error = null;
 
+            if (!tryCollectFollowCandidates(out var candidates, out error))
+                return false;
+
+            illust = candidates[RNG.Next(candidates.Count)];
+            return true;
+        }
+
+        public bool TryGetUncachedFollowIllust(PixivImageStore images, out PixivIllustInfo illust, out string? error)
+        {
+            illust = default;
+            error = null;
+
+            if (!tryCollectFollowCandidates(out var candidates, out error))
+                return false;
+
+            var uncached = candidates.Where(c => !images.IsCached(c)).ToList();
+
+            if (uncached.Count == 0)
+                return false;
+
+            illust = uncached[RNG.Next(uncached.Count)];
+            return true;
+        }
+
+        private bool tryCollectFollowCandidates(out List<PixivIllustInfo> candidates, out string? error)
+        {
+            candidates = new List<PixivIllustInfo>();
+            error = null;
+
             if (!authService.TryRefreshAccessToken(out string? accessToken, out error))
                 return false;
 
-            var candidates = new List<PixivIllustInfo>();
-            string? nextUrl = $"{PixivConstants.ApiBaseUrl}/v1/illust/follow?restrict=public";
+            string? nextUrl = $"{PixivConstants.API_BASE_URL}/v1/illust/follow?restrict=public";
 
             for (int page = 0; page < 3 && nextUrl != null; page++)
             {
@@ -46,7 +74,6 @@ namespace osu.Game.EzOsuGame.Background.Pixiv
                 return false;
             }
 
-            illust = candidates[RNG.Next(candidates.Count)];
             return true;
         }
 
@@ -60,7 +87,7 @@ namespace osu.Game.EzOsuGame.Background.Pixiv
 
             try
             {
-                using var request = createApiRequest($"{PixivConstants.ApiBaseUrl}/v2/user/account", accessToken!);
+                using var request = createApiRequest($"{PixivConstants.API_BASE_URL}/v2/user/account", accessToken!);
                 request.Perform();
 
                 if (request.ResponseStatusCode != HttpStatusCode.OK)
@@ -174,8 +201,8 @@ namespace osu.Game.EzOsuGame.Background.Pixiv
 
             return tags.Any(t =>
             {
-                string? name = t["name"]?.ToString() ?? t.ToString();
-                return name != null && name.Contains("R-18", StringComparison.OrdinalIgnoreCase);
+                string name = t["name"]?.ToString() ?? t.ToString();
+                return name.Contains("R-18", StringComparison.OrdinalIgnoreCase);
             });
         }
 
@@ -187,10 +214,10 @@ namespace osu.Game.EzOsuGame.Background.Pixiv
             };
 
             request.AddHeader("Authorization", $"Bearer {accessToken}");
-            request.AddHeader("User-Agent", PixivConstants.UserAgent);
-            request.AddHeader("App-OS", PixivConstants.AppOs);
-            request.AddHeader("App-OS-Version", PixivConstants.AppOsVersion);
-            request.AddHeader("App-Version", PixivConstants.AppVersion);
+            request.AddHeader("User-Agent", PixivConstants.USER_AGENT);
+            request.AddHeader("App-OS", PixivConstants.APP_OS);
+            request.AddHeader("App-OS-Version", PixivConstants.APP_OS_VERSION);
+            request.AddHeader("App-Version", PixivConstants.APP_VERSION);
             request.AddHeader("Accept-Language", "zh-CN");
 
             return request;

--- a/osu.Game/EzOsuGame/Background/Pixiv/PixivAuthService.cs
+++ b/osu.Game/EzOsuGame/Background/Pixiv/PixivAuthService.cs
@@ -177,17 +177,17 @@ namespace osu.Game.EzOsuGame.Background.Pixiv
 
         private static Framework.IO.Network.WebRequest createTokenRequest(Dictionary<string, string> formData)
         {
-            var request = new Framework.IO.Network.WebRequest(PixivConstants.AuthTokenUrl)
+            var request = new Framework.IO.Network.WebRequest(PixivConstants.AUTH_TOKEN_URL)
             {
                 Method = HttpMethod.Post,
             };
 
-            request.AddHeader("User-Agent", PixivConstants.UserAgent);
-            request.AddHeader("App-OS", PixivConstants.AppOs);
-            request.AddHeader("App-OS-Version", PixivConstants.AppOsVersion);
-            request.AddHeader("App-Version", PixivConstants.AppVersion);
-            request.AddParameter("client_id", PixivConstants.ClientId);
-            request.AddParameter("client_secret", PixivConstants.ClientSecret);
+            request.AddHeader("User-Agent", PixivConstants.USER_AGENT);
+            request.AddHeader("App-OS", PixivConstants.APP_OS);
+            request.AddHeader("App-OS-Version", PixivConstants.APP_OS_VERSION);
+            request.AddHeader("App-Version", PixivConstants.APP_VERSION);
+            request.AddParameter("client_id", PixivConstants.CLIENT_ID);
+            request.AddParameter("client_secret", PixivConstants.CLIENT_SECRET);
 
             foreach (var pair in formData)
                 request.AddParameter(pair.Key, pair.Value);

--- a/osu.Game/EzOsuGame/Background/Pixiv/PixivAutoDownloadProcessor.cs
+++ b/osu.Game/EzOsuGame/Background/Pixiv/PixivAutoDownloadProcessor.cs
@@ -1,0 +1,111 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading.Tasks;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Development;
+using osu.Framework.Graphics;
+using osu.Framework.Threading;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Notifications;
+
+namespace osu.Game.EzOsuGame.Background.Pixiv
+{
+    /// <summary>
+    /// Periodically downloads one uncached illustration from the Pixiv follow feed into BG_PIXIV.
+    /// </summary>
+    public partial class PixivAutoDownloadProcessor : Component
+    {
+        [Resolved]
+        private PixivBackgroundCoordinator coordinator { get; set; } = null!;
+
+        [Resolved]
+        private Ez2ConfigManager ezConfig { get; set; } = null!;
+
+        [Resolved(CanBeNull = true)]
+        private INotificationOverlay? notifications { get; set; }
+
+        private IBindable<bool> autoDownloadEnabled = null!;
+        private ScheduledDelegate? scheduledDownload;
+        private bool downloadInFlight;
+        private bool authFailureNotified;
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            if (DebugUtils.IsNUnitRunning)
+                return;
+
+            autoDownloadEnabled = ezConfig.GetBindable<bool>(Ez2Setting.PixivAutoDownloadEnabled);
+            autoDownloadEnabled.BindValueChanged(e => updateSchedule(e.NewValue), true);
+        }
+
+        private void updateSchedule(bool enabled)
+        {
+            scheduledDownload?.Cancel();
+            scheduledDownload = null;
+            authFailureNotified = false;
+
+            if (!enabled || !coordinator.Auth.HasRefreshToken)
+                return;
+
+            scheduleNext(PixivConstants.AUTO_DOWNLOAD_INTERVAL_MS);
+        }
+
+        private void scheduleNext(double delay)
+        {
+            scheduledDownload = Scheduler.AddDelayed(() =>
+            {
+                if (!autoDownloadEnabled.Value)
+                    return;
+
+                runDownload();
+                scheduleNext(PixivConstants.AUTO_DOWNLOAD_INTERVAL_MS);
+            }, delay);
+        }
+
+        private void runDownload()
+        {
+            if (downloadInFlight)
+                return;
+
+            downloadInFlight = true;
+
+            Task.Run(() =>
+            {
+                try
+                {
+                    if (!coordinator.TryDownloadNextUncached(out string? error))
+                    {
+                        if (!string.IsNullOrWhiteSpace(error))
+                            Scheduler.Add(() => handleFailure(error));
+                    }
+                }
+                finally
+                {
+                    downloadInFlight = false;
+                }
+            });
+        }
+
+        private void handleFailure(string error)
+        {
+            coordinator.LogFailure("Auto download", error);
+
+            if (authFailureNotified)
+                return;
+
+            authFailureNotified = true;
+            ezConfig.SetValue(Ez2Setting.PixivAutoDownloadEnabled, false);
+
+            notifications?.Post(new SimpleNotification
+            {
+                Text = EzSettingsStrings.PIXIV_AUTO_DOWNLOAD_PAUSED.Format(error),
+            });
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Background/Pixiv/PixivBackgroundCoordinator.cs
+++ b/osu.Game/EzOsuGame/Background/Pixiv/PixivBackgroundCoordinator.cs
@@ -44,6 +44,22 @@ namespace osu.Game.EzOsuGame.Background.Pixiv
             return true;
         }
 
+        public bool TryDownloadNextUncached(out string? error)
+        {
+            error = null;
+
+            if (!Auth.HasRefreshToken)
+            {
+                error = "Pixiv refresh token is not configured.";
+                return false;
+            }
+
+            if (!Api.TryGetUncachedFollowIllust(Images, out PixivIllustInfo illust, out error))
+                return false;
+
+            return Images.TryEnsureCached(illust, out _, out error);
+        }
+
         public void LogFailure(string context, string? error)
         {
             if (string.IsNullOrWhiteSpace(error))

--- a/osu.Game/EzOsuGame/Background/Pixiv/PixivConstants.cs
+++ b/osu.Game/EzOsuGame/Background/Pixiv/PixivConstants.cs
@@ -5,16 +5,18 @@ namespace osu.Game.EzOsuGame.Background.Pixiv
 {
     internal static class PixivConstants
     {
-        public const string ClientId = "MOBrBDS8blbauo1uch9Z4AXbbf";
-        public const string ClientSecret = "ttIDt8NdJJMxTCWRMTtPArt";
+        public const string CLIENT_ID = "MOBrBDS8blbauo1uch9Z4AXbbf";
+        public const string CLIENT_SECRET = "ttIDt8NdJJMxTCWRMTtPArt";
 
-        public const string AuthTokenUrl = "https://oauth.secure.pixiv.net/auth/token";
-        public const string ApiBaseUrl = "https://app-api.pixiv.net";
-        public const string ImageReferer = "https://www.pixiv.net/";
+        public const string AUTH_TOKEN_URL = "https://oauth.secure.pixiv.net/auth/token";
+        public const string API_BASE_URL = "https://app-api.pixiv.net";
+        public const string IMAGE_REFERER = "https://www.pixiv.net/";
 
-        public const string UserAgent = "PixivAndroidApp/5.0.234 (Android 11; Pixel 5)";
-        public const string AppOs = "android";
-        public const string AppOsVersion = "11";
-        public const string AppVersion = "5.0.234";
+        public const string USER_AGENT = "PixivAndroidApp/5.0.234 (Android 11; Pixel 5)";
+        public const string APP_OS = "android";
+        public const string APP_OS_VERSION = "11";
+        public const string APP_VERSION = "5.0.234";
+
+        public const double AUTO_DOWNLOAD_INTERVAL_MS = 3 * 60 * 1000;
     }
 }

--- a/osu.Game/EzOsuGame/Background/Pixiv/PixivImageStore.cs
+++ b/osu.Game/EzOsuGame/Background/Pixiv/PixivImageStore.cs
@@ -9,6 +9,7 @@ using System.Net.Http;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Framework.Utils;
+using osu.Game.EzOsuGame;
 
 namespace osu.Game.EzOsuGame.Background.Pixiv
 {
@@ -53,6 +54,17 @@ namespace osu.Game.EzOsuGame.Background.Pixiv
             }
         }
 
+        public bool IsCached(PixivIllustInfo illust)
+        {
+            string resourcePath = PixivFileNamer.BuildRelativePath(
+                illust.Account,
+                illust.IllustId,
+                illust.Page,
+                PixivFileNamer.GetExtensionFromUrl(illust.ImageUrl));
+
+            return storage.Exists(resourcePath);
+        }
+
         public bool TryEnsureCached(PixivIllustInfo illust, out string resourcePath, out string? error)
         {
             resourcePath = PixivFileNamer.BuildRelativePath(
@@ -83,8 +95,8 @@ namespace osu.Game.EzOsuGame.Background.Pixiv
                     Method = HttpMethod.Get,
                 };
 
-                request.AddHeader("Referer", PixivConstants.ImageReferer);
-                request.AddHeader("User-Agent", PixivConstants.UserAgent);
+                request.AddHeader("Referer", PixivConstants.IMAGE_REFERER);
+                request.AddHeader("User-Agent", PixivConstants.USER_AGENT);
 
                 request.Perform();
 

--- a/osu.Game/EzOsuGame/Configuration/Ez2ConfigManager.cs
+++ b/osu.Game/EzOsuGame/Configuration/Ez2ConfigManager.cs
@@ -197,6 +197,7 @@ namespace osu.Game.EzOsuGame.Configuration
             SetDefault(Ez2Setting.ServerGuToken, string.Empty);
             SetDefault(Ez2Setting.ServerManualUsername, string.Empty);
             SetDefault(Ez2Setting.ServerManualToken, string.Empty);
+            SetDefault(Ez2Setting.PixivAutoDownloadEnabled, false);
 
             #endregion
 
@@ -879,6 +880,8 @@ namespace osu.Game.EzOsuGame.Configuration
         ServerGuToken,
         ServerManualUsername,
         ServerManualToken,
+
+        PixivAutoDownloadEnabled,
 
         // 实验性功能
         InputAudioLatencyTracker,

--- a/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
@@ -392,6 +392,18 @@ namespace osu.Game.EzOsuGame.Localization
         public static readonly EzLocalizationManager.EzLocalisableString PIXIV_VERIFY_SUCCESS = new EzLocalizationManager.EzLocalisableString("Pixiv 登录成功：@{0}", "Pixiv login OK: @{0}");
         public static readonly EzLocalizationManager.EzLocalisableString PIXIV_VERIFY_FAILED = new EzLocalizationManager.EzLocalisableString("Pixiv 登录验证失败。", "Pixiv login verification failed.");
 
+        public static readonly EzLocalizationManager.EzLocalisableString PIXIV_AUTO_DOWNLOAD_ENABLED = new EzLocalizationManager.EzLocalisableString(
+            "Pixiv 后台自动下载", "Pixiv background auto-download");
+
+        public static readonly EzLocalizationManager.EzLocalisableString PIXIV_AUTO_DOWNLOAD_ENABLED_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "开启后每 3 分钟从关注流下载 1 张尚未缓存的作品到 EzResources/BG_PIXIV。"
+            + "\n与菜单背景显示独立；凭证失效时自动暂停。",
+            "When enabled, downloads one uncached follow-feed illustration to EzResources/BG_PIXIV every 3 minutes."
+            + "\nIndependent from menu background display; pauses automatically if credentials fail.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString PIXIV_AUTO_DOWNLOAD_PAUSED = new EzLocalizationManager.EzLocalisableString(
+            "Pixiv 自动下载已暂停：{0}", "Pixiv auto-download paused: {0}");
+
         #endregion
 
         #region 实验性功能

--- a/osu.Game/EzOsuGame/Overlays/EzPixivBackgroundSettings.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzPixivBackgroundSettings.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Bindables;
 using osu.Framework.Localisation;
 using osu.Game.EzOsuGame.Background.Pixiv;
+using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.Localization;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Overlays;
@@ -14,7 +15,7 @@ namespace osu.Game.EzOsuGame.Overlays
 {
     public static partial class EzPixivBackgroundSettings
     {
-        public static void AddTo(SettingsSubsection subsection, PixivBackgroundCoordinator coordinator, INotificationOverlay? notifications)
+        public static void AddTo(SettingsSubsection subsection, Ez2ConfigManager ezConfig, PixivBackgroundCoordinator coordinator, INotificationOverlay? notifications)
         {
             var tokenInput = new Bindable<string>(coordinator.Auth.LoadRefreshToken() ?? string.Empty);
 
@@ -91,6 +92,16 @@ namespace osu.Game.EzOsuGame.Overlays
             subsection.Add(saveButton);
             subsection.Add(verifyButton);
             subsection.Add(clearButton);
+
+            subsection.Add(new SettingsItemV2(new FormCheckBox
+            {
+                Caption = EzSettingsStrings.PIXIV_AUTO_DOWNLOAD_ENABLED,
+                HintText = EzSettingsStrings.PIXIV_AUTO_DOWNLOAD_ENABLED_TOOLTIP,
+                Current = ezConfig.GetBindable<bool>(Ez2Setting.PixivAutoDownloadEnabled),
+            })
+            {
+                Keywords = new[] { "pixiv", "background", "download", "auto", "cache", "bg_pixiv" }
+            });
         }
 
         private static void post(INotificationOverlay? notifications, LocalisableString text)

--- a/osu.Game/EzOsuGame/Overlays/EzUISettings.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzUISettings.cs
@@ -28,7 +28,7 @@ namespace osu.Game.EzOsuGame.Overlays
             IDialogOverlay? dialogOverlay,
             INotificationOverlay? notifications)
         {
-            EzPixivBackgroundSettings.AddTo(this, pixivBackgroundCoordinator, notifications);
+            EzPixivBackgroundSettings.AddTo(this, ezConfig, pixivBackgroundCoordinator, notifications);
 
             AddRange(new Drawable[]
             {

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1265,6 +1265,7 @@ namespace osu.Game
 
             loadComponentSingleFile(new BackgroundDataStoreProcessor(), Add, true);
             loadComponentSingleFile(new EzAnalysisWarmupProcessor(), Add, true);
+            loadComponentSingleFile(new EzOsuGame.Background.Pixiv.PixivAutoDownloadProcessor(), Add, true);
             loadComponentSingleFile<BeatmapStore>(detachedBeatmapStore = new RealmDetachedBeatmapStore(), Add, true);
             loadComponentSingleFile(new QueueController(), Add, true);
 


### PR DESCRIPTION
## Summary

- Add **Pixiv 后台自动下载** toggle (Ez2Setting.PixivAutoDownloadEnabled) in Ez UI settings.
- New PixivAutoDownloadProcessor runs every **3 minutes** when enabled: fetches follow feed, picks one **uncached** work, writes to EzResources/BG_PIXIV/.
- Independent from menu background display; skips quietly if everything in the sampled feed is already cached.
- On credential/API failure: logs, **disables the toggle**, and posts a one-time notification.

## Test plan

- [ ] Configure pixiv_auth.json, enable auto-download in Ez UI settings
- [ ] Wait ~3 minutes (or temporarily lower interval in dev); confirm new file appears in BG_PIXIV
- [ ] With feed fully cached, verify no error notification spam
- [ ] Invalidate token → notification + toggle turns off
- [ ] Menu Pixiv background still works independently

## Scope

P3 (content/naming filters) not included.

Made with [Cursor](https://cursor.com)