### PR TITLE
EzScoreRace: cleanup dead API, leaderboard perf, metric ordering

### DIFF
--- a/osu.Game.Rulesets.Osu/EzOsu/Statistics/OsuScoreHitEventGenerator.cs
+++ b/osu.Game.Rulesets.Osu/EzOsu/Statistics/OsuScoreHitEventGenerator.cs
@@ -20,6 +20,7 @@ namespace osu.Game.Rulesets.Osu.EzOsu.Statistics
     /// Osu 规则集的分数命中事件生成器实现。
     /// 通过分析回放帧和谱面对象计算命中判定。
     /// </summary>
+    // TODO(EZ-SR-TL-001): 新增 OsuReplaySession（对标 ManiaReplaySession），作为判定与 timeline 唯一源。
     public sealed class OsuScoreHitEventGenerator : IScoreHitEventGenerator
     {
         private readonly struct ReplayPressEvent
@@ -46,6 +47,7 @@ namespace osu.Game.Rulesets.Osu.EzOsu.Statistics
         {
             EzScoreReloadBridge.RegisterImplementation("osu", Instance);
             EzScoreReloadBridge.RegisterImplementation("0", Instance);
+            // TODO(EZ-SR-TL-004): 注册 OsuReplaySession.RunTimeline 到 EzScoreTimelineBridge（对称 ManiaScoreHitEventGenerator）。
         }
 
         /// <summary>
@@ -78,6 +80,7 @@ namespace osu.Game.Rulesets.Osu.EzOsu.Statistics
         /// <param name="playableBeatmap">与分数关联的可玩谱面</param>
         /// <param name="cancellationToken">用于停止生成的取消令牌</param>
         /// <returns>生成的命中事件列表，若无法生成则返回 null</returns>
+        // TODO(EZ-SR-TL-003): 改为 OsuReplaySession.Run(...).ToList()，与 timeline 同源。
         public List<HitEvent>? Generate(Score score, IBeatmap playableBeatmap, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -162,6 +165,7 @@ namespace osu.Game.Rulesets.Osu.EzOsu.Statistics
         /// <summary>
         /// 收集需要判定的所有目标对象（Circle、Slider、Spinner）。
         /// </summary>
+        // TODO(EZ-SR-TL-018): Osu Session 完成后删除 press 匹配遗留逻辑（collectJudgementTargets 等）。
         private static List<HitObject> collectJudgementTargets(IBeatmap beatmap, CancellationToken cancellationToken)
         {
             var targets = new List<HitObject>();

--- a/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
@@ -52,9 +52,6 @@ namespace osu.Game.EzOsuGame.HUD
 
         public bool WantsAcrylicCapture => BackgroundVisible.Value && BackdropBlurEnabled.Value;
 
-        [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_RACE_MOD_FILTER_LABEL), nameof(EzHUDStrings.SCORE_RACE_MOD_FILTER_DESCRIPTION))]
-        public Bindable<EzScoreModFilter> ModFilterSetting { get; } = new Bindable<EzScoreModFilter>(EzScoreModFilter.Any);
-
         [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.SCORE_COMPARE_CONDITION1_LABEL), nameof(EzHUDStrings.SCORE_COMPARE_CONDITION1_DESCRIPTION))]
         public Bindable<EzScoreRaceMetric> CompareCondition1Setting { get; } = new Bindable<EzScoreRaceMetric>(EzScoreRaceMetric.Accuracy);
 
@@ -144,16 +141,8 @@ namespace osu.Game.EzOsuGame.HUD
             };
         }
 
-        protected override void ConfigureSession()
-        {
-            // 仅同步 Mod 过滤；条目数由角逐榜组件负责。
-            Session?.ReloadIfNeeded(ModFilter.Value, Session.MaxEntryCount);
-        }
-
         protected override void LoadComplete()
         {
-            ModFilter.BindTo(ModFilterSetting);
-
             captureController = new EzAcrylicCaptureController(acrylicCaptureRegistrar, renderer, acrylicBackdrop);
 
             barsContainer = new Container

--- a/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
@@ -237,7 +237,7 @@ namespace osu.Game.EzOsuGame.HUD
                 return;
             }
 
-            long barScore = EzScoreRaceSession.QueryTimelineScore(pickedEntry, clockTime);
+            long barScore = EzScoreRaceSession.QuerySnapshot(pickedEntry, clockTime).TotalScore;
             bar.UpdateValues(
                 metric.GetLocalisableDescription(),
                 formatBarValue(barScore, pickedEntry),

--- a/osu.Game/EzOsuGame/HUD/EzHUDScoreRaceComponent.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDScoreRaceComponent.cs
@@ -5,14 +5,11 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Game.Beatmaps;
-using osu.Game.Database;
 using osu.Game.EzOsuGame.Localization;
 using osu.Game.EzOsuGame.Scoring;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Scoring;
-using osu.Game.Scoring;
 using osu.Game.Scoring.Legacy;
 using osu.Game.Screens.Play;
 
@@ -20,15 +17,6 @@ namespace osu.Game.EzOsuGame.HUD
 {
     public abstract partial class EzHUDScoreRaceComponent : CompositeDrawable
     {
-        [Resolved]
-        protected RealmAccess Realm { get; private set; } = null!;
-
-        [Resolved]
-        protected ScoreManager ScoreManager { get; private set; } = null!;
-
-        [Resolved]
-        protected BeatmapManager Beatmaps { get; private set; } = null!;
-
         [Resolved(canBeNull: true)]
         protected GameplayState? GameplayState { get; private set; }
 

--- a/osu.Game/EzOsuGame/HUD/EzHUDScoreRaceComponent.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDScoreRaceComponent.cs
@@ -127,13 +127,11 @@ namespace osu.Game.EzOsuGame.HUD
 
         protected virtual void ConfigureSession()
         {
-            Session?.Configure(ModFilter.Value, getEffectiveMaxEntryCount());
+            Session?.ReloadIfNeeded(ModFilter.Value, getEffectiveMaxEntryCount());
         }
 
         private void reloadSession()
-        {
-            Session?.ReloadIfNeeded(ModFilter.Value, getEffectiveMaxEntryCount());
-        }
+            => ConfigureSession();
 
         private int getEffectiveMaxEntryCount()
             => ContributesMaxEntryCount ? MaxEntries.Value : Session?.MaxEntryCount ?? MaxEntries.Value;

--- a/osu.Game/EzOsuGame/HUD/EzHUDScoreRaceLeaderboard.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDScoreRaceLeaderboard.cs
@@ -120,7 +120,7 @@ namespace osu.Game.EzOsuGame.HUD
                 state.MissCount = snapshot.MissCount;
             }
 
-            sortAndApply();
+            sortAndApplyIfNeeded();
         }
 
         protected override void Update()
@@ -204,8 +204,6 @@ namespace osu.Game.EzOsuGame.HUD
                 var state = new RaceEntryState(entry, leaderboardScore, drawable);
                 entryStates.Add(state);
                 Flow.Add(drawable);
-
-                drawable.DisplayOrder.BindValueChanged(_ => Schedule(sortAndApply), true);
             }
 
             sortAndApply();
@@ -263,7 +261,24 @@ namespace osu.Game.EzOsuGame.HUD
             };
         }
 
+        private void sortAndApplyIfNeeded()
+        {
+            var orderedList = getOrderedEntryStates();
+
+            for (int i = 0; i < orderedList.Count; i++)
+            {
+                if (orderedList[i].LeaderboardScore.DisplayOrder.Value != i + 1)
+                {
+                    applySortOrder(orderedList);
+                    return;
+                }
+            }
+        }
+
         private void sortAndApply()
+            => applySortOrder(getOrderedEntryStates());
+
+        private List<RaceEntryState> getOrderedEntryStates()
         {
             IOrderedEnumerable<RaceEntryState> ordered = SortCriterionSetting.Value switch
             {
@@ -282,8 +297,11 @@ namespace osu.Game.EzOsuGame.HUD
                 _ => entryStates.OrderByDescending(s => s.LeaderboardScore.TotalScore.Value),
             };
 
-            var orderedList = ordered.ThenBy(s => s.Tracked ? long.MaxValue : s.Tiebreaker).ToList();
+            return ordered.ThenBy(s => s.Tracked ? long.MaxValue : s.Tiebreaker).ToList();
+        }
 
+        private void applySortOrder(List<RaceEntryState> orderedList)
+        {
             for (int i = 0; i < orderedList.Count; i++)
             {
                 var state = orderedList[i];

--- a/osu.Game/EzOsuGame/HUD/EzHUDScoreRaceLeaderboard.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDScoreRaceLeaderboard.cs
@@ -105,15 +105,7 @@ namespace osu.Game.EzOsuGame.HUD
                 if (state.Tracked)
                     continue;
 
-                var timeline = state.Timeline;
-
-                if (timeline == null)
-                {
-                    state.MissCount = 0;
-                    continue;
-                }
-
-                var snapshot = timeline.QueryAtTime(clockTime);
+                var snapshot = EzScoreRaceSession.QuerySnapshot(state.Timeline, clockTime);
                 state.LeaderboardScore.TotalScore.Value = snapshot.TotalScore;
                 state.LeaderboardScore.Accuracy.Value = snapshot.Accuracy;
                 state.LeaderboardScore.Combo.Value = snapshot.HighestCombo;

--- a/osu.Game/EzOsuGame/HUD/EzHUDScoreRaceLeaderboard.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDScoreRaceLeaderboard.cs
@@ -105,7 +105,7 @@ namespace osu.Game.EzOsuGame.HUD
                 if (state.Tracked)
                     continue;
 
-                var timeline = findTimeline(state.ScoreInfoId);
+                var timeline = state.Timeline;
 
                 if (timeline == null)
                 {
@@ -214,7 +214,24 @@ namespace osu.Game.EzOsuGame.HUD
             if (needsStructuralRebuild())
                 rebuildRows();
             else
+            {
+                refreshTimelineRefs();
                 UpdateDisplay();
+            }
+        }
+
+        private void refreshTimelineRefs()
+        {
+            if (Session == null)
+                return;
+
+            foreach (var state in entryStates)
+            {
+                if (state.Tracked)
+                    continue;
+
+                state.Timeline = Session.Entries.FirstOrDefault(e => e.ScoreInfo.ID == state.ScoreInfoId)?.Timeline;
+            }
         }
 
         private bool needsStructuralRebuild()
@@ -236,8 +253,6 @@ namespace osu.Game.EzOsuGame.HUD
 
             return false;
         }
-
-        private EzScoreTimeline? findTimeline(Guid scoreInfoId) => Session?.Entries.FirstOrDefault(e => e.ScoreInfo.ID == scoreInfoId)?.Timeline;
 
         private static GameplayLeaderboardScore createGhostLeaderboardScore(EzScoreRaceEntry entry)
         {
@@ -326,6 +341,7 @@ namespace osu.Game.EzOsuGame.HUD
             public bool Tracked { get; }
             public long Tiebreaker { get; }
             public int MissCount { get; set; }
+            public EzScoreTimeline? Timeline { get; set; }
             public GameplayLeaderboardScore LeaderboardScore { get; }
             public DrawableGameplayLeaderboardScore Drawable { get; }
 
@@ -334,6 +350,7 @@ namespace osu.Game.EzOsuGame.HUD
                 ScoreInfoId = entry.ScoreInfo.ID;
                 Tracked = entry.Tracked;
                 Tiebreaker = entry.ScoreInfo.Date.ToUnixTimeSeconds();
+                Timeline = entry.Timeline;
                 LeaderboardScore = leaderboardScore;
                 Drawable = drawable;
             }

--- a/osu.Game/EzOsuGame/HUD/EzHUDScoreRaceLeaderboard.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDScoreRaceLeaderboard.cs
@@ -287,22 +287,13 @@ namespace osu.Game.EzOsuGame.HUD
 
         private List<RaceEntryState> getOrderedEntryStates()
         {
-            IOrderedEnumerable<RaceEntryState> ordered = SortCriterionSetting.Value switch
-            {
-                EzScoreRaceMetric.Accuracy => entryStates
-                                              .OrderByDescending(s => s.LeaderboardScore.Accuracy.Value)
-                                              .ThenByDescending(s => s.LeaderboardScore.TotalScore.Value),
-
-                EzScoreRaceMetric.MaxCombo => entryStates
-                                              .OrderByDescending(s => s.LeaderboardScore.Combo.Value)
-                                              .ThenByDescending(s => s.LeaderboardScore.TotalScore.Value),
-
-                EzScoreRaceMetric.MissCount => entryStates
-                                               .OrderBy(s => getMissCount(s))
-                                               .ThenByDescending(s => s.LeaderboardScore.TotalScore.Value),
-
-                _ => entryStates.OrderByDescending(s => s.LeaderboardScore.TotalScore.Value),
-            };
+            var ordered = EzScoreRaceMetricOrdering.ApplyMetricOrdering(
+                entryStates,
+                SortCriterionSetting.Value,
+                s => s.LeaderboardScore.TotalScore.Value,
+                s => s.LeaderboardScore.Accuracy.Value,
+                s => s.LeaderboardScore.Combo.Value,
+                getMissCount);
 
             return ordered.ThenBy(s => s.Tracked ? long.MaxValue : s.Tiebreaker).ToList();
         }

--- a/osu.Game/EzOsuGame/Scoring/EzLocalScoreQueries.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzLocalScoreQueries.cs
@@ -55,14 +55,18 @@ namespace osu.Game.EzOsuGame.Scoring
             if (metric == EzScoreRaceMetric.TheoreticalMaxScore)
                 return null;
 
-            return metric switch
-            {
-                EzScoreRaceMetric.TotalScore => scores.OrderByDescending(s => s.TotalScore).ThenByDescending(s => s.Date).FirstOrDefault(),
-                EzScoreRaceMetric.Accuracy => scores.OrderByDescending(s => s.Accuracy).ThenByDescending(s => s.TotalScore).FirstOrDefault(),
-                EzScoreRaceMetric.MaxCombo => scores.OrderByDescending(s => s.MaxCombo).ThenByDescending(s => s.TotalScore).FirstOrDefault(),
-                EzScoreRaceMetric.MissCount => scores.OrderBy(GetMissCount).ThenByDescending(s => s.TotalScore).FirstOrDefault(),
-                _ => throw new ArgumentOutOfRangeException(nameof(metric), metric, null),
-            };
+            var ordered = EzScoreRaceMetricOrdering.ApplyMetricOrdering(
+                scores,
+                metric,
+                s => s.TotalScore,
+                s => s.Accuracy,
+                s => s.MaxCombo,
+                GetMissCount);
+
+            if (metric == EzScoreRaceMetric.TotalScore)
+                return ordered.ThenByDescending(s => s.Date).FirstOrDefault();
+
+            return ordered.FirstOrDefault();
         }
 
         public static List<ScoreInfo> GetTopByTotalScore(IEnumerable<ScoreInfo> scores, int take)

--- a/osu.Game/EzOsuGame/Scoring/EzScoreRaceMetricOrdering.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreRaceMetricOrdering.cs
@@ -1,0 +1,38 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace osu.Game.EzOsuGame.Scoring
+{
+    internal static class EzScoreRaceMetricOrdering
+    {
+        public static IOrderedEnumerable<T> ApplyMetricOrdering<T>(
+            IEnumerable<T> source,
+            EzScoreRaceMetric metric,
+            Func<T, long> totalScore,
+            Func<T, double> accuracy,
+            Func<T, int> combo,
+            Func<T, int> missCount)
+        {
+            return metric switch
+            {
+                EzScoreRaceMetric.Accuracy => source
+                                              .OrderByDescending(accuracy)
+                                              .ThenByDescending(totalScore),
+
+                EzScoreRaceMetric.MaxCombo => source
+                                              .OrderByDescending(combo)
+                                              .ThenByDescending(totalScore),
+
+                EzScoreRaceMetric.MissCount => source
+                                               .OrderBy(missCount)
+                                               .ThenByDescending(totalScore),
+
+                _ => source.OrderByDescending(totalScore),
+            };
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Scoring/EzScoreRaceRulesetSupport.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreRaceRulesetSupport.cs
@@ -8,6 +8,7 @@ namespace osu.Game.EzOsuGame.Scoring
     public enum EzScoreRaceGhostTimelineMode
     {
         None,
+        // TODO(EZ-SR-TL-019): Osu Session 对齐后改为 OsuSession 并删除 HitEvents 枚举名。
         HitEvents,
         ManiaSession,
     }
@@ -31,6 +32,7 @@ namespace osu.Game.EzOsuGame.Scoring
                     return EzScoreRaceGhostTimelineMode.ManiaSession;
 
                 case 0:
+                    // TODO(EZ-SR-TL-006): 返回 OsuSession，改走 Bridge + OsuReplaySession.RunTimeline。
                     return EzScoreRaceGhostTimelineMode.HitEvents;
 
                 default:

--- a/osu.Game/EzOsuGame/Scoring/EzScoreRaceSession.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreRaceSession.cs
@@ -57,12 +57,6 @@ namespace osu.Game.EzOsuGame.Scoring
             this.scheduleCallback = scheduleCallback;
         }
 
-        public void Configure(EzScoreModFilter filter, int maxEntriesCount)
-        {
-            modFilter = filter;
-            MaxEntryCount = Math.Clamp(maxEntriesCount, 1, 10);
-        }
-
         public void EnsureLoaded()
         {
             if (loadCancellation != null)

--- a/osu.Game/EzOsuGame/Scoring/EzScoreRaceSession.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreRaceSession.cs
@@ -110,15 +110,21 @@ namespace osu.Game.EzOsuGame.Scoring
         }
 
         /// <summary>
+        /// 读取 ghost 在指定时钟的 timeline 快照；未就绪返回 <see cref="EzScoreTimelineSnapshot.Empty"/>。
+        /// </summary>
+        public static EzScoreTimelineSnapshot QuerySnapshot(EzScoreRaceEntry? entry, double clockTime)
+        {
+            if (entry == null || entry.Tracked || entry.Timeline == null)
+                return EzScoreTimelineSnapshot.Empty;
+
+            return entry.Timeline.QueryAtTime(clockTime);
+        }
+
+        /// <summary>
         /// 读取 ghost 在指定时钟的 timeline 分数；未就绪返回 0（禁止终局分回退）。
         /// </summary>
         public static long QueryTimelineScore(EzScoreRaceEntry? entry, double clockTime)
-        {
-            if (entry == null || entry.Tracked || entry.Timeline == null)
-                return 0;
-
-            return entry.Timeline.QueryAtTime(clockTime).TotalScore;
-        }
+            => QuerySnapshot(entry, clockTime).TotalScore;
 
         private IReadOnlyList<ScoreInfo> GetModFilteredScores()
         {

--- a/osu.Game/EzOsuGame/Scoring/EzScoreRaceSession.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreRaceSession.cs
@@ -122,7 +122,7 @@ namespace osu.Game.EzOsuGame.Scoring
             return entry.Timeline.QueryAtTime(clockTime).TotalScore;
         }
 
-        public IReadOnlyList<ScoreInfo> GetModFilteredScores()
+        private IReadOnlyList<ScoreInfo> GetModFilteredScores()
         {
             if (!scorePoolDirty)
                 return modFilteredScores;

--- a/osu.Game/EzOsuGame/Scoring/EzScoreRaceSession.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreRaceSession.cs
@@ -96,7 +96,7 @@ namespace osu.Game.EzOsuGame.Scoring
             if (!SupportsGhostRace)
                 return null;
 
-            var scoreInfo = EzLocalScoreQueries.PickBest(GetModFilteredScores(), metric);
+            var scoreInfo = EzLocalScoreQueries.PickBest(getModFilteredScores(), metric);
 
             if (scoreInfo == null)
                 return null;
@@ -114,10 +114,18 @@ namespace osu.Game.EzOsuGame.Scoring
         /// </summary>
         public static EzScoreTimelineSnapshot QuerySnapshot(EzScoreRaceEntry? entry, double clockTime)
         {
-            if (entry == null || entry.Tracked || entry.Timeline == null)
+            if (entry == null || entry.Tracked)
                 return EzScoreTimelineSnapshot.Empty;
 
-            return entry.Timeline.QueryAtTime(clockTime);
+            return QuerySnapshot(entry.Timeline, clockTime);
+        }
+
+        public static EzScoreTimelineSnapshot QuerySnapshot(EzScoreTimeline? timeline, double clockTime)
+        {
+            if (timeline == null)
+                return EzScoreTimelineSnapshot.Empty;
+
+            return timeline.QueryAtTime(clockTime);
         }
 
         /// <summary>
@@ -126,7 +134,7 @@ namespace osu.Game.EzOsuGame.Scoring
         public static long QueryTimelineScore(EzScoreRaceEntry? entry, double clockTime)
             => QuerySnapshot(entry, clockTime).TotalScore;
 
-        private IReadOnlyList<ScoreInfo> GetModFilteredScores()
+        private IReadOnlyList<ScoreInfo> getModFilteredScores()
         {
             if (!scorePoolDirty)
                 return modFilteredScores;
@@ -177,7 +185,7 @@ namespace osu.Game.EzOsuGame.Scoring
         }
 
         private IReadOnlyList<ScoreInfo> queryLeaderboardGhostScores()
-            => EzLocalScoreQueries.GetTopByTotalScore(GetModFilteredScores(), MaxEntryCount);
+            => EzLocalScoreQueries.GetTopByTotalScore(getModFilteredScores(), MaxEntryCount);
 
         private void ensureLeaderboardGhostPlaceholders()
         {

--- a/osu.Game/EzOsuGame/Scoring/EzScoreRaceSession.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreRaceSession.cs
@@ -38,7 +38,6 @@ namespace osu.Game.EzOsuGame.Scoring
         private bool scorePoolDirty = true;
 
         public IBindable<bool> IsReady => isReady;
-        public EzScoreRacePlayMode PlayMode { get; }
         public bool SupportsGhostRace { get; }
 
         public IReadOnlyList<EzScoreRaceEntry> Entries => entries;
@@ -53,7 +52,6 @@ namespace osu.Game.EzOsuGame.Scoring
             this.scoreManager = scoreManager;
             this.beatmaps = beatmaps;
             this.gameplayState = gameplayState;
-            PlayMode = playMode;
             SupportsGhostRace = EzScoreRaceRulesetSupport.SupportsGhostRace(gameplayState.Ruleset.RulesetInfo)
                                 && playMode != EzScoreRacePlayMode.SpectatingLive;
             this.scheduleCallback = scheduleCallback;

--- a/osu.Game/EzOsuGame/Scoring/EzScoreTimelineBridge.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreTimelineBridge.cs
@@ -11,17 +11,18 @@ namespace osu.Game.EzOsuGame.Scoring
     /// <summary>
     /// 规则集特定的时间线构建入口。Mania 由 Session 一遍判定直接采快照，不经 HitEvents 二次喂 SP。
     /// </summary>
+    // TODO(EZ-SR-TL-005): 泛化为多规则集 timeline 注册（OsuReplaySession），勿仅 Mania 语义。
     public static class EzScoreTimelineBridge
     {
-        private static Func<Score, IBeatmap, CancellationToken, EzScoreTimeline?>? mania_timeline_builder;
+        private static Func<Score, IBeatmap, CancellationToken, EzScoreTimeline?>? maniaTimelineBuilder;
 
         public static void RegisterManiaTimelineBuilder(Func<Score, IBeatmap, CancellationToken, EzScoreTimeline?> builder)
         {
             ArgumentNullException.ThrowIfNull(builder);
-            mania_timeline_builder = builder;
+            maniaTimelineBuilder = builder;
         }
 
         public static EzScoreTimeline? TryBuildManiaTimeline(Score score, IBeatmap playableBeatmap, CancellationToken cancellationToken = default)
-            => mania_timeline_builder?.Invoke(score, playableBeatmap, cancellationToken);
+            => maniaTimelineBuilder?.Invoke(score, playableBeatmap, cancellationToken);
     }
 }

--- a/osu.Game/EzOsuGame/Scoring/EzScoreTimelineBuilder.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreTimelineBuilder.cs
@@ -24,6 +24,7 @@ namespace osu.Game.EzOsuGame.Scoring
     /// 从本地 replay 构建分数时间线。Mania 走 Session 一遍 SP 快照；其他规则集暂用 HitEvents 重放（仅非 Mania）。
     /// 进程内缓存；重启进程即清空，无磁盘持久化。
     /// </summary>
+    // TODO(EZ-SR-TL-020): Osu Session 对齐后更新类注释，移除 HitEvents 重放描述。
     public static class EzScoreTimelineBuilder
     {
         private static readonly ConcurrentDictionary<string, EzScoreTimeline> timeline_cache = new ConcurrentDictionary<string, EzScoreTimeline>();
@@ -89,6 +90,7 @@ namespace osu.Game.EzOsuGame.Scoring
                     break;
 
                 case EzScoreRaceGhostTimelineMode.HitEvents:
+                    // TODO(EZ-SR-TL-007): 改走 OsuReplaySession + Bridge，勿再 resolveHitEvents/buildFromHitEvents。
                     var (hitEvents, offsetsRelativeToEnd) = resolveHitEvents(databasedScore, playableBeatmap, cancellationToken);
 
                     if (hitEvents == null || hitEvents.Count == 0)
@@ -110,6 +112,7 @@ namespace osu.Game.EzOsuGame.Scoring
             return timeline;
         }
 
+        // TODO(EZ-SR-TL-010): Osu Session 完成后删除；角逐 timeline 不再二次从 HitEvents 构建。
         private static (List<HitEvent>? hitEvents, bool offsetsRelativeToEnd) resolveHitEvents(Score databasedScore, IBeatmap playableBeatmap, CancellationToken cancellationToken)
         {
             // 统计页打开时 ScoreInfo 上可能有临时 HitEvents（[Ignored]，不持久化）。
@@ -119,6 +122,7 @@ namespace osu.Game.EzOsuGame.Scoring
             return (EzScoreReloadBridge.TryGenerate(databasedScore, playableBeatmap, cancellationToken), false);
         }
 
+        // TODO(EZ-SR-TL-011): Osu Session 完成后删除 buildFromHitEvents 及 BuildFromHitEventsForTesting。
         internal static EzScoreTimeline BuildFromHitEventsForTesting(Ruleset ruleset, IBeatmap beatmap, ScoreInfo scoreInfo, IReadOnlyList<HitEvent> hitEvents,
             bool offsetsRelativeToEnd = false)
             => buildFromHitEvents(ruleset, beatmap, scoreInfo, hitEvents, offsetsRelativeToEnd);
@@ -171,12 +175,14 @@ namespace osu.Game.EzOsuGame.Scoring
             return new EzScoreTimeline(snapshots);
         }
 
+        // TODO(EZ-SR-TL-012): Osu Session 完成后删除；仅 HitEvents 重放路径使用。
         private static double getJudgementTime(HitEvent hitEvent, bool offsetsRelativeToEnd, IBeatmap beatmap, double fallbackMissWindow, HitObject? beatmapHitObject = null)
         {
             beatmapHitObject ??= findBeatmapHitObject(beatmap, hitEvent.HitObject);
             return EzScoreTimelineJudgementTime.Get(hitEvent, offsetsRelativeToEnd, beatmapHitObject, fallbackMissWindow);
         }
 
+        // TODO(EZ-SR-TL-013): Osu Session 完成后删除 HitObject 查找补丁（findBeatmapHitObject 等）。
         private static HitObject findBeatmapHitObject(IBeatmap beatmap, HitObject hitObject)
         {
             foreach (var candidate in beatmap.HitObjects)
@@ -239,6 +245,7 @@ namespace osu.Game.EzOsuGame.Scoring
             return true;
         }
 
+        // TODO(EZ-SR-TL-014): Osu Session 完成后删除；Mania TimelineHitModeOverride 已在 ManiaReplaySession 内设置。
         private static void applyScoreProcessorContext(ScoreProcessor scoreProcessor, ScoreInfo scoreInfo)
         {
             if (scoreInfo.IsLegacyScore)
@@ -255,6 +262,7 @@ namespace osu.Game.EzOsuGame.Scoring
                 overrideProperty.SetValue(scoreProcessor, environment.ManiaHitMode);
         }
 
+        // TODO(EZ-SR-TL-015): Osu Session 完成后删除 ensureHitWindows/resolveFallbackMissWindow 等 HitEvents 专用辅助。
         private static void ensureHitWindows(IBeatmap beatmap, HitObject hitObject)
         {
             if (beatmap.BeatmapInfo == null)
@@ -310,6 +318,7 @@ namespace osu.Game.EzOsuGame.Scoring
             return null;
         }
 
+        // TODO(EZ-SR-TL-016): Osu Session 完成后删除；与 ManiaReplayTimelineRecorder 重复。
         private static EzScoreTimelineSnapshot createSnapshot(double clockTime, ScoreProcessor scoreProcessor, int missCount)
         {
             return new EzScoreTimelineSnapshot
@@ -340,6 +349,7 @@ namespace osu.Game.EzOsuGame.Scoring
                 }
 
                 case EzScoreRaceGhostTimelineMode.HitEvents:
+                    // TODO(EZ-SR-TL-008): Osu Session 对齐后定义 Osu 缓存键策略（参照 ManiaSession 环境键）。
                     return $"{identity}:mods:{getModFingerprint(scoreInfo.Mods)}";
 
                 default:

--- a/osu.Game/EzOsuGame/Scoring/EzScoreTimelineBuilder.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreTimelineBuilder.cs
@@ -29,10 +29,7 @@ namespace osu.Game.EzOsuGame.Scoring
         private static readonly ConcurrentDictionary<string, EzScoreTimeline> timeline_cache = new ConcurrentDictionary<string, EzScoreTimeline>();
         private static bool generatorsInitialised;
 
-        public static EzScoreTimeline? TryBuild(ScoreManager scoreManager, BeatmapManager beatmaps, ScoreInfo scoreInfo, CancellationToken cancellationToken = default)
-            => tryBuild(scoreManager, beatmaps, scoreInfo, sharedPlayableBeatmap: null, cancellationToken);
-
-        public static EzScoreTimeline? TryBuild(ScoreManager scoreManager, BeatmapManager beatmaps, ScoreInfo scoreInfo, IBeatmap? sharedPlayableBeatmap,
+        public static EzScoreTimeline? TryBuild(ScoreManager scoreManager, BeatmapManager beatmaps, ScoreInfo scoreInfo, IBeatmap? sharedPlayableBeatmap = null,
             CancellationToken cancellationToken = default)
             => tryBuild(scoreManager, beatmaps, scoreInfo, sharedPlayableBeatmap, cancellationToken);
 

--- a/osu.Game/EzOsuGame/Scoring/EzScoreTimelineBuilder.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreTimelineBuilder.cs
@@ -113,15 +113,6 @@ namespace osu.Game.EzOsuGame.Scoring
             return timeline;
         }
 
-        public static void InvalidateCache(ScoreInfo? scoreInfo)
-        {
-            if (scoreInfo == null)
-                return;
-
-            foreach (string key in timeline_cache.Keys.Where(k => k.Contains(getScoreIdentity(scoreInfo) ?? string.Empty)).ToArray())
-                timeline_cache.TryRemove(key, out _);
-        }
-
         private static (List<HitEvent>? hitEvents, bool offsetsRelativeToEnd) resolveHitEvents(Score databasedScore, IBeatmap playableBeatmap, CancellationToken cancellationToken)
         {
             // 统计页打开时 ScoreInfo 上可能有临时 HitEvents（[Ignored]，不持久化）。

--- a/osu.Game/EzOsuGame/Scoring/EzScoreTimelineJudgementTime.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreTimelineJudgementTime.cs
@@ -7,6 +7,7 @@ using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.EzOsuGame.Scoring
 {
+    // TODO(EZ-SR-TL-017): Osu Session 对齐后删除整文件；仅 HitEvents 重放时钟映射使用。
     internal static class EzScoreTimelineJudgementTime
     {
         public static double Get(HitEvent hitEvent, bool offsetsRelativeToEnd, HitObject? beatmapHitObject = null, double fallbackMissWindow = 0)


### PR DESCRIPTION
## Summary

- Remove dead API (InvalidateCache, Session.PlayMode, unused HUD Resolved) and narrow Session surface.
- Leaderboard: sort only when order changes, cache timelines, unify queries via QuerySnapshot.
- Add EzScoreRaceMetricOrdering shared by PickBest and leaderboard sort.
- Unify mod filter on leaderboard; remove Session.Configure (ReloadIfNeeded only).
- Mark Osu HitEvents timeline debt with TODO(EZ-SR-TL-xxx) comments (no behavior change).

Depends on #68.

## Test plan

- [ ] dotnet test osu.Game.Tests --filter FullyQualifiedName~EzScoreRace
- [ ] Leaderboard Acc/Combo/Miss sort switches correctly
- [ ] Compare bars still show score-height ghosts without dash placeholders

Made with [Cursor](https://cursor.com)