### PR TITLE
feat(pixiv): @ suffix normalization and illust quality filters

### DIFF
--- a/osu.Game/EzOsuGame/Background/Pixiv/PixivAccountNormalizer.cs
+++ b/osu.Game/EzOsuGame/Background/Pixiv/PixivAccountNormalizer.cs
@@ -1,0 +1,25 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.EzOsuGame.Background.Pixiv
+{
+    public static class PixivAccountNormalizer
+    {
+        /// <summary>
+        /// Strips promotional @ suffixes from Pixiv handles (e.g. "Anmi@画集発売中" → "Anmi").
+        /// </summary>
+        public static string Normalize(string? raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+                return string.Empty;
+
+            string trimmed = raw.Trim();
+            int atIndex = trimmed.IndexOf('@');
+
+            if (atIndex >= 0)
+                trimmed = trimmed.Substring(0, atIndex);
+
+            return trimmed.Trim();
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Background/Pixiv/PixivApiClient.cs
+++ b/osu.Game/EzOsuGame/Background/Pixiv/PixivApiClient.cs
@@ -155,23 +155,79 @@ namespace osu.Game.EzOsuGame.Background.Pixiv
         {
             info = default;
 
-            string? account = token["user"]?["account"]?.ToString();
+            string? rawAccount = token["user"]?["account"]?.ToString();
+
+            if (string.IsNullOrWhiteSpace(rawAccount))
+                rawAccount = token["user"]?["name"]?.ToString();
+
+            string account = PixivAccountNormalizer.Normalize(rawAccount);
             long illustId = token["id"]?.Value<long>() ?? 0;
+
             if (string.IsNullOrWhiteSpace(account) || illustId <= 0)
                 return false;
 
-            int pageCount = token["page_count"]?.Value<int>() ?? 1;
-            int page = pageCount <= 1 ? 0 : RNG.Next(0, pageCount);
+            int page = selectLandscapePage(token, out int width, out int height);
+
+            if (page < 0)
+                return false;
 
             string? imageUrl = getImageUrl(token, page);
+
             if (string.IsNullOrWhiteSpace(imageUrl))
                 return false;
 
             int sanityLevel = token["sanity_level"]?.Value<int>() ?? 0;
             string[] tags = extractTags(token);
+            string illustType = token["type"]?.ToString() ?? "illust";
+            int illustAiType = token["illust_ai_type"]?.Value<int>() ?? 0;
 
-            info = new PixivIllustInfo(account, illustId, page, imageUrl, sanityLevel, tags);
+            info = new PixivIllustInfo(account, illustId, page, imageUrl, sanityLevel, tags, illustType, width, height, illustAiType);
             return true;
+        }
+
+        private static int selectLandscapePage(JToken token, out int width, out int height)
+        {
+            width = 0;
+            height = 0;
+
+            int pageCount = token["page_count"]?.Value<int>() ?? 1;
+            var landscapePages = new List<int>();
+
+            for (int page = 0; page < pageCount; page++)
+            {
+                (int pageWidth, int pageHeight) = getPageDimensions(token, page);
+
+                if (pageWidth > pageHeight)
+                    landscapePages.Add(page);
+            }
+
+            if (landscapePages.Count == 0)
+                return -1;
+
+            int selectedPage = landscapePages[RNG.Next(landscapePages.Count)];
+            (width, height) = getPageDimensions(token, selectedPage);
+            return selectedPage;
+        }
+
+        private static (int width, int height) getPageDimensions(JToken token, int page)
+        {
+            if (page == 0)
+            {
+                return (
+                    token["width"]?.Value<int>() ?? 0,
+                    token["height"]?.Value<int>() ?? 0);
+            }
+
+            var pages = token["meta_pages"] as JArray;
+
+            if (pages == null || page >= pages.Count)
+                return (0, 0);
+
+            JToken pageToken = pages[page];
+
+            return (
+                pageToken["width"]?.Value<int>() ?? token["width"]?.Value<int>() ?? 0,
+                pageToken["height"]?.Value<int>() ?? token["height"]?.Value<int>() ?? 0);
         }
 
         private static string[] extractTags(JToken token)

--- a/osu.Game/EzOsuGame/Background/Pixiv/PixivAuthService.cs
+++ b/osu.Game/EzOsuGame/Background/Pixiv/PixivAuthService.cs
@@ -9,7 +9,6 @@ using System.Net.Http;
 using Newtonsoft.Json.Linq;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
-using osu.Game.EzOsuGame;
 
 namespace osu.Game.EzOsuGame.Background.Pixiv
 {

--- a/osu.Game/EzOsuGame/Background/Pixiv/PixivConstants.cs
+++ b/osu.Game/EzOsuGame/Background/Pixiv/PixivConstants.cs
@@ -18,5 +18,24 @@ namespace osu.Game.EzOsuGame.Background.Pixiv
         public const string APP_VERSION = "5.0.234";
 
         public const double AUTO_DOWNLOAD_INTERVAL_MS = 3 * 60 * 1000;
+
+        /// <summary>
+        /// Pixiv API: 1 = AI-generated work.
+        /// </summary>
+        public const int ILLUST_AI_TYPE_AI = 1;
+
+        public static readonly string[] AI_GENERATED_TAG_PATTERNS =
+        {
+            "AI生成",
+            "AI Generated",
+            "Stable Diffusion",
+            "StableDiffusion",
+            "novelAI",
+            "NovelAI",
+            "Midjourney",
+            "DALL·E",
+            "DALL-E",
+            "生成AI",
+        };
     }
 }

--- a/osu.Game/EzOsuGame/Background/Pixiv/PixivFileNamer.cs
+++ b/osu.Game/EzOsuGame/Background/Pixiv/PixivFileNamer.cs
@@ -5,7 +5,6 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
-using osu.Game.EzOsuGame;
 
 namespace osu.Game.EzOsuGame.Background.Pixiv
 {
@@ -15,10 +14,12 @@ namespace osu.Game.EzOsuGame.Background.Pixiv
 
         public static string SanitizeAccount(string account)
         {
+            account = PixivAccountNormalizer.Normalize(account);
+
             if (string.IsNullOrWhiteSpace(account))
                 return "unknown";
 
-            string sanitized = invalid_chars.Replace(account.Trim(), "_");
+            string sanitized = invalid_chars.Replace(account, "_");
             return string.IsNullOrWhiteSpace(sanitized) ? "unknown" : sanitized;
         }
 

--- a/osu.Game/EzOsuGame/Background/Pixiv/PixivFilterService.cs
+++ b/osu.Game/EzOsuGame/Background/Pixiv/PixivFilterService.cs
@@ -27,10 +27,13 @@ namespace osu.Game.EzOsuGame.Background.Pixiv
             if (!passesR18Rules(illust.SanityLevel, illust.Tags))
                 return false;
 
+            if (!passesIllustQualityRules(illust))
+                return false;
+
             return true;
         }
 
-        public bool AllowsCachedAccount(string account) => passesAccountRules(account);
+        public bool AllowsCachedAccount(string account) => passesAccountRules(PixivAccountNormalizer.Normalize(account));
 
         public bool ShouldSaveToDisk(PixivIllustInfo illust)
         {
@@ -50,17 +53,53 @@ namespace osu.Game.EzOsuGame.Background.Pixiv
 
         private bool passesAccountRules(string account)
         {
+            account = PixivAccountNormalizer.Normalize(account);
+
+            if (string.IsNullOrEmpty(account))
+                return false;
+
             string[] whitelist = PixivFilterListParser.Parse(config.Get<string>(Ez2Setting.PixivAccountWhitelist));
 
-            if (whitelist.Length > 0 && !whitelist.Any(entry => string.Equals(entry, account, StringComparison.OrdinalIgnoreCase)))
+            if (whitelist.Length > 0 && !whitelist.Any(entry => string.Equals(PixivAccountNormalizer.Normalize(entry), account, StringComparison.OrdinalIgnoreCase)))
                 return false;
 
             string[] blacklist = PixivFilterListParser.Parse(config.Get<string>(Ez2Setting.PixivAccountBlacklist));
 
-            if (blacklist.Any(entry => string.Equals(entry, account, StringComparison.OrdinalIgnoreCase)))
+            if (blacklist.Any(entry => string.Equals(PixivAccountNormalizer.Normalize(entry), account, StringComparison.OrdinalIgnoreCase)))
                 return false;
 
             return true;
+        }
+
+        private static bool passesIllustQualityRules(PixivIllustInfo illust)
+        {
+            if (!string.Equals(illust.IllustType, "illust", StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            if (illust.Width <= illust.Height)
+                return false;
+
+            if (illust.IllustAiType == PixivConstants.ILLUST_AI_TYPE_AI)
+                return false;
+
+            return !isAiTagged(illust.Tags);
+        }
+
+        private static bool isAiTagged(string[] tags)
+        {
+            foreach (string tag in tags)
+            {
+                if (string.Equals(tag, "AI", StringComparison.OrdinalIgnoreCase))
+                    return true;
+
+                foreach (string pattern in PixivConstants.AI_GENERATED_TAG_PATTERNS)
+                {
+                    if (tag.Contains(pattern, StringComparison.OrdinalIgnoreCase))
+                        return true;
+                }
+            }
+
+            return false;
         }
 
         private bool passesTagRules(string[] tags)

--- a/osu.Game/EzOsuGame/Background/Pixiv/PixivIllustInfo.cs
+++ b/osu.Game/EzOsuGame/Background/Pixiv/PixivIllustInfo.cs
@@ -13,9 +13,23 @@ namespace osu.Game.EzOsuGame.Background.Pixiv
         public string ImageUrl { get; }
         public int SanityLevel { get; }
         public string[] Tags { get; }
+        public string IllustType { get; }
+        public int Width { get; }
+        public int Height { get; }
+        public int IllustAiType { get; }
         public string AttributionLabel => $"{Account}_{IllustId}";
 
-        public PixivIllustInfo(string account, long illustId, int page, string imageUrl, int sanityLevel = 0, string[]? tags = null)
+        public PixivIllustInfo(
+            string account,
+            long illustId,
+            int page,
+            string imageUrl,
+            int sanityLevel = 0,
+            string[]? tags = null,
+            string illustType = "illust",
+            int width = 0,
+            int height = 0,
+            int illustAiType = 0)
         {
             Account = account;
             IllustId = illustId;
@@ -23,6 +37,10 @@ namespace osu.Game.EzOsuGame.Background.Pixiv
             ImageUrl = imageUrl;
             SanityLevel = sanityLevel;
             Tags = tags ?? Array.Empty<string>();
+            IllustType = illustType;
+            Width = width;
+            Height = height;
+            IllustAiType = illustAiType;
         }
     }
 }

--- a/osu.Game/EzOsuGame/Background/Pixiv/PixivImageStore.cs
+++ b/osu.Game/EzOsuGame/Background/Pixiv/PixivImageStore.cs
@@ -9,7 +9,6 @@ using System.Net.Http;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Framework.Utils;
-using osu.Game.EzOsuGame;
 
 namespace osu.Game.EzOsuGame.Background.Pixiv
 {
@@ -48,6 +47,8 @@ namespace osu.Game.EzOsuGame.Background.Pixiv
 
                     if (!PixivFileNamer.TryParseFileName(Path.GetFileName(file), out string account, out long illustId, out int page))
                         continue;
+
+                    account = PixivAccountNormalizer.Normalize(account);
 
                     if (!filters.AllowsCachedAccount(account))
                         continue;
@@ -118,16 +119,16 @@ namespace osu.Game.EzOsuGame.Background.Pixiv
                     return false;
                 }
 
-                byte[] data = request.GetResponseData();
+                byte[]? data = request.GetResponseData();
 
-                if (data.Length == 0)
+                if (data != null && data.Length == 0)
                 {
                     error = "Downloaded Pixiv image was empty.";
                     return false;
                 }
 
                 using var stream = storage.CreateFileSafely(resourcePath);
-                stream.Write(data, 0, data.Length);
+                if (data != null) stream.Write(data, 0, data.Length);
                 return true;
             }
             catch (Exception ex)

--- a/osu.Game/EzOsuGame/Configuration/Ez2ConfigManager.cs
+++ b/osu.Game/EzOsuGame/Configuration/Ez2ConfigManager.cs
@@ -811,6 +811,7 @@ namespace osu.Game.EzOsuGame.Configuration
         // 皮肤与舞台资源
         ColumnWidthStyle,
         HitPositionGlobalEnable, // 未来要考虑，是否统一成，整套系统套用在传统皮肤上，变成切换设置
+
         /// <summary>
         /// When enabled, switching skins applies per-skin EzSkin.json to in-memory Ez config only.
         /// </summary>

--- a/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
@@ -375,14 +375,17 @@ namespace osu.Game.EzOsuGame.Localization
             + "\nCredentials are stored only in pixiv_auth.json (osu data folder), not in framework.ini.");
 
         public static readonly EzLocalizationManager.EzLocalisableString PIXIV_SAVE_TOKEN = new EzLocalizationManager.EzLocalisableString("保存 Pixiv 凭证", "Save Pixiv credentials");
+
         public static readonly EzLocalizationManager.EzLocalisableString PIXIV_SAVE_TOKEN_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
             "写入 pixiv_auth.json。", "Writes to pixiv_auth.json.");
 
         public static readonly EzLocalizationManager.EzLocalisableString PIXIV_VERIFY_TOKEN = new EzLocalizationManager.EzLocalisableString("验证 Pixiv 登录", "Verify Pixiv login");
+
         public static readonly EzLocalizationManager.EzLocalisableString PIXIV_VERIFY_TOKEN_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
             "使用 refresh_token 换取 access_token 并显示 Pixiv 账号。", "Exchanges the refresh token and shows the Pixiv account name.");
 
         public static readonly EzLocalizationManager.EzLocalisableString PIXIV_CLEAR_TOKEN = new EzLocalizationManager.EzLocalisableString("清除 Pixiv 凭证", "Clear Pixiv credentials");
+
         public static readonly EzLocalizationManager.EzLocalisableString PIXIV_CLEAR_TOKEN_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
             "删除 pixiv_auth.json。", "Deletes pixiv_auth.json.");
 


### PR DESCRIPTION
## Summary

- **Account normalization**: strip \@\ and everything after (e.g. \Anmi@画集発売中\ → \Anmi\, \TonyG @__tony_g\ → \TonyG\) for filenames, attribution badge, and whitelist/blacklist matching. Applied on API parse, cache read, and \PixivFileNamer\.
- **Built-in quality filters** (always on, follow-feed + download paths):
  - \	ype == illust\ only (插画; excludes manga etc.)
  - **Landscape**: \width > height\ on the selected page (multi-page works pick a random landscape page, or skip if none)
  - **Non-AI**: reject \illust_ai_type == 1\ and common AI tags (\AI生成\, Stable Diffusion, novelAI, …)

## Test plan

- [ ] Follow feed no longer offers portrait / manga / AI-flagged works
- [ ] Badge and BG_PIXIV filename use handle without @ suffix
- [ ] Existing cached files with @ in name still load when account normalizes to a allowed handle

## Note

Already-cached portrait or AI images may still appear until manually removed from BG_PIXIV.

Made with [Cursor](https://cursor.com)