### PR TITLE
Add Mania score timeline (Session one-pass) for race HUD

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/EzScoreTimelineTryBuildIntegrationTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/EzScoreTimelineTryBuildIntegrationTest.cs
@@ -1,0 +1,164 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using osu.Framework.Allocation;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Scoring;
+using osu.Game.IO.Archives;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Rulesets.Mania.EzMania.ReplayJudge;
+using osu.Game.Rulesets.Mania.EzMania.Statistics;
+using osu.Game.Scoring;
+using osu.Game.Scoring.Legacy;
+using osu.Game.Tests;
+using osu.Game.Tests.Resources;
+using osu.Game.Tests.Scores.IO;
+
+namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
+{
+    [TestFixture]
+    public class EzScoreTimelineTryBuildIntegrationTest : ImportTest
+    {
+        [Test]
+        public void TestTryBuildManiaUsesSessionTimelineThroughScoreManager()
+        {
+            using var host = new CleanRunHeadlessGameHost();
+
+            try
+            {
+                var osu = LoadOsuIntoHost(host, withBeatmap: false);
+                EzScoreTimeline? timeline = null;
+                long sessionTotal = 0;
+                bool done = false;
+                Exception? error = null;
+
+                host.UpdateThread.Scheduler.Add(() =>
+                {
+                    try
+                    {
+                        var scoreManager = osu.Dependencies.Get<ScoreManager>();
+                        var beatmapManager = osu.Dependencies.Get<BeatmapManager>();
+
+                        var (score, testBeatmap, _) = LazerTapReplayFixtures.CreateTwoNoteColumnTap();
+                        var ruleset = new ManiaRuleset();
+                        var playableBeatmap = ruleset.CreateBeatmapConverter(testBeatmap).Convert();
+
+                        var importedSet = beatmapManager.Import(TestResources.CreateTestBeatmapSetInfo(1, rulesets: new[] { ruleset.RulesetInfo }));
+                        Assert.That(importedSet, Is.Not.Null);
+
+                        var beatmapInfo = importedSet!.PerformRead(set => set.Beatmaps.First(b => b.Ruleset.ShortName == ruleset.RulesetInfo.ShortName).Detach());
+
+                        score.ScoreInfo.BeatmapInfo = beatmapInfo;
+                        score.ScoreInfo.Ruleset = ruleset.RulesetInfo;
+                        score.ScoreInfo.User = new APIUser { Id = 1001, Username = "timeline_test" };
+
+                        using (var replayStream = new MemoryStream())
+                        {
+                            new LegacyScoreEncoder(score, playableBeatmap).Encode(replayStream);
+                            var imported = ImportScoreTest.LoadScoreIntoOsu(osu, score.ScoreInfo, new ByteArrayArchiveReader(replayStream.ToArray(), "replay.osr"));
+
+                            _ = ManiaScoreHitEventGenerator.Instance;
+
+                            timeline = EzScoreTimelineBuilder.TryBuild(scoreManager, beatmapManager, imported, sharedPlayableBeatmap: playableBeatmap);
+                            var databasedScore = scoreManager.GetScore(imported);
+                            sessionTotal = ManiaReplaySession.RunTimeline(databasedScore!, playableBeatmap, GameplayEnvironment.FromScore(imported, GlobalConfigStore.EzConfig))
+                                .FinalTotalScore;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        error = ex;
+                    }
+                    finally
+                    {
+                        done = true;
+                    }
+                });
+
+                waitForOrAssert(() => done, "timeline build did not complete");
+
+                if (error != null)
+                    throw error;
+
+                Assert.That(timeline, Is.Not.Null);
+                Assert.That(timeline!.FinalTotalScore, Is.EqualTo(sessionTotal));
+                Assert.That(timeline.FinalTotalScore, Is.GreaterThan(0));
+            }
+            finally
+            {
+                host.Exit();
+            }
+        }
+
+        [Test]
+        public void TestTryBuildReturnsNullWhenReplayUnavailable()
+        {
+            using var host = new CleanRunHeadlessGameHost();
+
+            try
+            {
+                var osu = LoadOsuIntoHost(host, withBeatmap: true);
+                EzScoreTimeline? timeline = null;
+                bool done = false;
+                Exception? error = null;
+
+                host.UpdateThread.Scheduler.Add(() =>
+                {
+                    try
+                    {
+                        var scoreManager = osu.Dependencies.Get<ScoreManager>();
+                        var beatmapManager = osu.Dependencies.Get<BeatmapManager>();
+                        var beatmapInfo = beatmapManager.GetAllUsableBeatmapSets().First().Beatmaps.First();
+
+                        var imported = ImportScoreTest.LoadScoreIntoOsu(osu, new ScoreInfo
+                        {
+                            Ruleset = beatmapInfo.Ruleset,
+                            BeatmapInfo = beatmapInfo,
+                            User = new APIUser { Id = 1002, Username = "no_replay" },
+                        }, new MemoryStreamArchiveReader(new MemoryStream(), "replay.osr"));
+
+                        timeline = EzScoreTimelineBuilder.TryBuild(scoreManager, beatmapManager, imported);
+                    }
+                    catch (Exception ex)
+                    {
+                        error = ex;
+                    }
+                    finally
+                    {
+                        done = true;
+                    }
+                });
+
+                waitForOrAssert(() => done, "TryBuild null check did not complete");
+
+                if (error != null)
+                    throw error;
+
+                Assert.That(timeline, Is.Null);
+            }
+            finally
+            {
+                host.Exit();
+            }
+        }
+
+        private static void waitForOrAssert(Func<bool> result, string failureMessage, int timeout = 60000)
+        {
+            Task task = Task.Run(() =>
+            {
+                while (!result()) Thread.Sleep(200);
+            });
+
+            ClassicAssert.True(task.Wait(timeout), failureMessage);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/EzScoreTimelineTryBuildIntegrationTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/EzScoreTimelineTryBuildIntegrationTest.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
 
                             timeline = EzScoreTimelineBuilder.TryBuild(scoreManager, beatmapManager, imported, sharedPlayableBeatmap: playableBeatmap);
                             var databasedScore = scoreManager.GetScore(imported);
-                            sessionTotal = ManiaReplaySession.RunTimeline(databasedScore!, playableBeatmap, GameplayEnvironment.FromScore(imported, GlobalConfigStore.EzConfig))
+                            sessionTotal = ManiaReplaySession.RunTimeline(databasedScore!, playableBeatmap, GameplayEnvironment.FromLive(GlobalConfigStore.EzConfig))
                                 .FinalTotalScore;
                         }
                     }

--- a/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/HitModeReplayFixtures.cs
+++ b/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/HitModeReplayFixtures.cs
@@ -140,6 +140,42 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
             return (createScore(ruleset, replay), beatmap, environment);
         }
 
+        public static (Score score, IBeatmap beatmap, GameplayEnvironment environment) CreateEz2AcManyNoteTap(int noteCount = 20)
+        {
+            var ruleset = new ManiaRuleset();
+            var hitObjects = new List<HitObject>();
+            var frames = new List<ReplayFrame>();
+
+            for (int i = 0; i < noteCount; i++)
+            {
+                double time = 1000 + i * 500;
+                hitObjects.Add(new Note { StartTime = time, Column = 0 });
+                frames.Add(new ManiaReplayFrame(time, ManiaAction.Key1));
+                frames.Add(new ManiaReplayFrame(time + 50));
+            }
+
+            var beatmap = new TestBeatmap(ruleset.RulesetInfo)
+            {
+                HitObjects = hitObjects,
+                ControlPointInfo = new ControlPointInfo(),
+            };
+
+            foreach (var obj in beatmap.HitObjects)
+                obj.ApplyDefaults(beatmap.ControlPointInfo, beatmap.Difficulty);
+
+            var replay = new Replay { Frames = frames };
+
+            var environment = new GameplayEnvironment
+            {
+                ManiaHitMode = EzEnumHitMode.EZ2AC,
+                ManiaHealthMode = EzEnumHealthMode.Ez2Ac,
+                JudgePrecedence = EzEnumJudgePrecedence.Earliest,
+            };
+
+            ReplayJudgeTestConfig.ApplyToGlobalConfig(environment);
+            return (createScore(ruleset, replay), beatmap, environment);
+        }
+
         public static (Score score, IBeatmap beatmap, GameplayEnvironment environment) CreateMalodyHoldPerfect(EzEnumHitMode hitMode = EzEnumHitMode.Malody_E)
         {
             const double head = 1500;

--- a/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/ManiaReplaySessionTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/ManiaReplaySessionTest.cs
@@ -332,5 +332,41 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
                 () => $"generator=[{ManiaReplayParityHelper.DescribeJudgements(generatorEvents)}] session=[{ManiaReplayParityHelper.DescribeJudgements(sessionEvents)}]");
             Assert.That(sessionEvents.Single(e => e.HitObject is HeadNote).Result, Is.EqualTo(Ez2AcHitModeJudgement.MapTo(Ez2AcJudge.Perfect)));
         }
+
+        [Test]
+        public void TestEz2AcTimelineTotalScoreMonotonicAndScalesFromZero()
+        {
+            const int note_count = 20;
+            var (score, beatmap, environment) = HitModeReplayFixtures.CreateEz2AcManyNoteTap(note_count);
+            var timeline = ManiaReplaySession.RunTimeline(score, beatmap, environment);
+
+            Assert.That(timeline.QueryAtTime(0).TotalScore, Is.EqualTo(0));
+            Assert.That(timeline.FinalTotalScore, Is.GreaterThan(0));
+
+            long firstJudgementScore = timeline.QueryAtTime(1000).TotalScore;
+            Assert.That(firstJudgementScore, Is.GreaterThan(0));
+            Assert.That(firstJudgementScore, Is.LessThan(timeline.FinalTotalScore * 0.2));
+
+            long previousScore = 0;
+            for (int i = 0; i < note_count; i++)
+            {
+                double time = 1000 + i * 500;
+                long scoreAtTime = timeline.QueryAtTime(time).TotalScore;
+                Assert.That(scoreAtTime, Is.GreaterThanOrEqualTo(previousScore), $"TotalScore decreased at t={time}");
+                previousScore = scoreAtTime;
+            }
+
+            Assert.That(timeline.QueryAtTime(1000 + (note_count - 1) * 500).TotalScore, Is.EqualTo(timeline.FinalTotalScore));
+        }
+
+        [Test]
+        public void TestRunTimelineFinalTotalScoreMatchesRunFinalTotalScore()
+        {
+            var (score, beatmap, environment) = HitModeReplayFixtures.CreateEz2AcManyNoteTap();
+            long sessionTotal = ManiaReplaySession.RunFinalTotalScore(score, beatmap, environment);
+            var timeline = ManiaReplaySession.RunTimeline(score, beatmap, environment);
+
+            Assert.That(timeline.FinalTotalScore, Is.EqualTo(sessionTotal));
+        }
     }
 }

--- a/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/ManiaReplaySessionTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/ManiaReplaySessionTest.cs
@@ -69,20 +69,25 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
         }
 
         [Test]
-        public void TestRunTimelineRespectsScoreHitMode()
+        public void TestRunTimelineUsesLiveHitModeNotScoreEmbedded()
         {
             var (score, beatmap, lazerEnvironment) = LazerTapReplayFixtures.CreateTwoNoteColumnTap();
-            ReplayJudgeTestConfig.ApplyEmbeddedModes(score, lazerEnvironment);
-
-            var lazerTimeline = ManiaReplaySession.RunTimeline(score, beatmap, GameplayEnvironment.FromScore(score.ScoreInfo, GlobalConfigStore.EzConfig));
-            Assert.That(lazerTimeline.FinalTotalScore, Is.GreaterThan(0));
-
             var iidxEnvironment = BmsTapReplayFixtures.CreateTwoNoteColumnTap().environment;
+
             ReplayJudgeTestConfig.ApplyEmbeddedModes(score, iidxEnvironment);
 
-            var iidxTimeline = ManiaReplaySession.RunTimeline(score, beatmap, GameplayEnvironment.FromScore(score.ScoreInfo, GlobalConfigStore.EzConfig));
+            var liveTimeline = ManiaReplaySession.RunTimeline(score, beatmap, GameplayEnvironment.FromLive(GlobalConfigStore.EzConfig));
+            var lazerTimeline = ManiaReplaySession.RunTimeline(score, beatmap, lazerEnvironment);
+            var iidxTimeline = ManiaReplaySession.RunTimeline(score, beatmap, iidxEnvironment);
 
-            Assert.That(iidxTimeline.FinalTotalScore, Is.Not.EqualTo(lazerTimeline.FinalTotalScore));
+            Assert.That(liveTimeline.FinalTotalScore, Is.EqualTo(lazerTimeline.FinalTotalScore));
+            Assert.That(liveTimeline.FinalTotalScore, Is.Not.EqualTo(iidxTimeline.FinalTotalScore));
+
+            _ = ManiaScoreHitEventGenerator.Instance;
+            var bridgeTimeline = EzScoreTimelineBridge.TryBuildManiaTimeline(score, beatmap);
+
+            Assert.That(bridgeTimeline, Is.Not.Null);
+            Assert.That(bridgeTimeline!.FinalTotalScore, Is.EqualTo(lazerTimeline.FinalTotalScore));
         }
 
         [Test]
@@ -348,6 +353,7 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
             Assert.That(firstJudgementScore, Is.LessThan(timeline.FinalTotalScore * 0.2));
 
             long previousScore = 0;
+
             for (int i = 0; i < note_count; i++)
             {
                 double time = 1000 + i * 500;

--- a/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/ManiaReplaySessionTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/ManiaReplaySessionTest.cs
@@ -60,6 +60,50 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
         }
 
         [Test]
+        public void TestRunTimelineRespectsScoreHitMode()
+        {
+            var (score, beatmap, lazerEnvironment) = LazerTapReplayFixtures.CreateTwoNoteColumnTap();
+            ReplayJudgeTestConfig.ApplyEmbeddedModes(score, lazerEnvironment);
+
+            var lazerTimeline = ManiaReplaySession.RunTimeline(score, beatmap, GameplayEnvironment.FromScore(score.ScoreInfo, GlobalConfigStore.EzConfig));
+            Assert.That(lazerTimeline.FinalTotalScore, Is.GreaterThan(0));
+
+            var iidxEnvironment = BmsTapReplayFixtures.CreateTwoNoteColumnTap().environment;
+            ReplayJudgeTestConfig.ApplyEmbeddedModes(score, iidxEnvironment);
+
+            var iidxTimeline = ManiaReplaySession.RunTimeline(score, beatmap, GameplayEnvironment.FromScore(score.ScoreInfo, GlobalConfigStore.EzConfig));
+
+            Assert.That(iidxTimeline.FinalTotalScore, Is.Not.EqualTo(lazerTimeline.FinalTotalScore));
+        }
+
+        [Test]
+        public void TestManiaTimelineBridgeMatchesRunTimeline()
+        {
+            _ = ManiaScoreHitEventGenerator.Instance;
+
+            var (score, beatmap, environment) = LazerTapReplayFixtures.CreateTwoNoteColumnTap();
+
+            var sessionTimeline = ManiaReplaySession.RunTimeline(score, beatmap, environment);
+            var bridgeTimeline = EzScoreTimelineBridge.TryBuildManiaTimeline(score, beatmap);
+
+            Assert.That(bridgeTimeline, Is.Not.Null);
+            Assert.That(bridgeTimeline!.FinalTotalScore, Is.EqualTo(sessionTimeline.FinalTotalScore));
+            Assert.That(bridgeTimeline.QueryAtTime(2500).TotalScore, Is.EqualTo(sessionTimeline.FinalTotalScore));
+        }
+
+        [Test]
+        public void TestRunTimelineReturnsEmptyForEmptyReplayFrames()
+        {
+            var (score, beatmap, environment) = LazerTapReplayFixtures.CreateTwoNoteColumnTap();
+            score.Replay!.Frames.Clear();
+
+            var timeline = ManiaReplaySession.RunTimeline(score, beatmap, environment);
+
+            Assert.That(timeline.FinalTotalScore, Is.EqualTo(0));
+            Assert.That(timeline.QueryAtTime(0).TotalScore, Is.EqualTo(0));
+        }
+
+        [Test]
         public void TestLazerTapSessionMatchesGeneratorJudgements()
         {
             var (score, beatmap, environment) = LazerTapReplayFixtures.CreateTwoNoteColumnTap();

--- a/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/ManiaReplaySessionTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/ManiaReplaySessionTest.cs
@@ -42,6 +42,19 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
         }
 
         [Test]
+        public void TestRunTimelineFinalScoreMatchesSessionRun()
+        {
+            var (score, beatmap, environment) = LazerTapReplayFixtures.CreateTwoNoteColumnTap();
+
+            var hitEvents = ManiaReplaySession.Run(score, beatmap, environment);
+            var timeline = ManiaReplaySession.RunTimeline(score, beatmap, environment);
+
+            Assert.That(timeline.FinalTotalScore, Is.EqualTo(hitEvents.Last().TotalScore ?? 0));
+            Assert.That(timeline.QueryAtTime(0).TotalScore, Is.EqualTo(0));
+            Assert.That(timeline.QueryAtTime(2500).TotalScore, Is.EqualTo(timeline.FinalTotalScore));
+        }
+
+        [Test]
         public void TestLazerTapSessionMatchesGeneratorJudgements()
         {
             var (score, beatmap, environment) = LazerTapReplayFixtures.CreateTwoNoteColumnTap();

--- a/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/ManiaReplaySessionTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/ManiaReplaySessionTest.cs
@@ -7,7 +7,6 @@ using NUnit.Framework;
 using osu.Game.Beatmaps;
 using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.Scoring;
-using osu.Game.Rulesets.Mania;
 using osu.Game.Rulesets.Mania.EzMania.ReplayJudge;
 using osu.Game.Rulesets.Mania.EzMania.ReplayJudge.Mappings;
 using osu.Game.Rulesets.Mania.EzMania.Statistics;
@@ -43,19 +42,29 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
         }
 
         [Test]
-        public void TestRunTimelineFinalScoreMatchesSessionRun()
+        public void TestRunTimelineFinalScoreMatchesSessionRunTotal()
         {
             var (score, beatmap, environment) = LazerTapReplayFixtures.CreateTwoNoteColumnTap();
 
             var hitEvents = ManiaReplaySession.Run(score, beatmap, environment);
+            long sessionTotal = ManiaReplaySession.RunFinalTotalScore(score, beatmap, environment);
             var timeline = ManiaReplaySession.RunTimeline(score, beatmap, environment);
 
             Assert.That(hitEvents, Has.Count.EqualTo(2));
-            Assert.That(timeline.FinalTotalScore, Is.GreaterThan(0));
+            Assert.That(sessionTotal, Is.GreaterThan(0));
+            Assert.That(timeline.FinalTotalScore, Is.EqualTo(sessionTotal));
             Assert.That(timeline.QueryAtTime(0).TotalScore, Is.EqualTo(0));
             Assert.That(timeline.QueryAtTime(2500).TotalScore, Is.EqualTo(timeline.FinalTotalScore));
+        }
 
+        [Test]
+        public void TestRunTimelineIsDeterministic()
+        {
+            var (score, beatmap, environment) = LazerTapReplayFixtures.CreateTwoNoteColumnTap();
+
+            var timeline = ManiaReplaySession.RunTimeline(score, beatmap, environment);
             var timelineRepeat = ManiaReplaySession.RunTimeline(score, beatmap, environment);
+
             Assert.That(timelineRepeat.FinalTotalScore, Is.EqualTo(timeline.FinalTotalScore));
         }
 

--- a/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/ManiaReplaySessionTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/ManiaReplaySessionTest.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using osu.Game.Beatmaps;
 using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.Scoring;
+using osu.Game.Rulesets.Mania;
 using osu.Game.Rulesets.Mania.EzMania.ReplayJudge;
 using osu.Game.Rulesets.Mania.EzMania.ReplayJudge.Mappings;
 using osu.Game.Rulesets.Mania.EzMania.Statistics;
@@ -49,9 +50,13 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
             var hitEvents = ManiaReplaySession.Run(score, beatmap, environment);
             var timeline = ManiaReplaySession.RunTimeline(score, beatmap, environment);
 
-            Assert.That(timeline.FinalTotalScore, Is.EqualTo(hitEvents.Last().TotalScore ?? 0));
+            Assert.That(hitEvents, Has.Count.EqualTo(2));
+            Assert.That(timeline.FinalTotalScore, Is.GreaterThan(0));
             Assert.That(timeline.QueryAtTime(0).TotalScore, Is.EqualTo(0));
             Assert.That(timeline.QueryAtTime(2500).TotalScore, Is.EqualTo(timeline.FinalTotalScore));
+
+            var timelineRepeat = ManiaReplaySession.RunTimeline(score, beatmap, environment);
+            Assert.That(timelineRepeat.FinalTotalScore, Is.EqualTo(timeline.FinalTotalScore));
         }
 
         [Test]

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaReplaySession.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaReplaySession.cs
@@ -25,6 +25,30 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
     public static class ManiaReplaySession
     {
         public static IReadOnlyList<HitEvent> Run(Score score, IBeatmap beatmap, IGameplayEnvironment environment, CancellationToken cancellationToken = default)
+            => run(score, beatmap, environment, recordTimeline: false, cancellationToken).HitEvents;
+
+        /// <summary>
+        /// 一遍 Session 判定同时采集分数时间线（与 <see cref="Run"/> 同源 SP，不经 HitEvents 二次重放）。
+        /// </summary>
+        public static EzScoreTimeline RunTimeline(Score score, IBeatmap beatmap, IGameplayEnvironment environment, CancellationToken cancellationToken = default)
+        {
+            var result = run(score, beatmap, environment, recordTimeline: true, cancellationToken);
+            return result.Timeline ?? new EzScoreTimeline(Array.Empty<EzScoreTimelineSnapshot>());
+        }
+
+        private readonly struct SessionRunResult
+        {
+            public IReadOnlyList<HitEvent> HitEvents { get; }
+            public EzScoreTimeline? Timeline { get; }
+
+            public SessionRunResult(IReadOnlyList<HitEvent> hitEvents, EzScoreTimeline? timeline)
+            {
+                HitEvents = hitEvents;
+                Timeline = timeline;
+            }
+        }
+
+        private static SessionRunResult run(Score score, IBeatmap beatmap, IGameplayEnvironment environment, bool recordTimeline, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(score);
             ArgumentNullException.ThrowIfNull(score.Replay);
@@ -32,7 +56,7 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
             ArgumentNullException.ThrowIfNull(environment);
 
             if (score.Replay.Frames.Count == 0)
-                return Array.Empty<HitEvent>();
+                return new SessionRunResult(Array.Empty<HitEvent>(), recordTimeline ? new EzScoreTimeline(Array.Empty<EzScoreTimelineSnapshot>()) : null);
 
             var noteStrategy = ManiaJudgementRegistry.GetNoteStrategy(environment);
 
@@ -42,6 +66,12 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
             var scoreProcessor = ruleset.CreateScoreProcessor();
             scoreProcessor.Mods.Value = score.ScoreInfo.Mods;
             scoreProcessor.ApplyBeatmap(beatmap);
+
+            if (scoreProcessor is ManiaScoreProcessor maniaScoreProcessor)
+                maniaScoreProcessor.TimelineHitModeOverride = environment.ManiaHitMode;
+
+            if (score.ScoreInfo.IsLegacyScore)
+                scoreProcessor.IsLegacyScore = true;
 
             foreach (var mod in score.ScoreInfo.Mods.OfType<IApplicableToScoreProcessor>())
                 mod.ApplyToScoreProcessor(scoreProcessor);
@@ -64,6 +94,8 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
             }
 
             double gameplayRate = ModUtils.CalculateRateWithMods(score.ScoreInfo.Mods);
+            var recorder = recordTimeline ? new ManiaReplayTimelineRecorder() : null;
+            recorder?.RecordInitial(scoreProcessor);
 
             ManiaReplaySessionSimulator.Simulate(
                 score,
@@ -77,6 +109,7 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
                 noteStrategy,
                 holdStrategy,
                 scoreProcessor,
+                recorder,
                 cancellationToken);
 
             foreach (var state in targets)
@@ -88,10 +121,10 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
 
                 state.Judged = true;
                 state.Result = HitResult.Miss;
-                ManiaReplaySessionSimulator.ApplyFinalResult(scoreProcessor, state.Target, HitResult.Miss, state.Target.GetEndTime(), gameplayRate);
+                ManiaReplaySessionSimulator.ApplyFinalResult(scoreProcessor, state.Target, HitResult.Miss, state.Target.GetEndTime(), gameplayRate, recorder);
             }
 
-            return scoreProcessor.HitEvents.ToList();
+            return new SessionRunResult(scoreProcessor.HitEvents.ToList(), recorder?.Build());
         }
 
         private static void alignHitWindows(IBeatmap beatmap, IGameplayEnvironment environment)

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaReplaySession.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaReplaySession.cs
@@ -36,15 +36,20 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
             return result.Timeline ?? new EzScoreTimeline(Array.Empty<EzScoreTimelineSnapshot>());
         }
 
+        internal static long RunFinalTotalScore(Score score, IBeatmap beatmap, IGameplayEnvironment environment, CancellationToken cancellationToken = default)
+            => run(score, beatmap, environment, recordTimeline: false, cancellationToken).FinalTotalScore;
+
         private readonly struct SessionRunResult
         {
             public IReadOnlyList<HitEvent> HitEvents { get; }
             public EzScoreTimeline? Timeline { get; }
+            public long FinalTotalScore { get; }
 
-            public SessionRunResult(IReadOnlyList<HitEvent> hitEvents, EzScoreTimeline? timeline)
+            public SessionRunResult(IReadOnlyList<HitEvent> hitEvents, EzScoreTimeline? timeline, long finalTotalScore)
             {
                 HitEvents = hitEvents;
                 Timeline = timeline;
+                FinalTotalScore = finalTotalScore;
             }
         }
 
@@ -56,7 +61,7 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
             ArgumentNullException.ThrowIfNull(environment);
 
             if (score.Replay.Frames.Count == 0)
-                return new SessionRunResult(Array.Empty<HitEvent>(), recordTimeline ? new EzScoreTimeline(Array.Empty<EzScoreTimelineSnapshot>()) : null);
+                return new SessionRunResult(Array.Empty<HitEvent>(), recordTimeline ? new EzScoreTimeline(Array.Empty<EzScoreTimelineSnapshot>()) : null, 0);
 
             var noteStrategy = ManiaJudgementRegistry.GetNoteStrategy(environment);
 
@@ -124,7 +129,7 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
                 ManiaReplaySessionSimulator.ApplyFinalResult(scoreProcessor, state.Target, HitResult.Miss, state.Target.GetEndTime(), gameplayRate, recorder);
             }
 
-            return new SessionRunResult(scoreProcessor.HitEvents.ToList(), recorder?.Build());
+            return new SessionRunResult(scoreProcessor.HitEvents.ToList(), recorder?.Build(), scoreProcessor.TotalScore.Value);
         }
 
         private static void alignHitWindows(IBeatmap beatmap, IGameplayEnvironment environment)

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaReplaySessionSimulator.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaReplaySessionSimulator.cs
@@ -34,6 +34,7 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
             IManiaNoteJudgementStrategy noteStrategy,
             IManiaHoldJudgementStrategy holdStrategy,
             ScoreProcessor scoreProcessor,
+            ManiaReplayTimelineRecorder? timelineRecorder,
             CancellationToken cancellationToken)
         {
             bool poorEnabled = HealthModeHelper.IsBMSHealthMode(environment.ManiaHealthMode)
@@ -76,7 +77,7 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
                         input.Time,
                         environment.OffsetPlusMania,
                         hitWindowHelper,
-                        (target, result) => ApplyTransientResult(scoreProcessor, target, result, input.Time - target.StartTime + environment.OffsetPlusMania, input.Time, gameplayRate));
+                        (target, result) => ApplyTransientResult(scoreProcessor, target, result, input.Time - target.StartTime + environment.OffsetPlusMania, input.Time, gameplayRate, timelineRecorder));
                 }
 
                 if (candidates.Count == 0)
@@ -140,7 +141,7 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
 
                     if (sessionOutcome.Kind == BmsHitModeJudgement.SessionPressKind.DispatchExtra)
                     {
-                        ApplyTransientResult(scoreProcessor, target, BmsHitModeJudgement.MapTo(sessionOutcome.Judge), timeOffsetForJudgement, input.Time, gameplayRate);
+                        ApplyTransientResult(scoreProcessor, target, BmsHitModeJudgement.MapTo(sessionOutcome.Judge), timeOffsetForJudgement, input.Time, gameplayRate, timelineRecorder);
                         continue;
                     }
 
@@ -160,13 +161,13 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
                 {
                     forced.Judged = true;
                     forced.Result = HitResult.Miss;
-                    ApplyFinalResult(scoreProcessor, forced.Target, HitResult.Miss, input.Time, gameplayRate);
+                    ApplyFinalResult(scoreProcessor, forced.Target, HitResult.Miss, input.Time, gameplayRate, timelineRecorder);
                 }
 
                 selected.Judged = true;
                 selected.Result = result;
 
-                ApplyFinalResult(scoreProcessor, target, result, input.Time, gameplayRate);
+                ApplyFinalResult(scoreProcessor, target, result, input.Time, gameplayRate, timelineRecorder);
 
                 if (target is HeadNote head)
                     headWasHit[head] = result.IsHit();
@@ -377,7 +378,8 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
             return bpm;
         }
 
-        internal static void ApplyFinalResult(ScoreProcessor scoreProcessor, HitObject target, HitResult result, double eventTime, double gameplayRate)
+        internal static void ApplyFinalResult(ScoreProcessor scoreProcessor, HitObject target, HitResult result, double eventTime, double gameplayRate,
+            ManiaReplayTimelineRecorder? timelineRecorder = null)
         {
             var judgementResult = new JudgementResult(target, target.Judgement)
             {
@@ -385,9 +387,11 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
             };
 
             scoreProcessor.ApplyResult(judgementResult);
+            timelineRecorder?.Record(scoreProcessor, eventTime, result);
         }
 
-        internal static void ApplyTransientResult(ScoreProcessor scoreProcessor, HitObject target, HitResult result, double timeOffset, double eventTime, double gameplayRate)
+        internal static void ApplyTransientResult(ScoreProcessor scoreProcessor, HitObject target, HitResult result, double timeOffset, double eventTime, double gameplayRate,
+            ManiaReplayTimelineRecorder? timelineRecorder = null)
         {
             var judgementResult = new JudgementResult(target, target.Judgement)
             {
@@ -396,6 +400,7 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
             };
 
             scoreProcessor.ApplyResult(judgementResult);
+            timelineRecorder?.Record(scoreProcessor, eventTime, result);
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaReplayTimelineRecorder.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaReplayTimelineRecorder.cs
@@ -1,0 +1,56 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.EzOsuGame.Scoring;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
+{
+    /// <summary>
+    /// 在 <see cref="ManiaReplaySession"/> 同一遍 SP 判定中采集分数时间线快照。
+    /// </summary>
+    internal sealed class ManiaReplayTimelineRecorder
+    {
+        private readonly List<EzScoreTimelineSnapshot> snapshots = new List<EzScoreTimelineSnapshot>();
+        private int missCount;
+        private double lastClockTime = double.NegativeInfinity;
+
+        public void RecordInitial(ScoreProcessor scoreProcessor)
+            => appendSnapshot(0, scoreProcessor, HitResult.None);
+
+        public void Record(ScoreProcessor scoreProcessor, double clockTime, HitResult result)
+            => appendSnapshot(clockTime, scoreProcessor, result);
+
+        public EzScoreTimeline Build()
+        {
+            if (snapshots.Count == 0)
+                snapshots.Add(new EzScoreTimelineSnapshot { ClockTime = 0 });
+            else if (snapshots[0].ClockTime > 0)
+                snapshots.Insert(0, new EzScoreTimelineSnapshot { ClockTime = 0 });
+
+            return new EzScoreTimeline(snapshots);
+        }
+
+        private void appendSnapshot(double clockTime, ScoreProcessor scoreProcessor, HitResult result)
+        {
+            if (result.IsMiss())
+                missCount++;
+
+            if (clockTime <= lastClockTime)
+                clockTime = lastClockTime + 0.001;
+
+            lastClockTime = clockTime;
+
+            snapshots.Add(new EzScoreTimelineSnapshot
+            {
+                ClockTime = clockTime,
+                TotalScore = scoreProcessor.TotalScore.Value,
+                Accuracy = scoreProcessor.Accuracy.Value,
+                Combo = scoreProcessor.Combo.Value,
+                HighestCombo = scoreProcessor.HighestCombo.Value,
+                MissCount = missCount,
+            });
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/REPLAY_JUDGE_MERGE.md
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/REPLAY_JUDGE_MERGE.md
@@ -43,6 +43,7 @@ Drawable replay 播放时，`ManiaEzDrawableJudgement` 优先从 `DrawableRulese
 
 - **禁止** Mania 生产路径：`HitEvents` → `buildFromHitEvents` → 第二遍 SP。
 - 下游（如角逐 HUD）只调用 `EzScoreTimelineBuilder.TryBuild`；`EzScoreTimelineBridge` 在 Mania 侧注册 `RunTimeline`。
+- 无本地 replay（`GetScore` 后 `Replay == null` 或空帧）→ `TryBuild` 返回 `null`；HUD 仅显示 `ScoreInfo` 静态最终分/准度，无分数轨。
 - 时钟轴 = replay 输入时刻（`input.Time`），与游玩 `GameplayClock` 对齐。
 
 ---

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/REPLAY_JUDGE_MERGE.md
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/REPLAY_JUDGE_MERGE.md
@@ -34,6 +34,17 @@ Drawable replay 播放时，`ManiaEzDrawableJudgement` 优先从 `DrawableRulese
 
 `ManiaRuleset.RunReplayAsync` 为无 UI 公开 API，与 Generator 同源；CLI/工具可直调。
 
+### 分数时间线（角逐 HUD 等下游消费）
+
+| 路径 | 数据源 |
+|------|--------|
+| 统计 / HitEvents | `ManiaReplaySession.Run` → `ScoreProcessor.HitEvents` |
+| **时间线** | `ManiaReplaySession.RunTimeline` → 同一遍 SP，每次 `ApplyResult` 后采 `TotalScore`/`Accuracy`/… 快照 → `EzScoreTimeline` |
+
+- **禁止** Mania 生产路径：`HitEvents` → `buildFromHitEvents` → 第二遍 SP。
+- 下游（如角逐 HUD）只调用 `EzScoreTimelineBuilder.TryBuild`；`EzScoreTimelineBridge` 在 Mania 侧注册 `RunTimeline`。
+- 时钟轴 = replay 输入时刻（`input.Time`），与游玩 `GameplayClock` 对齐。
+
 ---
 
 ## 合并 ppy/osu master 后

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/REPLAY_JUDGE_MERGE.md
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/REPLAY_JUDGE_MERGE.md
@@ -43,8 +43,18 @@ Drawable replay 播放时，`ManiaEzDrawableJudgement` 优先从 `DrawableRulese
 
 - **禁止** Mania 生产路径：`HitEvents` → `buildFromHitEvents` → 第二遍 SP。
 - 下游（如角逐 HUD）只调用 `EzScoreTimelineBuilder.TryBuild`；`EzScoreTimelineBridge` 在 Mania 侧注册 `RunTimeline`。
-- 无本地 replay（`GetScore` 后 `Replay == null` 或空帧）→ `TryBuild` 返回 `null`；HUD 仅显示 `ScoreInfo` 静态最终分/准度，无分数轨。
+- 无本地 replay（`GetScore` 后 `Replay == null` 或空帧）→ `TryBuild` 返回 `null`；角逐 ghost 在 timeline 未就绪前显示 0，**禁止**用终局 `ScoreInfo.TotalScore` 充当实时分。
 - 时钟轴 = replay 输入时刻（`input.Time`），与游玩 `GameplayClock` 对齐。
+- Ez 满分制 `TotalScore` = 整谱 ex 累积（`MinimumAccuracy × 1M`），与正常游玩 ScoreProcessor 同源；ghost 分数轨 = 同一 SP 快照，HUD **只读** `QueryAtTime(...).TotalScore`，不在 EzOsuGame 复刻公式。
+
+### 角逐 HUD 实机验收清单（Mania）
+
+1. 本地 Mania 谱面 ≥2 条带 replay 的 ghost + 角逐排行榜：占位先出（分数 0），时间线异步填入后分数/准度/Combo 随时钟变化。
+2. 同一时刻：主界面 ScoreCounter ≈ 角逐 Tracked 行 ≈ ghost 行（对应 replay 进度）；分数从 0 累积，无 acc 子集反算虚高。
+3. 角逐榜排序可配置（默认 TotalScore，可选 Accuracy / MissCount）；只影响榜位，不参与计分。
+4. ghost 成绩嵌入 HitMode 与全局不同：分数轨仍按成绩 HitMode 重算（非当前全局）。
+5. 无 replay 的 ghost：不进入角逐列表（`TryBuild` 返回 null）。
+6. DT/HT：时钟与 ghost 分数轨无明显错位（若有问题记录谱面与 mod 组合）。
 
 ---
 

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/REPLAY_JUDGE_MERGE.md
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/REPLAY_JUDGE_MERGE.md
@@ -26,7 +26,8 @@ Drawable replay 播放时，`ManiaEzDrawableJudgement` 优先从 `DrawableRulese
 
 | 字段                                 | 来源                                                                                   |
 |------------------------------------|--------------------------------------------------------------------------------------|
-| HitMode / HealthMode               | `ScoreInfo.ManiaHitMode` / `ManiaHealthMode`（提交时写入）→ `GameplayEnvironment.FromScore` |
+| HitMode / HealthMode（统计 HitEvents） | `ScoreInfo.ManiaHitMode` / `ManiaHealthMode`（提交时写入）→ `GameplayEnvironment.FromScore` |
+| HitMode / HealthMode（角逐时间线）     | **当前全局** `FromLive`；不读成绩嵌入字段                                                     |
 | JudgePrecedence / OffsetPlusMania  | 当前全局配置（`FromLive` fallback）                                                          |
 | **BmsPoorHitResultEnable (KPoor)** | **当前全局配置**（未写入 ScoreInfo；统计重算沿用打开成绩时的全局 KPoor 开关，与当时游玩可能不一致）                         |
 
@@ -52,7 +53,7 @@ Drawable replay 播放时，`ManiaEzDrawableJudgement` 优先从 `DrawableRulese
 1. 本地 Mania 谱面 ≥2 条带 replay 的 ghost + 角逐排行榜：占位先出（分数 0），时间线异步填入后分数/准度/Combo 随时钟变化。
 2. 同一时刻：主界面 ScoreCounter ≈ 角逐 Tracked 行 ≈ ghost 行（对应 replay 进度）；分数从 0 累积，无 acc 子集反算虚高。
 3. 角逐榜排序可配置（默认 TotalScore，可选 Accuracy / MissCount）；只影响榜位，不参与计分。
-4. ghost 成绩嵌入 HitMode 与全局不同：分数轨仍按成绩 HitMode 重算（非当前全局）。
+4. ghost 分数轨统一按**当前全局** HitMode/HealthMode 重算（`FromLive`）；不用成绩嵌入 HitMode，也不按嵌入 HitMode 过滤 ghost 列表。
 5. 无 replay 的 ghost：不进入角逐列表（`TryBuild` 返回 null）。
 6. DT/HT：时钟与 ghost 分数轨无明显错位（若有问题记录谱面与 mod 组合）。
 

--- a/osu.Game.Rulesets.Mania/EzMania/Statistics/ManiaScoreHitEventGenerator.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/Statistics/ManiaScoreHitEventGenerator.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Mania.EzMania.Statistics
 
             EzScoreTimelineBridge.RegisterManiaTimelineBuilder((score, beatmap, cancellationToken) =>
             {
-                var environment = GameplayEnvironment.FromScore(score.ScoreInfo, GlobalConfigStore.EzConfig);
+                var environment = GameplayEnvironment.FromLive(GlobalConfigStore.EzConfig);
                 return ManiaReplaySession.RunTimeline(score, beatmap, environment, cancellationToken);
             });
         }

--- a/osu.Game.Rulesets.Mania/EzMania/Statistics/ManiaScoreHitEventGenerator.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/Statistics/ManiaScoreHitEventGenerator.cs
@@ -26,6 +26,12 @@ namespace osu.Game.Rulesets.Mania.EzMania.Statistics
         {
             EzScoreReloadBridge.RegisterImplementation("mania", Instance);
             EzScoreReloadBridge.RegisterImplementation("3", Instance);
+
+            EzScoreTimelineBridge.RegisterManiaTimelineBuilder((score, beatmap, cancellationToken) =>
+            {
+                var environment = GameplayEnvironment.FromScore(score.ScoreInfo, GlobalConfigStore.EzConfig);
+                return ManiaReplaySession.RunTimeline(score, beatmap, environment, cancellationToken);
+            });
         }
 
         public bool Validate(Score score)

--- a/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
+++ b/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
@@ -50,11 +50,10 @@ namespace osu.Game.Rulesets.Mania.Scoring
                        + bonusPortion;
             }
 
-            // 由于Acc架构不同，非lazer模式在总分制下，只能依靠Acc反算分数。
             if (hitMode != EzEnumHitMode.Lazer && hitMode != EzEnumHitMode.Classic)
             {
-                // 对于满分制，只考虑判定准确性，不考虑combo和奖励加分
-                return 1000000 * Accuracy.Value;
+                // 满分制：TotalScore = 已获得 ex / 整谱最大 ex，从 0 随判定累积（非已判子集 acc 反算）
+                return 1_000_000 * MinimumAccuracy.Value;
             }
 
             return 150000 * comboProgress

--- a/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
+++ b/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
@@ -20,7 +20,13 @@ namespace osu.Game.Rulesets.Mania.Scoring
     {
         private const double combo_base = 4;
         private double calOD = 8;
-        private EzEnumHitMode hitMode => GlobalConfigStore.EzConfig.Get<EzEnumHitMode>(Ez2Setting.ManiaHitMode);
+
+        /// <summary>
+        /// Ghost 时间线重放时覆盖 HitMode，使用成绩自带环境而非当前玩家全局配置。
+        /// </summary>
+        public EzEnumHitMode? TimelineHitModeOverride { get; set; }
+
+        private EzEnumHitMode hitMode => TimelineHitModeOverride ?? GlobalConfigStore.EzConfig.Get<EzEnumHitMode>(Ez2Setting.ManiaHitMode);
 
         public ManiaScoreProcessor()
             : base(new ManiaRuleset())

--- a/osu.Game.Tests/EzOsuGame/Scoring/EzScoreTimelineTest.cs
+++ b/osu.Game.Tests/EzOsuGame/Scoring/EzScoreTimelineTest.cs
@@ -1,0 +1,155 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Scoring;
+using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Mania.Objects;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
+using osu.Game.Tests.Beatmaps;
+
+namespace osu.Game.Tests.EzOsuGame.Scoring
+{
+    [TestFixture]
+    public class EzScoreTimelineTest
+    {
+        [Test]
+        public void TestQueryAtTimeReturnsLatestSnapshotNotExceedingClock()
+        {
+            var timeline = new EzScoreTimeline(new List<EzScoreTimelineSnapshot>
+            {
+                new EzScoreTimelineSnapshot { ClockTime = 0, TotalScore = 0 },
+                new EzScoreTimelineSnapshot { ClockTime = 1000, TotalScore = 100 },
+                new EzScoreTimelineSnapshot { ClockTime = 2000, TotalScore = 250 },
+                new EzScoreTimelineSnapshot { ClockTime = 3000, TotalScore = 400 },
+            });
+
+            Assert.That(timeline.QueryAtTime(-100).TotalScore, Is.EqualTo(0));
+            Assert.That(timeline.QueryAtTime(0).TotalScore, Is.EqualTo(0));
+            Assert.That(timeline.QueryAtTime(1500).TotalScore, Is.EqualTo(100));
+            Assert.That(timeline.QueryAtTime(2000).TotalScore, Is.EqualTo(250));
+            Assert.That(timeline.QueryAtTime(9999).TotalScore, Is.EqualTo(400));
+            Assert.That(timeline.FinalTotalScore, Is.EqualTo(400));
+        }
+
+        [Test]
+        public void TestEmptyTimelineReturnsZeroScore()
+        {
+            var timeline = new EzScoreTimeline(Array.Empty<EzScoreTimelineSnapshot>());
+            Assert.That(timeline.QueryAtTime(1000).TotalScore, Is.EqualTo(0));
+            Assert.That(timeline.FinalTotalScore, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void TestJudgementTimeClampsEarlyOffsetsToObjectStart()
+        {
+            var circle = new HitCircle { StartTime = 10_000 };
+            var hitEvent = new HitEvent(-500, 1.0, HitResult.Great, circle, null, null);
+
+            Assert.That(EzScoreTimelineJudgementTime.Get(hitEvent, offsetsRelativeToEnd: true), Is.EqualTo(9_500));
+            Assert.That(EzScoreTimelineJudgementTime.Get(hitEvent, offsetsRelativeToEnd: false), Is.EqualTo(9_500));
+        }
+
+        [Test]
+        public void TestTimelineDoesNotInflateScoreAtClockZeroForLateHits()
+        {
+            var ruleset = new OsuRuleset();
+            var testBeatmap = new TestBeatmap(ruleset.RulesetInfo)
+            {
+                HitObjects = new List<HitObject> { new HitCircle { StartTime = 10_000 } }
+            };
+            var beatmap = ruleset.CreateBeatmapConverter(testBeatmap).Convert();
+            var circle = (HitCircle)beatmap.HitObjects[0];
+            var scoreInfo = new ScoreInfo { Ruleset = ruleset.RulesetInfo };
+
+            var hitEvents = new List<HitEvent>
+            {
+                new HitEvent(0, 1.0, HitResult.Great, circle, null, null),
+            };
+
+            var timeline = EzScoreTimelineBuilder.BuildFromHitEventsForTesting(ruleset, beatmap, scoreInfo, hitEvents, offsetsRelativeToEnd: false);
+
+            Assert.That(timeline.QueryAtTime(0).TotalScore, Is.EqualTo(0));
+            Assert.That(timeline.QueryAtTime(9_999).TotalScore, Is.EqualTo(0));
+            Assert.That(timeline.QueryAtTime(10_000).TotalScore, Is.GreaterThan(0));
+        }
+
+        [Test]
+        public void TestTimelineDoesNotInflateScoreWhenOffsetMisinterpretedAsStartRelative()
+        {
+            var ruleset = new OsuRuleset();
+            var testBeatmap = new TestBeatmap(ruleset.RulesetInfo)
+            {
+                HitObjects = new List<HitObject> { new HitCircle { StartTime = 10_000 } }
+            };
+            var beatmap = ruleset.CreateBeatmapConverter(testBeatmap).Convert();
+            var circle = (HitCircle)beatmap.HitObjects[0];
+            var scoreInfo = new ScoreInfo { Ruleset = ruleset.RulesetInfo };
+
+            var hitEvents = new List<HitEvent>
+            {
+                new HitEvent(-20_000, 1.0, HitResult.Great, circle, null, null),
+            };
+
+            var timeline = EzScoreTimelineBuilder.BuildFromHitEventsForTesting(ruleset, beatmap, scoreInfo, hitEvents, offsetsRelativeToEnd: true);
+
+            Assert.That(timeline.QueryAtTime(0).TotalScore, Is.EqualTo(0));
+            Assert.That(timeline.QueryAtTime(9_599).TotalScore, Is.EqualTo(0));
+            Assert.That(timeline.QueryAtTime(9_600).TotalScore, Is.GreaterThan(0));
+        }
+
+        [Test]
+        public void TestManiaTimelineUsesScoreHitModeNotGlobalConfig()
+        {
+            var ruleset = new ManiaRuleset();
+            var beatmap = new TestBeatmap(ruleset.RulesetInfo)
+            {
+                HitObjects = new List<HitObject> { new Note { StartTime = 1000, Column = 0 } },
+                ControlPointInfo = new ControlPointInfo(),
+            };
+
+            foreach (var obj in beatmap.HitObjects)
+                obj.ApplyDefaults(beatmap.ControlPointInfo, beatmap.Difficulty);
+
+            var note1 = (Note)beatmap.HitObjects[0];
+            beatmap.HitObjects.Add(new Note { StartTime = 2000, Column = 0 });
+            foreach (var obj in beatmap.HitObjects)
+                obj.ApplyDefaults(beatmap.ControlPointInfo, beatmap.Difficulty);
+
+            var note2 = (Note)beatmap.HitObjects[1];
+            var hitEvents = new List<HitEvent>
+            {
+                new HitEvent(0, 1.0, HitResult.Perfect, note1, null, null),
+                new HitEvent(0, 1.0, HitResult.Miss, note2, note1, null),
+            };
+
+            var lazerScoreInfo = new ScoreInfo
+            {
+                Ruleset = ruleset.RulesetInfo,
+                ManiaHitMode = (int)EzEnumHitMode.Lazer,
+                ManiaHealthMode = (int)EzEnumHealthMode.Lazer,
+            };
+
+            var bmsScoreInfo = new ScoreInfo
+            {
+                Ruleset = ruleset.RulesetInfo,
+                ManiaHitMode = (int)EzEnumHitMode.IIDX_HD,
+                ManiaHealthMode = (int)EzEnumHealthMode.IIDX_HD,
+            };
+
+            var lazerTimeline = EzScoreTimelineBuilder.BuildFromHitEventsForTesting(ruleset, beatmap, lazerScoreInfo, hitEvents);
+            var bmsTimeline = EzScoreTimelineBuilder.BuildFromHitEventsForTesting(ruleset, beatmap, bmsScoreInfo, hitEvents);
+
+            Assert.That(lazerTimeline.FinalTotalScore, Is.Not.EqualTo(bmsTimeline.FinalTotalScore));
+        }
+    }
+}

--- a/osu.Game.Tests/EzOsuGame/Scoring/EzScoreTimelineTest.cs
+++ b/osu.Game.Tests/EzOsuGame/Scoring/EzScoreTimelineTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using NUnit.Framework;
-using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.Scoring;

--- a/osu.Game/EzOsuGame/Scoring/EzScoreTimeline.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreTimeline.cs
@@ -1,0 +1,55 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+
+namespace osu.Game.EzOsuGame.Scoring
+{
+    public sealed class EzScoreTimeline
+    {
+        private readonly EzScoreTimelineSnapshot[] snapshots;
+
+        public long FinalTotalScore { get; }
+
+        public EzScoreTimeline(IReadOnlyList<EzScoreTimelineSnapshot> snapshots)
+        {
+            if (snapshots.Count == 0)
+            {
+                this.snapshots = Array.Empty<EzScoreTimelineSnapshot>();
+                FinalTotalScore = 0;
+                return;
+            }
+
+            this.snapshots = new EzScoreTimelineSnapshot[snapshots.Count];
+            for (int i = 0; i < snapshots.Count; i++)
+                this.snapshots[i] = snapshots[i];
+
+            FinalTotalScore = this.snapshots[^1].TotalScore;
+        }
+
+        public EzScoreTimelineSnapshot QueryAtTime(double clockTime)
+        {
+            if (snapshots.Length == 0)
+                return EzScoreTimelineSnapshot.Empty;
+
+            if (clockTime <= snapshots[0].ClockTime)
+                return snapshots[0];
+
+            int left = 0;
+            int right = snapshots.Length - 1;
+
+            while (left < right)
+            {
+                int mid = left + (right - left + 1) / 2;
+
+                if (snapshots[mid].ClockTime <= clockTime)
+                    left = mid;
+                else
+                    right = mid - 1;
+            }
+
+            return snapshots[left];
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Scoring/EzScoreTimelineBridge.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreTimelineBridge.cs
@@ -1,0 +1,27 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Threading;
+using osu.Game.Beatmaps;
+using osu.Game.Scoring;
+
+namespace osu.Game.EzOsuGame.Scoring
+{
+    /// <summary>
+    /// 规则集特定的时间线构建入口。Mania 由 Session 一遍判定直接采快照，不经 HitEvents 二次喂 SP。
+    /// </summary>
+    public static class EzScoreTimelineBridge
+    {
+        private static Func<Score, IBeatmap, CancellationToken, EzScoreTimeline?>? mania_timeline_builder;
+
+        public static void RegisterManiaTimelineBuilder(Func<Score, IBeatmap, CancellationToken, EzScoreTimeline?> builder)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+            mania_timeline_builder = builder;
+        }
+
+        public static EzScoreTimeline? TryBuildManiaTimeline(Score score, IBeatmap playableBeatmap, CancellationToken cancellationToken = default)
+            => mania_timeline_builder?.Invoke(score, playableBeatmap, cancellationToken);
+    }
+}

--- a/osu.Game/EzOsuGame/Scoring/EzScoreTimelineBuilder.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreTimelineBuilder.cs
@@ -20,8 +20,13 @@ using osu.Game.Scoring;
 
 namespace osu.Game.EzOsuGame.Scoring
 {
+    /// <summary>
+    /// 从本地 replay 构建分数时间线。Mania 走 Session 一遍 SP 快照；其他规则集暂用 HitEvents 重放（仅非 Mania）。
+    /// 进程内缓存；算法变更时 bump <see cref="timeline_cache_version"/>。
+    /// </summary>
     public static class EzScoreTimelineBuilder
     {
+        /// <summary>进程内缓存失效版本；非磁盘持久化。</summary>
         private const string timeline_cache_version = "v1";
 
         private static readonly ConcurrentDictionary<string, EzScoreTimeline> timeline_cache = new ConcurrentDictionary<string, EzScoreTimeline>();
@@ -48,13 +53,11 @@ namespace osu.Game.EzOsuGame.Scoring
             if (!string.IsNullOrEmpty(cacheKey) && timeline_cache.TryGetValue(cacheKey, out var cached))
                 return cached;
 
-            if (!hasReplayFile(scoreInfo))
-                return null;
-
             cancellationToken.ThrowIfCancellationRequested();
 
             var databasedScore = scoreManager.GetScore(scoreInfo);
 
+            // 唯一门槛：磁盘/库内是否有可读的 replay 帧（不依赖 ScoreInfo.Files 元数据）。
             if (databasedScore?.Replay == null || databasedScore.Replay.Frames.Count == 0)
                 return null;
 
@@ -82,10 +85,12 @@ namespace osu.Game.EzOsuGame.Scoring
 
             if (scoreInfo.Ruleset.OnlineID == 3)
             {
+                // Mania 生产路径：Session 一遍 SP 快照，禁止 buildFromHitEvents。
                 timeline = EzScoreTimelineBridge.TryBuildManiaTimeline(databasedScore, playableBeatmap, cancellationToken);
             }
             else
             {
+                // 非 Mania：统计页临时 HitEvents 或从 replay 生成；不是 Mania HUD 输入。
                 var (hitEvents, offsetsRelativeToEnd) = resolveHitEvents(databasedScore, playableBeatmap, cancellationToken);
 
                 if (hitEvents == null || hitEvents.Count == 0)
@@ -114,6 +119,7 @@ namespace osu.Game.EzOsuGame.Scoring
 
         private static (List<HitEvent>? hitEvents, bool offsetsRelativeToEnd) resolveHitEvents(Score databasedScore, IBeatmap playableBeatmap, CancellationToken cancellationToken)
         {
+            // 统计页打开时 ScoreInfo 上可能有临时 HitEvents（[Ignored]，不持久化）。
             if (databasedScore.ScoreInfo.HitEvents.Count > 0)
                 return (databasedScore.ScoreInfo.HitEvents.ToList(), true);
 
@@ -333,6 +339,7 @@ namespace osu.Game.EzOsuGame.Scoring
 
             if (scoreInfo!.Ruleset.OnlineID == 3)
             {
+                // 与 GameplayEnvironment.FromScore 一致；环境变则重算。
                 var environment = GameplayEnvironment.FromScore(scoreInfo, GlobalConfigStore.EzConfig);
                 return $"{timeline_cache_version}:{identity}:hm{(int)environment.ManiaHitMode}:hh{(int)environment.ManiaHealthMode}:jp{(int)environment.JudgePrecedence}";
             }
@@ -362,8 +369,5 @@ namespace osu.Game.EzOsuGame.Scoring
             generatorsInitialised = true;
             EzScoreReloadBridge.InitializeAllGenerators();
         }
-
-        private static bool hasReplayFile(ScoreInfo scoreInfo)
-            => scoreInfo.Files.Any(f => f.Filename.EndsWith(".osr", StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/osu.Game/EzOsuGame/Scoring/EzScoreTimelineBuilder.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreTimelineBuilder.cs
@@ -1,0 +1,369 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using osu.Game.Beatmaps;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Statistics;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
+
+namespace osu.Game.EzOsuGame.Scoring
+{
+    public static class EzScoreTimelineBuilder
+    {
+        private const string timeline_cache_version = "v1";
+
+        private static readonly ConcurrentDictionary<string, EzScoreTimeline> timeline_cache = new ConcurrentDictionary<string, EzScoreTimeline>();
+        private static bool generators_initialised;
+
+        public static EzScoreTimeline? TryBuild(ScoreManager scoreManager, BeatmapManager beatmaps, ScoreInfo scoreInfo, CancellationToken cancellationToken = default)
+            => tryBuild(scoreManager, beatmaps, scoreInfo, sharedPlayableBeatmap: null, cancellationToken);
+
+        public static EzScoreTimeline? TryBuild(ScoreManager scoreManager, BeatmapManager beatmaps, ScoreInfo scoreInfo, IBeatmap? sharedPlayableBeatmap,
+            CancellationToken cancellationToken = default)
+            => tryBuild(scoreManager, beatmaps, scoreInfo, sharedPlayableBeatmap, cancellationToken);
+
+        private static EzScoreTimeline? tryBuild(ScoreManager scoreManager, BeatmapManager beatmaps, ScoreInfo scoreInfo, IBeatmap? sharedPlayableBeatmap,
+            CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(scoreManager);
+            ArgumentNullException.ThrowIfNull(beatmaps);
+            ArgumentNullException.ThrowIfNull(scoreInfo);
+
+            ensureGeneratorsInitialised();
+
+            string? cacheKey = getCacheKey(scoreInfo);
+
+            if (!string.IsNullOrEmpty(cacheKey) && timeline_cache.TryGetValue(cacheKey, out var cached))
+                return cached;
+
+            if (!hasReplayFile(scoreInfo))
+                return null;
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var databasedScore = scoreManager.GetScore(scoreInfo);
+
+            if (databasedScore?.Replay == null || databasedScore.Replay.Frames.Count == 0)
+                return null;
+
+            var ruleset = scoreInfo.Ruleset.CreateInstance();
+            IBeatmap playableBeatmap;
+
+            if (sharedPlayableBeatmap != null)
+            {
+                playableBeatmap = sharedPlayableBeatmap;
+            }
+            else
+            {
+                var workingBeatmap = beatmaps.GetWorkingBeatmap(scoreInfo.BeatmapInfo);
+
+                if (workingBeatmap is DummyWorkingBeatmap)
+                    return null;
+
+                playableBeatmap = workingBeatmap.GetPlayableBeatmap(scoreInfo.Ruleset, scoreInfo.Mods);
+            }
+
+            if (playableBeatmap.HitObjects.Count == 0)
+                return null;
+
+            EzScoreTimeline? timeline;
+
+            if (scoreInfo.Ruleset.OnlineID == 3)
+            {
+                timeline = EzScoreTimelineBridge.TryBuildManiaTimeline(databasedScore, playableBeatmap, cancellationToken);
+            }
+            else
+            {
+                var (hitEvents, offsetsRelativeToEnd) = resolveHitEvents(databasedScore, playableBeatmap, cancellationToken);
+
+                if (hitEvents == null || hitEvents.Count == 0)
+                    return null;
+
+                timeline = buildFromHitEvents(ruleset, playableBeatmap, scoreInfo, hitEvents, offsetsRelativeToEnd);
+            }
+
+            if (timeline == null)
+                return null;
+
+            if (!string.IsNullOrEmpty(cacheKey))
+                timeline_cache[cacheKey] = timeline;
+
+            return timeline;
+        }
+
+        public static void InvalidateCache(ScoreInfo? scoreInfo)
+        {
+            if (scoreInfo == null)
+                return;
+
+            foreach (var key in timeline_cache.Keys.Where(k => k.Contains(getScoreIdentity(scoreInfo) ?? string.Empty)).ToArray())
+                timeline_cache.TryRemove(key, out _);
+        }
+
+        private static (List<HitEvent>? hitEvents, bool offsetsRelativeToEnd) resolveHitEvents(Score databasedScore, IBeatmap playableBeatmap, CancellationToken cancellationToken)
+        {
+            if (databasedScore.ScoreInfo.HitEvents.Count > 0)
+                return (databasedScore.ScoreInfo.HitEvents.ToList(), true);
+
+            return (EzScoreReloadBridge.TryGenerate(databasedScore, playableBeatmap, cancellationToken), false);
+        }
+
+        internal static EzScoreTimeline BuildFromHitEventsForTesting(Ruleset ruleset, IBeatmap beatmap, ScoreInfo scoreInfo, IReadOnlyList<HitEvent> hitEvents,
+            bool offsetsRelativeToEnd = false)
+            => buildFromHitEvents(ruleset, beatmap, scoreInfo, hitEvents, offsetsRelativeToEnd);
+
+        private static EzScoreTimeline buildFromHitEvents(Ruleset ruleset, IBeatmap beatmap, ScoreInfo scoreInfo, IReadOnlyList<HitEvent> hitEvents, bool offsetsRelativeToEnd)
+        {
+            double fallbackMissWindow = resolveFallbackMissWindow(beatmap);
+
+            var scoreProcessor = ruleset.CreateScoreProcessor();
+            applyScoreProcessorContext(scoreProcessor, scoreInfo);
+            scoreProcessor.ApplyBeatmap(beatmap);
+            scoreProcessor.Mods.Value = scoreInfo.Mods;
+
+            foreach (var mod in scoreInfo.Mods.OfType<IApplicableToScoreProcessor>())
+                mod.ApplyToScoreProcessor(scoreProcessor);
+
+            var snapshots = new List<EzScoreTimelineSnapshot>();
+            int missCount = 0;
+            double lastClockTime = double.NegativeInfinity;
+
+            foreach (var hitEvent in hitEvents.OrderBy(e => getJudgementTime(e, offsetsRelativeToEnd, beatmap, fallbackMissWindow)))
+            {
+                var beatmapHitObject = findBeatmapHitObject(beatmap, hitEvent.HitObject);
+                ensureHitWindows(beatmap, beatmapHitObject);
+
+                scoreProcessor.ApplyResult(new JudgementResult(hitEvent.HitObject, hitEvent.HitObject.CreateJudgement())
+                {
+                    Type = hitEvent.Result,
+                    TimeOffset = hitEvent.TimeOffset,
+                });
+
+                if (hitEvent.Result.IsMiss())
+                    missCount++;
+
+                double clockTime = getJudgementTime(hitEvent, offsetsRelativeToEnd, beatmap, fallbackMissWindow, beatmapHitObject);
+
+                // 保持时间线严格单调，避免同一时刻多条快照导致查询抖动。
+                if (clockTime <= lastClockTime)
+                    clockTime = lastClockTime + 0.001;
+
+                lastClockTime = clockTime;
+                snapshots.Add(createSnapshot(clockTime, scoreProcessor, missCount));
+            }
+
+            if (snapshots.Count == 0)
+                snapshots.Add(createSnapshot(0, scoreProcessor, 0));
+            else if (snapshots[0].ClockTime > 0)
+                snapshots.Insert(0, new EzScoreTimelineSnapshot { ClockTime = 0 });
+
+            return new EzScoreTimeline(snapshots);
+        }
+
+        private static double getJudgementTime(HitEvent hitEvent, bool offsetsRelativeToEnd, IBeatmap beatmap, double fallbackMissWindow, HitObject? beatmapHitObject = null)
+        {
+            beatmapHitObject ??= findBeatmapHitObject(beatmap, hitEvent.HitObject);
+            return EzScoreTimelineJudgementTime.Get(hitEvent, offsetsRelativeToEnd, beatmapHitObject, fallbackMissWindow);
+        }
+
+        private static HitObject findBeatmapHitObject(IBeatmap beatmap, HitObject hitObject)
+        {
+            foreach (var candidate in beatmap.HitObjects)
+            {
+                if (ReferenceEquals(candidate, hitObject))
+                    return candidate;
+
+                var nested = findNestedBeatmapHitObject(candidate, hitObject);
+                if (nested != null)
+                    return nested;
+            }
+
+            foreach (var candidate in beatmap.HitObjects)
+            {
+                if (objectsMatchForLookup(candidate, hitObject))
+                    return candidate;
+
+                var nested = findNestedBeatmapHitObject(candidate, hitObject);
+                if (nested != null)
+                    return nested;
+            }
+
+            return hitObject;
+        }
+
+        private static HitObject? findNestedBeatmapHitObject(HitObject parent, HitObject hitObject)
+        {
+            foreach (var nested in parent.NestedHitObjects)
+            {
+                if (ReferenceEquals(nested, hitObject))
+                    return nested;
+
+                var deeper = findNestedBeatmapHitObject(nested, hitObject);
+                if (deeper != null)
+                    return deeper;
+            }
+
+            foreach (var nested in parent.NestedHitObjects)
+            {
+                if (objectsMatchForLookup(nested, hitObject))
+                    return nested;
+            }
+
+            return null;
+        }
+
+        private static bool objectsMatchForLookup(HitObject candidate, HitObject hitObject)
+        {
+            if (candidate.StartTime != hitObject.StartTime || candidate.GetType() != hitObject.GetType())
+                return false;
+
+            if (hitObject is IHasColumn hitColumn)
+            {
+                if (candidate is IHasColumn candidateColumn)
+                    return candidateColumn.Column == hitColumn.Column;
+
+                return false;
+            }
+
+            return true;
+        }
+
+        private static void applyScoreProcessorContext(ScoreProcessor scoreProcessor, ScoreInfo scoreInfo)
+        {
+            if (scoreInfo.IsLegacyScore)
+                scoreProcessor.IsLegacyScore = true;
+
+            if (scoreInfo.Ruleset.OnlineID != 3)
+                return;
+
+            var environment = GameplayEnvironment.FromScore(scoreInfo, GlobalConfigStore.EzConfig);
+
+            PropertyInfo? overrideProperty = scoreProcessor.GetType().GetProperty("TimelineHitModeOverride", BindingFlags.Public | BindingFlags.Instance);
+
+            if (overrideProperty != null && overrideProperty.CanWrite)
+                overrideProperty.SetValue(scoreProcessor, environment.ManiaHitMode);
+        }
+
+        private static void ensureHitWindows(IBeatmap beatmap, HitObject hitObject)
+        {
+            if (beatmap.BeatmapInfo == null)
+                return;
+
+            if (hitObject.HitWindows != null && hitObject.HitWindows != HitWindows.Empty)
+                return;
+
+            if (hitObject.NestedHitObjects.Count > 0)
+                return;
+
+            hitObject.ApplyDefaults(beatmap.ControlPointInfo, beatmap.BeatmapInfo.Difficulty);
+        }
+
+        private static double resolveFallbackMissWindow(IBeatmap beatmap)
+        {
+            foreach (var hitObject in beatmap.HitObjects)
+            {
+                var windows = findFirstNonEmptyHitWindows(hitObject);
+                if (windows != null)
+                    return windows.WindowFor(HitResult.Miss);
+            }
+
+            if (beatmap.BeatmapInfo == null)
+                return 0;
+
+            foreach (var hitObject in beatmap.HitObjects)
+            {
+                if (hitObject.NestedHitObjects.Count > 0)
+                    continue;
+
+                hitObject.ApplyDefaults(beatmap.ControlPointInfo, beatmap.BeatmapInfo.Difficulty);
+
+                if (hitObject.HitWindows != null && hitObject.HitWindows != HitWindows.Empty)
+                    return hitObject.HitWindows.WindowFor(HitResult.Miss);
+            }
+
+            return 0;
+        }
+
+        private static HitWindows? findFirstNonEmptyHitWindows(HitObject hitObject)
+        {
+            if (hitObject.HitWindows != null && hitObject.HitWindows != HitWindows.Empty)
+                return hitObject.HitWindows;
+
+            foreach (var nested in hitObject.NestedHitObjects)
+            {
+                var windows = findFirstNonEmptyHitWindows(nested);
+                if (windows != null)
+                    return windows;
+            }
+
+            return null;
+        }
+
+        private static EzScoreTimelineSnapshot createSnapshot(double clockTime, ScoreProcessor scoreProcessor, int missCount)
+        {
+            return new EzScoreTimelineSnapshot
+            {
+                ClockTime = clockTime,
+                TotalScore = scoreProcessor.TotalScore.Value,
+                Accuracy = scoreProcessor.Accuracy.Value,
+                Combo = scoreProcessor.Combo.Value,
+                HighestCombo = scoreProcessor.HighestCombo.Value,
+                MissCount = missCount,
+            };
+        }
+
+        private static string? getCacheKey(ScoreInfo? scoreInfo)
+        {
+            string? identity = getScoreIdentity(scoreInfo);
+
+            if (identity == null)
+                return null;
+
+            if (scoreInfo!.Ruleset.OnlineID == 3)
+            {
+                var environment = GameplayEnvironment.FromScore(scoreInfo, GlobalConfigStore.EzConfig);
+                return $"{timeline_cache_version}:{identity}:hm{(int)environment.ManiaHitMode}:hh{(int)environment.ManiaHealthMode}:jp{(int)environment.JudgePrecedence}";
+            }
+
+            return $"{timeline_cache_version}:{identity}";
+        }
+
+        private static string? getScoreIdentity(ScoreInfo? scoreInfo)
+        {
+            if (scoreInfo == null)
+                return null;
+
+            if (!string.IsNullOrEmpty(scoreInfo.Hash))
+                return $"hash:{scoreInfo.Hash}";
+
+            if (scoreInfo.ID != Guid.Empty)
+                return $"id:{scoreInfo.ID}";
+
+            return null;
+        }
+
+        private static void ensureGeneratorsInitialised()
+        {
+            if (generators_initialised)
+                return;
+
+            generators_initialised = true;
+            EzScoreReloadBridge.InitializeAllGenerators();
+        }
+
+        private static bool hasReplayFile(ScoreInfo scoreInfo)
+            => scoreInfo.Files.Any(f => f.Filename.EndsWith(".osr", StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/osu.Game/EzOsuGame/Scoring/EzScoreTimelineBuilder.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreTimelineBuilder.cs
@@ -22,13 +22,10 @@ namespace osu.Game.EzOsuGame.Scoring
 {
     /// <summary>
     /// 从本地 replay 构建分数时间线。Mania 走 Session 一遍 SP 快照；其他规则集暂用 HitEvents 重放（仅非 Mania）。
-    /// 进程内缓存；算法变更时 bump <see cref="timeline_cache_version"/>。
+    /// 进程内缓存；重启进程即清空，无磁盘持久化。
     /// </summary>
     public static class EzScoreTimelineBuilder
     {
-        /// <summary>进程内缓存失效版本；非磁盘持久化。</summary>
-        private const string timeline_cache_version = "v1";
-
         private static readonly ConcurrentDictionary<string, EzScoreTimeline> timeline_cache = new ConcurrentDictionary<string, EzScoreTimeline>();
         private static bool generatorsInitialised;
 
@@ -341,10 +338,10 @@ namespace osu.Game.EzOsuGame.Scoring
             {
                 // 与 GameplayEnvironment.FromScore 一致；环境变则重算。
                 var environment = GameplayEnvironment.FromScore(scoreInfo, GlobalConfigStore.EzConfig);
-                return $"{timeline_cache_version}:{identity}:hm{(int)environment.ManiaHitMode}:hh{(int)environment.ManiaHealthMode}:jp{(int)environment.JudgePrecedence}";
+                return $"{identity}:hm{(int)environment.ManiaHitMode}:hh{(int)environment.ManiaHealthMode}:jp{(int)environment.JudgePrecedence}";
             }
 
-            return $"{timeline_cache_version}:{identity}";
+            return identity;
         }
 
         private static string? getScoreIdentity(ScoreInfo? scoreInfo)

--- a/osu.Game/EzOsuGame/Scoring/EzScoreTimelineBuilder.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreTimelineBuilder.cs
@@ -25,7 +25,7 @@ namespace osu.Game.EzOsuGame.Scoring
         private const string timeline_cache_version = "v1";
 
         private static readonly ConcurrentDictionary<string, EzScoreTimeline> timeline_cache = new ConcurrentDictionary<string, EzScoreTimeline>();
-        private static bool generators_initialised;
+        private static bool generatorsInitialised;
 
         public static EzScoreTimeline? TryBuild(ScoreManager scoreManager, BeatmapManager beatmaps, ScoreInfo scoreInfo, CancellationToken cancellationToken = default)
             => tryBuild(scoreManager, beatmaps, scoreInfo, sharedPlayableBeatmap: null, cancellationToken);
@@ -108,7 +108,7 @@ namespace osu.Game.EzOsuGame.Scoring
             if (scoreInfo == null)
                 return;
 
-            foreach (var key in timeline_cache.Keys.Where(k => k.Contains(getScoreIdentity(scoreInfo) ?? string.Empty)).ToArray())
+            foreach (string key in timeline_cache.Keys.Where(k => k.Contains(getScoreIdentity(scoreInfo) ?? string.Empty)).ToArray())
                 timeline_cache.TryRemove(key, out _);
         }
 
@@ -356,10 +356,10 @@ namespace osu.Game.EzOsuGame.Scoring
 
         private static void ensureGeneratorsInitialised()
         {
-            if (generators_initialised)
+            if (generatorsInitialised)
                 return;
 
-            generators_initialised = true;
+            generatorsInitialised = true;
             EzScoreReloadBridge.InitializeAllGenerators();
         }
 

--- a/osu.Game/EzOsuGame/Scoring/EzScoreTimelineBuilder.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreTimelineBuilder.cs
@@ -251,7 +251,7 @@ namespace osu.Game.EzOsuGame.Scoring
             if (scoreInfo.Ruleset.OnlineID != 3)
                 return;
 
-            var environment = GameplayEnvironment.FromScore(scoreInfo, GlobalConfigStore.EzConfig);
+            var environment = GameplayEnvironment.FromLive(GlobalConfigStore.EzConfig);
 
             PropertyInfo? overrideProperty = scoreProcessor.GetType().GetProperty("TimelineHitModeOverride", BindingFlags.Public | BindingFlags.Instance);
 
@@ -336,8 +336,8 @@ namespace osu.Game.EzOsuGame.Scoring
 
             if (scoreInfo!.Ruleset.OnlineID == 3)
             {
-                // 与 GameplayEnvironment.FromScore 一致；环境变则重算。
-                var environment = GameplayEnvironment.FromScore(scoreInfo, GlobalConfigStore.EzConfig);
+                // 与角逐 HUD 一致：全局 HitMode/HealthMode，不读成绩嵌入字段。
+                var environment = GameplayEnvironment.FromLive(GlobalConfigStore.EzConfig);
                 return $"{identity}:hm{(int)environment.ManiaHitMode}:hh{(int)environment.ManiaHealthMode}:jp{(int)environment.JudgePrecedence}";
             }
 

--- a/osu.Game/EzOsuGame/Scoring/EzScoreTimelineJudgementTime.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreTimelineJudgementTime.cs
@@ -1,0 +1,40 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.EzOsuGame.Scoring
+{
+    internal static class EzScoreTimelineJudgementTime
+    {
+        public static double Get(HitEvent hitEvent, bool offsetsRelativeToEnd, HitObject? beatmapHitObject = null, double fallbackMissWindow = 0)
+        {
+            double rate = hitEvent.GameplayRate ?? 1.0;
+            double offset = hitEvent.TimeOffset / rate;
+
+            var timingObject = beatmapHitObject ?? hitEvent.HitObject;
+            var windowObject = beatmapHitObject ?? hitEvent.HitObject;
+
+            double startTime = timingObject.StartTime;
+            double endTime = timingObject.GetEndTime();
+
+            double judgementTime = offsetsRelativeToEnd
+                ? endTime + offset
+                : startTime + offset;
+
+            double missWindow = windowObject.HitWindows != null && windowObject.HitWindows != HitWindows.Empty
+                ? windowObject.HitWindows.WindowFor(HitResult.Miss)
+                : 0;
+
+            if (missWindow <= 0 && fallbackMissWindow > 0)
+                missWindow = fallbackMissWindow;
+
+            if (missWindow > 0)
+                judgementTime = Math.Max(startTime - missWindow, judgementTime);
+
+            return judgementTime;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Scoring/EzScoreTimelineSnapshot.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreTimelineSnapshot.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.EzOsuGame.Scoring
+{
+    public readonly struct EzScoreTimelineSnapshot
+    {
+        public double ClockTime { get; init; }
+        public long TotalScore { get; init; }
+        public double Accuracy { get; init; }
+        public int Combo { get; init; }
+        public int HighestCombo { get; init; }
+        public int MissCount { get; init; }
+
+        public static EzScoreTimelineSnapshot Empty { get; } = new EzScoreTimelineSnapshot();
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ManiaReplaySession.RunTimeline` to snapshot `ScoreProcessor` state in a single replay pass (no HitEvents → second SP replay).
- Add `EzScoreTimeline` / `EzScoreTimelineBuilder` with Mania bridge; `TryBuild` gates on readable local replay only.
- Fix Ez full-score `TotalScore` to accumulate ex across the full chart (`MinimumAccuracy` × 1M).
- Race timeline builds use global `FromLive` HitMode/HealthMode (not score-embedded modes).
- Tests: Session parity, `TryBuild` integration, EZ2AC timeline, `FromLive` vs embedded HitMode.

## Test plan

- [x] `dotnet test osu.Game.Rulesets.Mania.Tests` (948 passed locally)
- [ ] Mania local play: ghost timeline scores rise from 0 with replay progress (downstream HUD branch)
- [ ] EZ2AC full-score mode: timeline `TotalScore` matches live SP, no early 70–80万 spike

Made with [Cursor](https://cursor.com)