### PR TITLE
feat(pixiv): content and save naming filters (P3)

### DIFF
--- a/osu.Game/EzOsuGame/Background/Pixiv/PixivApiClient.cs
+++ b/osu.Game/EzOsuGame/Background/Pixiv/PixivApiClient.cs
@@ -14,10 +14,12 @@ namespace osu.Game.EzOsuGame.Background.Pixiv
     public class PixivApiClient
     {
         private readonly PixivAuthService authService;
+        private readonly PixivFilterService filters;
 
-        public PixivApiClient(PixivAuthService authService)
+        public PixivApiClient(PixivAuthService authService, PixivFilterService filters)
         {
             this.authService = authService;
+            this.filters = filters;
         }
 
         public bool TryGetRandomFollowIllust(out PixivIllustInfo illust, out string? error)
@@ -134,7 +136,7 @@ namespace osu.Game.EzOsuGame.Background.Pixiv
                     if (!tryParseIllust(token, out PixivIllustInfo info))
                         continue;
 
-                    if (isRestricted(token))
+                    if (!filters.PassesContentFilter(info))
                         continue;
 
                     output.Add(info);
@@ -165,8 +167,23 @@ namespace osu.Game.EzOsuGame.Background.Pixiv
             if (string.IsNullOrWhiteSpace(imageUrl))
                 return false;
 
-            info = new PixivIllustInfo(account, illustId, page, imageUrl);
+            int sanityLevel = token["sanity_level"]?.Value<int>() ?? 0;
+            string[] tags = extractTags(token);
+
+            info = new PixivIllustInfo(account, illustId, page, imageUrl, sanityLevel, tags);
             return true;
+        }
+
+        private static string[] extractTags(JToken token)
+        {
+            if (token["tags"] is not JArray tagArray)
+                return Array.Empty<string>();
+
+            return tagArray
+                   .Select(t => t["name"]?.ToString())
+                   .Where(name => !string.IsNullOrWhiteSpace(name))
+                   .Distinct(StringComparer.OrdinalIgnoreCase)
+                   .ToArray()!;
         }
 
         private static string? getImageUrl(JToken token, int page)
@@ -187,23 +204,6 @@ namespace osu.Game.EzOsuGame.Background.Pixiv
 
             return pages[page]["image_urls"]?["large"]?.ToString()
                    ?? pages[page]["image_urls"]?["square_medium"]?.ToString();
-        }
-
-        private static bool isRestricted(JToken token)
-        {
-            int sanityLevel = token["sanity_level"]?.Value<int>() ?? 0;
-            if (sanityLevel >= 4)
-                return true;
-
-            var tags = token["tags"] as JArray;
-            if (tags == null)
-                return false;
-
-            return tags.Any(t =>
-            {
-                string name = t["name"]?.ToString() ?? t.ToString();
-                return name.Contains("R-18", StringComparison.OrdinalIgnoreCase);
-            });
         }
 
         private static Framework.IO.Network.WebRequest createApiRequest(string url, string accessToken)

--- a/osu.Game/EzOsuGame/Background/Pixiv/PixivBackgroundCoordinator.cs
+++ b/osu.Game/EzOsuGame/Background/Pixiv/PixivBackgroundCoordinator.cs
@@ -9,14 +9,18 @@ namespace osu.Game.EzOsuGame.Background.Pixiv
 {
     public class PixivBackgroundCoordinator
     {
+        private const int max_resolve_attempts = 5;
+
         public PixivAuthService Auth { get; }
         public PixivApiClient Api { get; }
         public PixivImageStore Images { get; }
+        public PixivFilterService Filters { get; }
 
-        public PixivBackgroundCoordinator(Storage storage)
+        public PixivBackgroundCoordinator(Storage storage, Ez2ConfigManager ezConfig)
         {
             Auth = new PixivAuthService(storage);
-            Api = new PixivApiClient(Auth);
+            Filters = new PixivFilterService(ezConfig);
+            Api = new PixivApiClient(Auth, Filters);
             Images = new PixivImageStore(storage);
         }
 
@@ -32,16 +36,26 @@ namespace osu.Game.EzOsuGame.Background.Pixiv
                 return false;
             }
 
-            if (Images.TryGetRandomCachedIllust(out illust, out resourcePath))
+            if (Images.TryGetRandomCachedIllust(Filters, out illust, out resourcePath))
                 return true;
 
-            if (!Api.TryGetRandomFollowIllust(out illust, out error))
-                return false;
+            for (int attempt = 0; attempt < max_resolve_attempts; attempt++)
+            {
+                if (!Api.TryGetRandomFollowIllust(out illust, out error))
+                    return false;
 
-            if (!Images.TryEnsureCached(illust, out resourcePath, out error))
-                return false;
+                if (!Filters.ShouldSaveToDisk(illust))
+                    continue;
 
-            return true;
+                if (Images.TryEnsureCached(illust, out resourcePath, out error))
+                    return true;
+
+                if (!string.IsNullOrWhiteSpace(error))
+                    return false;
+            }
+
+            error = "No Pixiv illustrations matched the current filter rules.";
+            return false;
         }
 
         public bool TryDownloadNextUncached(out string? error)
@@ -54,10 +68,18 @@ namespace osu.Game.EzOsuGame.Background.Pixiv
                 return false;
             }
 
-            if (!Api.TryGetUncachedFollowIllust(Images, out PixivIllustInfo illust, out error))
-                return false;
+            for (int attempt = 0; attempt < max_resolve_attempts; attempt++)
+            {
+                if (!Api.TryGetUncachedFollowIllust(Images, out PixivIllustInfo illust, out error))
+                    return false;
 
-            return Images.TryEnsureCached(illust, out _, out error);
+                if (!Filters.ShouldSaveToDisk(illust))
+                    continue;
+
+                return Images.TryEnsureCached(illust, out _, out error);
+            }
+
+            return false;
         }
 
         public void LogFailure(string context, string? error)

--- a/osu.Game/EzOsuGame/Background/Pixiv/PixivFileNamer.cs
+++ b/osu.Game/EzOsuGame/Background/Pixiv/PixivFileNamer.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using osu.Game.EzOsuGame;
 
 namespace osu.Game.EzOsuGame.Background.Pixiv
 {

--- a/osu.Game/EzOsuGame/Background/Pixiv/PixivFilterListParser.cs
+++ b/osu.Game/EzOsuGame/Background/Pixiv/PixivFilterListParser.cs
@@ -1,0 +1,18 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Game.EzOsuGame.Background.Pixiv
+{
+    internal static class PixivFilterListParser
+    {
+        public static string[] Parse(string? raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+                return Array.Empty<string>();
+
+            return raw.Split(new[] { '\r', '\n', ',', ';' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Background/Pixiv/PixivFilterService.cs
+++ b/osu.Game/EzOsuGame/Background/Pixiv/PixivFilterService.cs
@@ -1,0 +1,95 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Game.EzOsuGame.Configuration;
+
+namespace osu.Game.EzOsuGame.Background.Pixiv
+{
+    public class PixivFilterService
+    {
+        private readonly Ez2ConfigManager config;
+
+        public PixivFilterService(Ez2ConfigManager config)
+        {
+            this.config = config;
+        }
+
+        public bool PassesContentFilter(PixivIllustInfo illust)
+        {
+            if (!passesAccountRules(illust.Account))
+                return false;
+
+            if (!passesTagRules(illust.Tags))
+                return false;
+
+            if (!passesR18Rules(illust.SanityLevel, illust.Tags))
+                return false;
+
+            return true;
+        }
+
+        public bool AllowsCachedAccount(string account) => passesAccountRules(account);
+
+        public bool ShouldSaveToDisk(PixivIllustInfo illust)
+        {
+            foreach (string prefix in PixivFilterListParser.Parse(config.Get<string>(Ez2Setting.PixivSkipSaveAccountPrefixes)))
+            {
+                if (illust.Account.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                    return false;
+            }
+
+            string[] skipTags = PixivFilterListParser.Parse(config.Get<string>(Ez2Setting.PixivSkipSaveTags));
+
+            if (skipTags.Length > 0 && illust.Tags.Any(tag => containsEntry(skipTags, tag)))
+                return false;
+
+            return true;
+        }
+
+        private bool passesAccountRules(string account)
+        {
+            string[] whitelist = PixivFilterListParser.Parse(config.Get<string>(Ez2Setting.PixivAccountWhitelist));
+
+            if (whitelist.Length > 0 && !whitelist.Any(entry => string.Equals(entry, account, StringComparison.OrdinalIgnoreCase)))
+                return false;
+
+            string[] blacklist = PixivFilterListParser.Parse(config.Get<string>(Ez2Setting.PixivAccountBlacklist));
+
+            if (blacklist.Any(entry => string.Equals(entry, account, StringComparison.OrdinalIgnoreCase)))
+                return false;
+
+            return true;
+        }
+
+        private bool passesTagRules(string[] tags)
+        {
+            string[] includeTags = PixivFilterListParser.Parse(config.Get<string>(Ez2Setting.PixivTagInclude));
+
+            if (includeTags.Length > 0 && !tags.Any(tag => containsEntry(includeTags, tag)))
+                return false;
+
+            string[] excludeTags = PixivFilterListParser.Parse(config.Get<string>(Ez2Setting.PixivTagExclude));
+
+            if (excludeTags.Length > 0 && tags.Any(tag => containsEntry(excludeTags, tag)))
+                return false;
+
+            return true;
+        }
+
+        private bool passesR18Rules(int sanityLevel, string[] tags)
+        {
+            if (config.Get<bool>(Ez2Setting.PixivAllowR18))
+                return true;
+
+            if (sanityLevel >= 4)
+                return false;
+
+            return !tags.Any(tag => tag.Contains("R-18", StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static bool containsEntry(string[] entries, string value)
+            => entries.Any(entry => string.Equals(entry, value, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/osu.Game/EzOsuGame/Background/Pixiv/PixivIllustInfo.cs
+++ b/osu.Game/EzOsuGame/Background/Pixiv/PixivIllustInfo.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+
 namespace osu.Game.EzOsuGame.Background.Pixiv
 {
     public readonly struct PixivIllustInfo
@@ -9,14 +11,18 @@ namespace osu.Game.EzOsuGame.Background.Pixiv
         public long IllustId { get; }
         public int Page { get; }
         public string ImageUrl { get; }
+        public int SanityLevel { get; }
+        public string[] Tags { get; }
         public string AttributionLabel => $"{Account}_{IllustId}";
 
-        public PixivIllustInfo(string account, long illustId, int page, string imageUrl)
+        public PixivIllustInfo(string account, long illustId, int page, string imageUrl, int sanityLevel = 0, string[]? tags = null)
         {
             Account = account;
             IllustId = illustId;
             Page = page;
             ImageUrl = imageUrl;
+            SanityLevel = sanityLevel;
+            Tags = tags ?? Array.Empty<string>();
         }
     }
 }

--- a/osu.Game/EzOsuGame/Background/Pixiv/PixivImageStore.cs
+++ b/osu.Game/EzOsuGame/Background/Pixiv/PixivImageStore.cs
@@ -15,6 +15,8 @@ namespace osu.Game.EzOsuGame.Background.Pixiv
 {
     public class PixivImageStore
     {
+        private const int max_cached_pick_attempts = 32;
+
         private readonly Storage storage;
 
         public PixivImageStore(Storage storage)
@@ -22,7 +24,7 @@ namespace osu.Game.EzOsuGame.Background.Pixiv
             this.storage = storage;
         }
 
-        public bool TryGetRandomCachedIllust(out PixivIllustInfo illust, out string resourcePath)
+        public bool TryGetRandomCachedIllust(PixivFilterService filters, out PixivIllustInfo illust, out string resourcePath)
         {
             illust = default;
             resourcePath = string.Empty;
@@ -38,14 +40,24 @@ namespace osu.Game.EzOsuGame.Background.Pixiv
                 if (files.Length == 0)
                     return false;
 
-                string file = files[RNG.Next(files.Length)];
-                resourcePath = file.Replace('\\', '/');
+                int attempts = Math.Min(files.Length, max_cached_pick_attempts);
 
-                if (!PixivFileNamer.TryParseFileName(Path.GetFileName(file), out string account, out long illustId, out int page))
-                    return false;
+                for (int i = 0; i < attempts; i++)
+                {
+                    string file = files[RNG.Next(files.Length)];
 
-                illust = new PixivIllustInfo(account, illustId, page, string.Empty);
-                return true;
+                    if (!PixivFileNamer.TryParseFileName(Path.GetFileName(file), out string account, out long illustId, out int page))
+                        continue;
+
+                    if (!filters.AllowsCachedAccount(account))
+                        continue;
+
+                    resourcePath = file.Replace('\\', '/');
+                    illust = new PixivIllustInfo(account, illustId, page, string.Empty);
+                    return true;
+                }
+
+                return false;
             }
             catch (Exception ex)
             {

--- a/osu.Game/EzOsuGame/Configuration/Ez2ConfigManager.cs
+++ b/osu.Game/EzOsuGame/Configuration/Ez2ConfigManager.cs
@@ -197,6 +197,13 @@ namespace osu.Game.EzOsuGame.Configuration
             SetDefault(Ez2Setting.ServerGuToken, string.Empty);
             SetDefault(Ez2Setting.ServerManualUsername, string.Empty);
             SetDefault(Ez2Setting.ServerManualToken, string.Empty);
+            SetDefault(Ez2Setting.PixivAllowR18, false);
+            SetDefault(Ez2Setting.PixivAccountWhitelist, string.Empty);
+            SetDefault(Ez2Setting.PixivAccountBlacklist, string.Empty);
+            SetDefault(Ez2Setting.PixivTagInclude, string.Empty);
+            SetDefault(Ez2Setting.PixivTagExclude, string.Empty);
+            SetDefault(Ez2Setting.PixivSkipSaveAccountPrefixes, string.Empty);
+            SetDefault(Ez2Setting.PixivSkipSaveTags, string.Empty);
             SetDefault(Ez2Setting.PixivAutoDownloadEnabled, false);
 
             #endregion
@@ -881,6 +888,13 @@ namespace osu.Game.EzOsuGame.Configuration
         ServerManualUsername,
         ServerManualToken,
 
+        PixivAllowR18,
+        PixivAccountWhitelist,
+        PixivAccountBlacklist,
+        PixivTagInclude,
+        PixivTagExclude,
+        PixivSkipSaveAccountPrefixes,
+        PixivSkipSaveTags,
         PixivAutoDownloadEnabled,
 
         // 实验性功能

--- a/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
@@ -404,6 +404,55 @@ namespace osu.Game.EzOsuGame.Localization
         public static readonly EzLocalizationManager.EzLocalisableString PIXIV_AUTO_DOWNLOAD_PAUSED = new EzLocalizationManager.EzLocalisableString(
             "Pixiv 自动下载已暂停：{0}", "Pixiv auto-download paused: {0}");
 
+        public static readonly EzLocalizationManager.EzLocalisableString PIXIV_ALLOW_R18 = new EzLocalizationManager.EzLocalisableString(
+            "允许 R-18 作品", "Allow R-18 works");
+
+        public static readonly EzLocalizationManager.EzLocalisableString PIXIV_ALLOW_R18_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "关闭时过滤 sanity_level ≥ 4 或含 R-18 标签的作品（下载与关注流候选）。",
+            "When disabled, filters works with sanity_level ≥ 4 or R-18 tags from follow-feed candidates.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString PIXIV_ACCOUNT_WHITELIST = new EzLocalizationManager.EzLocalisableString(
+            "画师 account 白名单", "Artist account whitelist");
+
+        public static readonly EzLocalizationManager.EzLocalisableString PIXIV_ACCOUNT_WHITELIST_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "非空时仅允许列表中的 @ 句柄；每行一项，也可用逗号分隔。",
+            "When non-empty, only listed @ handles are allowed. One entry per line, or comma-separated.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString PIXIV_ACCOUNT_BLACKLIST = new EzLocalizationManager.EzLocalisableString(
+            "画师 account 黑名单", "Artist account blacklist");
+
+        public static readonly EzLocalizationManager.EzLocalisableString PIXIV_ACCOUNT_BLACKLIST_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "命中则跳过；每行一项，也可用逗号分隔。",
+            "Matching accounts are skipped. One entry per line, or comma-separated.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString PIXIV_TAG_INCLUDE = new EzLocalizationManager.EzLocalisableString(
+            "标签包含（任一）", "Tag include (any)");
+
+        public static readonly EzLocalizationManager.EzLocalisableString PIXIV_TAG_INCLUDE_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "非空时作品须至少包含其中一个标签（不区分大小写）。",
+            "When non-empty, works must include at least one listed tag (case-insensitive).");
+
+        public static readonly EzLocalizationManager.EzLocalisableString PIXIV_TAG_EXCLUDE = new EzLocalizationManager.EzLocalisableString(
+            "标签排除", "Tag exclude");
+
+        public static readonly EzLocalizationManager.EzLocalisableString PIXIV_TAG_EXCLUDE_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "命中任一标签则跳过；每行一项，也可用逗号分隔。",
+            "Works with any listed tag are skipped. One entry per line, or comma-separated.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString PIXIV_SKIP_SAVE_ACCOUNT_PREFIXES = new EzLocalizationManager.EzLocalisableString(
+            "落盘跳过：account 前缀", "Skip save: account prefixes");
+
+        public static readonly EzLocalizationManager.EzLocalisableString PIXIV_SKIP_SAVE_ACCOUNT_PREFIXES_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "画师 @ 句柄以这些前缀开头时不写入 BG_PIXIV；每行一项。",
+            "Do not write to BG_PIXIV when the artist @ handle starts with any prefix. One per line.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString PIXIV_SKIP_SAVE_TAGS = new EzLocalizationManager.EzLocalisableString(
+            "落盘跳过：标签", "Skip save: tags");
+
+        public static readonly EzLocalizationManager.EzLocalisableString PIXIV_SKIP_SAVE_TAGS_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "作品含任一标签时不写入 BG_PIXIV；每行一项，也可用逗号分隔。",
+            "Do not write to BG_PIXIV when the work has any listed tag. One per line, or comma-separated.");
+
         #endregion
 
         #region 实验性功能

--- a/osu.Game/EzOsuGame/Overlays/EzPixivBackgroundSettings.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzPixivBackgroundSettings.cs
@@ -102,6 +102,53 @@ namespace osu.Game.EzOsuGame.Overlays
             {
                 Keywords = new[] { "pixiv", "background", "download", "auto", "cache", "bg_pixiv" }
             });
+
+            subsection.Add(new SettingsItemV2(new FormCheckBox
+            {
+                Caption = EzSettingsStrings.PIXIV_ALLOW_R18,
+                HintText = EzSettingsStrings.PIXIV_ALLOW_R18_TOOLTIP,
+                Current = ezConfig.GetBindable<bool>(Ez2Setting.PixivAllowR18),
+            })
+            {
+                Keywords = new[] { "pixiv", "r-18", "r18", "nsfw", "filter" }
+            });
+
+            addListSetting(subsection, ezConfig, Ez2Setting.PixivAccountWhitelist, EzSettingsStrings.PIXIV_ACCOUNT_WHITELIST, EzSettingsStrings.PIXIV_ACCOUNT_WHITELIST_TOOLTIP,
+                new[] { "pixiv", "whitelist", "account", "artist", "filter" });
+
+            addListSetting(subsection, ezConfig, Ez2Setting.PixivAccountBlacklist, EzSettingsStrings.PIXIV_ACCOUNT_BLACKLIST, EzSettingsStrings.PIXIV_ACCOUNT_BLACKLIST_TOOLTIP,
+                new[] { "pixiv", "blacklist", "account", "artist", "filter" });
+
+            addListSetting(subsection, ezConfig, Ez2Setting.PixivTagInclude, EzSettingsStrings.PIXIV_TAG_INCLUDE, EzSettingsStrings.PIXIV_TAG_INCLUDE_TOOLTIP,
+                new[] { "pixiv", "tag", "include", "filter" });
+
+            addListSetting(subsection, ezConfig, Ez2Setting.PixivTagExclude, EzSettingsStrings.PIXIV_TAG_EXCLUDE, EzSettingsStrings.PIXIV_TAG_EXCLUDE_TOOLTIP,
+                new[] { "pixiv", "tag", "exclude", "filter" });
+
+            addListSetting(subsection, ezConfig, Ez2Setting.PixivSkipSaveAccountPrefixes, EzSettingsStrings.PIXIV_SKIP_SAVE_ACCOUNT_PREFIXES,
+                EzSettingsStrings.PIXIV_SKIP_SAVE_ACCOUNT_PREFIXES_TOOLTIP, new[] { "pixiv", "save", "prefix", "account", "naming" });
+
+            addListSetting(subsection, ezConfig, Ez2Setting.PixivSkipSaveTags, EzSettingsStrings.PIXIV_SKIP_SAVE_TAGS, EzSettingsStrings.PIXIV_SKIP_SAVE_TAGS_TOOLTIP,
+                new[] { "pixiv", "save", "tag", "naming" });
+        }
+
+        private static void addListSetting(
+            SettingsSubsection subsection,
+            Ez2ConfigManager ezConfig,
+            Ez2Setting setting,
+            EzLocalizationManager.EzLocalisableString caption,
+            EzLocalizationManager.EzLocalisableString hint,
+            string[] keywords)
+        {
+            subsection.Add(new SettingsItemV2(new FormTextBox
+            {
+                Caption = caption,
+                HintText = hint,
+                Current = ezConfig.GetBindable<string>(setting),
+            })
+            {
+                Keywords = keywords
+            });
         }
 
         private static void post(INotificationOverlay? notifications, LocalisableString text)

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -335,7 +335,7 @@ namespace osu.Game
             GlobalConfigStore.Config = LocalConfig;
             GlobalConfigStore.EzConfig = Ez2ConfigManager;
             dependencies.Cache(Ez2ConfigManager);
-            dependencies.Cache(new EzOsuGame.Background.Pixiv.PixivBackgroundCoordinator(Storage));
+            dependencies.Cache(new EzOsuGame.Background.Pixiv.PixivBackgroundCoordinator(Storage, Ez2ConfigManager));
 
             bindFrameLimiter(Ez2ConfigManager, frameworkConfig);
             EzSkinInfo = new EzSkinInfo(Ez2ConfigManager);


### PR DESCRIPTION
## Summary

- **Content filters** (follow-feed candidates + cached account pick): R-18 toggle, account whitelist/blacklist, tag include/exclude.
- **Save naming filters** (before writing BG_PIXIV): skip when account matches a prefix list, or when work has a listed tag.
- New \PixivFilterService\ wired through API client, image store, and coordinator retry logic.

## Settings (Ez UI → Pixiv)

| Setting | Effect |
|---------|--------|
| 允许 R-18 | Off = same default as P0 (sanity ≥ 4 or R-18 tag) |
| account 白/黑名单 | Exact @ handle match; whitelist empty = allow all |
| 标签包含/排除 | Exact tag name, case-insensitive |
| 落盘跳过前缀/标签 | Skip download only; does not delete existing files |

Lists accept **newline, comma, or semicolon** separators.

## Test plan

- [ ] Whitelist only artist A → background/auto-download only shows/downloads A
- [ ] Blacklist artist B → B never appears from feed; cached B not picked for background
- [ ] Tag exclude \R-18G\ → matching works skipped from feed
- [ ] Skip-save prefix → work still can show if already cached, but new downloads skipped
- [ ] Allow R-18 on → previously filtered works can appear

## Depends on

- #61 (P0), #62 (P2) — already on master.

Made with [Cursor](https://cursor.com)