### PR TITLE
Add score race HUD: leaderboard and compare bars

### DIFF
--- a/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
+++ b/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
@@ -61,6 +61,31 @@ namespace osu.Game.Rulesets.Mania.Scoring
                    + bonusPortion;
         }
 
+        protected override double ComputeTheoreticalPerfectJudgedTotalScore(double comboProgress, double accuracyProgress, double bonusPortion)
+        {
+            if (IsLegacyScore || hitMode == EzEnumHitMode.Classic)
+            {
+                return 150000 * comboProgress
+                       + 850000 * accuracyProgress
+                       + bonusPortion;
+            }
+
+            if (hitMode != EzEnumHitMode.Lazer && hitMode != EzEnumHitMode.Classic)
+            {
+                var stats = GetScoreProcessorStatistics();
+                double maximumBaseScoreOnChart = MinimumAccuracy.Value > 0 ? stats.BaseScore / MinimumAccuracy.Value : 0;
+
+                if (maximumBaseScoreOnChart <= 0)
+                    return 0;
+
+                return MAX_SCORE * stats.MaximumBaseScore / maximumBaseScoreOnChart;
+            }
+
+            return 150000 * comboProgress
+                   + 850000 * accuracyProgress
+                   + bonusPortion;
+        }
+
         protected override double GetComboScoreChange(JudgementResult result)
         {
             return getBaseComboScoreForResult(result.Type) * Math.Min(Math.Max(0.5, Math.Log(result.ComboAfterJudgement, combo_base)), Math.Log(400, combo_base));

--- a/osu.Game.Tests/EzOsuGame/Scoring/EzScoreRacePickGhostTest.cs
+++ b/osu.Game.Tests/EzOsuGame/Scoring/EzScoreRacePickGhostTest.cs
@@ -1,0 +1,50 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Game.EzOsuGame.Scoring;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Scoring;
+
+namespace osu.Game.Tests.EzOsuGame.Scoring
+{
+    [TestFixture]
+    public class EzScoreRacePickGhostTest
+    {
+        [Test]
+        public void TestPickBestSingleScoreReturnsSameForAllMetrics()
+        {
+            var score = createScore(totalScore: 1_000_000, accuracy: 0.97, maxCombo: 500);
+            var scores = new List<ScoreInfo> { score };
+
+            Assert.That(EzLocalScoreQueries.PickBest(scores, EzScoreRaceMetric.Accuracy)?.ID, Is.EqualTo(score.ID));
+            Assert.That(EzLocalScoreQueries.PickBest(scores, EzScoreRaceMetric.TotalScore)?.ID, Is.EqualTo(score.ID));
+            Assert.That(EzLocalScoreQueries.PickBest(scores, EzScoreRaceMetric.MaxCombo)?.ID, Is.EqualTo(score.ID));
+        }
+
+        [Test]
+        public void TestPickBestTwoScoresIndependentByMetric()
+        {
+            var highAccuracy = createScore(totalScore: 900_000, accuracy: 0.99, maxCombo: 400);
+            var highTotal = createScore(totalScore: 1_100_000, accuracy: 0.92, maxCombo: 600);
+            var scores = new List<ScoreInfo> { highAccuracy, highTotal };
+
+            Assert.That(EzLocalScoreQueries.PickBest(scores, EzScoreRaceMetric.Accuracy)?.ID, Is.EqualTo(highAccuracy.ID));
+            Assert.That(EzLocalScoreQueries.PickBest(scores, EzScoreRaceMetric.TotalScore)?.ID, Is.EqualTo(highTotal.ID));
+        }
+
+        private static ScoreInfo createScore(long totalScore, double accuracy, int maxCombo)
+        {
+            return new ScoreInfo
+            {
+                Ruleset = new OsuRuleset().RulesetInfo,
+                TotalScore = totalScore,
+                Accuracy = accuracy,
+                MaxCombo = maxCombo,
+                Date = DateTimeOffset.UtcNow,
+            };
+        }
+    }
+}

--- a/osu.Game.Tests/EzOsuGame/Scoring/EzScoreRacePlayModeTest.cs
+++ b/osu.Game.Tests/EzOsuGame/Scoring/EzScoreRacePlayModeTest.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.EzOsuGame.Scoring;
+using osu.Game.Scoring;
+using osu.Game.Screens.Play;
+
+namespace osu.Game.Tests.EzOsuGame.Scoring
+{
+    [TestFixture]
+    public class EzScoreRacePlayModeTest
+    {
+        [Test]
+        public void TestReplayPlayerResolvesToLocalReplayChase()
+        {
+            var replayPlayer = new ReplayPlayer(new Score());
+            Assert.That(EzScoreRacePlayModeResolver.Resolve(replayPlayer), Is.EqualTo(EzScoreRacePlayMode.LocalReplayChase));
+        }
+
+        [Test]
+        public void TestSoloPlayerResolvesToLocalLive()
+        {
+            var soloPlayer = new SoloPlayer();
+            Assert.That(EzScoreRacePlayModeResolver.Resolve(soloPlayer), Is.EqualTo(EzScoreRacePlayMode.LocalLive));
+        }
+
+        [Test]
+        public void TestSpectatorPlayerResolvesToSpectatingLive()
+        {
+            var spectatorPlayer = new SoloSpectatorPlayer(new Score());
+            Assert.That(EzScoreRacePlayModeResolver.Resolve(spectatorPlayer), Is.EqualTo(EzScoreRacePlayMode.SpectatingLive));
+        }
+    }
+}

--- a/osu.Game.Tests/EzOsuGame/Scoring/EzScoreRaceRulesetSupportTest.cs
+++ b/osu.Game.Tests/EzOsuGame/Scoring/EzScoreRaceRulesetSupportTest.cs
@@ -1,0 +1,48 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.EzOsuGame.Scoring;
+using osu.Game.Rulesets.Catch;
+using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Taiko;
+
+namespace osu.Game.Tests.EzOsuGame.Scoring
+{
+    [TestFixture]
+    public class EzScoreRaceRulesetSupportTest
+    {
+        [Test]
+        public void TestManiaSupportsGhostRace()
+        {
+            var ruleset = new ManiaRuleset().RulesetInfo;
+            Assert.That(EzScoreRaceRulesetSupport.SupportsGhostRace(ruleset), Is.True);
+            Assert.That(EzScoreRaceRulesetSupport.GetGhostTimelineMode(ruleset), Is.EqualTo(EzScoreRaceGhostTimelineMode.ManiaSession));
+        }
+
+        [Test]
+        public void TestOsuSupportsGhostRace()
+        {
+            var ruleset = new OsuRuleset().RulesetInfo;
+            Assert.That(EzScoreRaceRulesetSupport.SupportsGhostRace(ruleset), Is.True);
+            Assert.That(EzScoreRaceRulesetSupport.GetGhostTimelineMode(ruleset), Is.EqualTo(EzScoreRaceGhostTimelineMode.HitEvents));
+        }
+
+        [Test]
+        public void TestTaikoDoesNotSupportGhostRace()
+        {
+            var ruleset = new TaikoRuleset().RulesetInfo;
+            Assert.That(EzScoreRaceRulesetSupport.SupportsGhostRace(ruleset), Is.False);
+            Assert.That(EzScoreRaceRulesetSupport.GetGhostTimelineMode(ruleset), Is.EqualTo(EzScoreRaceGhostTimelineMode.None));
+        }
+
+        [Test]
+        public void TestCatchDoesNotSupportGhostRace()
+        {
+            var ruleset = new CatchRuleset().RulesetInfo;
+            Assert.That(EzScoreRaceRulesetSupport.SupportsGhostRace(ruleset), Is.False);
+            Assert.That(EzScoreRaceRulesetSupport.GetGhostTimelineMode(ruleset), Is.EqualTo(EzScoreRaceGhostTimelineMode.None));
+        }
+    }
+}

--- a/osu.Game.Tests/EzOsuGame/Scoring/EzScoreTimelineTest.cs
+++ b/osu.Game.Tests/EzOsuGame/Scoring/EzScoreTimelineTest.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.Scoring;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mania;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Objects;
@@ -149,6 +150,39 @@ namespace osu.Game.Tests.EzOsuGame.Scoring
             var bmsTimeline = EzScoreTimelineBuilder.BuildFromHitEventsForTesting(ruleset, beatmap, bmsScoreInfo, hitEvents);
 
             Assert.That(lazerTimeline.FinalTotalScore, Is.Not.EqualTo(bmsTimeline.FinalTotalScore));
+        }
+
+        [Test]
+        public void TestOsuTimelineFinalScoreMatchesScoreProcessorFeed()
+        {
+            var ruleset = new OsuRuleset();
+            var testBeatmap = new TestBeatmap(ruleset.RulesetInfo)
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new HitCircle { StartTime = 1000 },
+                    new HitCircle { StartTime = 2000 },
+                },
+            };
+            var beatmap = ruleset.CreateBeatmapConverter(testBeatmap).Convert();
+            var circle1 = (HitCircle)beatmap.HitObjects[0];
+            var circle2 = (HitCircle)beatmap.HitObjects[1];
+            var scoreInfo = new ScoreInfo { Ruleset = ruleset.RulesetInfo };
+
+            var hitEvents = new List<HitEvent>
+            {
+                new HitEvent(0, 1.0, HitResult.Great, circle1, null, null),
+                new HitEvent(0, 1.0, HitResult.Great, circle2, circle1, null),
+            };
+
+            var timeline = EzScoreTimelineBuilder.BuildFromHitEventsForTesting(ruleset, beatmap, scoreInfo, hitEvents);
+
+            var scoreProcessor = ruleset.CreateScoreProcessor();
+            scoreProcessor.ApplyBeatmap(beatmap);
+            scoreProcessor.ApplyResult(new JudgementResult(circle1, circle1.CreateJudgement()) { Type = HitResult.Great });
+            scoreProcessor.ApplyResult(new JudgementResult(circle2, circle2.CreateJudgement()) { Type = HitResult.Great });
+
+            Assert.That(timeline.FinalTotalScore, Is.EqualTo(scoreProcessor.TotalScore.Value));
         }
     }
 }

--- a/osu.Game.Tests/Visual/EzOsuGame/TestSceneEzHUDScoreCompareBars.cs
+++ b/osu.Game.Tests/Visual/EzOsuGame/TestSceneEzHUDScoreCompareBars.cs
@@ -1,0 +1,39 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.EzOsuGame.HUD;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Screens.Play;
+using osu.Game.Screens.Play.Leaderboards;
+using osu.Game.Tests.Gameplay;
+
+namespace osu.Game.Tests.Visual.EzOsuGame
+{
+    public partial class TestSceneEzHUDScoreCompareBars : OsuTestScene
+    {
+        [Cached]
+        private readonly GameplayState gameplayState = TestGameplayState.Create(new OsuRuleset());
+
+        [Cached(typeof(IGameplayClock))]
+        private readonly IGameplayClock gameplayClock = new GameplayClockContainer(new osu.Framework.Audio.Track.TrackVirtual(60000), false, false);
+
+        [Cached(typeof(IGameplayLeaderboardProvider))]
+        private readonly EmptyGameplayLeaderboardProvider leaderboardProvider = new EmptyGameplayLeaderboardProvider();
+
+        public TestSceneEzHUDScoreCompareBars()
+        {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Child = new EzHUDScoreCompareBars
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+            };
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/EzOsuGame/TestSceneEzHUDScoreRaceLeaderboard.cs
+++ b/osu.Game.Tests/Visual/EzOsuGame/TestSceneEzHUDScoreRaceLeaderboard.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.EzOsuGame.HUD;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Screens.Play;
+using osu.Game.Screens.Play.Leaderboards;
+using osu.Game.Tests.Gameplay;
+
+namespace osu.Game.Tests.Visual.EzOsuGame
+{
+    public partial class TestSceneEzHUDScoreRaceLeaderboard : OsuTestScene
+    {
+        [Cached]
+        private readonly GameplayState gameplayState = TestGameplayState.Create(new OsuRuleset());
+
+        [Cached(typeof(IGameplayClock))]
+        private readonly IGameplayClock gameplayClock = new GameplayClockContainer(new osu.Framework.Audio.Track.TrackVirtual(60000), false, false);
+
+        [Cached(typeof(IGameplayLeaderboardProvider))]
+        private readonly EmptyGameplayLeaderboardProvider leaderboardProvider = new EmptyGameplayLeaderboardProvider();
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Child = new EzHUDScoreRaceLeaderboard
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+            };
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -66,10 +67,10 @@ namespace osu.Game.EzOsuGame.HUD
         };
 
         [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_COMPARE_BAR_WIDTH_LABEL), nameof(EzHUDStrings.SCORE_COMPARE_BAR_WIDTH_DESCRIPTION))]
-        public BindableNumber<float> BarWidth { get; } = new BindableNumber<float>(50)
+        public BindableNumber<float> BarWidth { get; } = new BindableNumber<float>(38)
         {
-            MinValue = 20,
-            MaxValue = 100,
+            MinValue = 10,
+            MaxValue = 80,
             Precision = 1,
         };
 
@@ -84,6 +85,9 @@ namespace osu.Game.EzOsuGame.HUD
         private ScoreInfo? pickedScoreForCondition1;
         private ScoreInfo? pickedScoreForCondition2;
         private bool compareCacheDirty = true;
+
+        [Cached]
+        private OsuColour colours { get; set; } = null!;
 
         public EzHUDScoreCompareBars()
         {
@@ -157,17 +161,37 @@ namespace osu.Game.EzOsuGame.HUD
             long condition1BarScore = getBarScoreForMetric(CompareCondition1.Value, pickedScoreForCondition1, clockTime);
             long condition2BarScore = getBarScoreForMetric(CompareCondition2.Value, pickedScoreForCondition2, clockTime);
 
-            bars[0].UpdateValues(EzHUDStrings.SCORE_COMPARE_NOW_LABEL, formatScore(nowBarScore), nowBarScore, barScoreScale);
+            bars[0].UpdateValues(EzHUDStrings.SCORE_COMPARE_NOW_LABEL, formatScore(nowBarScore), nowBarScore, barScoreScale, getBarColour(isCurrent: true));
             bars[1].UpdateValues(
                 CompareCondition1.Value.GetLocalisableDescription(),
                 formatScore(condition1BarScore),
                 condition1BarScore,
-                barScoreScale);
+                barScoreScale,
+                getBarColour(CompareCondition1.Value));
             bars[2].UpdateValues(
                 CompareCondition2.Value.GetLocalisableDescription(),
                 formatScore(condition2BarScore),
                 condition2BarScore,
-                barScoreScale);
+                barScoreScale,
+                getBarColour(CompareCondition2.Value));
+        }
+
+        /// <summary>
+        /// 与角逐榜面板色系一致：当前=绿、最高分数=黄、最低 Miss=红、其余=蓝。
+        /// </summary>
+        private Color4 getBarColour(EzScoreRaceMetric metric = default, bool isCurrent = false)
+        {
+            const float alpha = 0.85f;
+
+            if (isCurrent)
+                return colours.Lime2.Opacity(alpha);
+
+            return metric switch
+            {
+                EzScoreRaceMetric.TotalScore => colours.YellowLight.Opacity(alpha),
+                EzScoreRaceMetric.MissCount => colours.Red2.Opacity(alpha),
+                _ => colours.Blue4.Opacity(alpha),
+            };
         }
 
         private void onCompareSelectionChanged()
@@ -300,6 +324,7 @@ namespace osu.Game.EzOsuGame.HUD
             private LocalisableString lastTitle;
             private string lastValue = string.Empty;
             private float lastBarHeight = -1;
+            private Color4 lastBarColour;
 
             public CompareBar()
             {
@@ -342,7 +367,6 @@ namespace osu.Game.EzOsuGame.HUD
                             {
                                 RelativeSizeAxes = Axes.None,
                                 Width = barThickness,
-                                Colour = new Color4(0.4f, 0.75f, 1f, 0.85f),
                             },
                         },
                         valueText = new OsuSpriteText
@@ -371,7 +395,7 @@ namespace osu.Game.EzOsuGame.HUD
                 }
             }
 
-            public void UpdateValues(LocalisableString title, string value, long barScore, long maxBarScore)
+            public void UpdateValues(LocalisableString title, string value, long barScore, long maxBarScore, Color4 barColour)
             {
                 Alpha = 1;
 
@@ -385,6 +409,12 @@ namespace osu.Game.EzOsuGame.HUD
                 {
                     valueText.Text = value;
                     lastValue = value;
+                }
+
+                if (lastBarColour != barColour)
+                {
+                    bar.Colour = barColour;
+                    lastBarColour = barColour;
                 }
 
                 float ratio = maxBarScore <= 0 ? 0 : (float)barScore / maxBarScore;

--- a/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
@@ -56,10 +56,10 @@ namespace osu.Game.EzOsuGame.HUD
         public Bindable<EzScoreModFilter> ModFilterSetting { get; } = new Bindable<EzScoreModFilter>(EzScoreModFilter.Any);
 
         [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_COMPARE_CONDITION1_LABEL), nameof(EzHUDStrings.SCORE_COMPARE_CONDITION1_DESCRIPTION))]
-        public Bindable<EzScoreRaceMetric> CompareCondition1 { get; } = new Bindable<EzScoreRaceMetric>(EzScoreRaceMetric.Accuracy);
+        public Bindable<EzScoreRaceMetric> CompareCondition1Setting { get; } = new Bindable<EzScoreRaceMetric>(EzScoreRaceMetric.Accuracy);
 
         [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_COMPARE_CONDITION2_LABEL), nameof(EzHUDStrings.SCORE_COMPARE_CONDITION2_DESCRIPTION))]
-        public Bindable<EzScoreRaceMetric> CompareCondition2 { get; } = new Bindable<EzScoreRaceMetric>(EzScoreRaceMetric.TheoreticalMaxScore);
+        public Bindable<EzScoreRaceMetric> CompareCondition2Setting { get; } = new Bindable<EzScoreRaceMetric>(EzScoreRaceMetric.TotalScore);
 
         [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_RACE_BAR_DIRECTION_LABEL), nameof(EzHUDStrings.SCORE_RACE_BAR_DIRECTION_DESCRIPTION))]
         public Bindable<EzScoreCompareBarDirection> BarDirection { get; } = new Bindable<EzScoreCompareBarDirection>(EzScoreCompareBarDirection.Upward);
@@ -176,8 +176,8 @@ namespace osu.Game.EzOsuGame.HUD
             BackgroundVisible.BindValueChanged(_ => updateBackgroundVisibility(), true);
             BackdropBlurEnabled.BindValueChanged(_ => SyncAcrylicCaptureState(), true);
 
-            CompareCondition1.BindValueChanged(_ => refreshPickedEntries(), true);
-            CompareCondition2.BindValueChanged(_ => refreshPickedEntries(), true);
+            CompareCondition1Setting.BindValueChanged(_ => onCompareConditionChanged(), true);
+            CompareCondition2Setting.BindValueChanged(_ => onCompareConditionChanged(), true);
             BarDirection.BindValueChanged(_ => layoutBars(), true);
             BarHeight.BindValueChanged(_ => layoutBars(), true);
             BarWidth.BindValueChanged(_ => layoutBars(), true);
@@ -198,39 +198,61 @@ namespace osu.Game.EzOsuGame.HUD
 
         protected override void OnSessionReady()
         {
-            Session?.IsReady.BindValueChanged(_ => refreshPickedEntries(), true);
+            Session?.IsReady.BindValueChanged(_ => onCompareConditionChanged(), true);
         }
 
         protected override void OnEntriesChangedScheduled()
         {
-            refreshPickedEntries();
+            // 时间线就绪后只刷新显示；勿重跑 PickGhost（会打断条件 2 刚发起的加载）。
+            UpdateDisplay();
         }
 
         protected override void UpdateDisplay()
         {
-            if (Session == null || !Session.IsReady.Value)
-                return;
-
             double clockTime = GetCurrentClockTime();
             long barScoreScale = getBarScoreScale();
-
             long nowBarScore = GetLiveDisplayScore();
-            long condition1BarScore = getBarScoreForMetric(CompareCondition1.Value, pickedEntryForCondition1, clockTime);
-            long condition2BarScore = getBarScoreForMetric(CompareCondition2.Value, pickedEntryForCondition2, clockTime);
 
             bars[0].UpdateValues(EzHUDStrings.SCORE_COMPARE_NOW_LABEL, formatScore(nowBarScore), nowBarScore, barScoreScale, getBarColour(isCurrent: true));
-            bars[1].UpdateValues(
-                CompareCondition1.Value.GetLocalisableDescription(),
-                formatScoreOrDash(condition1BarScore, pickedEntryForCondition1, CompareCondition1.Value),
-                condition1BarScore,
+            updateCompareBar(bars[1], CompareCondition1Setting.Value, pickedEntryForCondition1, clockTime, barScoreScale);
+            updateCompareBar(bars[2], CompareCondition2Setting.Value, pickedEntryForCondition2, clockTime, barScoreScale);
+        }
+
+        private void updateCompareBar(CompareBar bar, EzScoreRaceMetric metric, EzScoreRaceEntry? pickedEntry, double clockTime, long barScoreScale)
+        {
+            if (metric == EzScoreRaceMetric.TheoreticalMaxScore)
+            {
+                long theoreticalScore = getTheoreticalScoreAtTime();
+                bar.UpdateValues(
+                    metric.GetLocalisableDescription(),
+                    formatScore(theoreticalScore),
+                    theoreticalScore,
+                    barScoreScale,
+                    getBarColour(metric));
+                return;
+            }
+
+            if (Session == null || !Session.IsReady.Value)
+            {
+                bar.UpdateValues(metric.GetLocalisableDescription(), "-", 0, barScoreScale, getBarColour(metric));
+                return;
+            }
+
+            long barScore = EzScoreRaceSession.QueryTimelineScore(pickedEntry, clockTime);
+            bar.UpdateValues(
+                metric.GetLocalisableDescription(),
+                formatScoreOrDash(barScore, pickedEntry, metric),
+                barScore,
                 barScoreScale,
-                getBarColour(CompareCondition1.Value));
-            bars[2].UpdateValues(
-                CompareCondition2.Value.GetLocalisableDescription(),
-                formatScoreOrDash(condition2BarScore, pickedEntryForCondition2, CompareCondition2.Value),
-                condition2BarScore,
-                barScoreScale,
-                getBarColour(CompareCondition2.Value));
+                getBarColour(metric));
+        }
+
+        private void onCompareConditionChanged()
+        {
+            refreshPickedEntries();
+            bars[1].ResetVisualCache();
+            bars[2].ResetVisualCache();
+            UpdateDisplay();
         }
 
         protected override void Dispose(bool isDisposing)
@@ -274,17 +296,11 @@ namespace osu.Game.EzOsuGame.HUD
                 return;
             }
 
-            pickedEntryForCondition1 = Session.PickGhost(CompareCondition1.Value);
-            pickedEntryForCondition2 = Session.PickGhost(CompareCondition2.Value, pickedEntryForCondition1?.ScoreInfo);
+            pickedEntryForCondition1 = Session.PickGhost(CompareCondition1Setting.Value);
+            pickedEntryForCondition2 = Session.PickGhost(CompareCondition2Setting.Value, pickedEntryForCondition1?.ScoreInfo);
         }
 
-        private long getBarScoreForMetric(EzScoreRaceMetric metric, EzScoreRaceEntry? pickedEntry, double clockTime)
-        {
-            if (metric == EzScoreRaceMetric.TheoreticalMaxScore)
-                return getTheoreticalScoreAtTime();
-
-            return EzScoreRaceSession.QueryTimelineScore(pickedEntry, clockTime);
-        }
+        private static string formatScore(long score) => score.ToString("N0");
 
         /// <summary>
         /// 当前时刻「已判定区间全 Perfect」应达到的分数（≥ 当前实际分，与 live SP 同源）。
@@ -319,8 +335,6 @@ namespace osu.Game.EzOsuGame.HUD
 
             return (long)ScoreProcessor.MAX_SCORE;
         }
-
-        private static string formatScore(long score) => score.ToString("N0");
 
         private static string formatScoreOrDash(long score, EzScoreRaceEntry? pickedEntry, EzScoreRaceMetric metric)
         {
@@ -380,9 +394,6 @@ namespace osu.Game.EzOsuGame.HUD
                 maxBarSize = maxSize;
                 barThickness = thickness;
 
-                if (barTrack == null)
-                    return;
-
                 barTrack.Size = new Vector2(barThickness, maxSize);
                 bar.Width = barThickness;
                 applyBarAnchor();
@@ -439,6 +450,11 @@ namespace osu.Game.EzOsuGame.HUD
                     bar.Anchor = Anchor.TopCentre;
                     bar.Origin = Anchor.TopCentre;
                 }
+            }
+
+            public void ResetVisualCache()
+            {
+                lastBarHeight = -1;
             }
 
             public void UpdateValues(LocalisableString title, string value, long barScore, long maxBarScore, Color4 barColour)

--- a/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
@@ -37,7 +37,7 @@ namespace osu.Game.EzOsuGame.HUD
 
     /// <summary>
     /// BMS 风格三柱分数对比：当前局 + 两条按对比条件选出的参考柱。
-    /// 柱高与标签数值始终按 TotalScore 绘制；对比条件仅用于筛选对比哪条成绩。
+    /// 柱高与标签数值始终按 TotalScore 绘制；柱图总高度对应整谱理论满分。
     /// </summary>
     public partial class EzHUDScoreCompareBars : EzHUDScoreRaceComponent, ISerialisableDrawable
     {
@@ -66,10 +66,10 @@ namespace osu.Game.EzOsuGame.HUD
         };
 
         [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_COMPARE_BAR_WIDTH_LABEL), nameof(EzHUDStrings.SCORE_COMPARE_BAR_WIDTH_DESCRIPTION))]
-        public BindableNumber<float> BarWidth { get; } = new BindableNumber<float>(88)
+        public BindableNumber<float> BarWidth { get; } = new BindableNumber<float>(50)
         {
-            MinValue = 40,
-            MaxValue = 200,
+            MinValue = 20,
+            MaxValue = 100,
             Precision = 1,
         };
 
@@ -80,6 +80,11 @@ namespace osu.Game.EzOsuGame.HUD
         private Container barsContainer = null!;
         private readonly CompareBar[] bars = new CompareBar[3];
 
+        private List<ScoreInfo> compareCandidates = new List<ScoreInfo>();
+        private ScoreInfo? pickedScoreForCondition1;
+        private ScoreInfo? pickedScoreForCondition2;
+        private bool compareCacheDirty = true;
+
         public EzHUDScoreCompareBars()
         {
             Width = 3 * BarWidth.Value + 2 * bar_spacing + container_padding * 2;
@@ -88,16 +93,14 @@ namespace osu.Game.EzOsuGame.HUD
 
         protected override void ConfigureSession()
         {
-            if (Session == null)
-                return;
-
             // 仅同步 Mod 过滤；条目数由角逐榜组件负责。
-            Session.ReloadIfNeeded(ModFilter.Value, Session.MaxEntryCount);
+            Session?.ReloadIfNeeded(ModFilter.Value, Session.MaxEntryCount);
         }
 
         protected override void LoadComplete()
         {
             ModFilter.BindTo(ModFilterSetting);
+            ModFilter.BindValueChanged(_ => invalidateCompareCache(), true);
 
             barsContainer = new Container
             {
@@ -116,8 +119,8 @@ namespace osu.Game.EzOsuGame.HUD
 
             base.LoadComplete();
 
-            CompareCondition1.BindValueChanged(_ => refreshHistoricalBars(), true);
-            CompareCondition2.BindValueChanged(_ => refreshHistoricalBars(), true);
+            CompareCondition1.BindValueChanged(_ => onCompareSelectionChanged(), true);
+            CompareCondition2.BindValueChanged(_ => onCompareSelectionChanged(), true);
             BarDirection.BindValueChanged(_ => layoutBars(), true);
             BarHeight.BindValueChanged(_ => layoutBars(), true);
             BarWidth.BindValueChanged(_ => layoutBars(), true);
@@ -127,11 +130,16 @@ namespace osu.Game.EzOsuGame.HUD
 
         protected override void OnSessionReady()
         {
-            Session?.IsReady.BindValueChanged(_ => refreshHistoricalBars(), true);
+            Session?.IsReady.BindValueChanged(_ =>
+            {
+                invalidateCompareCache();
+                refreshHistoricalBars();
+            }, true);
         }
 
         protected override void OnEntriesChangedScheduled()
         {
+            invalidateCompareCache();
             refreshHistoricalBars();
         }
 
@@ -140,27 +148,57 @@ namespace osu.Game.EzOsuGame.HUD
             if (Session == null || !Session.IsReady.Value)
                 return;
 
+            ensureCompareCache();
+
             double clockTime = GetCurrentClockTime();
+            long barScoreScale = getBarScoreScale();
 
             long nowBarScore = GetLiveDisplayScore();
-            long condition1BarScore = getBarScoreAtTime(CompareCondition1.Value, clockTime, exclude: null);
-            long condition2BarScore = getBarScoreAtTime(CompareCondition2.Value, clockTime, getExcludeForCondition2());
+            long condition1BarScore = getBarScoreForMetric(CompareCondition1.Value, pickedScoreForCondition1, clockTime);
+            long condition2BarScore = getBarScoreForMetric(CompareCondition2.Value, pickedScoreForCondition2, clockTime);
 
-            long maxBarScore = Math.Max(1, nowBarScore);
-            maxBarScore = Math.Max(maxBarScore, condition1BarScore);
-            maxBarScore = Math.Max(maxBarScore, condition2BarScore);
-
-            bars[0].UpdateValues(EzHUDStrings.SCORE_COMPARE_NOW_LABEL, formatScore(nowBarScore), nowBarScore, maxBarScore);
+            bars[0].UpdateValues(EzHUDStrings.SCORE_COMPARE_NOW_LABEL, formatScore(nowBarScore), nowBarScore, barScoreScale);
             bars[1].UpdateValues(
                 CompareCondition1.Value.GetLocalisableDescription(),
                 formatScore(condition1BarScore),
                 condition1BarScore,
-                maxBarScore);
+                barScoreScale);
             bars[2].UpdateValues(
                 CompareCondition2.Value.GetLocalisableDescription(),
                 formatScore(condition2BarScore),
                 condition2BarScore,
-                maxBarScore);
+                barScoreScale);
+        }
+
+        private void onCompareSelectionChanged()
+        {
+            if (!compareCacheDirty)
+                rebuildPickedScores();
+
+            refreshHistoricalBars();
+        }
+
+        private void invalidateCompareCache() => compareCacheDirty = true;
+
+        private void ensureCompareCache()
+        {
+            if (!compareCacheDirty)
+                return;
+
+            compareCandidates = queryCompareCandidates();
+            rebuildPickedScores();
+            compareCacheDirty = false;
+        }
+
+        private void rebuildPickedScores()
+        {
+            pickedScoreForCondition1 = CompareCondition1.Value == EzScoreRaceMetric.TheoreticalMaxScore
+                ? null
+                : EzLocalScoreQueries.PickBest(compareCandidates, CompareCondition1.Value);
+
+            pickedScoreForCondition2 = CompareCondition2.Value == EzScoreRaceMetric.TheoreticalMaxScore
+                ? null
+                : EzLocalScoreQueries.PickBest(compareCandidates, CompareCondition2.Value, exclude: pickedScoreForCondition1);
         }
 
         private void refreshHistoricalBars()
@@ -171,24 +209,15 @@ namespace osu.Game.EzOsuGame.HUD
             UpdateDisplay();
         }
 
-        private ScoreInfo? getExcludeForCondition2()
-        {
-            if (CompareCondition1.Value == EzScoreRaceMetric.TheoreticalMaxScore)
-                return null;
-
-            return EzLocalScoreQueries.PickBest(getCompareCandidates(), CompareCondition1.Value);
-        }
-
-        private long getBarScoreAtTime(EzScoreRaceMetric metric, double clockTime, ScoreInfo? exclude)
+        private long getBarScoreForMetric(EzScoreRaceMetric metric, ScoreInfo? pickedScore, double clockTime)
         {
             if (metric == EzScoreRaceMetric.TheoreticalMaxScore)
                 return getTheoreticalScoreAtTime();
 
-            var scoreInfo = EzLocalScoreQueries.PickBest(getCompareCandidates(), metric, exclude);
-            return getTotalScoreAtTime(scoreInfo, clockTime);
+            return getTotalScoreAtTime(pickedScore, clockTime);
         }
 
-        private List<ScoreInfo> getCompareCandidates()
+        private List<ScoreInfo> queryCompareCandidates()
         {
             if (GameplayState == null)
                 return new List<ScoreInfo>();
@@ -210,12 +239,26 @@ namespace osu.Game.EzOsuGame.HUD
             return scoreInfo.TotalScore;
         }
 
+        /// <summary>
+        /// 当前时刻理论满分进度（与 live SP 一致）。
+        /// </summary>
         private long getTheoreticalScoreAtTime()
         {
             if (ScoreProcessor == null)
                 return 0;
 
             return (long)Math.Round(ScoreProcessor.MinimumAccuracy.Value * ScoreProcessor.MAX_SCORE);
+        }
+
+        /// <summary>
+        /// 柱图满刻度 = 整谱理论满分（<see cref="ScoreProcessor.MaximumTotalScore"/>）。
+        /// </summary>
+        private long getBarScoreScale()
+        {
+            if (ScoreProcessor != null && ScoreProcessor.MaximumTotalScore > 0)
+                return ScoreProcessor.MaximumTotalScore;
+
+            return (long)ScoreProcessor.MAX_SCORE;
         }
 
         private static string formatScore(long score) => score.ToString("N0");
@@ -232,7 +275,7 @@ namespace osu.Game.EzOsuGame.HUD
             for (int i = 0; i < bars.Length; i++)
             {
                 var bar = bars[i];
-                bar.Configure(direction, barAxisHeight);
+                bar.Configure(direction, barAxisHeight, barThickness);
 
                 bar.Anchor = Anchor.BottomLeft;
                 bar.Origin = Anchor.BottomLeft;
@@ -244,27 +287,34 @@ namespace osu.Game.EzOsuGame.HUD
 
         private partial class CompareBar : CompositeDrawable
         {
+            private const float min_bar_height = 3;
+
             private Box bar = null!;
             private OsuSpriteText titleText = null!;
             private OsuSpriteText valueText = null!;
             private Container barTrack = null!;
             private EzScoreCompareBarDirection direction = EzScoreCompareBarDirection.Upward;
             private float maxBarSize;
+            private float barThickness;
+
+            private LocalisableString lastTitle;
+            private string lastValue = string.Empty;
+            private float lastBarHeight = -1;
 
             public CompareBar()
             {
                 RelativeSizeAxes = Axes.None;
             }
 
-            public void Configure(EzScoreCompareBarDirection barDirection, float maxSize)
+            public void Configure(EzScoreCompareBarDirection barDirection, float maxSize, float thickness)
             {
                 direction = barDirection;
                 maxBarSize = maxSize;
+                barThickness = thickness;
 
-                if (barTrack == null)
-                    return;
+                barTrack.Size = new Vector2(barThickness, maxSize);
 
-                barTrack.Height = maxSize;
+                bar.Width = barThickness;
                 applyBarAnchor();
             }
 
@@ -287,10 +337,11 @@ namespace osu.Game.EzOsuGame.HUD
                         },
                         barTrack = new Container
                         {
-                            RelativeSizeAxes = Axes.X,
-                            Height = maxBarSize,
+                            Size = new Vector2(barThickness, maxBarSize),
                             Child = bar = new Box
                             {
+                                RelativeSizeAxes = Axes.None,
+                                Width = barThickness,
                                 Colour = new Color4(0.4f, 0.75f, 1f, 0.85f),
                             },
                         },
@@ -308,9 +359,6 @@ namespace osu.Game.EzOsuGame.HUD
 
             private void applyBarAnchor()
             {
-                if (bar == null)
-                    return;
-
                 if (direction == EzScoreCompareBarDirection.Upward)
                 {
                     bar.Anchor = Anchor.BottomCentre;
@@ -326,14 +374,34 @@ namespace osu.Game.EzOsuGame.HUD
             public void UpdateValues(LocalisableString title, string value, long barScore, long maxBarScore)
             {
                 Alpha = 1;
-                titleText.Text = title;
-                valueText.Text = value;
+
+                if (!lastTitle.Equals(title))
+                {
+                    titleText.Text = title;
+                    lastTitle = title;
+                }
+
+                if (lastValue != value)
+                {
+                    valueText.Text = value;
+                    lastValue = value;
+                }
 
                 float ratio = maxBarScore <= 0 ? 0 : (float)barScore / maxBarScore;
                 ratio = Math.Clamp(ratio, 0, 1);
 
-                bar.RelativeSizeAxes = Axes.X;
-                bar.Height = maxBarSize * ratio;
+                float barHeight = maxBarSize * ratio;
+
+                if (barScore > 0 && barHeight < min_bar_height)
+                    barHeight = min_bar_height;
+
+                if (Math.Abs(lastBarHeight - barHeight) < 0.01f)
+                    return;
+
+                lastBarHeight = barHeight;
+                bar.RelativeSizeAxes = Axes.None;
+                bar.Width = barThickness;
+                bar.Height = barHeight;
             }
         }
     }

--- a/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
@@ -85,6 +87,9 @@ namespace osu.Game.EzOsuGame.HUD
         private ScoreInfo? pickedScoreForCondition1;
         private ScoreInfo? pickedScoreForCondition2;
         private bool compareCacheDirty = true;
+        private readonly Dictionary<Guid, EzScoreTimeline> pickedTimelines = new Dictionary<Guid, EzScoreTimeline>();
+        private readonly HashSet<Guid> pickedTimelineLoadsPending = new HashSet<Guid>();
+        private CancellationTokenSource? pickedTimelineLoadCts;
 
         [Cached]
         private OsuColour colours { get; set; } = null!;
@@ -164,13 +169,13 @@ namespace osu.Game.EzOsuGame.HUD
             bars[0].UpdateValues(EzHUDStrings.SCORE_COMPARE_NOW_LABEL, formatScore(nowBarScore), nowBarScore, barScoreScale, getBarColour(isCurrent: true));
             bars[1].UpdateValues(
                 CompareCondition1.Value.GetLocalisableDescription(),
-                formatScore(condition1BarScore),
+                formatScoreOrDash(condition1BarScore, pickedScoreForCondition1, CompareCondition1.Value),
                 condition1BarScore,
                 barScoreScale,
                 getBarColour(CompareCondition1.Value));
             bars[2].UpdateValues(
                 CompareCondition2.Value.GetLocalisableDescription(),
-                formatScore(condition2BarScore),
+                formatScoreOrDash(condition2BarScore, pickedScoreForCondition2, CompareCondition2.Value),
                 condition2BarScore,
                 barScoreScale,
                 getBarColour(CompareCondition2.Value));
@@ -197,12 +202,23 @@ namespace osu.Game.EzOsuGame.HUD
         private void onCompareSelectionChanged()
         {
             if (!compareCacheDirty)
+            {
                 rebuildPickedScores();
+                schedulePickedTimelineLoads();
+            }
 
             refreshHistoricalBars();
         }
 
-        private void invalidateCompareCache() => compareCacheDirty = true;
+        private void invalidateCompareCache()
+        {
+            compareCacheDirty = true;
+            pickedTimelines.Clear();
+            pickedTimelineLoadsPending.Clear();
+            pickedTimelineLoadCts?.Cancel();
+            pickedTimelineLoadCts?.Dispose();
+            pickedTimelineLoadCts = null;
+        }
 
         private void ensureCompareCache()
         {
@@ -212,6 +228,7 @@ namespace osu.Game.EzOsuGame.HUD
             compareCandidates = queryCompareCandidates();
             rebuildPickedScores();
             compareCacheDirty = false;
+            schedulePickedTimelineLoads();
         }
 
         private void rebuildPickedScores()
@@ -233,12 +250,100 @@ namespace osu.Game.EzOsuGame.HUD
             UpdateDisplay();
         }
 
+        protected override void Dispose(bool isDisposing)
+        {
+            if (isDisposing)
+            {
+                pickedTimelineLoadCts?.Cancel();
+                pickedTimelineLoadCts?.Dispose();
+            }
+
+            base.Dispose(isDisposing);
+        }
+
         private long getBarScoreForMetric(EzScoreRaceMetric metric, ScoreInfo? pickedScore, double clockTime)
         {
             if (metric == EzScoreRaceMetric.TheoreticalMaxScore)
                 return getTheoreticalScoreAtTime();
 
             return getTotalScoreAtTime(pickedScore, clockTime);
+        }
+
+        private EzScoreTimeline? findTimeline(ScoreInfo scoreInfo)
+        {
+            var sessionEntry = Session?.Entries.FirstOrDefault(e => !e.Tracked && e.ScoreInfo.ID == scoreInfo.ID);
+
+            if (sessionEntry?.Timeline != null)
+                return sessionEntry.Timeline;
+
+            pickedTimelines.TryGetValue(scoreInfo.ID, out var timeline);
+            return timeline;
+        }
+
+        private void schedulePickedTimelineLoads()
+        {
+            if (Session == null || GameplayState == null)
+                return;
+
+            var playableBeatmap = GameplayState.Beatmap;
+            var cancellationToken = getPickedTimelineLoadToken();
+            var scoresToLoad = new List<ScoreInfo>();
+
+            foreach (var scoreInfo in new[] { pickedScoreForCondition1, pickedScoreForCondition2 })
+            {
+                if (scoreInfo == null || findTimeline(scoreInfo) != null)
+                    continue;
+
+                if (!pickedTimelineLoadsPending.Add(scoreInfo.ID))
+                    continue;
+
+                scoresToLoad.Add(scoreInfo);
+            }
+
+            if (scoresToLoad.Count == 0)
+                return;
+
+            Task.Run(async () =>
+            {
+                try
+                {
+                    var buildTasks = scoresToLoad.Select(scoreInfo => Task.Run(() =>
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        return (scoreInfo.ID, EzScoreTimelineBuilder.TryBuild(ScoreManager, Beatmaps, scoreInfo, playableBeatmap, cancellationToken));
+                    }, cancellationToken)).ToArray();
+
+                    var results = await Task.WhenAll(buildTasks).ConfigureAwait(false);
+
+                    foreach (var (scoreId, timeline) in results)
+                    {
+                        if (cancellationToken.IsCancellationRequested)
+                            return;
+
+                        if (timeline == null)
+                        {
+                            Schedule(() => pickedTimelineLoadsPending.Remove(scoreId));
+                            continue;
+                        }
+
+                        Schedule(() =>
+                        {
+                            pickedTimelineLoadsPending.Remove(scoreId);
+                            pickedTimelines[scoreId] = timeline;
+                            refreshHistoricalBars();
+                        });
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                }
+            }, cancellationToken);
+        }
+
+        private CancellationToken getPickedTimelineLoadToken()
+        {
+            pickedTimelineLoadCts ??= new CancellationTokenSource();
+            return pickedTimelineLoadCts.Token;
         }
 
         private List<ScoreInfo> queryCompareCandidates()
@@ -255,23 +360,36 @@ namespace osu.Game.EzOsuGame.HUD
             if (scoreInfo == null || Session == null)
                 return 0;
 
-            var entry = Session.Entries.FirstOrDefault(e => !e.Tracked && e.ScoreInfo.ID == scoreInfo.ID);
+            var timeline = findTimeline(scoreInfo);
 
-            if (entry?.Timeline != null)
-                return entry.Timeline.QueryAtTime(clockTime).TotalScore;
+            if (timeline != null)
+                return timeline.QueryAtTime(clockTime).TotalScore;
 
-            return scoreInfo.TotalScore;
+            // 禁止用终局分充当实时柱高；时间线未就绪前保持 0。
+            return 0;
         }
 
         /// <summary>
-        /// 当前时刻理论满分进度（与 live SP 一致）。
+        /// 当前时刻「已判定区间全 Perfect」应达到的分数（≥ 当前实际分，与 live SP 同源）。
         /// </summary>
         private long getTheoreticalScoreAtTime()
         {
             if (ScoreProcessor == null)
                 return 0;
 
-            return (long)Math.Round(ScoreProcessor.MinimumAccuracy.Value * ScoreProcessor.MAX_SCORE);
+            double accuracy = ScoreProcessor.Accuracy.Value;
+
+            if (accuracy <= double.Epsilon)
+                return 0;
+
+            long currentScore = GetLiveDisplayScore();
+
+            if (currentScore <= 0)
+                return 0;
+
+            // MinimumAccuracy/Accuracy = 当前已出现 ex 上限 / 整谱 ex（Perfect 时等于 MinimumAccuracy）。
+            double perfectProgressRatio = ScoreProcessor.MinimumAccuracy.Value / accuracy;
+            return (long)Math.Round(currentScore * perfectProgressRatio);
         }
 
         /// <summary>
@@ -282,10 +400,18 @@ namespace osu.Game.EzOsuGame.HUD
             if (ScoreProcessor != null && ScoreProcessor.MaximumTotalScore > 0)
                 return ScoreProcessor.MaximumTotalScore;
 
-            return (long)ScoreProcessor.MAX_SCORE;
+            return (long)global::osu.Game.Rulesets.Scoring.ScoreProcessor.MAX_SCORE;
         }
 
         private static string formatScore(long score) => score.ToString("N0");
+
+        private static string formatScoreOrDash(long score, ScoreInfo? pickedScore, EzScoreRaceMetric metric)
+        {
+            if (metric == EzScoreRaceMetric.TheoreticalMaxScore || pickedScore == null)
+                return formatScore(score);
+
+            return score > 0 ? formatScore(score) : "-";
+        }
 
         private void layoutBars()
         {
@@ -314,6 +440,7 @@ namespace osu.Game.EzOsuGame.HUD
             private const float min_bar_height = 3;
 
             private Box bar = null!;
+            private Box trackBackground = null!;
             private OsuSpriteText titleText = null!;
             private OsuSpriteText valueText = null!;
             private Container barTrack = null!;
@@ -337,7 +464,13 @@ namespace osu.Game.EzOsuGame.HUD
                 maxBarSize = maxSize;
                 barThickness = thickness;
 
+                if (barTrack == null)
+                    return;
+
                 barTrack.Size = new Vector2(barThickness, maxSize);
+
+                if (trackBackground != null)
+                    trackBackground.Size = new Vector2(barThickness, maxSize);
 
                 bar.Width = barThickness;
                 applyBarAnchor();
@@ -363,10 +496,18 @@ namespace osu.Game.EzOsuGame.HUD
                         barTrack = new Container
                         {
                             Size = new Vector2(barThickness, maxBarSize),
-                            Child = bar = new Box
+                            Children = new Drawable[]
                             {
-                                RelativeSizeAxes = Axes.None,
-                                Width = barThickness,
+                                trackBackground = new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Colour = Color4.White.Opacity(0.12f),
+                                },
+                                bar = new Box
+                                {
+                                    RelativeSizeAxes = Axes.None,
+                                    Width = barThickness,
+                                },
                             },
                         },
                         valueText = new OsuSpriteText

--- a/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
@@ -289,7 +289,7 @@ namespace osu.Game.EzOsuGame.HUD
 
         private void refreshPickedEntries()
         {
-            if (Session == null || !Session.IsReady.Value)
+            if (!SupportsGhostRace || Session == null || !Session.IsReady.Value)
             {
                 pickedEntryForCondition1 = null;
                 pickedEntryForCondition2 = null;

--- a/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
@@ -310,19 +310,7 @@ namespace osu.Game.EzOsuGame.HUD
             if (ScoreProcessor == null)
                 return 0;
 
-            double accuracy = ScoreProcessor.Accuracy.Value;
-
-            if (accuracy <= double.Epsilon)
-                return 0;
-
-            long currentScore = GetLiveDisplayScore();
-
-            if (currentScore <= 0)
-                return 0;
-
-            // MinimumAccuracy/Accuracy = 当前已出现 ex 上限 / 整谱 ex（Perfect 时等于 MinimumAccuracy）。
-            double perfectProgressRatio = ScoreProcessor.MinimumAccuracy.Value / accuracy;
-            return (long)Math.Round(currentScore * perfectProgressRatio);
+            return ScoreProcessor.GetTheoreticalPerfectJudgedDisplayScore();
         }
 
         /// <summary>

--- a/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
@@ -5,22 +5,24 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Reflection;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Localisation;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
 using osu.Game.Configuration;
 using osu.Game.EzOsuGame.Localization;
 using osu.Game.EzOsuGame.Scoring;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Skinning;
 using osuTK;
 using osuTK.Graphics;
+using Container = osu.Framework.Graphics.Containers.Container;
 
 namespace osu.Game.EzOsuGame.HUD
 {
@@ -47,10 +49,10 @@ namespace osu.Game.EzOsuGame.HUD
         public Bindable<EzScoreModFilter> ModFilterSetting { get; } = new Bindable<EzScoreModFilter>(EzScoreModFilter.Any);
 
         [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_COMPARE_CONDITION1_LABEL), nameof(EzHUDStrings.SCORE_COMPARE_CONDITION1_DESCRIPTION))]
-        public Bindable<EzScoreCompareCondition> CompareCondition1 { get; } = new Bindable<EzScoreCompareCondition>(EzScoreCompareCondition.BestAccuracy);
+        public Bindable<EzScoreRaceMetric> CompareCondition1 { get; } = new Bindable<EzScoreRaceMetric>(EzScoreRaceMetric.Accuracy);
 
         [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_COMPARE_CONDITION2_LABEL), nameof(EzHUDStrings.SCORE_COMPARE_CONDITION2_DESCRIPTION))]
-        public Bindable<EzScoreCompareCondition> CompareCondition2 { get; } = new Bindable<EzScoreCompareCondition>(EzScoreCompareCondition.BestTotalScore);
+        public Bindable<EzScoreRaceMetric> CompareCondition2 { get; } = new Bindable<EzScoreRaceMetric>(EzScoreRaceMetric.TheoreticalMaxScore);
 
         [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_RACE_BAR_DIRECTION_LABEL), nameof(EzHUDStrings.SCORE_RACE_BAR_DIRECTION_DESCRIPTION))]
         public Bindable<EzScoreCompareBarDirection> BarDirection { get; } = new Bindable<EzScoreCompareBarDirection>(EzScoreCompareBarDirection.Upward);
@@ -75,7 +77,7 @@ namespace osu.Game.EzOsuGame.HUD
         private const float label_area_height = 36;
         private const float container_padding = 6;
 
-        private osu.Framework.Graphics.Containers.Container barsContainer = null!;
+        private Container barsContainer = null!;
         private readonly CompareBar[] bars = new CompareBar[3];
 
         public EzHUDScoreCompareBars()
@@ -97,7 +99,7 @@ namespace osu.Game.EzOsuGame.HUD
         {
             ModFilter.BindTo(ModFilterSetting);
 
-            barsContainer = new osu.Framework.Graphics.Containers.Container
+            barsContainer = new Container
             {
                 RelativeSizeAxes = Axes.Both,
                 Padding = new MarginPadding(container_padding),
@@ -150,12 +152,12 @@ namespace osu.Game.EzOsuGame.HUD
 
             bars[0].UpdateValues(EzHUDStrings.SCORE_COMPARE_NOW_LABEL, formatScore(nowBarScore), nowBarScore, maxBarScore);
             bars[1].UpdateValues(
-                new LocalisableString(formatCondition(CompareCondition1.Value)),
+                CompareCondition1.Value.GetLocalisableDescription(),
                 formatScore(condition1BarScore),
                 condition1BarScore,
                 maxBarScore);
             bars[2].UpdateValues(
-                new LocalisableString(formatCondition(CompareCondition2.Value)),
+                CompareCondition2.Value.GetLocalisableDescription(),
                 formatScore(condition2BarScore),
                 condition2BarScore,
                 maxBarScore);
@@ -171,18 +173,18 @@ namespace osu.Game.EzOsuGame.HUD
 
         private ScoreInfo? getExcludeForCondition2()
         {
-            if (CompareCondition1.Value == EzScoreCompareCondition.TheoreticalMaxScore)
+            if (CompareCondition1.Value == EzScoreRaceMetric.TheoreticalMaxScore)
                 return null;
 
             return EzLocalScoreQueries.PickBest(getCompareCandidates(), CompareCondition1.Value);
         }
 
-        private long getBarScoreAtTime(EzScoreCompareCondition condition, double clockTime, ScoreInfo? exclude)
+        private long getBarScoreAtTime(EzScoreRaceMetric metric, double clockTime, ScoreInfo? exclude)
         {
-            if (condition == EzScoreCompareCondition.TheoreticalMaxScore)
+            if (metric == EzScoreRaceMetric.TheoreticalMaxScore)
                 return getTheoreticalScoreAtTime();
 
-            var scoreInfo = EzLocalScoreQueries.PickBest(getCompareCandidates(), condition, exclude);
+            var scoreInfo = EzLocalScoreQueries.PickBest(getCompareCandidates(), metric, exclude);
             return getTotalScoreAtTime(scoreInfo, clockTime);
         }
 
@@ -213,7 +215,7 @@ namespace osu.Game.EzOsuGame.HUD
             if (ScoreProcessor == null)
                 return 0;
 
-            return (long)Math.Round(ScoreProcessor.MinimumAccuracy.Value * osu.Game.Rulesets.Scoring.ScoreProcessor.MAX_SCORE);
+            return (long)Math.Round(ScoreProcessor.MinimumAccuracy.Value * ScoreProcessor.MAX_SCORE);
         }
 
         private static string formatScore(long score) => score.ToString("N0");
@@ -240,23 +242,12 @@ namespace osu.Game.EzOsuGame.HUD
             }
         }
 
-        private static string formatCondition(EzScoreCompareCondition condition)
-        {
-            var field = typeof(EzScoreCompareCondition).GetField(condition.ToString());
-
-            if (field == null)
-                return condition.ToString();
-
-            var description = field.GetCustomAttribute<DescriptionAttribute>()?.Description;
-            return string.IsNullOrEmpty(description) ? condition.ToString() : description;
-        }
-
         private partial class CompareBar : CompositeDrawable
         {
             private Box bar = null!;
             private OsuSpriteText titleText = null!;
             private OsuSpriteText valueText = null!;
-            private osu.Framework.Graphics.Containers.Container barTrack = null!;
+            private Container barTrack = null!;
             private EzScoreCompareBarDirection direction = EzScoreCompareBarDirection.Upward;
             private float maxBarSize;
 
@@ -294,7 +285,7 @@ namespace osu.Game.EzOsuGame.HUD
                             Origin = Anchor.TopCentre,
                             Font = OsuFont.GetFont(size: 11, weight: FontWeight.Bold),
                         },
-                        barTrack = new osu.Framework.Graphics.Containers.Container
+                        barTrack = new Container
                         {
                             RelativeSizeAxes = Axes.X,
                             Height = maxBarSize,

--- a/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
@@ -2,12 +2,15 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Reflection;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Localisation;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Configuration;
 using osu.Game.EzOsuGame.Localization;
@@ -31,63 +34,73 @@ namespace osu.Game.EzOsuGame.HUD
     }
 
     /// <summary>
-    /// BMS 风格三柱分数对比：当前局 + 两条按条件选出的历史最佳成绩。
-    /// 柱高始终按 TotalScore 绘制；上下文字分别为指标名与指标值。
+    /// BMS 风格三柱分数对比：当前局 + 两条按对比条件选出的参考柱。
+    /// 柱高与标签数值始终按 TotalScore 绘制；对比条件仅用于筛选对比哪条成绩。
     /// </summary>
     public partial class EzHUDScoreCompareBars : EzHUDScoreRaceComponent, ISerialisableDrawable
     {
         public bool UsesFixedAnchor { get; set; }
 
-        protected override bool ContributesMaxEntryCount => true;
+        protected override bool ContributesMaxEntryCount => false;
 
         [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_RACE_MOD_FILTER_LABEL), nameof(EzHUDStrings.SCORE_RACE_MOD_FILTER_DESCRIPTION))]
         public Bindable<EzScoreModFilter> ModFilterSetting { get; } = new Bindable<EzScoreModFilter>(EzScoreModFilter.Any);
 
-        [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_RACE_MAX_ENTRIES_LABEL), nameof(EzHUDStrings.SCORE_RACE_MAX_ENTRIES_DESCRIPTION))]
-        public BindableNumber<int> MaxEntriesSetting { get; } = new BindableNumber<int>(10)
-        {
-            MinValue = 1,
-            MaxValue = 10,
-        };
+        [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_COMPARE_CONDITION1_LABEL), nameof(EzHUDStrings.SCORE_COMPARE_CONDITION1_DESCRIPTION))]
+        public Bindable<EzScoreCompareCondition> CompareCondition1 { get; } = new Bindable<EzScoreCompareCondition>(EzScoreCompareCondition.BestAccuracy);
 
-        [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_RACE_SLOT1_CRITERION_LABEL), nameof(EzHUDStrings.SCORE_RACE_SLOT1_CRITERION_DESCRIPTION))]
-        public Bindable<EzScorePickCriterion> Slot1Criterion { get; } = new Bindable<EzScorePickCriterion>(EzScorePickCriterion.Accuracy);
-
-        [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_RACE_SLOT2_CRITERION_LABEL), nameof(EzHUDStrings.SCORE_RACE_SLOT2_CRITERION_DESCRIPTION))]
-        public Bindable<EzScorePickCriterion> Slot2Criterion { get; } = new Bindable<EzScorePickCriterion>(EzScorePickCriterion.TotalScore);
+        [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_COMPARE_CONDITION2_LABEL), nameof(EzHUDStrings.SCORE_COMPARE_CONDITION2_DESCRIPTION))]
+        public Bindable<EzScoreCompareCondition> CompareCondition2 { get; } = new Bindable<EzScoreCompareCondition>(EzScoreCompareCondition.BestTotalScore);
 
         [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_RACE_BAR_DIRECTION_LABEL), nameof(EzHUDStrings.SCORE_RACE_BAR_DIRECTION_DESCRIPTION))]
         public Bindable<EzScoreCompareBarDirection> BarDirection { get; } = new Bindable<EzScoreCompareBarDirection>(EzScoreCompareBarDirection.Upward);
 
-        [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_RACE_MAX_BAR_HEIGHT_LABEL), nameof(EzHUDStrings.SCORE_RACE_MAX_BAR_HEIGHT_DESCRIPTION))]
-        public BindableNumber<float> MaxBarHeight { get; } = new BindableNumber<float>(120)
+        [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_COMPARE_BAR_HEIGHT_LABEL), nameof(EzHUDStrings.SCORE_COMPARE_BAR_HEIGHT_DESCRIPTION))]
+        public BindableNumber<float> BarHeight { get; } = new BindableNumber<float>(120)
         {
             MinValue = 40,
             MaxValue = 400,
             Precision = 1,
         };
 
+        [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_COMPARE_BAR_WIDTH_LABEL), nameof(EzHUDStrings.SCORE_COMPARE_BAR_WIDTH_DESCRIPTION))]
+        public BindableNumber<float> BarWidth { get; } = new BindableNumber<float>(88)
+        {
+            MinValue = 40,
+            MaxValue = 200,
+            Precision = 1,
+        };
+
         private const float bar_spacing = 4;
         private const float label_area_height = 36;
+        private const float container_padding = 6;
 
         private osu.Framework.Graphics.Containers.Container barsContainer = null!;
         private readonly CompareBar[] bars = new CompareBar[3];
 
         public EzHUDScoreCompareBars()
         {
-            Width = 340;
-            Height = 210;
+            Width = 3 * BarWidth.Value + 2 * bar_spacing + container_padding * 2;
+            Height = BarHeight.Value + label_area_height + container_padding * 2;
+        }
+
+        protected override void ConfigureSession()
+        {
+            if (Session == null)
+                return;
+
+            // 仅同步 Mod 过滤；条目数由角逐榜组件负责。
+            Session.ReloadIfNeeded(ModFilter.Value, Session.MaxEntryCount);
         }
 
         protected override void LoadComplete()
         {
             ModFilter.BindTo(ModFilterSetting);
-            MaxEntries.BindTo(MaxEntriesSetting);
 
             barsContainer = new osu.Framework.Graphics.Containers.Container
             {
                 RelativeSizeAxes = Axes.Both,
-                Padding = new MarginPadding(6),
+                Padding = new MarginPadding(container_padding),
             };
 
             for (int i = 0; i < bars.Length; i++)
@@ -101,10 +114,11 @@ namespace osu.Game.EzOsuGame.HUD
 
             base.LoadComplete();
 
-            Slot1Criterion.BindValueChanged(_ => refreshHistoricalBars(), true);
-            Slot2Criterion.BindValueChanged(_ => refreshHistoricalBars(), true);
+            CompareCondition1.BindValueChanged(_ => refreshHistoricalBars(), true);
+            CompareCondition2.BindValueChanged(_ => refreshHistoricalBars(), true);
             BarDirection.BindValueChanged(_ => layoutBars(), true);
-            MaxBarHeight.BindValueChanged(_ => layoutBars(), true);
+            BarHeight.BindValueChanged(_ => layoutBars(), true);
+            BarWidth.BindValueChanged(_ => layoutBars(), true);
 
             layoutBars();
         }
@@ -127,25 +141,23 @@ namespace osu.Game.EzOsuGame.HUD
             double clockTime = GetCurrentClockTime();
 
             long nowBarScore = GetLiveDisplayScore();
-            var slot1Info = getSlotScoreInfo(1);
-            var slot2Info = getSlotScoreInfo(2);
-            long slot1BarScore = getTotalScoreAtTime(slot1Info, clockTime);
-            long slot2BarScore = getTotalScoreAtTime(slot2Info, clockTime);
+            long condition1BarScore = getBarScoreAtTime(CompareCondition1.Value, clockTime, exclude: null);
+            long condition2BarScore = getBarScoreAtTime(CompareCondition2.Value, clockTime, getExcludeForCondition2());
 
             long maxBarScore = Math.Max(1, nowBarScore);
-            maxBarScore = Math.Max(maxBarScore, slot1BarScore);
-            maxBarScore = Math.Max(maxBarScore, slot2BarScore);
+            maxBarScore = Math.Max(maxBarScore, condition1BarScore);
+            maxBarScore = Math.Max(maxBarScore, condition2BarScore);
 
-            bars[0].UpdateValues("Now", formatMetricValue(EzScorePickCriterion.TotalScore, nowBarScore, null), nowBarScore, maxBarScore);
+            bars[0].UpdateValues(EzHUDStrings.SCORE_COMPARE_NOW_LABEL, formatScore(nowBarScore), nowBarScore, maxBarScore);
             bars[1].UpdateValues(
-                formatCriterion(Slot1Criterion.Value),
-                formatMetricValue(Slot1Criterion.Value, 0, slot1Info, clockTime),
-                slot1BarScore,
+                new LocalisableString(formatCondition(CompareCondition1.Value)),
+                formatScore(condition1BarScore),
+                condition1BarScore,
                 maxBarScore);
             bars[2].UpdateValues(
-                formatCriterion(Slot2Criterion.Value),
-                formatMetricValue(Slot2Criterion.Value, 0, slot2Info, clockTime),
-                slot2BarScore,
+                new LocalisableString(formatCondition(CompareCondition2.Value)),
+                formatScore(condition2BarScore),
+                condition2BarScore,
                 maxBarScore);
         }
 
@@ -157,19 +169,30 @@ namespace osu.Game.EzOsuGame.HUD
             UpdateDisplay();
         }
 
-        private ScoreInfo? getSlotScoreInfo(int slot)
+        private ScoreInfo? getExcludeForCondition2()
         {
-            if (Session == null)
+            if (CompareCondition1.Value == EzScoreCompareCondition.TheoreticalMaxScore)
                 return null;
 
-            var candidates = Session.Entries.Where(e => !e.Tracked).Select(e => e.ScoreInfo).ToList();
+            return EzLocalScoreQueries.PickBest(getCompareCandidates(), CompareCondition1.Value);
+        }
 
-            return slot switch
-            {
-                1 => EzLocalScoreQueries.PickBest(candidates, Slot1Criterion.Value),
-                2 => EzLocalScoreQueries.PickBest(candidates, Slot2Criterion.Value, exclude: EzLocalScoreQueries.PickBest(candidates, Slot1Criterion.Value)),
-                _ => null,
-            };
+        private long getBarScoreAtTime(EzScoreCompareCondition condition, double clockTime, ScoreInfo? exclude)
+        {
+            if (condition == EzScoreCompareCondition.TheoreticalMaxScore)
+                return getTheoreticalScoreAtTime();
+
+            var scoreInfo = EzLocalScoreQueries.PickBest(getCompareCandidates(), condition, exclude);
+            return getTotalScoreAtTime(scoreInfo, clockTime);
+        }
+
+        private List<ScoreInfo> getCompareCandidates()
+        {
+            if (GameplayState == null)
+                return new List<ScoreInfo>();
+
+            var localScores = EzLocalScoreQueries.GetLocalScoresWithReplay(Realm, GameplayState.Beatmap.BeatmapInfo, GameplayState.Ruleset.RulesetInfo);
+            return EzLocalScoreQueries.FilterByMods(localScores, GameplayState.Mods.ToArray(), ModFilter.Value).ToList();
         }
 
         private long getTotalScoreAtTime(ScoreInfo? scoreInfo, double clockTime)
@@ -185,89 +208,48 @@ namespace osu.Game.EzOsuGame.HUD
             return scoreInfo.TotalScore;
         }
 
-        private long getMetricAtTime(ScoreInfo? scoreInfo, EzScorePickCriterion criterion, double clockTime)
+        private long getTheoreticalScoreAtTime()
         {
-            if (scoreInfo == null || Session == null)
+            if (ScoreProcessor == null)
                 return 0;
 
-            var entry = Session.Entries.FirstOrDefault(e => !e.Tracked && e.ScoreInfo.ID == scoreInfo.ID);
-
-            if (entry?.Timeline != null)
-                return getSnapshotMetric(entry.Timeline.QueryAtTime(clockTime), criterion, scoreInfo);
-
-            return getStaticMetric(scoreInfo, criterion);
+            return (long)Math.Round(ScoreProcessor.MinimumAccuracy.Value * osu.Game.Rulesets.Scoring.ScoreProcessor.MAX_SCORE);
         }
 
-        private string formatMetricValue(EzScorePickCriterion criterion, long liveValue, ScoreInfo? scoreInfo, double clockTime = 0)
-        {
-            if (criterion == EzScorePickCriterion.TotalScore && scoreInfo == null)
-                return liveValue.ToString("N0");
-
-            if (scoreInfo == null)
-                return "-";
-
-            long metric = getMetricAtTime(scoreInfo, criterion, clockTime);
-
-            return criterion switch
-            {
-                EzScorePickCriterion.TotalScore => metric.ToString("N0"),
-                EzScorePickCriterion.Accuracy => (metric / 1_000_000.0).ToString("P2"),
-                EzScorePickCriterion.MaxCombo => metric.ToString("N0"),
-                EzScorePickCriterion.MissCount => metric.ToString("N0"),
-                _ => metric.ToString("N0"),
-            };
-        }
-
-        private static long getSnapshotMetric(EzScoreTimelineSnapshot snapshot, EzScorePickCriterion criterion, ScoreInfo scoreInfo)
-        {
-            return criterion switch
-            {
-                EzScorePickCriterion.TotalScore => snapshot.TotalScore,
-                EzScorePickCriterion.Accuracy => (long)Math.Round(snapshot.Accuracy * 1_000_000),
-                EzScorePickCriterion.MaxCombo => snapshot.HighestCombo,
-                EzScorePickCriterion.MissCount => snapshot.MissCount,
-                _ => 0,
-            };
-        }
-
-        private static long getStaticMetric(ScoreInfo scoreInfo, EzScorePickCriterion criterion)
-        {
-            return criterion switch
-            {
-                EzScorePickCriterion.TotalScore => scoreInfo.TotalScore,
-                EzScorePickCriterion.Accuracy => (long)Math.Round(scoreInfo.Accuracy * 1_000_000),
-                EzScorePickCriterion.MaxCombo => scoreInfo.MaxCombo,
-                EzScorePickCriterion.MissCount => EzLocalScoreQueries.GetMissCount(scoreInfo),
-                _ => 0,
-            };
-        }
+        private static string formatScore(long score) => score.ToString("N0");
 
         private void layoutBars()
         {
-            float barThickness = Math.Max(88, (barsContainer.DrawWidth - bar_spacing * 2) / 3);
+            float barThickness = BarWidth.Value;
+            float barAxisHeight = BarHeight.Value;
             var direction = BarDirection.Value;
+
+            Width = bars.Length * barThickness + (bars.Length - 1) * bar_spacing + container_padding * 2;
+            Height = barAxisHeight + label_area_height + container_padding * 2;
 
             for (int i = 0; i < bars.Length; i++)
             {
                 var bar = bars[i];
-                bar.Configure(direction, MaxBarHeight.Value);
+                bar.Configure(direction, barAxisHeight);
 
                 bar.Anchor = Anchor.BottomLeft;
                 bar.Origin = Anchor.BottomLeft;
                 bar.Width = barThickness;
-                bar.Height = MaxBarHeight.Value + label_area_height;
+                bar.Height = barAxisHeight + label_area_height;
                 bar.X = i * (barThickness + bar_spacing);
             }
         }
 
-        private static string formatCriterion(EzScorePickCriterion criterion) => criterion switch
+        private static string formatCondition(EzScoreCompareCondition condition)
         {
-            EzScorePickCriterion.TotalScore => "Score",
-            EzScorePickCriterion.Accuracy => "Acc",
-            EzScorePickCriterion.MaxCombo => "Combo",
-            EzScorePickCriterion.MissCount => "Miss",
-            _ => criterion.ToString(),
-        };
+            var field = typeof(EzScoreCompareCondition).GetField(condition.ToString());
+
+            if (field == null)
+                return condition.ToString();
+
+            var description = field.GetCustomAttribute<DescriptionAttribute>()?.Description;
+            return string.IsNullOrEmpty(description) ? condition.ToString() : description;
+        }
 
         private partial class CompareBar : CompositeDrawable
         {
@@ -350,7 +332,7 @@ namespace osu.Game.EzOsuGame.HUD
                 }
             }
 
-            public void UpdateValues(string title, string value, long barScore, long maxBarScore)
+            public void UpdateValues(LocalisableString title, string value, long barScore, long maxBarScore)
             {
                 Alpha = 1;
                 titleText.Text = title;

--- a/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
@@ -9,13 +9,17 @@ using osu.Framework.Extensions;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
+using osu.Game.EzOsuGame.Acrylic;
 using osu.Game.EzOsuGame.Localization;
 using osu.Game.EzOsuGame.Scoring;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Localisation.SkinComponents;
+using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Skinning;
 using osuTK;
@@ -38,11 +42,15 @@ namespace osu.Game.EzOsuGame.HUD
     /// 柱高与标签数值始终按 TotalScore 绘制；柱图总高度对应整谱理论满分。
     /// Ghost 查询与时间线经 <see cref="EzScoreRaceSession"/> 统一提供。
     /// </summary>
-    public partial class EzHUDScoreCompareBars : EzHUDScoreRaceComponent, ISerialisableDrawable
+    public partial class EzHUDScoreCompareBars : EzHUDScoreRaceComponent, ISerialisableDrawable, IAcrylicBackdropConsumer
     {
+        private const float backdrop_blur_strength = 16;
+
         public bool UsesFixedAnchor { get; set; }
 
         protected override bool ContributesMaxEntryCount => false;
+
+        public bool WantsAcrylicCapture => BackgroundVisible.Value && BackdropBlurEnabled.Value;
 
         [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_RACE_MOD_FILTER_LABEL), nameof(EzHUDStrings.SCORE_RACE_MOD_FILTER_DESCRIPTION))]
         public Bindable<EzScoreModFilter> ModFilterSetting { get; } = new Bindable<EzScoreModFilter>(EzScoreModFilter.Any);
@@ -72,12 +80,31 @@ namespace osu.Game.EzOsuGame.HUD
             Precision = 1,
         };
 
+        [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_COMPARE_BACKGROUND_VISIBLE_LABEL), nameof(EzHUDStrings.SCORE_COMPARE_BACKGROUND_VISIBLE_DESCRIPTION))]
+        public BindableBool BackgroundVisible { get; } = new BindableBool(true);
+
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.CornerRadius), nameof(SkinnableComponentStrings.CornerRadiusDescription),
+            SettingControlType = typeof(SettingsPercentageSlider<float>))]
+        public new BindableFloat CornerRadius { get; } = new BindableFloat(0.12f)
+        {
+            MinValue = 0,
+            MaxValue = 0.5f,
+            Precision = 0.01f,
+        };
+
+        [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_COMPARE_BACKDROP_BLUR_LABEL), nameof(EzHUDStrings.SCORE_COMPARE_BACKDROP_BLUR_DESCRIPTION))]
+        public BindableBool BackdropBlurEnabled { get; } = new BindableBool(false);
+
         private const float bar_spacing = 4;
         private const float label_area_height = 36;
         private const float container_padding = 6;
 
+        private readonly AcrylicBackdropDrawable acrylicBackdrop;
+        private readonly Box backgroundTint;
+        private readonly Container backgroundLayer;
         private Container barsContainer = null!;
         private readonly CompareBar[] bars = new CompareBar[3];
+        private EzAcrylicCaptureController? captureController;
 
         private EzScoreRaceEntry? pickedEntryForCondition1;
         private EzScoreRaceEntry? pickedEntryForCondition2;
@@ -85,10 +112,36 @@ namespace osu.Game.EzOsuGame.HUD
         [Resolved]
         private OsuColour colours { get; set; } = null!;
 
+        [Resolved(canBeNull: true)]
+        private IAcrylicCaptureRegistrar? acrylicCaptureRegistrar { get; set; }
+
+        [Resolved]
+        private IRenderer renderer { get; set; } = null!;
+
         public EzHUDScoreCompareBars()
         {
             Width = 3 * BarWidth.Value + 2 * bar_spacing + container_padding * 2;
             Height = BarHeight.Value + label_area_height + container_padding * 2;
+            Masking = true;
+
+            InternalChild = backgroundLayer = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    acrylicBackdrop = new AcrylicBackdropDrawable
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        EffectEnabled = false,
+                        FrameBufferScale = Vector2.One,
+                    },
+                    backgroundTint = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = Color4.White.Opacity(0.12f),
+                    },
+                },
+            };
         }
 
         protected override void ConfigureSession()
@@ -100,6 +153,8 @@ namespace osu.Game.EzOsuGame.HUD
         protected override void LoadComplete()
         {
             ModFilter.BindTo(ModFilterSetting);
+
+            captureController = new EzAcrylicCaptureController(acrylicCaptureRegistrar, renderer, acrylicBackdrop);
 
             barsContainer = new Container
             {
@@ -118,13 +173,27 @@ namespace osu.Game.EzOsuGame.HUD
 
             base.LoadComplete();
 
+            BackgroundVisible.BindValueChanged(_ => updateBackgroundVisibility(), true);
+            BackdropBlurEnabled.BindValueChanged(_ => SyncAcrylicCaptureState(), true);
+
             CompareCondition1.BindValueChanged(_ => refreshPickedEntries(), true);
             CompareCondition2.BindValueChanged(_ => refreshPickedEntries(), true);
             BarDirection.BindValueChanged(_ => layoutBars(), true);
             BarHeight.BindValueChanged(_ => layoutBars(), true);
             BarWidth.BindValueChanged(_ => layoutBars(), true);
 
+            SyncAcrylicCaptureState();
             layoutBars();
+        }
+
+        public void SyncAcrylicCaptureState()
+            => captureController?.Sync(WantsAcrylicCapture, backdrop_blur_strength);
+
+        protected override void Update()
+        {
+            base.Update();
+
+            base.CornerRadius = CornerRadius.Value * Math.Min(DrawWidth, DrawHeight);
         }
 
         protected override void OnSessionReady()
@@ -162,6 +231,20 @@ namespace osu.Game.EzOsuGame.HUD
                 condition2BarScore,
                 barScoreScale,
                 getBarColour(CompareCondition2.Value));
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (isDisposing)
+                captureController?.Dispose();
+
+            base.Dispose(isDisposing);
+        }
+
+        private void updateBackgroundVisibility()
+        {
+            backgroundLayer.Alpha = BackgroundVisible.Value ? 1 : 0;
+            SyncAcrylicCaptureState();
         }
 
         /// <summary>
@@ -274,7 +357,6 @@ namespace osu.Game.EzOsuGame.HUD
             private const float min_bar_height = 3;
 
             private Box bar = null!;
-            private Box trackBackground = null!;
             private OsuSpriteText titleText = null!;
             private OsuSpriteText valueText = null!;
             private Container barTrack = null!;
@@ -301,10 +383,7 @@ namespace osu.Game.EzOsuGame.HUD
                 if (barTrack == null)
                     return;
 
-                var trackSize = new Vector2(barThickness, maxSize);
-                barTrack.Size = trackSize;
-                trackBackground.Size = trackSize;
-
+                barTrack.Size = new Vector2(barThickness, maxSize);
                 bar.Width = barThickness;
                 applyBarAnchor();
             }
@@ -330,19 +409,10 @@ namespace osu.Game.EzOsuGame.HUD
                         {
                             RelativeSizeAxes = Axes.None,
                             Size = new Vector2(barThickness, maxBarSize),
-                            Children = new Drawable[]
+                            Child = bar = new Box
                             {
-                                trackBackground = new Box
-                                {
-                                    RelativeSizeAxes = Axes.None,
-                                    Size = new Vector2(barThickness, maxBarSize),
-                                    Colour = Color4.White.Opacity(0.12f),
-                                },
-                                bar = new Box
-                                {
-                                    RelativeSizeAxes = Axes.None,
-                                    Width = barThickness,
-                                },
+                                RelativeSizeAxes = Axes.None,
+                                Width = barThickness,
                             },
                         },
                         valueText = new OsuSpriteText

--- a/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
@@ -298,9 +298,12 @@ namespace osu.Game.EzOsuGame.HUD
                 maxBarSize = maxSize;
                 barThickness = thickness;
 
-                barTrack.Size = new Vector2(barThickness, maxSize);
+                if (barTrack == null)
+                    return;
 
-                trackBackground.Size = new Vector2(barThickness, maxSize);
+                var trackSize = new Vector2(barThickness, maxSize);
+                barTrack.Size = trackSize;
+                trackBackground.Size = trackSize;
 
                 bar.Width = barThickness;
                 applyBarAnchor();
@@ -325,12 +328,14 @@ namespace osu.Game.EzOsuGame.HUD
                         },
                         barTrack = new Container
                         {
+                            RelativeSizeAxes = Axes.None,
                             Size = new Vector2(barThickness, maxBarSize),
                             Children = new Drawable[]
                             {
                                 trackBackground = new Box
                                 {
-                                    RelativeSizeAxes = Axes.Both,
+                                    RelativeSizeAxes = Axes.None,
+                                    Size = new Vector2(barThickness, maxBarSize),
                                     Colour = Color4.White.Opacity(0.12f),
                                 },
                                 bar = new Box

--- a/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
@@ -1,0 +1,367 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.ComponentModel;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Configuration;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.EzOsuGame.Scoring;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Scoring;
+using osu.Game.Skinning;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.EzOsuGame.HUD
+{
+    public enum EzScoreCompareBarDirection
+    {
+        [Description("Upward")]
+        Upward,
+
+        [Description("Downward")]
+        Downward,
+    }
+
+    /// <summary>
+    /// BMS 风格三柱分数对比：当前局 + 两条按条件选出的历史最佳成绩。
+    /// 柱高始终按 TotalScore 绘制；上下文字分别为指标名与指标值。
+    /// </summary>
+    public partial class EzHUDScoreCompareBars : EzHUDScoreRaceComponent, ISerialisableDrawable
+    {
+        public bool UsesFixedAnchor { get; set; }
+
+        protected override bool ContributesMaxEntryCount => true;
+
+        [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_RACE_MOD_FILTER_LABEL), nameof(EzHUDStrings.SCORE_RACE_MOD_FILTER_DESCRIPTION))]
+        public Bindable<EzScoreModFilter> ModFilterSetting { get; } = new Bindable<EzScoreModFilter>(EzScoreModFilter.Any);
+
+        [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_RACE_MAX_ENTRIES_LABEL), nameof(EzHUDStrings.SCORE_RACE_MAX_ENTRIES_DESCRIPTION))]
+        public BindableNumber<int> MaxEntriesSetting { get; } = new BindableNumber<int>(10)
+        {
+            MinValue = 1,
+            MaxValue = 10,
+        };
+
+        [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_RACE_SLOT1_CRITERION_LABEL), nameof(EzHUDStrings.SCORE_RACE_SLOT1_CRITERION_DESCRIPTION))]
+        public Bindable<EzScorePickCriterion> Slot1Criterion { get; } = new Bindable<EzScorePickCriterion>(EzScorePickCriterion.Accuracy);
+
+        [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_RACE_SLOT2_CRITERION_LABEL), nameof(EzHUDStrings.SCORE_RACE_SLOT2_CRITERION_DESCRIPTION))]
+        public Bindable<EzScorePickCriterion> Slot2Criterion { get; } = new Bindable<EzScorePickCriterion>(EzScorePickCriterion.TotalScore);
+
+        [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_RACE_BAR_DIRECTION_LABEL), nameof(EzHUDStrings.SCORE_RACE_BAR_DIRECTION_DESCRIPTION))]
+        public Bindable<EzScoreCompareBarDirection> BarDirection { get; } = new Bindable<EzScoreCompareBarDirection>(EzScoreCompareBarDirection.Upward);
+
+        [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_RACE_MAX_BAR_HEIGHT_LABEL), nameof(EzHUDStrings.SCORE_RACE_MAX_BAR_HEIGHT_DESCRIPTION))]
+        public BindableNumber<float> MaxBarHeight { get; } = new BindableNumber<float>(120)
+        {
+            MinValue = 40,
+            MaxValue = 400,
+            Precision = 1,
+        };
+
+        private const float bar_spacing = 4;
+        private const float label_area_height = 36;
+
+        private osu.Framework.Graphics.Containers.Container barsContainer = null!;
+        private readonly CompareBar[] bars = new CompareBar[3];
+
+        public EzHUDScoreCompareBars()
+        {
+            Width = 340;
+            Height = 210;
+        }
+
+        protected override void LoadComplete()
+        {
+            ModFilter.BindTo(ModFilterSetting);
+            MaxEntries.BindTo(MaxEntriesSetting);
+
+            barsContainer = new osu.Framework.Graphics.Containers.Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Padding = new MarginPadding(6),
+            };
+
+            for (int i = 0; i < bars.Length; i++)
+            {
+                bars[i] = new CompareBar();
+                barsContainer.Add(bars[i]);
+            }
+
+            AddInternal(barsContainer);
+            EnsureLoadingOverlay();
+
+            base.LoadComplete();
+
+            Slot1Criterion.BindValueChanged(_ => refreshHistoricalBars(), true);
+            Slot2Criterion.BindValueChanged(_ => refreshHistoricalBars(), true);
+            BarDirection.BindValueChanged(_ => layoutBars(), true);
+            MaxBarHeight.BindValueChanged(_ => layoutBars(), true);
+
+            layoutBars();
+        }
+
+        protected override void OnSessionReady()
+        {
+            Session?.IsReady.BindValueChanged(_ => refreshHistoricalBars(), true);
+        }
+
+        protected override void OnEntriesChangedScheduled()
+        {
+            refreshHistoricalBars();
+        }
+
+        protected override void UpdateDisplay()
+        {
+            if (Session == null || !Session.IsReady.Value)
+                return;
+
+            double clockTime = GetCurrentClockTime();
+
+            long nowBarScore = GetLiveDisplayScore();
+            var slot1Info = getSlotScoreInfo(1);
+            var slot2Info = getSlotScoreInfo(2);
+            long slot1BarScore = getTotalScoreAtTime(slot1Info, clockTime);
+            long slot2BarScore = getTotalScoreAtTime(slot2Info, clockTime);
+
+            long maxBarScore = Math.Max(1, nowBarScore);
+            maxBarScore = Math.Max(maxBarScore, slot1BarScore);
+            maxBarScore = Math.Max(maxBarScore, slot2BarScore);
+
+            bars[0].UpdateValues("Now", formatMetricValue(EzScorePickCriterion.TotalScore, nowBarScore, null), nowBarScore, maxBarScore);
+            bars[1].UpdateValues(
+                formatCriterion(Slot1Criterion.Value),
+                formatMetricValue(Slot1Criterion.Value, 0, slot1Info, clockTime),
+                slot1BarScore,
+                maxBarScore);
+            bars[2].UpdateValues(
+                formatCriterion(Slot2Criterion.Value),
+                formatMetricValue(Slot2Criterion.Value, 0, slot2Info, clockTime),
+                slot2BarScore,
+                maxBarScore);
+        }
+
+        private void refreshHistoricalBars()
+        {
+            if (Session == null || !Session.IsReady.Value)
+                return;
+
+            UpdateDisplay();
+        }
+
+        private ScoreInfo? getSlotScoreInfo(int slot)
+        {
+            if (Session == null)
+                return null;
+
+            var candidates = Session.Entries.Where(e => !e.Tracked).Select(e => e.ScoreInfo).ToList();
+
+            return slot switch
+            {
+                1 => EzLocalScoreQueries.PickBest(candidates, Slot1Criterion.Value),
+                2 => EzLocalScoreQueries.PickBest(candidates, Slot2Criterion.Value, exclude: EzLocalScoreQueries.PickBest(candidates, Slot1Criterion.Value)),
+                _ => null,
+            };
+        }
+
+        private long getTotalScoreAtTime(ScoreInfo? scoreInfo, double clockTime)
+        {
+            if (scoreInfo == null || Session == null)
+                return 0;
+
+            var entry = Session.Entries.FirstOrDefault(e => !e.Tracked && e.ScoreInfo.ID == scoreInfo.ID);
+
+            if (entry?.Timeline != null)
+                return entry.Timeline.QueryAtTime(clockTime).TotalScore;
+
+            return scoreInfo.TotalScore;
+        }
+
+        private long getMetricAtTime(ScoreInfo? scoreInfo, EzScorePickCriterion criterion, double clockTime)
+        {
+            if (scoreInfo == null || Session == null)
+                return 0;
+
+            var entry = Session.Entries.FirstOrDefault(e => !e.Tracked && e.ScoreInfo.ID == scoreInfo.ID);
+
+            if (entry?.Timeline != null)
+                return getSnapshotMetric(entry.Timeline.QueryAtTime(clockTime), criterion, scoreInfo);
+
+            return getStaticMetric(scoreInfo, criterion);
+        }
+
+        private string formatMetricValue(EzScorePickCriterion criterion, long liveValue, ScoreInfo? scoreInfo, double clockTime = 0)
+        {
+            if (criterion == EzScorePickCriterion.TotalScore && scoreInfo == null)
+                return liveValue.ToString("N0");
+
+            if (scoreInfo == null)
+                return "-";
+
+            long metric = getMetricAtTime(scoreInfo, criterion, clockTime);
+
+            return criterion switch
+            {
+                EzScorePickCriterion.TotalScore => metric.ToString("N0"),
+                EzScorePickCriterion.Accuracy => (metric / 1_000_000.0).ToString("P2"),
+                EzScorePickCriterion.MaxCombo => metric.ToString("N0"),
+                EzScorePickCriterion.MissCount => metric.ToString("N0"),
+                _ => metric.ToString("N0"),
+            };
+        }
+
+        private static long getSnapshotMetric(EzScoreTimelineSnapshot snapshot, EzScorePickCriterion criterion, ScoreInfo scoreInfo)
+        {
+            return criterion switch
+            {
+                EzScorePickCriterion.TotalScore => snapshot.TotalScore,
+                EzScorePickCriterion.Accuracy => (long)Math.Round(snapshot.Accuracy * 1_000_000),
+                EzScorePickCriterion.MaxCombo => snapshot.HighestCombo,
+                EzScorePickCriterion.MissCount => snapshot.MissCount,
+                _ => 0,
+            };
+        }
+
+        private static long getStaticMetric(ScoreInfo scoreInfo, EzScorePickCriterion criterion)
+        {
+            return criterion switch
+            {
+                EzScorePickCriterion.TotalScore => scoreInfo.TotalScore,
+                EzScorePickCriterion.Accuracy => (long)Math.Round(scoreInfo.Accuracy * 1_000_000),
+                EzScorePickCriterion.MaxCombo => scoreInfo.MaxCombo,
+                EzScorePickCriterion.MissCount => EzLocalScoreQueries.GetMissCount(scoreInfo),
+                _ => 0,
+            };
+        }
+
+        private void layoutBars()
+        {
+            float barThickness = Math.Max(88, (barsContainer.DrawWidth - bar_spacing * 2) / 3);
+            var direction = BarDirection.Value;
+
+            for (int i = 0; i < bars.Length; i++)
+            {
+                var bar = bars[i];
+                bar.Configure(direction, MaxBarHeight.Value);
+
+                bar.Anchor = Anchor.BottomLeft;
+                bar.Origin = Anchor.BottomLeft;
+                bar.Width = barThickness;
+                bar.Height = MaxBarHeight.Value + label_area_height;
+                bar.X = i * (barThickness + bar_spacing);
+            }
+        }
+
+        private static string formatCriterion(EzScorePickCriterion criterion) => criterion switch
+        {
+            EzScorePickCriterion.TotalScore => "Score",
+            EzScorePickCriterion.Accuracy => "Acc",
+            EzScorePickCriterion.MaxCombo => "Combo",
+            EzScorePickCriterion.MissCount => "Miss",
+            _ => criterion.ToString(),
+        };
+
+        private partial class CompareBar : CompositeDrawable
+        {
+            private Box bar = null!;
+            private OsuSpriteText titleText = null!;
+            private OsuSpriteText valueText = null!;
+            private osu.Framework.Graphics.Containers.Container barTrack = null!;
+            private EzScoreCompareBarDirection direction = EzScoreCompareBarDirection.Upward;
+            private float maxBarSize;
+
+            public CompareBar()
+            {
+                RelativeSizeAxes = Axes.None;
+            }
+
+            public void Configure(EzScoreCompareBarDirection barDirection, float maxSize)
+            {
+                direction = barDirection;
+                maxBarSize = maxSize;
+
+                if (barTrack == null)
+                    return;
+
+                barTrack.Height = maxSize;
+                applyBarAnchor();
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                InternalChild = new FillFlowContainer
+                {
+                    Direction = FillDirection.Vertical,
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Spacing = new Vector2(0, 2),
+                    Children = new Drawable[]
+                    {
+                        titleText = new OsuSpriteText
+                        {
+                            Anchor = Anchor.TopCentre,
+                            Origin = Anchor.TopCentre,
+                            Font = OsuFont.GetFont(size: 11, weight: FontWeight.Bold),
+                        },
+                        barTrack = new osu.Framework.Graphics.Containers.Container
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            Height = maxBarSize,
+                            Child = bar = new Box
+                            {
+                                Colour = new Color4(0.4f, 0.75f, 1f, 0.85f),
+                            },
+                        },
+                        valueText = new OsuSpriteText
+                        {
+                            Anchor = Anchor.TopCentre,
+                            Origin = Anchor.TopCentre,
+                            Font = OsuFont.GetFont(size: 11),
+                        },
+                    },
+                };
+
+                applyBarAnchor();
+            }
+
+            private void applyBarAnchor()
+            {
+                if (bar == null)
+                    return;
+
+                if (direction == EzScoreCompareBarDirection.Upward)
+                {
+                    bar.Anchor = Anchor.BottomCentre;
+                    bar.Origin = Anchor.BottomCentre;
+                }
+                else
+                {
+                    bar.Anchor = Anchor.TopCentre;
+                    bar.Origin = Anchor.TopCentre;
+                }
+            }
+
+            public void UpdateValues(string title, string value, long barScore, long maxBarScore)
+            {
+                Alpha = 1;
+                titleText.Text = title;
+                valueText.Text = value;
+
+                float ratio = maxBarScore <= 0 ? 0 : (float)barScore / maxBarScore;
+                ratio = Math.Clamp(ratio, 0, 1);
+
+                bar.RelativeSizeAxes = Axes.X;
+                bar.Height = maxBarSize * ratio;
+            }
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
@@ -2,11 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
@@ -21,7 +17,6 @@ using osu.Game.EzOsuGame.Scoring;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Scoring;
-using osu.Game.Scoring;
 using osu.Game.Skinning;
 using osuTK;
 using osuTK.Graphics;
@@ -41,6 +36,7 @@ namespace osu.Game.EzOsuGame.HUD
     /// <summary>
     /// BMS 风格三柱分数对比：当前局 + 两条按对比条件选出的参考柱。
     /// 柱高与标签数值始终按 TotalScore 绘制；柱图总高度对应整谱理论满分。
+    /// Ghost 查询与时间线经 <see cref="EzScoreRaceSession"/> 统一提供。
     /// </summary>
     public partial class EzHUDScoreCompareBars : EzHUDScoreRaceComponent, ISerialisableDrawable
     {
@@ -83,15 +79,10 @@ namespace osu.Game.EzOsuGame.HUD
         private Container barsContainer = null!;
         private readonly CompareBar[] bars = new CompareBar[3];
 
-        private List<ScoreInfo> compareCandidates = new List<ScoreInfo>();
-        private ScoreInfo? pickedScoreForCondition1;
-        private ScoreInfo? pickedScoreForCondition2;
-        private bool compareCacheDirty = true;
-        private readonly Dictionary<Guid, EzScoreTimeline> pickedTimelines = new Dictionary<Guid, EzScoreTimeline>();
-        private readonly HashSet<Guid> pickedTimelineLoadsPending = new HashSet<Guid>();
-        private CancellationTokenSource? pickedTimelineLoadCts;
+        private EzScoreRaceEntry? pickedEntryForCondition1;
+        private EzScoreRaceEntry? pickedEntryForCondition2;
 
-        [Cached]
+        [Resolved]
         private OsuColour colours { get; set; } = null!;
 
         public EzHUDScoreCompareBars()
@@ -109,7 +100,6 @@ namespace osu.Game.EzOsuGame.HUD
         protected override void LoadComplete()
         {
             ModFilter.BindTo(ModFilterSetting);
-            ModFilter.BindValueChanged(_ => invalidateCompareCache(), true);
 
             barsContainer = new Container
             {
@@ -128,8 +118,8 @@ namespace osu.Game.EzOsuGame.HUD
 
             base.LoadComplete();
 
-            CompareCondition1.BindValueChanged(_ => onCompareSelectionChanged(), true);
-            CompareCondition2.BindValueChanged(_ => onCompareSelectionChanged(), true);
+            CompareCondition1.BindValueChanged(_ => refreshPickedEntries(), true);
+            CompareCondition2.BindValueChanged(_ => refreshPickedEntries(), true);
             BarDirection.BindValueChanged(_ => layoutBars(), true);
             BarHeight.BindValueChanged(_ => layoutBars(), true);
             BarWidth.BindValueChanged(_ => layoutBars(), true);
@@ -139,17 +129,12 @@ namespace osu.Game.EzOsuGame.HUD
 
         protected override void OnSessionReady()
         {
-            Session?.IsReady.BindValueChanged(_ =>
-            {
-                invalidateCompareCache();
-                refreshHistoricalBars();
-            }, true);
+            Session?.IsReady.BindValueChanged(_ => refreshPickedEntries(), true);
         }
 
         protected override void OnEntriesChangedScheduled()
         {
-            invalidateCompareCache();
-            refreshHistoricalBars();
+            refreshPickedEntries();
         }
 
         protected override void UpdateDisplay()
@@ -157,25 +142,23 @@ namespace osu.Game.EzOsuGame.HUD
             if (Session == null || !Session.IsReady.Value)
                 return;
 
-            ensureCompareCache();
-
             double clockTime = GetCurrentClockTime();
             long barScoreScale = getBarScoreScale();
 
             long nowBarScore = GetLiveDisplayScore();
-            long condition1BarScore = getBarScoreForMetric(CompareCondition1.Value, pickedScoreForCondition1, clockTime);
-            long condition2BarScore = getBarScoreForMetric(CompareCondition2.Value, pickedScoreForCondition2, clockTime);
+            long condition1BarScore = getBarScoreForMetric(CompareCondition1.Value, pickedEntryForCondition1, clockTime);
+            long condition2BarScore = getBarScoreForMetric(CompareCondition2.Value, pickedEntryForCondition2, clockTime);
 
             bars[0].UpdateValues(EzHUDStrings.SCORE_COMPARE_NOW_LABEL, formatScore(nowBarScore), nowBarScore, barScoreScale, getBarColour(isCurrent: true));
             bars[1].UpdateValues(
                 CompareCondition1.Value.GetLocalisableDescription(),
-                formatScoreOrDash(condition1BarScore, pickedScoreForCondition1, CompareCondition1.Value),
+                formatScoreOrDash(condition1BarScore, pickedEntryForCondition1, CompareCondition1.Value),
                 condition1BarScore,
                 barScoreScale,
                 getBarColour(CompareCondition1.Value));
             bars[2].UpdateValues(
                 CompareCondition2.Value.GetLocalisableDescription(),
-                formatScoreOrDash(condition2BarScore, pickedScoreForCondition2, CompareCondition2.Value),
+                formatScoreOrDash(condition2BarScore, pickedEntryForCondition2, CompareCondition2.Value),
                 condition2BarScore,
                 barScoreScale,
                 getBarColour(CompareCondition2.Value));
@@ -199,174 +182,25 @@ namespace osu.Game.EzOsuGame.HUD
             };
         }
 
-        private void onCompareSelectionChanged()
-        {
-            if (!compareCacheDirty)
-            {
-                rebuildPickedScores();
-                schedulePickedTimelineLoads();
-            }
-
-            refreshHistoricalBars();
-        }
-
-        private void invalidateCompareCache()
-        {
-            compareCacheDirty = true;
-            pickedTimelines.Clear();
-            pickedTimelineLoadsPending.Clear();
-            pickedTimelineLoadCts?.Cancel();
-            pickedTimelineLoadCts?.Dispose();
-            pickedTimelineLoadCts = null;
-        }
-
-        private void ensureCompareCache()
-        {
-            if (!compareCacheDirty)
-                return;
-
-            compareCandidates = queryCompareCandidates();
-            rebuildPickedScores();
-            compareCacheDirty = false;
-            schedulePickedTimelineLoads();
-        }
-
-        private void rebuildPickedScores()
-        {
-            pickedScoreForCondition1 = CompareCondition1.Value == EzScoreRaceMetric.TheoreticalMaxScore
-                ? null
-                : EzLocalScoreQueries.PickBest(compareCandidates, CompareCondition1.Value);
-
-            pickedScoreForCondition2 = CompareCondition2.Value == EzScoreRaceMetric.TheoreticalMaxScore
-                ? null
-                : EzLocalScoreQueries.PickBest(compareCandidates, CompareCondition2.Value, exclude: pickedScoreForCondition1);
-        }
-
-        private void refreshHistoricalBars()
+        private void refreshPickedEntries()
         {
             if (Session == null || !Session.IsReady.Value)
-                return;
-
-            UpdateDisplay();
-        }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            if (isDisposing)
             {
-                pickedTimelineLoadCts?.Cancel();
-                pickedTimelineLoadCts?.Dispose();
+                pickedEntryForCondition1 = null;
+                pickedEntryForCondition2 = null;
+                return;
             }
 
-            base.Dispose(isDisposing);
+            pickedEntryForCondition1 = Session.PickGhost(CompareCondition1.Value);
+            pickedEntryForCondition2 = Session.PickGhost(CompareCondition2.Value, pickedEntryForCondition1?.ScoreInfo);
         }
 
-        private long getBarScoreForMetric(EzScoreRaceMetric metric, ScoreInfo? pickedScore, double clockTime)
+        private long getBarScoreForMetric(EzScoreRaceMetric metric, EzScoreRaceEntry? pickedEntry, double clockTime)
         {
             if (metric == EzScoreRaceMetric.TheoreticalMaxScore)
                 return getTheoreticalScoreAtTime();
 
-            return getTotalScoreAtTime(pickedScore, clockTime);
-        }
-
-        private EzScoreTimeline? findTimeline(ScoreInfo scoreInfo)
-        {
-            var sessionEntry = Session?.Entries.FirstOrDefault(e => !e.Tracked && e.ScoreInfo.ID == scoreInfo.ID);
-
-            if (sessionEntry?.Timeline != null)
-                return sessionEntry.Timeline;
-
-            pickedTimelines.TryGetValue(scoreInfo.ID, out var timeline);
-            return timeline;
-        }
-
-        private void schedulePickedTimelineLoads()
-        {
-            if (Session == null || GameplayState == null)
-                return;
-
-            var playableBeatmap = GameplayState.Beatmap;
-            var cancellationToken = getPickedTimelineLoadToken();
-            var scoresToLoad = new List<ScoreInfo>();
-
-            foreach (var scoreInfo in new[] { pickedScoreForCondition1, pickedScoreForCondition2 })
-            {
-                if (scoreInfo == null || findTimeline(scoreInfo) != null)
-                    continue;
-
-                if (!pickedTimelineLoadsPending.Add(scoreInfo.ID))
-                    continue;
-
-                scoresToLoad.Add(scoreInfo);
-            }
-
-            if (scoresToLoad.Count == 0)
-                return;
-
-            Task.Run(async () =>
-            {
-                try
-                {
-                    var buildTasks = scoresToLoad.Select(scoreInfo => Task.Run(() =>
-                    {
-                        cancellationToken.ThrowIfCancellationRequested();
-                        return (scoreInfo.ID, EzScoreTimelineBuilder.TryBuild(ScoreManager, Beatmaps, scoreInfo, playableBeatmap, cancellationToken));
-                    }, cancellationToken)).ToArray();
-
-                    var results = await Task.WhenAll(buildTasks).ConfigureAwait(false);
-
-                    foreach (var (scoreId, timeline) in results)
-                    {
-                        if (cancellationToken.IsCancellationRequested)
-                            return;
-
-                        if (timeline == null)
-                        {
-                            Schedule(() => pickedTimelineLoadsPending.Remove(scoreId));
-                            continue;
-                        }
-
-                        Schedule(() =>
-                        {
-                            pickedTimelineLoadsPending.Remove(scoreId);
-                            pickedTimelines[scoreId] = timeline;
-                            refreshHistoricalBars();
-                        });
-                    }
-                }
-                catch (OperationCanceledException)
-                {
-                }
-            }, cancellationToken);
-        }
-
-        private CancellationToken getPickedTimelineLoadToken()
-        {
-            pickedTimelineLoadCts ??= new CancellationTokenSource();
-            return pickedTimelineLoadCts.Token;
-        }
-
-        private List<ScoreInfo> queryCompareCandidates()
-        {
-            if (GameplayState == null)
-                return new List<ScoreInfo>();
-
-            var localScores = EzLocalScoreQueries.GetLocalScoresWithReplay(Realm, GameplayState.Beatmap.BeatmapInfo, GameplayState.Ruleset.RulesetInfo);
-            return EzLocalScoreQueries.FilterByMods(localScores, GameplayState.Mods.ToArray(), ModFilter.Value).ToList();
-        }
-
-        private long getTotalScoreAtTime(ScoreInfo? scoreInfo, double clockTime)
-        {
-            if (scoreInfo == null || Session == null)
-                return 0;
-
-            var timeline = findTimeline(scoreInfo);
-
-            if (timeline != null)
-                return timeline.QueryAtTime(clockTime).TotalScore;
-
-            // 禁止用终局分充当实时柱高；时间线未就绪前保持 0。
-            return 0;
+            return EzScoreRaceSession.QueryTimelineScore(pickedEntry, clockTime);
         }
 
         /// <summary>
@@ -400,14 +234,14 @@ namespace osu.Game.EzOsuGame.HUD
             if (ScoreProcessor != null && ScoreProcessor.MaximumTotalScore > 0)
                 return ScoreProcessor.MaximumTotalScore;
 
-            return (long)global::osu.Game.Rulesets.Scoring.ScoreProcessor.MAX_SCORE;
+            return (long)ScoreProcessor.MAX_SCORE;
         }
 
         private static string formatScore(long score) => score.ToString("N0");
 
-        private static string formatScoreOrDash(long score, ScoreInfo? pickedScore, EzScoreRaceMetric metric)
+        private static string formatScoreOrDash(long score, EzScoreRaceEntry? pickedEntry, EzScoreRaceMetric metric)
         {
-            if (metric == EzScoreRaceMetric.TheoreticalMaxScore || pickedScore == null)
+            if (metric == EzScoreRaceMetric.TheoreticalMaxScore || pickedEntry == null)
                 return formatScore(score);
 
             return score > 0 ? formatScore(score) : "-";
@@ -464,13 +298,9 @@ namespace osu.Game.EzOsuGame.HUD
                 maxBarSize = maxSize;
                 barThickness = thickness;
 
-                if (barTrack == null)
-                    return;
-
                 barTrack.Size = new Vector2(barThickness, maxSize);
 
-                if (trackBackground != null)
-                    trackBackground.Size = new Vector2(barThickness, maxSize);
+                trackBackground.Size = new Vector2(barThickness, maxSize);
 
                 bar.Width = barThickness;
                 applyBarAnchor();

--- a/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
@@ -203,7 +203,6 @@ namespace osu.Game.EzOsuGame.HUD
 
         protected override void OnEntriesChangedScheduled()
         {
-            // 时间线就绪后只刷新显示；勿重跑 PickGhost（会打断条件 2 刚发起的加载）。
             UpdateDisplay();
         }
 
@@ -234,14 +233,14 @@ namespace osu.Game.EzOsuGame.HUD
 
             if (Session == null || !Session.IsReady.Value)
             {
-                bar.UpdateValues(metric.GetLocalisableDescription(), "-", 0, barScoreScale, getBarColour(metric));
+                bar.UpdateValues(metric.GetLocalisableDescription(), string.Empty, 0, barScoreScale, getBarColour(metric));
                 return;
             }
 
             long barScore = EzScoreRaceSession.QueryTimelineScore(pickedEntry, clockTime);
             bar.UpdateValues(
                 metric.GetLocalisableDescription(),
-                formatScoreOrDash(barScore, pickedEntry, metric),
+                formatBarValue(barScore, pickedEntry),
                 barScore,
                 barScoreScale,
                 getBarColour(metric));
@@ -296,11 +295,23 @@ namespace osu.Game.EzOsuGame.HUD
                 return;
             }
 
-            pickedEntryForCondition1 = Session.PickGhost(CompareCondition1Setting.Value);
-            pickedEntryForCondition2 = Session.PickGhost(CompareCondition2Setting.Value, pickedEntryForCondition1?.ScoreInfo);
+            pickedEntryForCondition1 = CompareCondition1Setting.Value == EzScoreRaceMetric.TheoreticalMaxScore
+                ? null
+                : Session.PickGhost(CompareCondition1Setting.Value);
+            pickedEntryForCondition2 = CompareCondition2Setting.Value == EzScoreRaceMetric.TheoreticalMaxScore
+                ? null
+                : Session.PickGhost(CompareCondition2Setting.Value);
         }
 
         private static string formatScore(long score) => score.ToString("N0");
+
+        private static string formatBarValue(long barScore, EzScoreRaceEntry? pickedEntry)
+        {
+            if (pickedEntry == null || barScore <= 0)
+                return string.Empty;
+
+            return formatScore(barScore);
+        }
 
         /// <summary>
         /// 当前时刻「已判定区间全 Perfect」应达到的分数（≥ 当前实际分，与 live SP 同源）。
@@ -322,14 +333,6 @@ namespace osu.Game.EzOsuGame.HUD
                 return ScoreProcessor.MaximumTotalScore;
 
             return (long)ScoreProcessor.MAX_SCORE;
-        }
-
-        private static string formatScoreOrDash(long score, EzScoreRaceEntry? pickedEntry, EzScoreRaceMetric metric)
-        {
-            if (metric == EzScoreRaceMetric.TheoreticalMaxScore || pickedEntry == null)
-                return formatScore(score);
-
-            return score > 0 ? formatScore(score) : "-";
         }
 
         private void layoutBars()

--- a/osu.Game/EzOsuGame/HUD/EzHUDScoreRaceComponent.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDScoreRaceComponent.cs
@@ -49,6 +49,9 @@ namespace osu.Game.EzOsuGame.HUD
         /// </summary>
         protected virtual bool ContributesMaxEntryCount => true;
 
+        protected bool SupportsGhostRace =>
+            Session?.SupportsGhostRace ?? EzScoreRaceRulesetSupport.SupportsGhostRace(GameplayState?.Ruleset.RulesetInfo);
+
         private OsuSpriteText? loadingText;
 
         protected override void LoadComplete()
@@ -154,6 +157,12 @@ namespace osu.Game.EzOsuGame.HUD
         {
             if (loadingText == null)
                 return;
+
+            if (!SupportsGhostRace)
+            {
+                loadingText.Alpha = 0;
+                return;
+            }
 
             loadingText.Alpha = Session?.IsReady.Value == true ? 0 : 1;
         }

--- a/osu.Game/EzOsuGame/HUD/EzHUDScoreRaceComponent.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDScoreRaceComponent.cs
@@ -144,10 +144,7 @@ namespace osu.Game.EzOsuGame.HUD
 
         private void reloadSession()
         {
-            if (Session == null)
-                return;
-
-            Session.ReloadIfNeeded(ModFilter.Value, getEffectiveMaxEntryCount());
+            Session?.ReloadIfNeeded(ModFilter.Value, getEffectiveMaxEntryCount());
         }
 
         private int getEffectiveMaxEntryCount()

--- a/osu.Game/EzOsuGame/HUD/EzHUDScoreRaceComponent.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDScoreRaceComponent.cs
@@ -1,0 +1,159 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.EzOsuGame.Scoring;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
+using osu.Game.Scoring.Legacy;
+using osu.Game.Screens.Play;
+
+namespace osu.Game.EzOsuGame.HUD
+{
+    public abstract partial class EzHUDScoreRaceComponent : CompositeDrawable
+    {
+        [Resolved]
+        protected RealmAccess Realm { get; private set; } = null!;
+
+        [Resolved]
+        protected ScoreManager ScoreManager { get; private set; } = null!;
+
+        [Resolved]
+        protected BeatmapManager Beatmaps { get; private set; } = null!;
+
+        [Resolved(canBeNull: true)]
+        protected GameplayState? GameplayState { get; private set; }
+
+        [Resolved(canBeNull: true)]
+        protected ScoreProcessor? ScoreProcessor { get; private set; }
+
+        [Resolved(canBeNull: true)]
+        private EzScoreRaceSessionHost? sessionHost { get; set; }
+
+        protected EzScoreRaceSession? Session { get; private set; }
+        protected GameplayClockContainer? GameplayClock { get; private set; }
+
+        protected readonly Bindable<EzScoreModFilter> ModFilter = new Bindable<EzScoreModFilter>(EzScoreModFilter.Any);
+        protected readonly BindableInt MaxEntries = new BindableInt(5) { MinValue = 1, MaxValue = 10 };
+
+        /// <summary>
+        /// 为 false 时本组件不覆盖 Session 的 <see cref="EzScoreRaceSession.MaxEntryCount"/>（如 CompareBars）。
+        /// </summary>
+        protected virtual bool ContributesMaxEntryCount => true;
+
+        private OsuSpriteText? loadingText;
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            GameplayClock = this.FindClosestParent<GameplayClockContainer>();
+
+            if (GameplayState == null)
+                return;
+
+            bindSessionWhenAvailable();
+        }
+
+        private void bindSessionWhenAvailable()
+        {
+            if (Session != null)
+                return;
+
+            Session = sessionHost?.Session;
+
+            if (Session == null)
+            {
+                Schedule(bindSessionWhenAvailable);
+                return;
+            }
+
+            Session.Configure(ModFilter.Value, getEffectiveMaxEntryCount());
+
+            ModFilter.BindValueChanged(_ => reloadSession(), true);
+            MaxEntries.BindValueChanged(_ => reloadSession(), true);
+            Session.IsReady.BindValueChanged(_ => updateLoadingState(), true);
+            Session.EntriesChanged += onEntriesChanged;
+            updateLoadingState();
+            OnSessionReady();
+        }
+
+        /// <summary>
+        /// <see cref="Session"/> 可用后调用（可能晚于 <see cref="LoadComplete"/>）。
+        /// </summary>
+        protected virtual void OnSessionReady()
+        {
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+            UpdateDisplay();
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (isDisposing && Session != null)
+                Session.EntriesChanged -= onEntriesChanged;
+
+            base.Dispose(isDisposing);
+        }
+
+        protected abstract void UpdateDisplay();
+
+        protected double GetCurrentClockTime()
+        {
+            GameplayClock ??= this.FindClosestParent<GameplayClockContainer>();
+            return GameplayClock?.CurrentTime ?? 0;
+        }
+
+        protected long GetLiveDisplayScore(ScoringMode mode = ScoringMode.Standardised)
+            => ScoreProcessor?.GetDisplayScore(mode) ?? 0;
+
+        protected void EnsureLoadingOverlay()
+        {
+            if (loadingText != null)
+                return;
+
+            loadingText = new OsuSpriteText
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Text = EzHUDStrings.SCORE_RACE_LOADING_LABEL,
+                Font = OsuFont.GetFont(size: 14),
+            };
+
+            AddInternal(loadingText);
+        }
+
+        private void reloadSession()
+        {
+            Session?.ReloadIfNeeded(ModFilter.Value, getEffectiveMaxEntryCount());
+        }
+
+        private int getEffectiveMaxEntryCount()
+            => ContributesMaxEntryCount ? MaxEntries.Value : Session?.MaxEntryCount ?? MaxEntries.Value;
+
+        private void updateLoadingState()
+        {
+            if (loadingText == null)
+                return;
+
+            loadingText.Alpha = Session?.IsReady.Value == true ? 0 : 1;
+        }
+
+        private void onEntriesChanged() => Schedule(OnEntriesChangedScheduled);
+
+        protected virtual void OnEntriesChangedScheduled()
+        {
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/HUD/EzHUDScoreRaceComponent.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDScoreRaceComponent.cs
@@ -76,7 +76,7 @@ namespace osu.Game.EzOsuGame.HUD
                 return;
             }
 
-            Session.Configure(ModFilter.Value, getEffectiveMaxEntryCount());
+            ConfigureSession();
 
             ModFilter.BindValueChanged(_ => reloadSession(), true);
             MaxEntries.BindValueChanged(_ => reloadSession(), true);
@@ -134,9 +134,17 @@ namespace osu.Game.EzOsuGame.HUD
             AddInternal(loadingText);
         }
 
+        protected virtual void ConfigureSession()
+        {
+            Session?.Configure(ModFilter.Value, getEffectiveMaxEntryCount());
+        }
+
         private void reloadSession()
         {
-            Session?.ReloadIfNeeded(ModFilter.Value, getEffectiveMaxEntryCount());
+            if (Session == null)
+                return;
+
+            Session.ReloadIfNeeded(ModFilter.Value, getEffectiveMaxEntryCount());
         }
 
         private int getEffectiveMaxEntryCount()

--- a/osu.Game/EzOsuGame/HUD/EzHUDScoreRaceLeaderboard.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDScoreRaceLeaderboard.cs
@@ -40,7 +40,7 @@ namespace osu.Game.EzOsuGame.HUD
         };
 
         [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_RACE_SORT_CRITERION_LABEL), nameof(EzHUDStrings.SCORE_RACE_SORT_CRITERION_DESCRIPTION))]
-        public Bindable<EzScoreRaceSortCriterion> SortCriterionSetting { get; } = new Bindable<EzScoreRaceSortCriterion>(EzScoreRaceSortCriterion.TotalScore);
+        public Bindable<EzScoreRaceMetric> SortCriterionSetting { get; } = new Bindable<EzScoreRaceMetric>(EzScoreRaceMetric.TotalScore);
 
         protected readonly FillFlowContainer<DrawableGameplayLeaderboardScore> Flow;
 
@@ -239,8 +239,7 @@ namespace osu.Game.EzOsuGame.HUD
             return false;
         }
 
-        private EzScoreTimeline? findTimeline(Guid scoreInfoId)
-            => Session?.Entries.FirstOrDefault(e => e.ScoreInfo.ID == scoreInfoId)?.Timeline;
+        private EzScoreTimeline? findTimeline(Guid scoreInfoId) => Session?.Entries.FirstOrDefault(e => e.ScoreInfo.ID == scoreInfoId)?.Timeline;
 
         private static GameplayLeaderboardScore createGhostLeaderboardScore(EzScoreRaceEntry entry)
         {
@@ -268,13 +267,17 @@ namespace osu.Game.EzOsuGame.HUD
         {
             IOrderedEnumerable<RaceEntryState> ordered = SortCriterionSetting.Value switch
             {
-                EzScoreRaceSortCriterion.Accuracy => entryStates
-                    .OrderByDescending(s => s.LeaderboardScore.Accuracy.Value)
-                    .ThenByDescending(s => s.LeaderboardScore.TotalScore.Value),
+                EzScoreRaceMetric.Accuracy => entryStates
+                                              .OrderByDescending(s => s.LeaderboardScore.Accuracy.Value)
+                                              .ThenByDescending(s => s.LeaderboardScore.TotalScore.Value),
 
-                EzScoreRaceSortCriterion.MissCount => entryStates
-                    .OrderBy(s => getMissCount(s))
-                    .ThenByDescending(s => s.LeaderboardScore.TotalScore.Value),
+                EzScoreRaceMetric.MaxCombo => entryStates
+                                              .OrderByDescending(s => s.LeaderboardScore.Combo.Value)
+                                              .ThenByDescending(s => s.LeaderboardScore.TotalScore.Value),
+
+                EzScoreRaceMetric.MissCount => entryStates
+                                               .OrderBy(s => getMissCount(s))
+                                               .ThenByDescending(s => s.LeaderboardScore.TotalScore.Value),
 
                 _ => entryStates.OrderByDescending(s => s.LeaderboardScore.TotalScore.Value),
             };

--- a/osu.Game/EzOsuGame/HUD/EzHUDScoreRaceLeaderboard.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDScoreRaceLeaderboard.cs
@@ -1,0 +1,332 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Configuration;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.EzOsuGame.Scoring;
+using osu.Game.Graphics.Containers;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Screens.Play.HUD;
+using osu.Game.Screens.Play.Leaderboards;
+using osu.Game.Skinning;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.EzOsuGame.HUD
+{
+    /// <summary>
+    /// 本地多成绩实时角逐排行榜。外观与 <see cref="DrawableGameplayLeaderboard"/> 一致。
+    /// </summary>
+    public partial class EzHUDScoreRaceLeaderboard : EzHUDScoreRaceComponent, ISerialisableDrawable
+    {
+        public bool UsesFixedAnchor { get; set; }
+
+        [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_RACE_MOD_FILTER_LABEL), nameof(EzHUDStrings.SCORE_RACE_MOD_FILTER_DESCRIPTION))]
+        public Bindable<EzScoreModFilter> ModFilterSetting { get; } = new Bindable<EzScoreModFilter>(EzScoreModFilter.Any);
+
+        [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_RACE_MAX_ENTRIES_LABEL), nameof(EzHUDStrings.SCORE_RACE_MAX_ENTRIES_DESCRIPTION))]
+        public BindableNumber<int> MaxEntriesSetting { get; } = new BindableNumber<int>(5)
+        {
+            MinValue = 1,
+            MaxValue = 10,
+        };
+
+        [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_RACE_SORT_CRITERION_LABEL), nameof(EzHUDStrings.SCORE_RACE_SORT_CRITERION_DESCRIPTION))]
+        public Bindable<EzScoreRaceSortCriterion> SortCriterionSetting { get; } = new Bindable<EzScoreRaceSortCriterion>(EzScoreRaceSortCriterion.TotalScore);
+
+        protected readonly FillFlowContainer<DrawableGameplayLeaderboardScore> Flow;
+
+        private bool requiresScroll;
+        private readonly InputDisabledScrollContainer scroll;
+        private DrawableGameplayLeaderboardScore? trackedScore;
+        private readonly BindableBool expanded = new BindableBool(true);
+        private readonly List<RaceEntryState> entryStates = new List<RaceEntryState>();
+
+        public EzHUDScoreRaceLeaderboard()
+        {
+            float xOffset = DrawableGameplayLeaderboardScore.SHEAR_WIDTH + DrawableGameplayLeaderboardScore.ELASTIC_WIDTH_LENIENCE;
+
+            Width = 260 + xOffset;
+            Height = 300;
+
+            InternalChildren = new Drawable[]
+            {
+                scroll = new InputDisabledScrollContainer
+                {
+                    ClampExtension = 0,
+                    RelativeSizeAxes = Axes.Both,
+                    Child = Flow = new FillFlowContainer<DrawableGameplayLeaderboardScore>
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        X = xOffset,
+                        AutoSizeAxes = Axes.Y,
+                        Direction = FillDirection.Vertical,
+                        Spacing = new Vector2(2.5f),
+                        LayoutDuration = 450,
+                        LayoutEasing = Easing.OutQuint,
+                    },
+                },
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            ModFilter.BindTo(ModFilterSetting);
+            MaxEntries.BindTo(MaxEntriesSetting);
+            SortCriterionSetting.BindValueChanged(_ => sortAndApply());
+
+            EnsureLoadingOverlay();
+
+            base.LoadComplete();
+        }
+
+        protected override void OnSessionReady()
+        {
+            Session?.IsReady.BindValueChanged(_ => rebuildRows(), true);
+        }
+
+        protected override void UpdateDisplay()
+        {
+            if (Session == null || !Session.IsReady.Value)
+                return;
+
+            double clockTime = GetCurrentClockTime();
+
+            foreach (var state in entryStates)
+            {
+                if (state.Tracked)
+                    continue;
+
+                var timeline = findTimeline(state.ScoreInfoId);
+
+                if (timeline == null)
+                {
+                    state.MissCount = 0;
+                    continue;
+                }
+
+                var snapshot = timeline.QueryAtTime(clockTime);
+                state.LeaderboardScore.TotalScore.Value = snapshot.TotalScore;
+                state.LeaderboardScore.Accuracy.Value = snapshot.Accuracy;
+                state.LeaderboardScore.Combo.Value = snapshot.HighestCombo;
+                state.MissCount = snapshot.MissCount;
+            }
+
+            sortAndApply();
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            Width = Math.Max(Width, Flow.X + DrawableGameplayLeaderboardScore.MIN_WIDTH);
+            Height = Math.Max(Height, DrawableGameplayLeaderboardScore.PANEL_HEIGHT);
+
+            requiresScroll = Flow.DrawHeight > Height;
+
+            if (requiresScroll && trackedScore != null)
+            {
+                double scrollTarget = scroll.GetChildPosInContent(trackedScore) + trackedScore.DrawHeight / 2 - scroll.DrawHeight / 2;
+                scroll.ScrollTo(scrollTarget);
+            }
+
+            const float panel_height = DrawableGameplayLeaderboardScore.PANEL_HEIGHT;
+
+            float fadeBottom = (float)(scroll.Current + scroll.DrawHeight);
+            float fadeTop = (float)(scroll.Current + panel_height);
+
+            if (scroll.IsScrolledToStart())
+                fadeTop -= panel_height;
+
+            if (!scroll.IsScrolledToEnd())
+                fadeBottom -= panel_height;
+
+            foreach (var c in Flow)
+            {
+                float topY = c.ToSpaceOfOtherDrawable(Vector2.Zero, Flow).Y;
+                float bottomY = topY + panel_height;
+
+                bool requireTopFade = requiresScroll && topY <= fadeTop;
+                bool requireBottomFade = requiresScroll && bottomY >= fadeBottom;
+
+                if (!requireTopFade && !requireBottomFade)
+                    c.Colour = Color4.White;
+                else if (topY > fadeBottom + panel_height || bottomY < fadeTop - panel_height)
+                    c.Colour = Color4.Transparent;
+                else
+                {
+                    if (requireBottomFade)
+                    {
+                        c.Colour = ColourInfo.GradientVertical(
+                            Color4.White.Opacity(Math.Min(1 - (topY - fadeBottom) / panel_height, 1)),
+                            Color4.White.Opacity(Math.Min(1 - (bottomY - fadeBottom) / panel_height, 1)));
+                    }
+                    else if (requiresScroll)
+                    {
+                        c.Colour = ColourInfo.GradientVertical(
+                            Color4.White.Opacity(Math.Min(1 - (fadeTop - topY) / panel_height, 1)),
+                            Color4.White.Opacity(Math.Min(1 - (fadeTop - bottomY) / panel_height, 1)));
+                    }
+                }
+            }
+        }
+
+        private void rebuildRows()
+        {
+            Flow.Clear();
+            entryStates.Clear();
+            trackedScore = null;
+            scroll.ScrollToStart(false);
+
+            if (Session == null)
+                return;
+
+            foreach (var entry in Session.Entries)
+            {
+                GameplayLeaderboardScore leaderboardScore = entry.Tracked
+                    ? createTrackedLeaderboardScore()
+                    : createGhostLeaderboardScore(entry);
+
+                var drawable = new DrawableGameplayLeaderboardScore(leaderboardScore);
+                drawable.Expanded.BindTo(expanded);
+
+                if (entry.Tracked)
+                    trackedScore = drawable;
+
+                var state = new RaceEntryState(entry, leaderboardScore, drawable);
+                entryStates.Add(state);
+                Flow.Add(drawable);
+
+                drawable.DisplayOrder.BindValueChanged(_ => Schedule(sortAndApply), true);
+            }
+
+            sortAndApply();
+        }
+
+        protected override void OnEntriesChangedScheduled()
+        {
+            if (needsStructuralRebuild())
+                rebuildRows();
+            else
+                UpdateDisplay();
+        }
+
+        private bool needsStructuralRebuild()
+        {
+            if (Session == null)
+                return entryStates.Count > 0;
+
+            if (entryStates.Count != Session.Entries.Count)
+                return true;
+
+            var sessionIds = Session.Entries.Select(e => e.ScoreInfo.ID).OrderBy(id => id).ToArray();
+            var stateIds = entryStates.Select(s => s.ScoreInfoId).OrderBy(id => id).ToArray();
+
+            for (int i = 0; i < sessionIds.Length; i++)
+            {
+                if (sessionIds[i] != stateIds[i])
+                    return true;
+            }
+
+            return false;
+        }
+
+        private EzScoreTimeline? findTimeline(Guid scoreInfoId)
+            => Session?.Entries.FirstOrDefault(e => e.ScoreInfo.ID == scoreInfoId)?.Timeline;
+
+        private static GameplayLeaderboardScore createGhostLeaderboardScore(EzScoreRaceEntry entry)
+        {
+            var leaderboardScore = new GameplayLeaderboardScore(entry.ScoreInfo, false, GameplayLeaderboardScore.ComboDisplayMode.Highest);
+            var scoreInfo = entry.ScoreInfo;
+            leaderboardScore.TotalScore.Value = 0;
+            leaderboardScore.Accuracy.Value = 0;
+            leaderboardScore.Combo.Value = 0;
+            leaderboardScore.GetDisplayScore = mode => EzScoreRaceDisplayScore.ForLeaderboardScore(leaderboardScore, scoreInfo, mode);
+            return leaderboardScore;
+        }
+
+        private GameplayLeaderboardScore createTrackedLeaderboardScore()
+        {
+            if (GameplayState == null)
+                throw new InvalidOperationException("Tracked score requires GameplayState.");
+
+            return new GameplayLeaderboardScore(GameplayState, tracked: true, GameplayLeaderboardScore.ComboDisplayMode.Highest)
+            {
+                TotalScoreTiebreaker = long.MaxValue,
+            };
+        }
+
+        private void sortAndApply()
+        {
+            IOrderedEnumerable<RaceEntryState> ordered = SortCriterionSetting.Value switch
+            {
+                EzScoreRaceSortCriterion.Accuracy => entryStates
+                    .OrderByDescending(s => s.LeaderboardScore.Accuracy.Value)
+                    .ThenByDescending(s => s.LeaderboardScore.TotalScore.Value),
+
+                EzScoreRaceSortCriterion.MissCount => entryStates
+                    .OrderBy(s => getMissCount(s))
+                    .ThenByDescending(s => s.LeaderboardScore.TotalScore.Value),
+
+                _ => entryStates.OrderByDescending(s => s.LeaderboardScore.TotalScore.Value),
+            };
+
+            var orderedList = ordered.ThenBy(s => s.Tracked ? long.MaxValue : s.Tiebreaker).ToList();
+
+            for (int i = 0; i < orderedList.Count; i++)
+            {
+                var state = orderedList[i];
+                int rank = i + 1;
+                state.LeaderboardScore.DisplayOrder.Value = rank;
+                state.LeaderboardScore.Position.Value = rank;
+                Flow.SetLayoutPosition(state.Drawable, rank);
+            }
+        }
+
+        private int getMissCount(RaceEntryState state)
+        {
+            if (state.Tracked)
+                return ScoreProcessor?.Statistics.GetValueOrDefault(HitResult.Miss) ?? 0;
+
+            return state.MissCount;
+        }
+
+        private sealed class RaceEntryState
+        {
+            public Guid ScoreInfoId { get; }
+            public bool Tracked { get; }
+            public long Tiebreaker { get; }
+            public int MissCount { get; set; }
+            public GameplayLeaderboardScore LeaderboardScore { get; }
+            public DrawableGameplayLeaderboardScore Drawable { get; }
+
+            public RaceEntryState(EzScoreRaceEntry entry, GameplayLeaderboardScore leaderboardScore, DrawableGameplayLeaderboardScore drawable)
+            {
+                ScoreInfoId = entry.ScoreInfo.ID;
+                Tracked = entry.Tracked;
+                Tiebreaker = entry.ScoreInfo.Date.ToUnixTimeSeconds();
+                LeaderboardScore = leaderboardScore;
+                Drawable = drawable;
+            }
+        }
+
+        private partial class InputDisabledScrollContainer : OsuScrollContainer
+        {
+            public InputDisabledScrollContainer()
+            {
+                ScrollbarVisible = false;
+            }
+
+            public override bool HandlePositionalInput => false;
+            public override bool HandleNonPositionalInput => false;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Localization/EzHUDStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzHUDStrings.cs
@@ -190,16 +190,19 @@ namespace osu.Game.EzOsuGame.Localization
             "速度变化时在折线右端显示不显眼的闪烁白点。",
             "Show a subtle blinking white dot at the line endpoint while speed is changing.");
 
-        public static readonly LocalisableString SCORE_RACE_SLOT1_CRITERION_LABEL = new EzLocalizationManager.EzLocalisableString("历史柱 1 条件", "History Bar 1 Criterion");
-        public static readonly LocalisableString SCORE_RACE_SLOT1_CRITERION_DESCRIPTION = new EzLocalizationManager.EzLocalisableString("按此条件选择第一条历史最佳成绩", "Pick the first historical score by this criterion.");
-        public static readonly LocalisableString SCORE_RACE_SLOT2_CRITERION_LABEL = new EzLocalizationManager.EzLocalisableString("历史柱 2 条件", "History Bar 2 Criterion");
-        public static readonly LocalisableString SCORE_RACE_SLOT2_CRITERION_DESCRIPTION = new EzLocalizationManager.EzLocalisableString("按此条件选择第二条历史最佳成绩", "Pick the second historical score by this criterion.");
+        public static readonly LocalisableString SCORE_COMPARE_CONDITION1_LABEL = new EzLocalizationManager.EzLocalisableString("对比条件 1", "Compare Condition 1");
+        public static readonly LocalisableString SCORE_COMPARE_CONDITION1_DESCRIPTION = new EzLocalizationManager.EzLocalisableString("按此条件筛选第一条对比成绩（柱高始终为分数）", "Pick the first comparison score by this criterion (bar height is always score).");
+        public static readonly LocalisableString SCORE_COMPARE_CONDITION2_LABEL = new EzLocalizationManager.EzLocalisableString("对比条件 2", "Compare Condition 2");
+        public static readonly LocalisableString SCORE_COMPARE_CONDITION2_DESCRIPTION = new EzLocalizationManager.EzLocalisableString("按此条件筛选第二条对比成绩（柱高始终为分数）", "Pick the second comparison score by this criterion (bar height is always score).");
+        public static readonly LocalisableString SCORE_COMPARE_BAR_HEIGHT_LABEL = new EzLocalizationManager.EzLocalisableString("柱状图高度", "Bar Height");
+        public static readonly LocalisableString SCORE_COMPARE_BAR_HEIGHT_DESCRIPTION = new EzLocalizationManager.EzLocalisableString("柱体主轴的像素高度", "Pixel height of the bar axis.");
+        public static readonly LocalisableString SCORE_COMPARE_BAR_WIDTH_LABEL = new EzLocalizationManager.EzLocalisableString("柱状图宽度", "Bar Width");
+        public static readonly LocalisableString SCORE_COMPARE_BAR_WIDTH_DESCRIPTION = new EzLocalizationManager.EzLocalisableString("单根柱体的像素宽度", "Pixel width of each bar.");
+        public static readonly LocalisableString SCORE_COMPARE_NOW_LABEL = new EzLocalizationManager.EzLocalisableString("当前", "Now");
         public static readonly LocalisableString SCORE_RACE_MOD_FILTER_LABEL = new EzLocalizationManager.EzLocalisableString("Mod 过滤", "Mod Filter");
         public static readonly LocalisableString SCORE_RACE_MOD_FILTER_DESCRIPTION = new EzLocalizationManager.EzLocalisableString("对比成绩的 Mod 范围", "Which mod combinations to include when selecting scores.");
         public static readonly LocalisableString SCORE_RACE_BAR_DIRECTION_LABEL = new EzLocalizationManager.EzLocalisableString("柱图方向", "Bar Direction");
         public static readonly LocalisableString SCORE_RACE_BAR_DIRECTION_DESCRIPTION = new EzLocalizationManager.EzLocalisableString("柱体向上或向下增长", "Bars grow upward or downward.");
-        public static readonly LocalisableString SCORE_RACE_MAX_BAR_HEIGHT_LABEL = new EzLocalizationManager.EzLocalisableString("柱图最大尺寸", "Max Bar Size");
-        public static readonly LocalisableString SCORE_RACE_MAX_BAR_HEIGHT_DESCRIPTION = new EzLocalizationManager.EzLocalisableString("柱图主轴的最大像素长度", "Maximum pixel length along the bar axis.");
         public static readonly LocalisableString SCORE_RACE_SHOW_LABELS_LABEL = new EzLocalizationManager.EzLocalisableString("显示标签", "Show Labels");
         public static readonly LocalisableString SCORE_RACE_SHOW_LABELS_DESCRIPTION = new EzLocalizationManager.EzLocalisableString("显示柱下条件与统计标签", "Show criterion and stat labels under bars.");
         public static readonly LocalisableString SCORE_RACE_MAX_ENTRIES_LABEL = new EzLocalizationManager.EzLocalisableString("列表条目数", "List Entry Count");

--- a/osu.Game/EzOsuGame/Localization/EzHUDStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzHUDStrings.cs
@@ -190,8 +190,18 @@ namespace osu.Game.EzOsuGame.Localization
             "速度变化时在折线右端显示不显眼的闪烁白点。",
             "Show a subtle blinking white dot at the line endpoint while speed is changing.");
 
+        public static readonly LocalisableString SCORE_RACE_SLOT1_CRITERION_LABEL = new EzLocalizationManager.EzLocalisableString("历史柱 1 条件", "History Bar 1 Criterion");
+        public static readonly LocalisableString SCORE_RACE_SLOT1_CRITERION_DESCRIPTION = new EzLocalizationManager.EzLocalisableString("按此条件选择第一条历史最佳成绩", "Pick the first historical score by this criterion.");
+        public static readonly LocalisableString SCORE_RACE_SLOT2_CRITERION_LABEL = new EzLocalizationManager.EzLocalisableString("历史柱 2 条件", "History Bar 2 Criterion");
+        public static readonly LocalisableString SCORE_RACE_SLOT2_CRITERION_DESCRIPTION = new EzLocalizationManager.EzLocalisableString("按此条件选择第二条历史最佳成绩", "Pick the second historical score by this criterion.");
         public static readonly LocalisableString SCORE_RACE_MOD_FILTER_LABEL = new EzLocalizationManager.EzLocalisableString("Mod 过滤", "Mod Filter");
         public static readonly LocalisableString SCORE_RACE_MOD_FILTER_DESCRIPTION = new EzLocalizationManager.EzLocalisableString("对比成绩的 Mod 范围", "Which mod combinations to include when selecting scores.");
+        public static readonly LocalisableString SCORE_RACE_BAR_DIRECTION_LABEL = new EzLocalizationManager.EzLocalisableString("柱图方向", "Bar Direction");
+        public static readonly LocalisableString SCORE_RACE_BAR_DIRECTION_DESCRIPTION = new EzLocalizationManager.EzLocalisableString("柱体向上或向下增长", "Bars grow upward or downward.");
+        public static readonly LocalisableString SCORE_RACE_MAX_BAR_HEIGHT_LABEL = new EzLocalizationManager.EzLocalisableString("柱图最大尺寸", "Max Bar Size");
+        public static readonly LocalisableString SCORE_RACE_MAX_BAR_HEIGHT_DESCRIPTION = new EzLocalizationManager.EzLocalisableString("柱图主轴的最大像素长度", "Maximum pixel length along the bar axis.");
+        public static readonly LocalisableString SCORE_RACE_SHOW_LABELS_LABEL = new EzLocalizationManager.EzLocalisableString("显示标签", "Show Labels");
+        public static readonly LocalisableString SCORE_RACE_SHOW_LABELS_DESCRIPTION = new EzLocalizationManager.EzLocalisableString("显示柱下条件与统计标签", "Show criterion and stat labels under bars.");
         public static readonly LocalisableString SCORE_RACE_MAX_ENTRIES_LABEL = new EzLocalizationManager.EzLocalisableString("列表条目数", "List Entry Count");
         public static readonly LocalisableString SCORE_RACE_MAX_ENTRIES_DESCRIPTION = new EzLocalizationManager.EzLocalisableString("角逐排行榜显示的最大成绩数", "Maximum scores shown in the race leaderboard.");
         public static readonly LocalisableString SCORE_RACE_SORT_CRITERION_LABEL = new EzLocalizationManager.EzLocalisableString("排序依据", "Sort By");

--- a/osu.Game/EzOsuGame/Localization/EzHUDStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzHUDStrings.cs
@@ -199,6 +199,19 @@ namespace osu.Game.EzOsuGame.Localization
         public static readonly LocalisableString SCORE_COMPARE_BAR_WIDTH_LABEL = new EzLocalizationManager.EzLocalisableString("柱状图宽度", "Bar Width");
         public static readonly LocalisableString SCORE_COMPARE_BAR_WIDTH_DESCRIPTION = new EzLocalizationManager.EzLocalisableString("单根柱体的像素宽度", "Pixel width of each bar.");
         public static readonly LocalisableString SCORE_COMPARE_NOW_LABEL = new EzLocalizationManager.EzLocalisableString("当前", "Now");
+
+        public static readonly LocalisableString SCORE_COMPARE_BACKGROUND_VISIBLE_LABEL = new EzLocalizationManager.EzLocalisableString("显示背景", "Show Background");
+
+        public static readonly LocalisableString SCORE_COMPARE_BACKGROUND_VISIBLE_DESCRIPTION = new EzLocalizationManager.EzLocalisableString(
+            "显示整块圆角背景框（不含单柱分区底色）。",
+            "Show a single rounded background behind all bars (not per-bar track colours).");
+
+        public static readonly LocalisableString SCORE_COMPARE_BACKDROP_BLUR_LABEL = new EzLocalizationManager.EzLocalisableString("穿透虚化", "Backdrop Blur");
+
+        public static readonly LocalisableString SCORE_COMPARE_BACKDROP_BLUR_DESCRIPTION = new EzLocalizationManager.EzLocalisableString(
+            "开启后真穿透虚化背景框下方 OsuScreenStack 内已绘制内容；关闭时仅显示半透明底色。",
+            "When enabled, acrylic-blurs content rendered within OsuScreenStack beneath the background; when disabled, only the tint is shown.");
+
         public static readonly LocalisableString SCORE_RACE_MOD_FILTER_LABEL = new EzLocalizationManager.EzLocalisableString("Mod 过滤", "Mod Filter");
         public static readonly LocalisableString SCORE_RACE_MOD_FILTER_DESCRIPTION = new EzLocalizationManager.EzLocalisableString("对比成绩的 Mod 范围", "Which mod combinations to include when selecting scores.");
         public static readonly LocalisableString SCORE_RACE_BAR_DIRECTION_LABEL = new EzLocalizationManager.EzLocalisableString("柱图方向", "Bar Direction");

--- a/osu.Game/EzOsuGame/Localization/EzHUDStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzHUDStrings.cs
@@ -195,7 +195,7 @@ namespace osu.Game.EzOsuGame.Localization
         public static readonly LocalisableString SCORE_COMPARE_CONDITION2_LABEL = new EzLocalizationManager.EzLocalisableString("对比条件 2", "Compare Condition 2");
         public static readonly LocalisableString SCORE_COMPARE_CONDITION2_DESCRIPTION = new EzLocalizationManager.EzLocalisableString("按此条件筛选第二条对比成绩（柱高始终为分数）", "Pick the second comparison score by this criterion (bar height is always score).");
         public static readonly LocalisableString SCORE_COMPARE_BAR_HEIGHT_LABEL = new EzLocalizationManager.EzLocalisableString("柱状图高度", "Bar Height");
-        public static readonly LocalisableString SCORE_COMPARE_BAR_HEIGHT_DESCRIPTION = new EzLocalizationManager.EzLocalisableString("柱体主轴的像素高度", "Pixel height of the bar axis.");
+        public static readonly LocalisableString SCORE_COMPARE_BAR_HEIGHT_DESCRIPTION = new EzLocalizationManager.EzLocalisableString("柱体主轴像素高度；满柱对应整谱理论满分", "Pixel height of the bar axis; full bar equals theoretical max score.");
         public static readonly LocalisableString SCORE_COMPARE_BAR_WIDTH_LABEL = new EzLocalizationManager.EzLocalisableString("柱状图宽度", "Bar Width");
         public static readonly LocalisableString SCORE_COMPARE_BAR_WIDTH_DESCRIPTION = new EzLocalizationManager.EzLocalisableString("单根柱体的像素宽度", "Pixel width of each bar.");
         public static readonly LocalisableString SCORE_COMPARE_NOW_LABEL = new EzLocalizationManager.EzLocalisableString("当前", "Now");

--- a/osu.Game/EzOsuGame/Localization/EzHUDStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzHUDStrings.cs
@@ -208,7 +208,7 @@ namespace osu.Game.EzOsuGame.Localization
         public static readonly LocalisableString SCORE_RACE_MAX_ENTRIES_LABEL = new EzLocalizationManager.EzLocalisableString("列表条目数", "List Entry Count");
         public static readonly LocalisableString SCORE_RACE_MAX_ENTRIES_DESCRIPTION = new EzLocalizationManager.EzLocalisableString("角逐排行榜显示的最大成绩数", "Maximum scores shown in the race leaderboard.");
         public static readonly LocalisableString SCORE_RACE_SORT_CRITERION_LABEL = new EzLocalizationManager.EzLocalisableString("排序依据", "Sort By");
-        public static readonly LocalisableString SCORE_RACE_SORT_CRITERION_DESCRIPTION = new EzLocalizationManager.EzLocalisableString("角逐榜实时排名的比较指标", "Metric used to rank entries during the race.");
+        public static readonly LocalisableString SCORE_RACE_SORT_CRITERION_DESCRIPTION = new EzLocalizationManager.EzLocalisableString("角逐榜实时排名的比较指标（分数 / Acc / Combo / Miss）", "Metric used to rank entries during the race (score / acc / combo / miss).");
         public static readonly LocalisableString SCORE_RACE_LOADING_LABEL = new EzLocalizationManager.EzLocalisableString("加载角逐成绩…", "Loading race scores…");
     }
 }

--- a/osu.Game/EzOsuGame/Localization/EzHUDStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzHUDStrings.cs
@@ -189,5 +189,13 @@ namespace osu.Game.EzOsuGame.Localization
         public static readonly LocalisableString DYNAMIC_SPEED_ENDPOINT_BLINK_DESCRIPTION = new EzLocalizationManager.EzLocalisableString(
             "速度变化时在折线右端显示不显眼的闪烁白点。",
             "Show a subtle blinking white dot at the line endpoint while speed is changing.");
+
+        public static readonly LocalisableString SCORE_RACE_MOD_FILTER_LABEL = new EzLocalizationManager.EzLocalisableString("Mod 过滤", "Mod Filter");
+        public static readonly LocalisableString SCORE_RACE_MOD_FILTER_DESCRIPTION = new EzLocalizationManager.EzLocalisableString("对比成绩的 Mod 范围", "Which mod combinations to include when selecting scores.");
+        public static readonly LocalisableString SCORE_RACE_MAX_ENTRIES_LABEL = new EzLocalizationManager.EzLocalisableString("列表条目数", "List Entry Count");
+        public static readonly LocalisableString SCORE_RACE_MAX_ENTRIES_DESCRIPTION = new EzLocalizationManager.EzLocalisableString("角逐排行榜显示的最大成绩数", "Maximum scores shown in the race leaderboard.");
+        public static readonly LocalisableString SCORE_RACE_SORT_CRITERION_LABEL = new EzLocalizationManager.EzLocalisableString("排序依据", "Sort By");
+        public static readonly LocalisableString SCORE_RACE_SORT_CRITERION_DESCRIPTION = new EzLocalizationManager.EzLocalisableString("角逐榜实时排名的比较指标", "Metric used to rank entries during the race.");
+        public static readonly LocalisableString SCORE_RACE_LOADING_LABEL = new EzLocalizationManager.EzLocalisableString("加载角逐成绩…", "Loading race scores…");
     }
 }

--- a/osu.Game/EzOsuGame/Scoring/EzLocalScoreQueries.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzLocalScoreQueries.cs
@@ -50,19 +50,17 @@ namespace osu.Game.EzOsuGame.Scoring
 
         public static bool ModsMatch(Mod[] left, Mod[] right) => modsMatch(left, right);
 
-        public static ScoreInfo? PickBest(IEnumerable<ScoreInfo> scores, EzScoreRaceMetric metric, ScoreInfo? exclude = null)
+        public static ScoreInfo? PickBest(IEnumerable<ScoreInfo> scores, EzScoreRaceMetric metric)
         {
             if (metric == EzScoreRaceMetric.TheoreticalMaxScore)
                 return null;
 
-            var candidates = scores.Where(s => exclude == null || s.ID != exclude.ID);
-
             return metric switch
             {
-                EzScoreRaceMetric.TotalScore => candidates.OrderByDescending(s => s.TotalScore).ThenByDescending(s => s.Date).FirstOrDefault(),
-                EzScoreRaceMetric.Accuracy => candidates.OrderByDescending(s => s.Accuracy).ThenByDescending(s => s.TotalScore).FirstOrDefault(),
-                EzScoreRaceMetric.MaxCombo => candidates.OrderByDescending(s => s.MaxCombo).ThenByDescending(s => s.TotalScore).FirstOrDefault(),
-                EzScoreRaceMetric.MissCount => candidates.OrderBy(GetMissCount).ThenByDescending(s => s.TotalScore).FirstOrDefault(),
+                EzScoreRaceMetric.TotalScore => scores.OrderByDescending(s => s.TotalScore).ThenByDescending(s => s.Date).FirstOrDefault(),
+                EzScoreRaceMetric.Accuracy => scores.OrderByDescending(s => s.Accuracy).ThenByDescending(s => s.TotalScore).FirstOrDefault(),
+                EzScoreRaceMetric.MaxCombo => scores.OrderByDescending(s => s.MaxCombo).ThenByDescending(s => s.TotalScore).FirstOrDefault(),
+                EzScoreRaceMetric.MissCount => scores.OrderBy(GetMissCount).ThenByDescending(s => s.TotalScore).FirstOrDefault(),
                 _ => throw new ArgumentOutOfRangeException(nameof(metric), metric, null),
             };
         }

--- a/osu.Game/EzOsuGame/Scoring/EzLocalScoreQueries.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzLocalScoreQueries.cs
@@ -64,6 +64,23 @@ namespace osu.Game.EzOsuGame.Scoring
             };
         }
 
+        public static ScoreInfo? PickBest(IEnumerable<ScoreInfo> scores, EzScoreCompareCondition condition, ScoreInfo? exclude = null)
+        {
+            if (condition == EzScoreCompareCondition.TheoreticalMaxScore)
+                return null;
+
+            return PickBest(scores, toPickCriterion(condition), exclude);
+        }
+
+        private static EzScorePickCriterion toPickCriterion(EzScoreCompareCondition condition) => condition switch
+        {
+            EzScoreCompareCondition.BestTotalScore => EzScorePickCriterion.TotalScore,
+            EzScoreCompareCondition.BestAccuracy => EzScorePickCriterion.Accuracy,
+            EzScoreCompareCondition.BestMaxCombo => EzScorePickCriterion.MaxCombo,
+            EzScoreCompareCondition.BestMissCount => EzScorePickCriterion.MissCount,
+            _ => throw new ArgumentOutOfRangeException(nameof(condition), condition, null),
+        };
+
         public static List<ScoreInfo> GetTopByTotalScore(IEnumerable<ScoreInfo> scores, int take)
         {
             return scores.OrderByDescending(s => s.TotalScore)

--- a/osu.Game/EzOsuGame/Scoring/EzLocalScoreQueries.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzLocalScoreQueries.cs
@@ -1,0 +1,86 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
+
+namespace osu.Game.EzOsuGame.Scoring
+{
+    public static class EzLocalScoreQueries
+    {
+        /// <summary>
+        /// 返回当前谱面规则集下的本地成绩（含无 <c>.osr</c> 元数据但磁盘有 replay 的项）。
+        /// 能否构建时间线由 EzScoreTimelineBuilder.TryBuild（GetScore().Replay 门槛）过滤。
+        /// </summary>
+        public static List<ScoreInfo> GetLocalScoresWithReplay(RealmAccess realm, BeatmapInfo beatmap, RulesetInfo ruleset)
+        {
+            ArgumentNullException.ThrowIfNull(beatmap);
+            ArgumentNullException.ThrowIfNull(ruleset);
+
+            return realm.Run(r =>
+            {
+                var liveBeatmap = r.Find<BeatmapInfo>(beatmap.ID);
+
+                if (liveBeatmap == null)
+                    return new List<ScoreInfo>();
+
+                // 与选歌界面一致：走 BeatmapInfo.Scores 关联，避免 BeatmapHash 字段不一致时漏成绩。
+                return liveBeatmap.Scores
+                                  .AsEnumerable()
+                                  .Where(s => s.Ruleset.ShortName == ruleset.ShortName && !s.DeletePending)
+                                  .Select(s => s.Detach())
+                                  .ToList();
+            });
+        }
+
+        public static IEnumerable<ScoreInfo> FilterByMods(IEnumerable<ScoreInfo> scores, Mod[] currentMods, EzScoreModFilter filter)
+        {
+            if (filter == EzScoreModFilter.Any)
+                return scores;
+
+            return scores.Where(s => ModsMatch(s.Mods, currentMods));
+        }
+
+        public static bool ModsMatch(Mod[] left, Mod[] right) => modsMatch(left, right);
+
+        public static ScoreInfo? PickBest(IEnumerable<ScoreInfo> scores, EzScorePickCriterion criterion, ScoreInfo? exclude = null)
+        {
+            var candidates = scores.Where(s => exclude == null || s.ID != exclude.ID);
+
+            return criterion switch
+            {
+                EzScorePickCriterion.TotalScore => candidates.OrderByDescending(s => s.TotalScore).ThenByDescending(s => s.Date).FirstOrDefault(),
+                EzScorePickCriterion.Accuracy => candidates.OrderByDescending(s => s.Accuracy).ThenByDescending(s => s.TotalScore).FirstOrDefault(),
+                EzScorePickCriterion.MaxCombo => candidates.OrderByDescending(s => s.MaxCombo).ThenByDescending(s => s.TotalScore).FirstOrDefault(),
+                EzScorePickCriterion.MissCount => candidates.OrderBy(GetMissCount).ThenByDescending(s => s.TotalScore).FirstOrDefault(),
+                _ => throw new ArgumentOutOfRangeException(nameof(criterion), criterion, null),
+            };
+        }
+
+        public static List<ScoreInfo> GetTopByTotalScore(IEnumerable<ScoreInfo> scores, int take)
+        {
+            return scores.OrderByDescending(s => s.TotalScore)
+                         .ThenByDescending(s => s.Date)
+                         .Take(take)
+                         .ToList();
+        }
+
+        public static int GetMissCount(ScoreInfo score)
+        {
+            return score.Statistics.Where(kv => kv.Key.IsMiss()).Sum(kv => kv.Value);
+        }
+
+        private static bool modsMatch(Mod[] left, Mod[] right)
+        {
+            static IEnumerable<string> acronyms(Mod[] mods) => mods.OrderBy(m => m.Acronym).Select(m => m.Acronym);
+            return acronyms(left).SequenceEqual(acronyms(right));
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Scoring/EzLocalScoreQueries.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzLocalScoreQueries.cs
@@ -50,36 +50,22 @@ namespace osu.Game.EzOsuGame.Scoring
 
         public static bool ModsMatch(Mod[] left, Mod[] right) => modsMatch(left, right);
 
-        public static ScoreInfo? PickBest(IEnumerable<ScoreInfo> scores, EzScorePickCriterion criterion, ScoreInfo? exclude = null)
+        public static ScoreInfo? PickBest(IEnumerable<ScoreInfo> scores, EzScoreRaceMetric metric, ScoreInfo? exclude = null)
         {
-            var candidates = scores.Where(s => exclude == null || s.ID != exclude.ID);
-
-            return criterion switch
-            {
-                EzScorePickCriterion.TotalScore => candidates.OrderByDescending(s => s.TotalScore).ThenByDescending(s => s.Date).FirstOrDefault(),
-                EzScorePickCriterion.Accuracy => candidates.OrderByDescending(s => s.Accuracy).ThenByDescending(s => s.TotalScore).FirstOrDefault(),
-                EzScorePickCriterion.MaxCombo => candidates.OrderByDescending(s => s.MaxCombo).ThenByDescending(s => s.TotalScore).FirstOrDefault(),
-                EzScorePickCriterion.MissCount => candidates.OrderBy(GetMissCount).ThenByDescending(s => s.TotalScore).FirstOrDefault(),
-                _ => throw new ArgumentOutOfRangeException(nameof(criterion), criterion, null),
-            };
-        }
-
-        public static ScoreInfo? PickBest(IEnumerable<ScoreInfo> scores, EzScoreCompareCondition condition, ScoreInfo? exclude = null)
-        {
-            if (condition == EzScoreCompareCondition.TheoreticalMaxScore)
+            if (metric == EzScoreRaceMetric.TheoreticalMaxScore)
                 return null;
 
-            return PickBest(scores, toPickCriterion(condition), exclude);
-        }
+            var candidates = scores.Where(s => exclude == null || s.ID != exclude.ID);
 
-        private static EzScorePickCriterion toPickCriterion(EzScoreCompareCondition condition) => condition switch
-        {
-            EzScoreCompareCondition.BestTotalScore => EzScorePickCriterion.TotalScore,
-            EzScoreCompareCondition.BestAccuracy => EzScorePickCriterion.Accuracy,
-            EzScoreCompareCondition.BestMaxCombo => EzScorePickCriterion.MaxCombo,
-            EzScoreCompareCondition.BestMissCount => EzScorePickCriterion.MissCount,
-            _ => throw new ArgumentOutOfRangeException(nameof(condition), condition, null),
-        };
+            return metric switch
+            {
+                EzScoreRaceMetric.TotalScore => candidates.OrderByDescending(s => s.TotalScore).ThenByDescending(s => s.Date).FirstOrDefault(),
+                EzScoreRaceMetric.Accuracy => candidates.OrderByDescending(s => s.Accuracy).ThenByDescending(s => s.TotalScore).FirstOrDefault(),
+                EzScoreRaceMetric.MaxCombo => candidates.OrderByDescending(s => s.MaxCombo).ThenByDescending(s => s.TotalScore).FirstOrDefault(),
+                EzScoreRaceMetric.MissCount => candidates.OrderBy(GetMissCount).ThenByDescending(s => s.TotalScore).FirstOrDefault(),
+                _ => throw new ArgumentOutOfRangeException(nameof(metric), metric, null),
+            };
+        }
 
         public static List<ScoreInfo> GetTopByTotalScore(IEnumerable<ScoreInfo> scores, int take)
         {

--- a/osu.Game/EzOsuGame/Scoring/EzScoreRaceDisplayScore.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreRaceDisplayScore.cs
@@ -1,0 +1,51 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
+using osu.Game.Screens.Play.Leaderboards;
+
+namespace osu.Game.EzOsuGame.Scoring
+{
+    internal static class EzScoreRaceDisplayScore
+    {
+        public static long ForLeaderboardScore(GameplayLeaderboardScore leaderboardScore, ScoreInfo scoreInfo, ScoringMode mode)
+            => forLiveTotal(scoreInfo, leaderboardScore.TotalScore.Value, mode);
+
+        private static long forLiveTotal(ScoreInfo scoreInfo, long liveTotalScore, ScoringMode mode)
+        {
+            if (mode == ScoringMode.Standardised)
+                return liveTotalScore;
+
+            int maxBasicJudgements = scoreInfo.MaximumStatistics
+                                     .Where(k => k.Key.IsBasic())
+                                     .Select(k => k.Value)
+                                     .DefaultIfEmpty(0)
+                                     .Sum();
+
+            return convertStandardisedToClassic(scoreInfo.Ruleset.OnlineID, liveTotalScore, maxBasicJudgements);
+        }
+
+        // Mirrors ScoreInfoExtensions private conversion; kept here to avoid touching non-Ez files.
+        private static long convertStandardisedToClassic(int rulesetId, long standardisedTotalScore, int objectCount)
+        {
+            switch (rulesetId)
+            {
+                case 0:
+                    return (long)Math.Round((Math.Pow(objectCount, 2) * 32.57 + 100000) * standardisedTotalScore / ScoreProcessor.MAX_SCORE);
+
+                case 1:
+                    return (long)Math.Round((objectCount * 1109 + 100000) * standardisedTotalScore / ScoreProcessor.MAX_SCORE);
+
+                case 2:
+                    return (long)Math.Round(Math.Pow(standardisedTotalScore / ScoreProcessor.MAX_SCORE * objectCount, 2) * 21.62 + standardisedTotalScore / 10d);
+
+                case 3:
+                default:
+                    return standardisedTotalScore;
+            }
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Scoring/EzScoreRaceEntry.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreRaceEntry.cs
@@ -1,0 +1,21 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Scoring;
+
+namespace osu.Game.EzOsuGame.Scoring
+{
+    public sealed class EzScoreRaceEntry
+    {
+        public ScoreInfo ScoreInfo { get; }
+        public EzScoreTimeline? Timeline { get; internal set; }
+        public bool Tracked { get; internal set; }
+
+        public EzScoreRaceEntry(ScoreInfo scoreInfo, EzScoreTimeline? timeline = null, bool tracked = false)
+        {
+            ScoreInfo = scoreInfo;
+            Timeline = timeline;
+            Tracked = tracked;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Scoring/EzScoreRacePlayMode.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreRacePlayMode.cs
@@ -1,0 +1,32 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Screens.Play;
+
+namespace osu.Game.EzOsuGame.Scoring
+{
+    public enum EzScoreRacePlayMode
+    {
+        LocalLive,
+        LocalReplayChase,
+        SpectatingLive,
+    }
+
+    internal static class EzScoreRacePlayModeResolver
+    {
+        public static EzScoreRacePlayMode Resolve(Player player)
+        {
+            switch (player)
+            {
+                case ReplayPlayer:
+                    return EzScoreRacePlayMode.LocalReplayChase;
+
+                case SpectatorPlayer:
+                    return EzScoreRacePlayMode.SpectatingLive;
+
+                default:
+                    return EzScoreRacePlayMode.LocalLive;
+            }
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Scoring/EzScoreRaceRulesetSupport.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreRaceRulesetSupport.cs
@@ -1,0 +1,41 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets;
+
+namespace osu.Game.EzOsuGame.Scoring
+{
+    public enum EzScoreRaceGhostTimelineMode
+    {
+        None,
+        HitEvents,
+        ManiaSession,
+    }
+
+    /// <summary>
+    /// 角逐 HUD 规则集能力：Mania + Osu 支持 ghost 时间线；其余规则集仅当前局/理论柱，不加载 ghost。
+    /// </summary>
+    public static class EzScoreRaceRulesetSupport
+    {
+        public static bool SupportsGhostRace(RulesetInfo? ruleset)
+            => GetGhostTimelineMode(ruleset) != EzScoreRaceGhostTimelineMode.None;
+
+        public static EzScoreRaceGhostTimelineMode GetGhostTimelineMode(RulesetInfo? ruleset)
+        {
+            if (ruleset == null)
+                return EzScoreRaceGhostTimelineMode.None;
+
+            switch (ruleset.OnlineID)
+            {
+                case 3:
+                    return EzScoreRaceGhostTimelineMode.ManiaSession;
+
+                case 0:
+                    return EzScoreRaceGhostTimelineMode.HitEvents;
+
+                default:
+                    return EzScoreRaceGhostTimelineMode.None;
+            }
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Scoring/EzScoreRaceSession.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreRaceSession.cs
@@ -1,0 +1,226 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using osu.Framework.Bindables;
+using osu.Framework.Logging;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.Scoring;
+using osu.Game.Screens.Play;
+
+namespace osu.Game.EzOsuGame.Scoring
+{
+    public sealed class EzScoreRaceSession
+    {
+        private readonly RealmAccess realm;
+        private readonly ScoreManager scoreManager;
+        private readonly BeatmapManager beatmaps;
+        private readonly GameplayState gameplayState;
+        private readonly Action<Action>? scheduleCallback;
+
+        private readonly BindableBool isReady = new BindableBool();
+        private readonly List<EzScoreRaceEntry> entries = new List<EzScoreRaceEntry>();
+
+        private CancellationTokenSource? loadCancellation;
+        private EzScoreModFilter modFilter = EzScoreModFilter.SameAsCurrent;
+
+        public IBindable<bool> IsReady => isReady;
+        public EzScoreRacePlayMode PlayMode { get; }
+
+        public IReadOnlyList<EzScoreRaceEntry> Entries => entries;
+        public int MaxEntryCount { get; private set; } = 10;
+
+        public event Action? EntriesChanged;
+
+        public EzScoreRaceSession(RealmAccess realm, ScoreManager scoreManager, BeatmapManager beatmaps, GameplayState gameplayState, EzScoreRacePlayMode playMode,
+            Action<Action>? scheduleCallback = null)
+        {
+            this.realm = realm;
+            this.scoreManager = scoreManager;
+            this.beatmaps = beatmaps;
+            this.gameplayState = gameplayState;
+            this.PlayMode = playMode;
+            this.scheduleCallback = scheduleCallback;
+        }
+
+        public void Configure(EzScoreModFilter filter, int maxEntriesCount)
+        {
+            modFilter = filter;
+            MaxEntryCount = Math.Clamp(maxEntriesCount, 1, 10);
+        }
+
+        public void EnsureLoaded()
+        {
+            if (loadCancellation != null)
+                return;
+
+            loadCancellation = new CancellationTokenSource();
+            beginLoad(loadCancellation.Token);
+        }
+
+        public void ReloadIfNeeded(EzScoreModFilter filter, int maxEntriesCount)
+        {
+            int clamped = Math.Clamp(maxEntriesCount, 1, 10);
+
+            if (modFilter == filter && MaxEntryCount == clamped && loadCancellation != null)
+                return;
+
+            modFilter = filter;
+            MaxEntryCount = clamped;
+            cancelLoad();
+            entries.RemoveAll(e => !e.Tracked);
+            loadCancellation = new CancellationTokenSource();
+            beginLoad(loadCancellation.Token);
+        }
+
+        public void Dispose()
+        {
+            cancelLoad();
+        }
+
+        private void beginLoad(CancellationToken cancellationToken)
+        {
+            schedule(() =>
+            {
+                if (cancellationToken.IsCancellationRequested)
+                    return;
+
+                ensureTrackedEntry();
+
+                if (PlayMode != EzScoreRacePlayMode.SpectatingLive)
+                    ensureGhostPlaceholders();
+
+                isReady.Value = true;
+                notifyEntriesChanged();
+            });
+
+            if (PlayMode == EzScoreRacePlayMode.SpectatingLive)
+                return;
+
+            loadGhostTimelinesAsync(cancellationToken);
+        }
+
+        private void ensureTrackedEntry()
+        {
+            if (entries.Any(e => e.Tracked))
+                return;
+
+            entries.Add(new EzScoreRaceEntry(gameplayState.Score.ScoreInfo, tracked: true));
+        }
+
+        private IReadOnlyList<ScoreInfo> queryGhostScores()
+        {
+            var beatmapInfo = gameplayState.Beatmap.BeatmapInfo;
+            var rulesetInfo = gameplayState.Ruleset.RulesetInfo;
+            var currentMods = gameplayState.Mods.ToArray();
+
+            var localScores = EzLocalScoreQueries.GetLocalScoresWithReplay(realm, beatmapInfo, rulesetInfo);
+            var filteredScores = EzLocalScoreQueries.FilterByMods(localScores, currentMods, modFilter).ToList();
+            return EzLocalScoreQueries.GetTopByTotalScore(filteredScores, MaxEntryCount);
+        }
+
+        private void ensureGhostPlaceholders()
+        {
+            foreach (var scoreInfo in queryGhostScores())
+            {
+                if (entries.Any(e => !e.Tracked && e.ScoreInfo.ID == scoreInfo.ID))
+                    continue;
+
+                int trackedIndex = entries.FindIndex(e => e.Tracked);
+                var ghostEntry = new EzScoreRaceEntry(scoreInfo);
+
+                if (trackedIndex >= 0)
+                    entries.Insert(trackedIndex, ghostEntry);
+                else
+                    entries.Add(ghostEntry);
+            }
+        }
+
+        private void loadGhostTimelinesAsync(CancellationToken cancellationToken)
+        {
+            var topScores = queryGhostScores();
+            var currentMods = gameplayState.Mods.ToArray();
+            IBeatmap? sharedPlayableBeatmap = gameplayState.Beatmap;
+
+            Task.Run(async () =>
+            {
+                try
+                {
+                    var buildTasks = topScores.Select(scoreInfo => Task.Run(() =>
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        try
+                        {
+                            IBeatmap? beatmapForBuild = EzLocalScoreQueries.ModsMatch(scoreInfo.Mods, currentMods)
+                                ? sharedPlayableBeatmap
+                                : null;
+
+                            return (scoreInfo, EzScoreTimelineBuilder.TryBuild(scoreManager, beatmaps, scoreInfo, beatmapForBuild, cancellationToken));
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            throw;
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.Error(ex, $"[EzScoreRace] Failed to build timeline for score {scoreInfo.ID}", Ez2ConfigManager.LOGGER_NAME);
+                            return (scoreInfo, null);
+                        }
+                    }, cancellationToken)).ToArray();
+
+                    var results = await Task.WhenAll(buildTasks).ConfigureAwait(false);
+
+                    foreach (var (scoreInfo, timeline) in results)
+                    {
+                        if (cancellationToken.IsCancellationRequested)
+                            return;
+
+                        if (timeline == null)
+                            continue;
+
+                        schedule(() =>
+                        {
+                            if (cancellationToken.IsCancellationRequested)
+                                return;
+
+                            var entry = entries.FirstOrDefault(e => !e.Tracked && e.ScoreInfo.ID == scoreInfo.ID);
+
+                            if (entry == null || entry.Timeline != null)
+                                return;
+
+                            entry.Timeline = timeline;
+                            notifyEntriesChanged();
+                        });
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                }
+            }, cancellationToken);
+        }
+
+        private void notifyEntriesChanged() => EntriesChanged?.Invoke();
+
+        private void schedule(Action action)
+        {
+            if (scheduleCallback != null)
+                scheduleCallback(action);
+            else
+                action();
+        }
+
+        private void cancelLoad()
+        {
+            loadCancellation?.Cancel();
+            loadCancellation?.Dispose();
+            loadCancellation = null;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Scoring/EzScoreRaceSession.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreRaceSession.cs
@@ -40,6 +40,7 @@ namespace osu.Game.EzOsuGame.Scoring
 
         public IBindable<bool> IsReady => isReady;
         public EzScoreRacePlayMode PlayMode { get; }
+        public bool SupportsGhostRace { get; }
 
         public IReadOnlyList<EzScoreRaceEntry> Entries => entries;
         public int MaxEntryCount { get; private set; } = 10;
@@ -54,6 +55,8 @@ namespace osu.Game.EzOsuGame.Scoring
             this.beatmaps = beatmaps;
             this.gameplayState = gameplayState;
             PlayMode = playMode;
+            SupportsGhostRace = EzScoreRaceRulesetSupport.SupportsGhostRace(gameplayState.Ruleset.RulesetInfo)
+                                && playMode != EzScoreRacePlayMode.SpectatingLive;
             this.scheduleCallback = scheduleCallback;
         }
 
@@ -94,6 +97,9 @@ namespace osu.Game.EzOsuGame.Scoring
         /// </summary>
         public EzScoreRaceEntry? PickGhost(EzScoreRaceMetric metric, ScoreInfo? exclude = null)
         {
+            if (!SupportsGhostRace)
+                return null;
+
             if (metric == EzScoreRaceMetric.TheoreticalMaxScore)
                 return null;
 
@@ -151,14 +157,14 @@ namespace osu.Game.EzOsuGame.Scoring
 
                 ensureTrackedEntry();
 
-                if (PlayMode != EzScoreRacePlayMode.SpectatingLive)
+                if (SupportsGhostRace)
                     ensureLeaderboardGhostPlaceholders();
 
                 isReady.Value = true;
                 notifyEntriesChanged();
             });
 
-            if (PlayMode == EzScoreRacePlayMode.SpectatingLive)
+            if (!SupportsGhostRace)
                 return;
 
             ensureTimelinesLoaded(queryLeaderboardGhostScores(), cancellationToken);
@@ -238,7 +244,7 @@ namespace osu.Game.EzOsuGame.Scoring
 
         private void ensureTimelinesLoaded(IEnumerable<ScoreInfo> scoreInfos, CancellationToken cancellationToken = default)
         {
-            if (PlayMode == EzScoreRacePlayMode.SpectatingLive)
+            if (!SupportsGhostRace)
                 return;
 
             cancellationToken = cancellationToken == CancellationToken.None ? loadCancellation?.Token ?? CancellationToken.None : cancellationToken;

--- a/osu.Game/EzOsuGame/Scoring/EzScoreRaceSession.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreRaceSession.cs
@@ -30,7 +30,6 @@ namespace osu.Game.EzOsuGame.Scoring
 
         private readonly BindableBool isReady = new BindableBool();
         private readonly List<EzScoreRaceEntry> entries = new List<EzScoreRaceEntry>();
-        private readonly Dictionary<Guid, EzScoreRaceEntry> pickEntries = new Dictionary<Guid, EzScoreRaceEntry>();
         private readonly HashSet<Guid> timelineLoadsPending = new HashSet<Guid>();
 
         private CancellationTokenSource? loadCancellation;
@@ -86,7 +85,6 @@ namespace osu.Game.EzOsuGame.Scoring
             MaxEntryCount = clamped;
             cancelLoad();
             entries.RemoveAll(e => !e.Tracked);
-            pickEntries.Clear();
             scorePoolDirty = true;
             loadCancellation = new CancellationTokenSource();
             beginLoad(loadCancellation.Token);
@@ -95,21 +93,17 @@ namespace osu.Game.EzOsuGame.Scoring
         /// <summary>
         /// 在 Mod 过滤后的全量候选里，按指标选出 ghost 并确保 Session 条目与时间线加载。
         /// </summary>
-        public EzScoreRaceEntry? PickGhost(EzScoreRaceMetric metric, ScoreInfo? exclude = null)
+        public EzScoreRaceEntry? PickGhost(EzScoreRaceMetric metric)
         {
             if (!SupportsGhostRace)
                 return null;
 
-            if (metric == EzScoreRaceMetric.TheoreticalMaxScore)
-                return null;
-
-            var scoreInfo = EzLocalScoreQueries.PickBest(GetModFilteredScores(), metric, exclude);
+            var scoreInfo = EzLocalScoreQueries.PickBest(GetModFilteredScores(), metric);
 
             if (scoreInfo == null)
                 return null;
 
-            var entry = getOrCreatePickEntry(scoreInfo);
-            syncTimelineFromEntries(entry);
+            var entry = ensureGhostEntry(scoreInfo);
 
             if (entry.Timeline == null)
                 ensureTimelinesLoaded(new[] { scoreInfo });
@@ -187,20 +181,6 @@ namespace osu.Game.EzOsuGame.Scoring
                 ensureGhostEntry(scoreInfo);
         }
 
-        private EzScoreRaceEntry getOrCreatePickEntry(ScoreInfo scoreInfo)
-        {
-            if (pickEntries.TryGetValue(scoreInfo.ID, out var existing))
-            {
-                syncTimelineFromEntries(existing);
-                return existing;
-            }
-
-            var pickEntry = new EzScoreRaceEntry(scoreInfo);
-            syncTimelineFromEntries(pickEntry);
-            pickEntries[scoreInfo.ID] = pickEntry;
-            return pickEntry;
-        }
-
         private EzScoreRaceEntry ensureGhostEntry(ScoreInfo scoreInfo)
         {
             var existing = entries.FirstOrDefault(e => !e.Tracked && e.ScoreInfo.ID == scoreInfo.ID);
@@ -216,30 +196,15 @@ namespace osu.Game.EzOsuGame.Scoring
             else
                 entries.Add(ghostEntry);
 
-            syncTimelineFromEntries(ghostEntry);
             return ghostEntry;
-        }
-
-        private void syncTimelineFromEntries(EzScoreRaceEntry entry)
-        {
-            if (entry.Timeline != null)
-                return;
-
-            var sessionEntry = entries.FirstOrDefault(e => e.ScoreInfo.ID == entry.ScoreInfo.ID);
-
-            if (sessionEntry?.Timeline != null)
-                entry.Timeline = sessionEntry.Timeline;
         }
 
         private void assignTimeline(ScoreInfo scoreInfo, EzScoreTimeline timeline)
         {
-            var sessionEntry = entries.FirstOrDefault(e => !e.Tracked && e.ScoreInfo.ID == scoreInfo.ID);
+            var entry = entries.FirstOrDefault(e => e.ScoreInfo.ID == scoreInfo.ID);
 
-            if (sessionEntry != null)
-                sessionEntry.Timeline = timeline;
-
-            if (pickEntries.TryGetValue(scoreInfo.ID, out var pickEntry))
-                pickEntry.Timeline = timeline;
+            if (entry != null)
+                entry.Timeline = timeline;
         }
 
         private void ensureTimelinesLoaded(IEnumerable<ScoreInfo> scoreInfos, CancellationToken cancellationToken = default)
@@ -321,12 +286,7 @@ namespace osu.Game.EzOsuGame.Scoring
         }
 
         private bool hasTimeline(ScoreInfo scoreInfo)
-        {
-            if (entries.FirstOrDefault(e => e.ScoreInfo.ID == scoreInfo.ID)?.Timeline != null)
-                return true;
-
-            return pickEntries.TryGetValue(scoreInfo.ID, out var pickEntry) && pickEntry.Timeline != null;
-        }
+            => entries.FirstOrDefault(e => e.ScoreInfo.ID == scoreInfo.ID)?.Timeline != null;
 
         private void notifyEntriesChanged() => EntriesChanged?.Invoke();
 

--- a/osu.Game/EzOsuGame/Scoring/EzScoreRaceSession.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreRaceSession.cs
@@ -103,7 +103,11 @@ namespace osu.Game.EzOsuGame.Scoring
                 return null;
 
             var entry = getOrCreatePickEntry(scoreInfo);
-            ensureTimelinesLoaded(new[] { scoreInfo });
+            syncTimelineFromEntries(entry);
+
+            if (entry.Timeline == null)
+                ensureTimelinesLoaded(new[] { scoreInfo });
+
             return entry;
         }
 

--- a/osu.Game/EzOsuGame/Scoring/EzScoreRaceSession.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreRaceSession.cs
@@ -16,6 +16,10 @@ using osu.Game.Screens.Play;
 
 namespace osu.Game.EzOsuGame.Scoring
 {
+    /// <summary>
+    /// 单局共享角逐 Session：Mod 过滤、按指标 Pick ghost、时间线构建的唯一入口。
+    /// 两个 HUD 只读 <see cref="Entries"/> / 调用 <see cref="PickGhost"/>，禁止各自查 Realm 或自建 timeline。
+    /// </summary>
     public sealed class EzScoreRaceSession
     {
         private readonly RealmAccess realm;
@@ -26,9 +30,13 @@ namespace osu.Game.EzOsuGame.Scoring
 
         private readonly BindableBool isReady = new BindableBool();
         private readonly List<EzScoreRaceEntry> entries = new List<EzScoreRaceEntry>();
+        private readonly Dictionary<Guid, EzScoreRaceEntry> pickEntries = new Dictionary<Guid, EzScoreRaceEntry>();
+        private readonly HashSet<Guid> timelineLoadsPending = new HashSet<Guid>();
 
         private CancellationTokenSource? loadCancellation;
         private EzScoreModFilter modFilter = EzScoreModFilter.SameAsCurrent;
+        private List<ScoreInfo> modFilteredScores = new List<ScoreInfo>();
+        private bool scorePoolDirty = true;
 
         public IBindable<bool> IsReady => isReady;
         public EzScoreRacePlayMode PlayMode { get; }
@@ -39,13 +47,13 @@ namespace osu.Game.EzOsuGame.Scoring
         public event Action? EntriesChanged;
 
         public EzScoreRaceSession(RealmAccess realm, ScoreManager scoreManager, BeatmapManager beatmaps, GameplayState gameplayState, EzScoreRacePlayMode playMode,
-            Action<Action>? scheduleCallback = null)
+                                  Action<Action>? scheduleCallback = null)
         {
             this.realm = realm;
             this.scoreManager = scoreManager;
             this.beatmaps = beatmaps;
             this.gameplayState = gameplayState;
-            this.PlayMode = playMode;
+            PlayMode = playMode;
             this.scheduleCallback = scheduleCallback;
         }
 
@@ -75,8 +83,54 @@ namespace osu.Game.EzOsuGame.Scoring
             MaxEntryCount = clamped;
             cancelLoad();
             entries.RemoveAll(e => !e.Tracked);
+            pickEntries.Clear();
+            scorePoolDirty = true;
             loadCancellation = new CancellationTokenSource();
             beginLoad(loadCancellation.Token);
+        }
+
+        /// <summary>
+        /// 在 Mod 过滤后的全量候选里，按指标选出 ghost 并确保 Session 条目与时间线加载。
+        /// </summary>
+        public EzScoreRaceEntry? PickGhost(EzScoreRaceMetric metric, ScoreInfo? exclude = null)
+        {
+            if (metric == EzScoreRaceMetric.TheoreticalMaxScore)
+                return null;
+
+            var scoreInfo = EzLocalScoreQueries.PickBest(GetModFilteredScores(), metric, exclude);
+
+            if (scoreInfo == null)
+                return null;
+
+            var entry = getOrCreatePickEntry(scoreInfo);
+            ensureTimelinesLoaded(new[] { scoreInfo });
+            return entry;
+        }
+
+        /// <summary>
+        /// 读取 ghost 在指定时钟的 timeline 分数；未就绪返回 0（禁止终局分回退）。
+        /// </summary>
+        public static long QueryTimelineScore(EzScoreRaceEntry? entry, double clockTime)
+        {
+            if (entry == null || entry.Tracked || entry.Timeline == null)
+                return 0;
+
+            return entry.Timeline.QueryAtTime(clockTime).TotalScore;
+        }
+
+        public IReadOnlyList<ScoreInfo> GetModFilteredScores()
+        {
+            if (!scorePoolDirty)
+                return modFilteredScores;
+
+            var beatmapInfo = gameplayState.Beatmap.BeatmapInfo;
+            var rulesetInfo = gameplayState.Ruleset.RulesetInfo;
+            var currentMods = gameplayState.Mods.ToArray();
+
+            var localScores = EzLocalScoreQueries.GetLocalScoresWithReplay(realm, beatmapInfo, rulesetInfo);
+            modFilteredScores = EzLocalScoreQueries.FilterByMods(localScores, currentMods, modFilter).ToList();
+            scorePoolDirty = false;
+            return modFilteredScores;
         }
 
         public void Dispose()
@@ -94,7 +148,7 @@ namespace osu.Game.EzOsuGame.Scoring
                 ensureTrackedEntry();
 
                 if (PlayMode != EzScoreRacePlayMode.SpectatingLive)
-                    ensureGhostPlaceholders();
+                    ensureLeaderboardGhostPlaceholders();
 
                 isReady.Value = true;
                 notifyEntriesChanged();
@@ -103,7 +157,7 @@ namespace osu.Game.EzOsuGame.Scoring
             if (PlayMode == EzScoreRacePlayMode.SpectatingLive)
                 return;
 
-            loadGhostTimelinesAsync(cancellationToken);
+            ensureTimelinesLoaded(queryLeaderboardGhostScores(), cancellationToken);
         }
 
         private void ensureTrackedEntry()
@@ -114,45 +168,95 @@ namespace osu.Game.EzOsuGame.Scoring
             entries.Add(new EzScoreRaceEntry(gameplayState.Score.ScoreInfo, tracked: true));
         }
 
-        private IReadOnlyList<ScoreInfo> queryGhostScores()
-        {
-            var beatmapInfo = gameplayState.Beatmap.BeatmapInfo;
-            var rulesetInfo = gameplayState.Ruleset.RulesetInfo;
-            var currentMods = gameplayState.Mods.ToArray();
+        private IReadOnlyList<ScoreInfo> queryLeaderboardGhostScores()
+            => EzLocalScoreQueries.GetTopByTotalScore(GetModFilteredScores(), MaxEntryCount);
 
-            var localScores = EzLocalScoreQueries.GetLocalScoresWithReplay(realm, beatmapInfo, rulesetInfo);
-            var filteredScores = EzLocalScoreQueries.FilterByMods(localScores, currentMods, modFilter).ToList();
-            return EzLocalScoreQueries.GetTopByTotalScore(filteredScores, MaxEntryCount);
+        private void ensureLeaderboardGhostPlaceholders()
+        {
+            foreach (var scoreInfo in queryLeaderboardGhostScores())
+                ensureGhostEntry(scoreInfo);
         }
 
-        private void ensureGhostPlaceholders()
+        private EzScoreRaceEntry getOrCreatePickEntry(ScoreInfo scoreInfo)
         {
-            foreach (var scoreInfo in queryGhostScores())
+            if (pickEntries.TryGetValue(scoreInfo.ID, out var existing))
             {
-                if (entries.Any(e => !e.Tracked && e.ScoreInfo.ID == scoreInfo.ID))
-                    continue;
-
-                int trackedIndex = entries.FindIndex(e => e.Tracked);
-                var ghostEntry = new EzScoreRaceEntry(scoreInfo);
-
-                if (trackedIndex >= 0)
-                    entries.Insert(trackedIndex, ghostEntry);
-                else
-                    entries.Add(ghostEntry);
+                syncTimelineFromEntries(existing);
+                return existing;
             }
+
+            var pickEntry = new EzScoreRaceEntry(scoreInfo);
+            syncTimelineFromEntries(pickEntry);
+            pickEntries[scoreInfo.ID] = pickEntry;
+            return pickEntry;
         }
 
-        private void loadGhostTimelinesAsync(CancellationToken cancellationToken)
+        private EzScoreRaceEntry ensureGhostEntry(ScoreInfo scoreInfo)
         {
-            var topScores = queryGhostScores();
+            var existing = entries.FirstOrDefault(e => !e.Tracked && e.ScoreInfo.ID == scoreInfo.ID);
+
+            if (existing != null)
+                return existing;
+
+            int trackedIndex = entries.FindIndex(e => e.Tracked);
+            var ghostEntry = new EzScoreRaceEntry(scoreInfo);
+
+            if (trackedIndex >= 0)
+                entries.Insert(trackedIndex, ghostEntry);
+            else
+                entries.Add(ghostEntry);
+
+            syncTimelineFromEntries(ghostEntry);
+            return ghostEntry;
+        }
+
+        private void syncTimelineFromEntries(EzScoreRaceEntry entry)
+        {
+            if (entry.Timeline != null)
+                return;
+
+            var sessionEntry = entries.FirstOrDefault(e => e.ScoreInfo.ID == entry.ScoreInfo.ID);
+
+            if (sessionEntry?.Timeline != null)
+                entry.Timeline = sessionEntry.Timeline;
+        }
+
+        private void assignTimeline(ScoreInfo scoreInfo, EzScoreTimeline timeline)
+        {
+            var sessionEntry = entries.FirstOrDefault(e => !e.Tracked && e.ScoreInfo.ID == scoreInfo.ID);
+
+            if (sessionEntry != null)
+                sessionEntry.Timeline = timeline;
+
+            if (pickEntries.TryGetValue(scoreInfo.ID, out var pickEntry))
+                pickEntry.Timeline = timeline;
+        }
+
+        private void ensureTimelinesLoaded(IEnumerable<ScoreInfo> scoreInfos, CancellationToken cancellationToken = default)
+        {
+            if (PlayMode == EzScoreRacePlayMode.SpectatingLive)
+                return;
+
+            cancellationToken = cancellationToken == CancellationToken.None ? loadCancellation?.Token ?? CancellationToken.None : cancellationToken;
+
+            if (cancellationToken == CancellationToken.None)
+                return;
+
+            var scoresToLoad = scoreInfos
+                               .Where(s => !hasTimeline(s) && timelineLoadsPending.Add(s.ID))
+                               .ToList();
+
+            if (scoresToLoad.Count == 0)
+                return;
+
             var currentMods = gameplayState.Mods.ToArray();
-            IBeatmap? sharedPlayableBeatmap = gameplayState.Beatmap;
+            IBeatmap sharedPlayableBeatmap = gameplayState.Beatmap;
 
             Task.Run(async () =>
             {
                 try
                 {
-                    var buildTasks = topScores.Select(scoreInfo => Task.Run(() =>
+                    var buildTasks = scoresToLoad.Select(scoreInfo => Task.Run(() =>
                     {
                         cancellationToken.ThrowIfCancellationRequested();
 
@@ -182,20 +286,20 @@ namespace osu.Game.EzOsuGame.Scoring
                         if (cancellationToken.IsCancellationRequested)
                             return;
 
-                        if (timeline == null)
-                            continue;
-
                         schedule(() =>
                         {
+                            timelineLoadsPending.Remove(scoreInfo.ID);
+
                             if (cancellationToken.IsCancellationRequested)
                                 return;
 
-                            var entry = entries.FirstOrDefault(e => !e.Tracked && e.ScoreInfo.ID == scoreInfo.ID);
-
-                            if (entry == null || entry.Timeline != null)
+                            if (timeline == null)
                                 return;
 
-                            entry.Timeline = timeline;
+                            if (hasTimeline(scoreInfo))
+                                return;
+
+                            assignTimeline(scoreInfo, timeline);
                             notifyEntriesChanged();
                         });
                     }
@@ -204,6 +308,14 @@ namespace osu.Game.EzOsuGame.Scoring
                 {
                 }
             }, cancellationToken);
+        }
+
+        private bool hasTimeline(ScoreInfo scoreInfo)
+        {
+            if (entries.FirstOrDefault(e => e.ScoreInfo.ID == scoreInfo.ID)?.Timeline != null)
+                return true;
+
+            return pickEntries.TryGetValue(scoreInfo.ID, out var pickEntry) && pickEntry.Timeline != null;
         }
 
         private void notifyEntriesChanged() => EntriesChanged?.Invoke();
@@ -221,6 +333,7 @@ namespace osu.Game.EzOsuGame.Scoring
             loadCancellation?.Cancel();
             loadCancellation?.Dispose();
             loadCancellation = null;
+            timelineLoadsPending.Clear();
         }
     }
 }

--- a/osu.Game/EzOsuGame/Scoring/EzScoreRaceSessionHost.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreRaceSessionHost.cs
@@ -1,0 +1,56 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+using osu.Game.Scoring;
+using osu.Game.Screens.Play;
+
+namespace osu.Game.EzOsuGame.Scoring
+{
+    /// <summary>
+    /// 单局共享的 <see cref="EzScoreRaceSession"/> 宿主，供多个角逐 HUD 组件注入。
+    /// </summary>
+    [Cached]
+    public partial class EzScoreRaceSessionHost : Component
+    {
+        public EzScoreRaceSession? Session { get; private set; }
+
+        [Resolved]
+        private RealmAccess realm { get; set; } = null!;
+
+        [Resolved]
+        private ScoreManager scoreManager { get; set; } = null!;
+
+        [Resolved]
+        private BeatmapManager beatmaps { get; set; } = null!;
+
+        [Resolved(canBeNull: true)]
+        private GameplayState? gameplayState { get; set; }
+
+        [Resolved]
+        private Player player { get; set; } = null!;
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            if (gameplayState == null)
+                return;
+
+            var playMode = EzScoreRacePlayModeResolver.Resolve(player);
+            Session = new EzScoreRaceSession(realm, scoreManager, beatmaps, gameplayState, playMode, action => Schedule(action));
+            Session.EnsureLoaded();
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (isDisposing)
+                Session?.Dispose();
+
+            base.Dispose(isDisposing);
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Scoring/EzScoreRaceTypes.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreRaceTypes.cs
@@ -1,64 +1,50 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.ComponentModel;
+using osu.Framework.Localisation;
+using osu.Game.EzOsuGame.Localization;
 
 namespace osu.Game.EzOsuGame.Scoring
 {
-    public enum EzScorePickCriterion
-    {
-        [Description("Total score")]
-        TotalScore,
-
-        [Description("Accuracy")]
-        Accuracy,
-
-        [Description("Max combo")]
-        MaxCombo,
-
-        [Description("Miss count")]
-        MissCount,
-    }
-
     /// <summary>
-    /// 三柱对比条件：筛选要对比的历史成绩；柱高始终按分数绘制。
+    /// 角逐 HUD 共用指标维度。三柱 HUD 用于筛选对比哪条成绩；角逐榜用于实时排序。
     /// </summary>
-    public enum EzScoreCompareCondition
+    public enum EzScoreRaceMetric
     {
-        [Description("理论最高分数")]
+        [LocalisableDescription(typeof(EzScoreRaceStrings), nameof(EzScoreRaceStrings.METRIC_THEORETICAL_MAX_SCORE))]
         TheoreticalMaxScore,
 
-        [Description("历史最高分数")]
-        BestTotalScore,
-
-        [Description("历史最高 Acc")]
-        BestAccuracy,
-
-        [Description("历史最大 Combo")]
-        BestMaxCombo,
-
-        [Description("历史最低 Miss")]
-        BestMissCount,
-    }
-
-    public enum EzScoreRaceSortCriterion
-    {
-        [Description("Total score")]
+        [LocalisableDescription(typeof(EzScoreRaceStrings), nameof(EzScoreRaceStrings.METRIC_TOTAL_SCORE))]
         TotalScore,
 
-        [Description("Accuracy")]
+        [LocalisableDescription(typeof(EzScoreRaceStrings), nameof(EzScoreRaceStrings.METRIC_ACCURACY))]
         Accuracy,
 
-        [Description("Miss count")]
+        [LocalisableDescription(typeof(EzScoreRaceStrings), nameof(EzScoreRaceStrings.METRIC_MAX_COMBO))]
+        MaxCombo,
+
+        [LocalisableDescription(typeof(EzScoreRaceStrings), nameof(EzScoreRaceStrings.METRIC_MISS_COUNT))]
         MissCount,
     }
 
     public enum EzScoreModFilter
     {
-        [Description("Same mods as current")]
+        [LocalisableDescription(typeof(EzScoreRaceStrings), nameof(EzScoreRaceStrings.MOD_FILTER_SAME_AS_CURRENT))]
         SameAsCurrent,
 
-        [Description("Any mods")]
+        [LocalisableDescription(typeof(EzScoreRaceStrings), nameof(EzScoreRaceStrings.MOD_FILTER_ANY))]
         Any,
+    }
+
+    public static class EzScoreRaceStrings
+    {
+        public static readonly LocalisableString METRIC_THEORETICAL_MAX_SCORE = new EzLocalizationManager.EzLocalisableString("理论最高分", "Theoretical max score");
+        public static readonly LocalisableString METRIC_TOTAL_SCORE = new EzLocalizationManager.EzLocalisableString("分数", "Score");
+        public static readonly LocalisableString METRIC_ACCURACY = new EzLocalizationManager.EzLocalisableString("Acc", "Acc");
+        public static readonly LocalisableString METRIC_MAX_COMBO = new EzLocalizationManager.EzLocalisableString("Combo", "Combo");
+        public static readonly LocalisableString METRIC_MISS_COUNT = new EzLocalizationManager.EzLocalisableString("Miss", "Miss");
+
+        public static readonly LocalisableString MOD_FILTER_SAME_AS_CURRENT = new EzLocalizationManager.EzLocalisableString("相同 Mod", "Same mods as current");
+        public static readonly LocalisableString MOD_FILTER_ANY = new EzLocalizationManager.EzLocalisableString("任意 Mod", "Any mods");
     }
 }

--- a/osu.Game/EzOsuGame/Scoring/EzScoreRaceTypes.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreRaceTypes.cs
@@ -20,6 +20,27 @@ namespace osu.Game.EzOsuGame.Scoring
         MissCount,
     }
 
+    /// <summary>
+    /// 三柱对比条件：筛选要对比的历史成绩；柱高始终按分数绘制。
+    /// </summary>
+    public enum EzScoreCompareCondition
+    {
+        [Description("理论最高分数")]
+        TheoreticalMaxScore,
+
+        [Description("历史最高分数")]
+        BestTotalScore,
+
+        [Description("历史最高 Acc")]
+        BestAccuracy,
+
+        [Description("历史最大 Combo")]
+        BestMaxCombo,
+
+        [Description("历史最低 Miss")]
+        BestMissCount,
+    }
+
     public enum EzScoreRaceSortCriterion
     {
         [Description("Total score")]

--- a/osu.Game/EzOsuGame/Scoring/EzScoreRaceTypes.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreRaceTypes.cs
@@ -1,0 +1,43 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.ComponentModel;
+
+namespace osu.Game.EzOsuGame.Scoring
+{
+    public enum EzScorePickCriterion
+    {
+        [Description("Total score")]
+        TotalScore,
+
+        [Description("Accuracy")]
+        Accuracy,
+
+        [Description("Max combo")]
+        MaxCombo,
+
+        [Description("Miss count")]
+        MissCount,
+    }
+
+    public enum EzScoreRaceSortCriterion
+    {
+        [Description("Total score")]
+        TotalScore,
+
+        [Description("Accuracy")]
+        Accuracy,
+
+        [Description("Miss count")]
+        MissCount,
+    }
+
+    public enum EzScoreModFilter
+    {
+        [Description("Same mods as current")]
+        SameAsCurrent,
+
+        [Description("Any mods")]
+        Any,
+    }
+}

--- a/osu.Game/EzOsuGame/Scoring/EzScoreTimelineBuilder.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreTimelineBuilder.cs
@@ -45,7 +45,12 @@ namespace osu.Game.EzOsuGame.Scoring
 
             ensureGeneratorsInitialised();
 
-            string? cacheKey = getCacheKey(scoreInfo);
+            var timelineMode = EzScoreRaceRulesetSupport.GetGhostTimelineMode(scoreInfo.Ruleset);
+
+            if (timelineMode == EzScoreRaceGhostTimelineMode.None)
+                return null;
+
+            string? cacheKey = getCacheKey(scoreInfo, timelineMode);
 
             if (!string.IsNullOrEmpty(cacheKey) && timeline_cache.TryGetValue(cacheKey, out var cached))
                 return cached;
@@ -80,20 +85,23 @@ namespace osu.Game.EzOsuGame.Scoring
 
             EzScoreTimeline? timeline;
 
-            if (scoreInfo.Ruleset.OnlineID == 3)
+            switch (timelineMode)
             {
-                // Mania 生产路径：Session 一遍 SP 快照，禁止 buildFromHitEvents。
-                timeline = EzScoreTimelineBridge.TryBuildManiaTimeline(databasedScore, playableBeatmap, cancellationToken);
-            }
-            else
-            {
-                // 非 Mania：统计页临时 HitEvents 或从 replay 生成；不是 Mania HUD 输入。
-                var (hitEvents, offsetsRelativeToEnd) = resolveHitEvents(databasedScore, playableBeatmap, cancellationToken);
+                case EzScoreRaceGhostTimelineMode.ManiaSession:
+                    timeline = EzScoreTimelineBridge.TryBuildManiaTimeline(databasedScore, playableBeatmap, cancellationToken);
+                    break;
 
-                if (hitEvents == null || hitEvents.Count == 0)
+                case EzScoreRaceGhostTimelineMode.HitEvents:
+                    var (hitEvents, offsetsRelativeToEnd) = resolveHitEvents(databasedScore, playableBeatmap, cancellationToken);
+
+                    if (hitEvents == null || hitEvents.Count == 0)
+                        return null;
+
+                    timeline = buildFromHitEvents(ruleset, playableBeatmap, scoreInfo, hitEvents, offsetsRelativeToEnd);
+                    break;
+
+                default:
                     return null;
-
-                timeline = buildFromHitEvents(ruleset, playableBeatmap, scoreInfo, hitEvents, offsetsRelativeToEnd);
             }
 
             if (timeline == null)
@@ -327,22 +335,32 @@ namespace osu.Game.EzOsuGame.Scoring
             };
         }
 
-        private static string? getCacheKey(ScoreInfo? scoreInfo)
+        private static string? getCacheKey(ScoreInfo? scoreInfo, EzScoreRaceGhostTimelineMode timelineMode)
         {
             string? identity = getScoreIdentity(scoreInfo);
 
-            if (identity == null)
+            if (identity == null || scoreInfo == null)
                 return null;
 
-            if (scoreInfo!.Ruleset.OnlineID == 3)
+            switch (timelineMode)
             {
-                // 与角逐 HUD 一致：全局 HitMode/HealthMode，不读成绩嵌入字段。
-                var environment = GameplayEnvironment.FromLive(GlobalConfigStore.EzConfig);
-                return $"{identity}:hm{(int)environment.ManiaHitMode}:hh{(int)environment.ManiaHealthMode}:jp{(int)environment.JudgePrecedence}";
-            }
+                case EzScoreRaceGhostTimelineMode.ManiaSession:
+                {
+                    // 与角逐 HUD 一致：全局 HitMode/HealthMode，不读成绩嵌入字段。
+                    var environment = GameplayEnvironment.FromLive(GlobalConfigStore.EzConfig);
+                    return $"{identity}:hm{(int)environment.ManiaHitMode}:hh{(int)environment.ManiaHealthMode}:jp{(int)environment.JudgePrecedence}";
+                }
 
-            return identity;
+                case EzScoreRaceGhostTimelineMode.HitEvents:
+                    return $"{identity}:mods:{getModFingerprint(scoreInfo.Mods)}";
+
+                default:
+                    return null;
+            }
         }
+
+        private static string getModFingerprint(IReadOnlyList<Mod> mods)
+            => string.Join(',', mods.OrderBy(m => m.Acronym).Select(m => m.Acronym));
 
         private static string? getScoreIdentity(ScoreInfo? scoreInfo)
         {

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -467,6 +467,28 @@ namespace osu.Game.Rulesets.Scoring
         }
 
         /// <summary>
+        /// 已判定区间全 Perfect 时应达到的标准化总分（含 Mod 倍率）。
+        /// 与 live <see cref="TotalScore"/> 同源公式，按规则集 / HitMode 切换计分方式。
+        /// </summary>
+        public long GetTheoreticalPerfectJudgedDisplayScore()
+        {
+            double comboProgress = maximumComboPortion > 0 ? currentComboPortion / maximumComboPortion : 1;
+            double accuracyProgress = maximumAccuracyJudgementCount > 0 ? (double)currentAccuracyJudgementCount / maximumAccuracyJudgementCount : 1;
+            double theoreticalWithoutMods = ComputeTheoreticalPerfectJudgedTotalScore(comboProgress, accuracyProgress, currentBonusPortion);
+            return (long)Math.Round(theoreticalWithoutMods * scoreMultiplier);
+        }
+
+        /// <summary>
+        /// 已判定区间全 Perfect 时的标准化总分（不含 Mod 倍率）。
+        /// </summary>
+        protected virtual double ComputeTheoreticalPerfectJudgedTotalScore(double comboProgress, double accuracyProgress, double bonusPortion)
+        {
+            return 500000 * comboProgress +
+                   500000 * accuracyProgress +
+                   bonusPortion;
+        }
+
+        /// <summary>
         /// Resets this ScoreProcessor to a default state.
         /// </summary>
         /// <param name="storeResults">Whether to store the current state of the <see cref="ScoreProcessor"/> for future use.</param>

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -250,6 +250,7 @@ namespace osu.Game.Screens.Play
         }
 
         private ScreenSuspensionHandler screenSuspension;
+        private EzScoreRaceSessionHost scoreRaceSessionHost;
 
         private DependencyContainer dependencies;
 
@@ -355,6 +356,9 @@ namespace osu.Game.Screens.Play
             Score.ScoreInfo.Mods = gameplayMods;
 
             dependencies.CacheAs(GameplayState = new GameplayState(playableBeatmap, ruleset, gameplayMods, Score, ScoreProcessor, HealthProcessor, Beatmap.Value.Storyboard, PlayingState));
+
+            AddInternal(scoreRaceSessionHost = new EzScoreRaceSessionHost());
+            dependencies.CacheAs(scoreRaceSessionHost);
 
             var rulesetSkinProvider = new RulesetSkinProvidingContainer(ruleset, playableBeatmap, Beatmap.Value.Skin);
             config.BindWith(OsuSetting.BeatmapSkins, rulesetSkinProvider.BeatmapSkins);

--- a/osu.Game/Skinning/EzStyleProSkin.cs
+++ b/osu.Game/Skinning/EzStyleProSkin.cs
@@ -125,6 +125,8 @@ namespace osu.Game.Skinning
                                 var pps = container.OfType<ArgonPerformancePointsCounter>().FirstOrDefault();
                                 var acc = container.OfType<EzHUDAccuracyCounter>().FirstOrDefault();
                                 var songProgress = container.OfType<ArgonSongProgress>().FirstOrDefault();
+                                var scoreRaceLeaderboard = container.OfType<EzHUDScoreRaceLeaderboard>().FirstOrDefault();
+                                var unused = container.OfType<EzHUDScoreCompareBars>().FirstOrDefault();
 
                                 const float x_offset = 20;
                                 const float padding = 10;
@@ -201,6 +203,13 @@ namespace osu.Game.Skinning
                                         }
                                     }
 
+                                    if (scoreRaceLeaderboard != null)
+                                    {
+                                        scoreRaceLeaderboard.Anchor = Anchor.BottomLeft;
+                                        scoreRaceLeaderboard.Origin = Anchor.BottomLeft;
+                                        scoreRaceLeaderboard.Position = new Vector2(x_offset, 0);
+                                    }
+
                                     if (songProgress != null)
                                     {
                                         songProgress.Position = new Vector2(0, -padding);
@@ -232,6 +241,7 @@ namespace osu.Game.Skinning
                                         Origin = Anchor.CentreLeft,
                                         Position = new Vector2(20, 0),
                                     },
+                                    new EzHUDScoreRaceLeaderboard(),
                                 }
                             };
 


### PR DESCRIPTION
## Summary

- Add EzHUDScoreRaceLeaderboard and EzHUDScoreCompareBars with shared EzScoreRaceSession.
- Mania/Osu ghost timelines for live race; other rulesets degrade safely.
- Compare bars: score-only bar height, theoretical column via ScoreProcessor, acrylic background.

## Test plan

- [x] Mania local score: leaderboard + compare bars with mod filter
- [ ] Osu local score: ghost columns and leaderboard sorting
- [x] Switch compare conditions 1/2 independently
- [ ] Taiko/Catch: no ghost race, current/theoretical bars only

Made with [Cursor](https://cursor.com)