### PR TITLE
Mania 判定轻量化 Phase A：ManiaJudgementRound + ResolveEnvironment

### DIFF
--- a/osu.Game.Benchmarks/BenchmarkManiaReplaySession.cs
+++ b/osu.Game.Benchmarks/BenchmarkManiaReplaySession.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Benchmarks
             beatmap = createTestBeatmap();
             score = createTestScore(beatmap);
 
-            var environment = GlobalConfigStore.EzConfig.ResolveForSession(ReplayRunPurpose.ForStored, score.ScoreInfo);
+            var environment = GlobalConfigStore.EzConfig.ResolveEnvironment(ReplayRunPurpose.ForStored, score.ScoreInfo);
             GlobalConfigStore.EzConfig.SetValue(Ez2Setting.ManiaHitMode, environment.ManiaHitMode);
             GlobalConfigStore.EzConfig.SetValue(Ez2Setting.ManiaHealthMode, environment.ManiaHealthMode);
             GlobalConfigStore.EzConfig.SetValue(Ez2Setting.JudgePrecedence, environment.JudgePrecedence);

--- a/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/EzScoreTimelineTryBuildIntegrationTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/EzScoreTimelineTryBuildIntegrationTest.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
 
                             timeline = EzScoreTimelineBuilder.TryBuild(scoreManager, beatmapManager, imported, sharedPlayableBeatmap: playableBeatmap);
                             var databasedScore = scoreManager.GetScore(imported);
-                            sessionTotal = ManiaReplaySession.RunTimeline(databasedScore!, playableBeatmap, GlobalConfigStore.EzConfig.ResolveForSession(ReplayRunPurpose.ForLive, databasedScore!.ScoreInfo))
+                            sessionTotal = ManiaReplaySession.RunTimeline(databasedScore!, playableBeatmap, GlobalConfigStore.EzConfig.ResolveEnvironment(ReplayRunPurpose.ForLive, databasedScore!.ScoreInfo, ignoreOffset: true))
                                 .FinalTotalScore;
                         }
                     }

--- a/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/ManiaCrossSourceInvariantTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/ManiaCrossSourceInvariantTest.cs
@@ -107,7 +107,7 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
             ReplayJudgeTestConfig.ApplyToGlobalConfig(environment);
             ReplayJudgeTestConfig.ApplyEmbeddedModes(score, environment);
 
-            var fromScore = snapshotRun(score, beatmap, GlobalConfigStore.EzConfig.ResolveForSession(ReplayRunPurpose.ForStored, score.ScoreInfo));
+            var fromScore = snapshotRun(score, beatmap, GlobalConfigStore.EzConfig.ResolveEnvironment(ReplayRunPurpose.ForStored, score.ScoreInfo));
             var fromLive = snapshotRun(score, beatmap, GlobalConfigStore.EzConfig.GetGameplayEnvironment());
 
             Assert.That(ManiaReplayParityHelper.AreHitEventsEquivalent(fromScore.hitEvents, fromLive.hitEvents), Is.True);
@@ -157,7 +157,7 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
             ReplayJudgeTestConfig.ApplyEmbeddedModes(score, iidxEnvironment);
             ReplayJudgeTestConfig.ApplyToGlobalConfig(lazerEnvironment);
 
-            var fromScore = snapshotRun(score, beatmap, GlobalConfigStore.EzConfig.ResolveForSession(ReplayRunPurpose.ForStored, score.ScoreInfo));
+            var fromScore = snapshotRun(score, beatmap, GlobalConfigStore.EzConfig.ResolveEnvironment(ReplayRunPurpose.ForStored, score.ScoreInfo));
             var fromLive = snapshotRun(score, beatmap, GlobalConfigStore.EzConfig.GetGameplayEnvironment());
 
             Assert.That(ManiaReplayParityHelper.AreHitEventsEquivalent(fromScore.hitEvents, fromLive.hitEvents), Is.False);
@@ -188,7 +188,7 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
             ManiaReplaySessionService service, Score score, IBeatmap beatmap)
         {
             var combined = await service.RunRequestAsync(new ReplayRunRequest(score, beatmap, ReplayRunPurpose.ForStored)).ConfigureAwait(true);
-            var info = combined.Score!.ScoreInfo;
+            var info = combined.Score.ScoreInfo;
             return (info.HitEvents.ToList(), info.Statistics.ToDictionary(), info.Accuracy, info.TotalScore);
         }
     }

--- a/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/ManiaKPoorHealthGateTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/ManiaKPoorHealthGateTest.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
         }
 
         [Test]
-        public void TestResolveForSessionForStoredUsesEmbeddedModesOrLazerFallback()
+        public void TestResolveEnvironmentForStoredUsesEmbeddedModesOrLazerFallback()
         {
             var config = GlobalConfigStore.EzConfig;
             config.SetValue(Ez2Setting.ManiaHitMode, EzEnumHitMode.IIDX_HD);
@@ -54,12 +54,12 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
                 ManiaHealthMode = (int)EzEnumHealthMode.IIDX_HD,
             };
 
-            var stored = config.ResolveForSession(ReplayRunPurpose.ForStored, scoreInfo);
+            var stored = config.ResolveEnvironment(ReplayRunPurpose.ForStored, scoreInfo);
             Assert.That(stored.ManiaHitMode, Is.EqualTo(EzEnumHitMode.LR2_HD));
             Assert.That(stored.ManiaHealthMode, Is.EqualTo(EzEnumHealthMode.IIDX_HD));
             Assert.That(stored.OffsetPlusMania, Is.EqualTo(0));
 
-            var legacy = config.ResolveForSession(ReplayRunPurpose.ForStored, new ScoreInfo { Ruleset = new ManiaRuleset().RulesetInfo });
+            var legacy = config.ResolveEnvironment(ReplayRunPurpose.ForStored, new ScoreInfo { Ruleset = new ManiaRuleset().RulesetInfo });
             Assert.That(legacy.ManiaHitMode, Is.EqualTo(EzEnumHitMode.Lazer));
             Assert.That(legacy.ManiaHealthMode, Is.EqualTo(EzEnumHealthMode.Lazer));
 
@@ -68,7 +68,7 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
             Assert.That(live.ManiaHealthMode, Is.EqualTo(EzEnumHealthMode.Lazer));
             Assert.That(live.OffsetPlusMania, Is.EqualTo(25.0));
 
-            var recalcStored = config.ResolveForSession(ReplayRunPurpose.ForStored, scoreInfo);
+            var recalcStored = config.ResolveEnvironment(ReplayRunPurpose.ForStored, scoreInfo);
             Assert.That(recalcStored.OffsetPlusMania, Is.EqualTo(0));
         }
     }

--- a/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/ManiaReplaySessionTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/ManiaReplaySessionTest.cs
@@ -91,7 +91,7 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
 
             ReplayJudgeTestConfig.ApplyEmbeddedModes(score, iidxEnvironment);
 
-            var liveTimeline = ManiaReplaySession.RunTimeline(score, beatmap, GlobalConfigStore.EzConfig.ResolveForSession(ReplayRunPurpose.ForLive, score.ScoreInfo));
+            var liveTimeline = ManiaReplaySession.RunTimeline(score, beatmap, GlobalConfigStore.EzConfig.ResolveEnvironment(ReplayRunPurpose.ForLive, score.ScoreInfo, ignoreOffset: true));
             var lazerTimeline = ManiaReplaySession.RunTimeline(score, beatmap, lazerEnvironment);
             var iidxTimeline = ManiaReplaySession.RunTimeline(score, beatmap, iidxEnvironment);
 
@@ -206,7 +206,7 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
             var lazerEnvironment = LazerTapReplayFixtures.CreateTwoNoteColumnTap().environment;
             ReplayJudgeTestConfig.ApplyToGlobalConfig(lazerEnvironment);
 
-            var fromScore = GlobalConfigStore.EzConfig.ResolveForSession(ReplayRunPurpose.ForStored, score.ScoreInfo);
+            var fromScore = GlobalConfigStore.EzConfig.ResolveEnvironment(ReplayRunPurpose.ForStored, score.ScoreInfo);
             var generatorEvents = ManiaScoreHitEventGenerator.Instance.Generate(score, beatmap);
             var sessionFromScore = ManiaReplaySession.RunHitEvents(score, beatmap, fromScore);
             var sessionLazer = ManiaReplaySession.RunHitEvents(score, beatmap, lazerEnvironment);
@@ -228,7 +228,7 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
             ReplayJudgeTestConfig.ApplyEmbeddedModes(score, environment);
             configure?.Invoke();
 
-            var sessionEnvironment = GlobalConfigStore.EzConfig.ResolveForSession(ReplayRunPurpose.ForStored, score.ScoreInfo);
+            var sessionEnvironment = GlobalConfigStore.EzConfig.ResolveEnvironment(ReplayRunPurpose.ForStored, score.ScoreInfo);
             var sessionEvents = ManiaReplaySession.RunHitEvents(score, beatmap, sessionEnvironment);
             var generatorEvents = ManiaScoreHitEventGenerator.Instance.Generate(score, beatmap);
 

--- a/osu.Game.Rulesets.Mania.Tests/EzMania/Scoring/ManiaResolveEnvironmentTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/EzMania/Scoring/ManiaResolveEnvironmentTest.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.Scoring
             var scoreInfo = new ScoreInfo { Ruleset = new ManiaRuleset().RulesetInfo };
             ReplayJudgeTestConfig.ApplyEmbeddedModes(new Score { ScoreInfo = scoreInfo }, ReplayJudgeTestConfig.Create(EzEnumHitMode.IIDX_HD, EzEnumHealthMode.IIDX_HD));
 
-            var env = GlobalConfigStore.EzConfig.ResolveForSession(ReplayRunPurpose.ForStored, scoreInfo);
+            var env = GlobalConfigStore.EzConfig.ResolveEnvironment(ReplayRunPurpose.ForStored, scoreInfo);
 
             Assert.That(env.ManiaHitMode, Is.EqualTo(EzEnumHitMode.IIDX_HD));
             Assert.That(env.ManiaHealthMode, Is.EqualTo(EzEnumHealthMode.IIDX_HD));
@@ -54,7 +54,7 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.Scoring
         {
             var scoreInfo = new ScoreInfo { Ruleset = new ManiaRuleset().RulesetInfo };
 
-            var stored = GlobalConfigStore.EzConfig.ResolveForSession(ReplayRunPurpose.ForStored, scoreInfo);
+            var stored = GlobalConfigStore.EzConfig.ResolveEnvironment(ReplayRunPurpose.ForStored, scoreInfo);
 
             Assert.That(stored.ManiaHitMode, Is.EqualTo(EzEnumHitMode.Lazer));
             Assert.That(stored.ManiaHealthMode, Is.EqualTo(EzEnumHealthMode.Lazer));
@@ -63,11 +63,11 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.Scoring
         }
 
         [Test]
-        public void TestResolveForSessionZerosOffset()
+        public void TestResolveEnvironmentZerosOffsetForSession()
         {
             var scoreInfo = new ScoreInfo { Ruleset = new ManiaRuleset().RulesetInfo };
 
-            var session = GlobalConfigStore.EzConfig.ResolveForSession(ReplayRunPurpose.ForLive, scoreInfo);
+            var session = GlobalConfigStore.EzConfig.ResolveEnvironment(ReplayRunPurpose.ForLive, scoreInfo, ignoreOffset: true);
             var live = GlobalConfigStore.EzConfig.GetGameplayEnvironment();
 
             Assert.That(session.OffsetPlusMania, Is.EqualTo(0));

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaEzDrawableJudgement.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaEzDrawableJudgement.cs
@@ -7,12 +7,12 @@ using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
 using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.Scoring;
-using osu.Game.Rulesets.Mania.EzMania.Helper;
 using osu.Game.Rulesets.Mania.EzMania.ReplayJudge.Mappings;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mania.Objects.Drawables;
 using osu.Game.Rulesets.Mania.Objects.EzCurrentHitObject;
 using osu.Game.Rulesets.Mania.Scoring;
+using osu.Game.Rulesets.Mania.UI;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
@@ -30,18 +30,12 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
         private static readonly ConditionalWeakTable<DrawableHoldNote, O2HitModeJudgement.HoldBreakState> o2_hold_states =
             new ConditionalWeakTable<DrawableHoldNote, O2HitModeJudgement.HoldBreakState>();
 
-        private static readonly ConditionalWeakTable<DrawableRuleset, ManiaReplayJudgementState> o2_judgement_states =
-            new ConditionalWeakTable<DrawableRuleset, ManiaReplayJudgementState>();
-
         public static bool CanRouteToKPoor(DrawableNote note) => GetBmsState(note).CanRouteToKPoor;
 
         public static bool CanRouteToKPoor(DrawableHoldNoteTail tail) => GetBmsState(tail).CanRouteToKPoor;
 
         public static bool ShouldHideTailDisplayResult()
-        {
-            var environment = getGameplayEnvironment();
-            return environment.ManiaHitMode == EzEnumHitMode.O2Jam;
-        }
+            => GlobalConfigStore.EzConfig.ResolveEnvironment(ReplayRunPurpose.ForLive).ManiaHitMode == EzEnumHitMode.O2Jam;
 
         internal static BmsHitModeJudgement.BmsRouteState GetBmsState(DrawableNote note)
             => note_bms_states.GetValue(note, _ => new BmsHitModeJudgement.BmsRouteState());
@@ -49,27 +43,22 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
         internal static BmsHitModeJudgement.BmsRouteState GetBmsState(DrawableHoldNoteTail tail)
             => tail_bms_states.GetValue(tail, _ => new BmsHitModeJudgement.BmsRouteState());
 
-        private static ManiaReplayJudgementState getO2JudgementState(DrawableHitObject drawable)
+        private static ManiaJudgementRound getJudgementRound(DrawableHitObject? drawable = null)
         {
-            var ruleset = drawable.FindClosestParent<DrawableRuleset>();
+            if (drawable?.FindClosestParent<DrawableManiaRuleset>() is { JudgementRound: { } round })
+                return round;
 
-            if (ruleset == null)
-                return new ManiaReplayJudgementState();
-
-            return o2_judgement_states.GetValue(ruleset, _ => new ManiaReplayJudgementState());
-        }
-
-        private static GameplayEnvironment getGameplayEnvironment(DrawableHitObject? drawable = null)
-        {
             var ruleset = drawable?.FindClosestParent<DrawableRuleset>();
-            return GlobalConfigStore.EzConfig.ResolveForDrawable(ruleset?.ReplayScore?.ScoreInfo);
+            var purpose = ruleset?.ReplayScore != null ? ReplayRunPurpose.ForStored : ReplayRunPurpose.ForLive;
+            var env = GlobalConfigStore.EzConfig.ResolveEnvironment(purpose, ruleset?.ReplayScore?.ScoreInfo);
+            return ManiaJudgementRound.Create(env);
         }
 
         internal static bool TryMalodyHoldOnReleased(DrawableHoldNote hold)
         {
-            var environment = getGameplayEnvironment(hold);
+            var round = getJudgementRound(hold);
 
-            if (!MalodyHitModeJudgement.IsMalodyMode(environment.ManiaHitMode))
+            if (!MalodyHitModeJudgement.IsMalodyMode(round.Environment.ManiaHitMode))
                 return false;
 
             if (!hold.IsHolding.Value)
@@ -83,9 +72,9 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
 
         internal static bool TryMalodyHoldCheckForResult(DrawableHoldNote hold, bool userTriggered, double timeOffset)
         {
-            var environment = getGameplayEnvironment(hold);
+            var round = getJudgementRound(hold);
 
-            if (!MalodyHitModeJudgement.IsMalodyMode(environment.ManiaHitMode))
+            if (!MalodyHitModeJudgement.IsMalodyMode(round.Environment.ManiaHitMode))
                 return false;
 
             if (!hold.Tail.AllJudged)
@@ -106,23 +95,22 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
             if (note.HitObject.HitWindows is not ManiaHitWindows maniaWindows)
                 return false;
 
+            var round = getJudgementRound(note);
             var state = GetBmsState(note);
-            var environment = getGameplayEnvironment(note);
-            bool poorEnabled = HealthModeHelper.ComputeKPoorEnabled(environment.ManiaHealthMode, environment.BmsPoorHitResultEnable);
-            var action = BmsHitModeJudgement.Instance.TryPostBadOnPressed(maniaWindows, state, poorEnabled);
+            var action = BmsHitModeJudgement.Instance.TryPostBadOnPressed(maniaWindows, state, round.PoorEnabled);
 
             if (!action.Handled)
                 return false;
 
-            ApplyBmsAction(note, action, state);
+            ApplyBmsAction(note, round, action, state);
             return true;
         }
 
         internal static void TryO2HoldUpdate(DrawableHoldNote hold)
         {
-            var environment = getGameplayEnvironment(hold);
+            var round = getJudgementRound(hold);
 
-            if (environment.ManiaHitMode != EzEnumHitMode.O2Jam)
+            if (round.Environment.ManiaHitMode != EzEnumHitMode.O2Jam)
                 return;
 
             var state = o2_hold_states.GetValue(hold, _ => new O2HitModeJudgement.HoldBreakState());
@@ -131,22 +119,20 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
 
         internal static bool TryO2HoldCheckForResult(DrawableHoldNote hold, bool userTriggered, double timeOffset)
         {
-            var environment = getGameplayEnvironment(hold);
+            var round = getJudgementRound(hold);
 
-            if (environment.ManiaHitMode != EzEnumHitMode.O2Jam)
+            if (round.Environment.ManiaHitMode != EzEnumHitMode.O2Jam)
                 return false;
 
             return O2HitModeJudgement.Instance.TryO2HoldCheckForResult(hold, userTriggered, timeOffset);
         }
 
-        internal static void ApplyNoteOutcome(DrawableNote drawable, ManiaNoteJudgementOutcome outcome)
+        internal static void ApplyNoteOutcome(DrawableNote drawable, ManiaJudgementRound round, ManiaNoteJudgementOutcome outcome)
         {
-            var environment = getGameplayEnvironment(drawable);
-
             switch (outcome.Kind)
             {
                 case ManiaNoteJudgementOutcomeKind.Apply:
-                    drawable.EzApplyFinalResult(outcome.Result, environment.ManiaHitMode);
+                    drawable.EzApplyFinalResult(outcome.Result, round.Environment.ManiaHitMode);
                     break;
 
                 case ManiaNoteJudgementOutcomeKind.DispatchExtra:
@@ -155,17 +141,11 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
             }
         }
 
-        internal static void ApplyBmsAction(DrawableNote drawable, BmsHitModeJudgement.DrawableAction action, BmsHitModeJudgement.BmsRouteState state)
-        {
-            var environment = getGameplayEnvironment(drawable);
-            applyBmsAction(drawable, r => drawable.EzApplyFinalResult(r, environment.ManiaHitMode), drawable.EzDispatchExtraResult, action, state);
-        }
+        internal static void ApplyBmsAction(DrawableNote drawable, ManiaJudgementRound round, BmsHitModeJudgement.DrawableAction action, BmsHitModeJudgement.BmsRouteState state)
+            => applyBmsAction(drawable, r => drawable.EzApplyFinalResult(r, round.Environment.ManiaHitMode), drawable.EzDispatchExtraResult, action, state);
 
-        internal static void ApplyBmsAction(DrawableHoldNoteTail drawable, BmsHitModeJudgement.DrawableAction action, BmsHitModeJudgement.BmsRouteState state)
-        {
-            var environment = getGameplayEnvironment(drawable);
-            applyBmsAction(drawable, r => drawable.EzApplyFinalResult(r, environment.ManiaHitMode), drawable.EzDispatchExtraResult, action, state);
-        }
+        internal static void ApplyBmsAction(DrawableHoldNoteTail drawable, ManiaJudgementRound round, BmsHitModeJudgement.DrawableAction action, BmsHitModeJudgement.BmsRouteState state)
+            => applyBmsAction(drawable, r => drawable.EzApplyFinalResult(r, round.Environment.ManiaHitMode), drawable.EzDispatchExtraResult, action, state);
 
         private static void applyBmsAction<T>(
             T _,
@@ -189,12 +169,12 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
 
         internal static bool TryApplyEzNoteCheckForResult(DrawableNote drawable, bool userTriggered, double timeOffset)
         {
-            var environment = getGameplayEnvironment(drawable);
+            var round = getJudgementRound(drawable);
 
-            if (!ManiaJudgementRegistry.IsEzHitMode(environment.ManiaHitMode))
+            if (!round.IsEzHitMode)
                 return false;
 
-            var hitMode = ManiaJudgementRegistry.GetHitModeJudgement(environment.ManiaHitMode);
+            var hitMode = round.Strategy;
             if (hitMode == null)
                 return false;
 
@@ -204,13 +184,12 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
                     return true;
 
                 var state = GetBmsState(drawable);
-                bool poorEnabled = HealthModeHelper.ComputeKPoorEnabled(environment.ManiaHealthMode, environment.BmsPoorHitResultEnable);
 
                 var action = userTriggered
-                    ? bms.EvaluateDrawablePress(maniaWindows, timeOffset, state, poorEnabled)
+                    ? bms.EvaluateDrawablePress(maniaWindows, timeOffset, state, round.PoorEnabled)
                     : bms.EvaluateDrawableAutoMiss(maniaWindows, timeOffset);
 
-                ApplyBmsAction(drawable, action, state);
+                ApplyBmsAction(drawable, round, action, state);
                 return true;
             }
 
@@ -226,15 +205,15 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
                         CurrentTime = drawable.Time.Current,
                         PillCheckPassed = cont,
                         UpgradeToPerfect = upgradeToPerfect,
-                    }, getO2JudgementState(drawable));
+                    }, round.MutableState);
 
                     if (outcome != null)
-                        ApplyNoteOutcome(drawable, outcome.Value);
+                        ApplyNoteOutcome(drawable, round, outcome.Value);
 
                     return true;
                 }
 
-                ApplyNoteOutcome(drawable, o2.EvaluateAutoMiss(timeOffset, drawable.HitObject.HitWindows!));
+                ApplyNoteOutcome(drawable, round, o2.EvaluateAutoMiss(timeOffset, drawable.HitObject.HitWindows!));
                 return true;
             }
 
@@ -242,40 +221,37 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
             {
                 if (userTriggered)
                 {
-                    ApplyNoteOutcome(drawable, ez2Ac.EvaluateDrawablePress(timeOffset, drawable.HitObject.HitWindows!, drawable.HitObject is HeadNote));
+                    ApplyNoteOutcome(drawable, round, ez2Ac.EvaluateDrawablePress(timeOffset, drawable.HitObject.HitWindows!, drawable.HitObject is HeadNote));
                     return true;
                 }
 
-                ApplyNoteOutcome(drawable, ez2Ac.EvaluateAutoMiss(timeOffset, drawable.HitObject.HitWindows!));
+                ApplyNoteOutcome(drawable, round, ez2Ac.EvaluateAutoMiss(timeOffset, drawable.HitObject.HitWindows!));
                 return true;
             }
 
             if (userTriggered)
             {
-                ApplyNoteOutcome(drawable, hitMode.EvaluatePress(timeOffset, drawable.HitObject.HitWindows!));
+                ApplyNoteOutcome(drawable, round, hitMode.EvaluatePress(timeOffset, drawable.HitObject.HitWindows!));
                 return true;
             }
 
-            ApplyNoteOutcome(drawable, hitMode.EvaluateAutoMiss(timeOffset, drawable.HitObject.HitWindows!));
+            ApplyNoteOutcome(drawable, round, hitMode.EvaluateAutoMiss(timeOffset, drawable.HitObject.HitWindows!));
             return true;
         }
 
         internal static bool TryApplyEzHoldTailCheckForResult(DrawableHoldNoteTail drawable, bool userTriggered, double timeOffset)
         {
-            var environment = getGameplayEnvironment(drawable);
+            var round = getJudgementRound(drawable);
 
-            if (!ManiaJudgementRegistry.IsEzHitMode(environment.ManiaHitMode))
+            if (!round.IsEzHitMode)
                 return false;
 
-            var hitMode = ManiaJudgementRegistry.GetHitModeJudgement(environment.ManiaHitMode);
+            var hitMode = round.Strategy;
 
             if (hitMode is MalodyHitModeJudgement)
             {
                 if (!userTriggered && timeOffset >= 0)
-                {
-                    var env = getGameplayEnvironment(drawable);
-                    drawable.EzApplyFinalResult(HitResult.IgnoreHit, env.ManiaHitMode);
-                }
+                    drawable.EzApplyFinalResult(HitResult.IgnoreHit, round.Environment.ManiaHitMode);
 
                 return true;
             }
@@ -287,13 +263,12 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
 
                 var state = GetBmsState(drawable);
                 bool forcePoor = !drawable.HoldNote.IsHolding.Value && drawable.HoldNote.Body.HasHoldBreak;
-                bool poorEnabled = HealthModeHelper.ComputeKPoorEnabled(environment.ManiaHealthMode, environment.BmsPoorHitResultEnable);
 
                 var action = userTriggered
-                    ? bms.EvaluateDrawablePress(maniaWindows, timeOffset, state, poorEnabled, forcePoorOnTailHoldBreak: forcePoor)
+                    ? bms.EvaluateDrawablePress(maniaWindows, timeOffset, state, round.PoorEnabled, forcePoorOnTailHoldBreak: forcePoor)
                     : bms.EvaluateDrawableAutoMiss(maniaWindows, timeOffset);
 
-                ApplyBmsAction(drawable, action, state);
+                ApplyBmsAction(drawable, round, action, state);
                 return true;
             }
 
@@ -308,7 +283,7 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
                         if (timeOffset < 0)
                             return true;
 
-                        drawable.EzApplyFinalResult(O2HitModeJudgement.MapTo(O2Judge.Miss), environment.ManiaHitMode);
+                        drawable.EzApplyFinalResult(O2HitModeJudgement.MapTo(O2Judge.Miss), round.Environment.ManiaHitMode);
                         return true;
                     }
 
@@ -327,11 +302,11 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
                     HeadHit = drawable.HoldNote.Head.IsHit,
                     HoldBroken = drawable.HoldNote.Body.HasHoldBreak,
                     WasHolding = drawable.HoldNote.IsHolding.Value,
-                    PillModeEnabled = environment.ManiaHealthMode.ToString().Contains("O2Jam"),
-                }, getO2JudgementState(drawable));
+                    PillModeEnabled = round.PillModeEnabled,
+                }, round.MutableState);
 
                 if (result != null)
-                    drawable.EzApplyFinalResult(result.Value, environment.ManiaHitMode);
+                    drawable.EzApplyFinalResult(result.Value, round.Environment.ManiaHitMode);
 
                 return true;
             }
@@ -373,7 +348,7 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
                     return true;
                 }
 
-                drawable.EzApplyFinalResult(Ez2AcHitModeJudgement.MapTo(tailJudge), environment.ManiaHitMode);
+                drawable.EzApplyFinalResult(Ez2AcHitModeJudgement.MapTo(tailJudge), round.Environment.ManiaHitMode);
                 return true;
             }
 
@@ -394,7 +369,7 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
             if (genericResult == HitResult.None)
                 return true;
 
-            drawable.EzApplyFinalResult(genericResult, environment.ManiaHitMode);
+            drawable.EzApplyFinalResult(genericResult, round.Environment.ManiaHitMode);
             return true;
         }
     }

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaJudgementRound.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaJudgementRound.cs
@@ -1,0 +1,59 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Scoring;
+using osu.Game.Rulesets.Mania.EzMania.Helper;
+using osu.Game.Rulesets.Mania.EzMania.ReplayJudge.Mappings;
+
+namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
+{
+    /// <summary>
+    /// 单局 Mania 判定上下文：开局冻结环境、策略与派生标志，热路径禁止再解析全局配置。
+    /// </summary>
+    public sealed class ManiaJudgementRound
+    {
+        public GameplayEnvironment Environment { get; }
+
+        public IManiaHitModeJudgement? Strategy { get; }
+
+        public bool PoorEnabled { get; }
+
+        public bool PillModeEnabled { get; }
+
+        public EzEnumJudgePrecedence JudgePrecedence { get; }
+
+        public ManiaReplayJudgementState MutableState { get; }
+
+        private ManiaJudgementRound(
+            GameplayEnvironment environment,
+            IManiaHitModeJudgement? strategy,
+            bool poorEnabled,
+            bool pillModeEnabled,
+            ManiaReplayJudgementState mutableState)
+        {
+            Environment = environment;
+            Strategy = strategy;
+            PoorEnabled = poorEnabled;
+            PillModeEnabled = pillModeEnabled;
+            JudgePrecedence = environment.JudgePrecedence;
+            MutableState = mutableState;
+        }
+
+        public static ManiaJudgementRound Create(GameplayEnvironment environment)
+        {
+            var strategy = ManiaJudgementRegistry.GetHitModeJudgement(environment.ManiaHitMode);
+            bool poorEnabled = HealthModeHelper.ComputeKPoorEnabled(environment.ManiaHealthMode, environment.BmsPoorHitResultEnable);
+            bool pillModeEnabled = environment.ManiaHealthMode.ToString().Contains("O2Jam");
+
+            return new ManiaJudgementRound(
+                environment,
+                strategy,
+                poorEnabled,
+                pillModeEnabled,
+                new ManiaReplayJudgementState());
+        }
+
+        public bool IsEzHitMode => ManiaJudgementRegistry.IsEzHitMode(Environment.ManiaHitMode);
+    }
+}

--- a/osu.Game.Rulesets.Mania/EzMania/Statistics/EzScoreGraphMania.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/Statistics/EzScoreGraphMania.cs
@@ -13,7 +13,6 @@ using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.Extensions;
-using osu.Game.EzOsuGame.Scoring;
 using osu.Game.EzOsuGame.Statistics;
 using osu.Game.Rulesets.Mania.EzMania.Helper;
 using osu.Game.Rulesets.Mania.EzMania.ReplayJudge;
@@ -31,8 +30,8 @@ namespace osu.Game.Rulesets.Mania.EzMania.Statistics
 {
     /// <summary>
     /// Mania 判定偏移分布图。Original 用 Realm 静态 <see cref="ScoreInfo"/>；
-    /// Now 经 <see cref="ManiaReplaySession"/>（ForLive，含 live config offset）；
-    /// offset 滑条同步控制展示层 fake 平移与 Session 真实 offset。
+    /// Now 经 <see cref="ManiaReplaySession"/>（ForLive，Session 强制 zero offset）；
+    /// offset 滑条仅控制展示层 fake 平移，不注入 Session。
     /// </summary>
     public partial class EzScoreGraphMania : EzScoreGraphBase
     {
@@ -151,9 +150,6 @@ namespace osu.Game.Rulesets.Mania.EzMania.Statistics
                 e.LastHitObject,
                 e.Position)).ToList();
         }
-
-        protected override ReplayRunRequest CreateReplayRunRequest(Score score)
-            => new ReplayRunRequest(score, Beatmap, ReplayRunPurpose.ForLive, offsetPlusMania.Value);
 
         protected override void CalculateNowAccuracy()
         {

--- a/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
@@ -27,6 +27,7 @@ using osu.Game.Replays;
 using osu.Game.Rulesets.Mania.Beatmaps;
 using osu.Game.Rulesets.Mania.Configuration;
 using osu.Game.Rulesets.Mania.EzMania;
+using osu.Game.Rulesets.Mania.EzMania.ReplayJudge;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mania.Objects.EzCurrentHitObject;
 using osu.Game.Rulesets.Mania.Replays;
@@ -100,6 +101,11 @@ namespace osu.Game.Rulesets.Mania.UI
 
         int IManiaGameplayModeSnapshot.HitMode => (int)gameplayHitMode;
         int IManiaGameplayModeSnapshot.HealthMode => (int)ManiaHealthProcessor.ActiveHealthMode;
+
+        /// <summary>
+        /// 本局冻结的判定上下文；热路径读取此实例，禁止再解析全局配置。
+        /// </summary>
+        public ManiaJudgementRound? JudgementRound { get; private set; }
 
         private readonly Bindable<EzManiaScrollingStyle> scrollingStyle = new Bindable<EzManiaScrollingStyle>();
         private readonly BindableDouble configBaseMs = new BindableDouble();
@@ -185,6 +191,9 @@ namespace osu.Game.Rulesets.Mania.UI
             base.LoadComplete();
 
             gameplayHitMode = hitModeBindable.Value;
+
+            var purpose = ReplayScore != null ? ReplayRunPurpose.ForStored : ReplayRunPurpose.ForLive;
+            JudgementRound = ManiaJudgementRound.Create(ezConfig.ResolveEnvironment(purpose, ReplayScore?.ScoreInfo));
 
             hitModeBindable.BindValueChanged(h =>
             {

--- a/osu.Game.Rulesets.Osu.Tests/EzOsu/ReplayJudge/OsuReplayFixtures.cs
+++ b/osu.Game.Rulesets.Osu.Tests/EzOsu/ReplayJudge/OsuReplayFixtures.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Rulesets.Osu.Tests.EzOsu.ReplayJudge
             };
 
             var score = new Score { ScoreInfo = scoreInfo, Replay = replay };
-            var environment = GlobalConfigStore.EzConfig.ResolveForSession(ReplayRunPurpose.ForStored, scoreInfo);
+            var environment = GlobalConfigStore.EzConfig.ResolveEnvironment(ReplayRunPurpose.ForStored, scoreInfo);
 
             return (score, beatmap, environment);
         }
@@ -106,7 +106,7 @@ namespace osu.Game.Rulesets.Osu.Tests.EzOsu.ReplayJudge
             };
 
             var score = new Score { ScoreInfo = scoreInfo, Replay = replay };
-            var environment = GlobalConfigStore.EzConfig.ResolveForSession(ReplayRunPurpose.ForStored, scoreInfo);
+            var environment = GlobalConfigStore.EzConfig.ResolveEnvironment(ReplayRunPurpose.ForStored, scoreInfo);
 
             return (score, beatmap, environment);
         }
@@ -145,7 +145,7 @@ namespace osu.Game.Rulesets.Osu.Tests.EzOsu.ReplayJudge
             };
 
             var score = new Score { ScoreInfo = scoreInfo, Replay = new Replay { Frames = frames } };
-            var environment = GlobalConfigStore.EzConfig.ResolveForSession(ReplayRunPurpose.ForStored, scoreInfo);
+            var environment = GlobalConfigStore.EzConfig.ResolveEnvironment(ReplayRunPurpose.ForStored, scoreInfo);
 
             return (score, beatmap, environment);
         }

--- a/osu.Game/EzOsuGame/Configuration/Ez2ConfigManager.cs
+++ b/osu.Game/EzOsuGame/Configuration/Ez2ConfigManager.cs
@@ -280,9 +280,38 @@ namespace osu.Game.EzOsuGame.Configuration
         #region 公共方法
 
         /// <summary>
-        /// 从当前配置读取实时游玩环境快照。
+        /// 从当前配置读取实时游玩环境快照（等同 <see cref="ResolveEnvironment"/> + <see cref="ReplayRunPurpose.ForLive"/>）。
         /// </summary>
-        public GameplayEnvironment GetGameplayEnvironment() => new GameplayEnvironment
+        public GameplayEnvironment GetGameplayEnvironment()
+            => ResolveEnvironment(ReplayRunPurpose.ForLive);
+
+        /// <summary>
+        /// 统一环境解析：Purpose 决定 HitMode/HealthMode 来源；score 可选。
+        /// </summary>
+        /// <param name="purpose">
+        /// <see cref="ReplayRunPurpose.ForStored"/>：读 score 嵌入 HitMode/HealthMode（无嵌入时 Mania 回退 Lazer）。
+        /// <see cref="ReplayRunPurpose.ForLive"/>：读当前全局配置。
+        /// </param>
+        /// <param name="score">可选；ForStored 时用于嵌入模式查询。</param>
+        /// <param name="ignoreOffset">
+        /// 为 true 时强制 offset = 0（Session / 分析的 <see cref="ReplayRunPurpose.ForLive"/>）。
+        /// 省略时：<see cref="ReplayRunPurpose.ForStored"/> 恒为 0；<see cref="ReplayRunPurpose.ForLive"/> 读全局设置。
+        /// </param>
+        public GameplayEnvironment ResolveEnvironment(ReplayRunPurpose purpose, ScoreInfo? score = null, bool ignoreOffset = false)
+        {
+            var live = readLiveGameplayEnvironment();
+
+            GameplayEnvironment resolved = purpose switch
+            {
+                ReplayRunPurpose.ForStored => resolveStoredModes(live, score),
+                _ => live,
+            };
+
+            double offset = purpose == ReplayRunPurpose.ForStored || ignoreOffset ? 0 : live.OffsetPlusMania;
+            return resolved with { OffsetPlusMania = offset };
+        }
+
+        private GameplayEnvironment readLiveGameplayEnvironment() => new GameplayEnvironment
         {
             ManiaHitMode = Get<EzEnumHitMode>(Ez2Setting.ManiaHitMode),
             ManiaHealthMode = Get<EzEnumHealthMode>(Ez2Setting.ManiaHealthMode),
@@ -291,60 +320,28 @@ namespace osu.Game.EzOsuGame.Configuration
             BmsPoorHitResultEnable = Get<bool>(Ez2Setting.BmsPoorHitResultEnable),
         };
 
-        /// <summary>
-        /// Drawable 判定环境：有 replay 成绩时用 ForStored 嵌入；否则实时全局（含 <see cref="GameplayEnvironment.OffsetPlusMania"/>）。
-        /// </summary>
-        public GameplayEnvironment ResolveForDrawable(ScoreInfo? replayScore = null)
+        private static GameplayEnvironment resolveStoredModes(GameplayEnvironment live, ScoreInfo? score)
         {
-            if (replayScore != null)
-                return ResolveForSession(ReplayRunPurpose.ForStored, replayScore);
-
-            return GetGameplayEnvironment();
-        }
-
-        /// <summary>
-        /// Replay 环境解析（含 OffsetPlusMania）。Session 路径请用 <see cref="ResolveForSession"/>。
-        /// </summary>
-        internal GameplayEnvironment ResolveForReplay(ReplayRunPurpose purpose, ScoreInfo? score = null)
-        {
-            var live = GetGameplayEnvironment();
-
-            switch (purpose)
+            if (score != null && score.TryGetManiaGameplayModes(out int hitMode, out int healthMode))
             {
-                case ReplayRunPurpose.ForStored:
-
-                    if (score != null && score.TryGetManiaGameplayModes(out int hitMode, out int healthMode))
-                    {
-                        return live with
-                        {
-                            ManiaHitMode = (EzEnumHitMode)hitMode,
-                            ManiaHealthMode = (EzEnumHealthMode)healthMode,
-                            OffsetPlusMania = 0,
-                        };
-                    }
-
-                    if (score?.Ruleset.OnlineID == 3)
-                    {
-                        return live with
-                        {
-                            ManiaHitMode = EzEnumHitMode.Lazer,
-                            ManiaHealthMode = EzEnumHealthMode.Lazer,
-                            OffsetPlusMania = 0,
-                        };
-                    }
-
-                    return live with { OffsetPlusMania = 0 };
-
-                default:
-                    return live;
+                return live with
+                {
+                    ManiaHitMode = (EzEnumHitMode)hitMode,
+                    ManiaHealthMode = (EzEnumHealthMode)healthMode,
+                };
             }
-        }
 
-        /// <summary>
-        /// 非对局 replay 环境：HitMode/HealthMode 等同 <see cref="ResolveForReplay"/>，且强制 <see cref="GameplayEnvironment.OffsetPlusMania"/> = 0。
-        /// </summary>
-        public GameplayEnvironment ResolveForSession(ReplayRunPurpose purpose, ScoreInfo score)
-            => ResolveForReplay(purpose, score) with { OffsetPlusMania = 0 };
+            if (score?.Ruleset.OnlineID == 3)
+            {
+                return live with
+                {
+                    ManiaHitMode = EzEnumHitMode.Lazer,
+                    ManiaHealthMode = EzEnumHealthMode.Lazer,
+                };
+            }
+
+            return live;
+        }
 
         /// <summary>
         /// 获取列宽

--- a/osu.Game/EzOsuGame/Scoring/EzReplaySession.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzReplaySession.cs
@@ -98,12 +98,19 @@ namespace osu.Game.EzOsuGame.Scoring
 
         protected static GameplayEnvironment ResolveEnvironment(ReplayRunRequest request)
         {
-            var env = GlobalConfigStore.EzConfig.ResolveForSession(request.Purpose, request.Score.ScoreInfo);
-            return request.OffsetPlusMania == 0 ? env : env with { OffsetPlusMania = request.OffsetPlusMania };
+            if (request.Purpose == ReplayRunPurpose.ForLive)
+                return GlobalConfigStore.EzConfig.ResolveEnvironment(request.Purpose, request.Score.ScoreInfo, ignoreOffset: true);
+
+            return GlobalConfigStore.EzConfig.ResolveEnvironment(request.Purpose, request.Score.ScoreInfo);
         }
 
         protected static GameplayEnvironment ResolveEnvironment(Score score, ReplayRunPurpose purpose)
-            => GlobalConfigStore.EzConfig.ResolveForSession(purpose, score.ScoreInfo);
+        {
+            if (purpose == ReplayRunPurpose.ForLive)
+                return GlobalConfigStore.EzConfig.ResolveEnvironment(purpose, score.ScoreInfo, ignoreOffset: true);
+
+            return GlobalConfigStore.EzConfig.ResolveEnvironment(purpose, score.ScoreInfo);
+        }
 
         protected static Task<T> GetOrCreate<T>(ConcurrentDictionary<string, Lazy<Task<T>>> cache, string cacheKey, Func<Task<T>> factory)
         {

--- a/osu.Game/EzOsuGame/Scoring/EzScoreTimelineBuilder.cs
+++ b/osu.Game/EzOsuGame/Scoring/EzScoreTimelineBuilder.cs
@@ -43,7 +43,7 @@ namespace osu.Game.EzOsuGame.Scoring
                 return null;
 
             var playableBeatmap = resolvePlayableBeatmap(beatmaps, scoreInfo, sharedPlayableBeatmap);
-            var resolvedEnvironment = GlobalConfigStore.EzConfig.ResolveForSession(ReplayRunPurpose.ForLive, scoreInfo);
+            var resolvedEnvironment = GlobalConfigStore.EzConfig.ResolveEnvironment(ReplayRunPurpose.ForLive, scoreInfo, ignoreOffset: true);
 
             string? cacheKey = playableBeatmap != null
                 ? getCacheKey(scoreInfo, timelineMode, resolvedEnvironment, playableBeatmap)

--- a/osu.Game/EzOsuGame/Scoring/GameplayEnvironment.cs
+++ b/osu.Game/EzOsuGame/Scoring/GameplayEnvironment.cs
@@ -7,7 +7,7 @@ namespace osu.Game.EzOsuGame.Scoring
 {
     /// <summary>
     /// 单局游玩环境快照（纯数据 record）。
-    /// 环境构建由 <c>Ez2ConfigManager.ResolveForSession</c>（Session / Graph / 重算）或 <c>ResolveForDrawable</c>（Drawable 判定）负责。
+    /// 环境构建由 <c>Ez2ConfigManager.ResolveEnvironment</c>（Purpose + 可选 score；ForLive Session 可传 ignoreOffset）负责。
     /// </summary>
     public sealed record GameplayEnvironment : IGameplayEnvironment
     {

--- a/osu.Game/EzOsuGame/Scoring/IEzReplaySession.cs
+++ b/osu.Game/EzOsuGame/Scoring/IEzReplaySession.cs
@@ -13,7 +13,7 @@ namespace osu.Game.EzOsuGame.Scoring
     /// <summary>
     /// 统一 Replay Session 入口：负责 async、环境解析与共享 cache。
     /// 进程内由 <see cref="EzReplaySessionRouter"/> 按 <see cref="ScoreInfo.Ruleset"/> 分发；Panel / Graph / Race 注入本接口即可。
-    /// <para>环境由 Session 按 <see cref="ReplayRunPurpose"/> 经 <see cref="Configuration.Ez2ConfigManager.ResolveForSession"/> 解析。</para>
+    /// <para>环境由 Session 按 <see cref="ReplayRunPurpose"/> 经 <see cref="Configuration.Ez2ConfigManager.ResolveEnvironment"/> 解析。</para>
     /// </summary>
     public interface IEzReplaySession
     {

--- a/osu.Game/EzOsuGame/Scoring/IGameplayEnvironment.cs
+++ b/osu.Game/EzOsuGame/Scoring/IGameplayEnvironment.cs
@@ -6,8 +6,7 @@ using osu.Game.EzOsuGame.Configuration;
 namespace osu.Game.EzOsuGame.Scoring
 {
     /// <summary>
-    /// 单局游玩环境快照。由 <see cref="Configuration.Ez2ConfigManager.ResolveForSession"/> 或
-    /// <see cref="Configuration.Ez2ConfigManager.ResolveForDrawable"/> 在 resolve 时刻从 EzConfig 读出；
+    /// 单局游玩环境快照。由 <see cref="Configuration.Ez2ConfigManager.ResolveEnvironment"/> 在 resolve 时刻从 EzConfig 读出；
     /// 下游仿真/判定须使用已解析实例，禁止再读全局 bindable。
     /// </summary>
     public interface IGameplayEnvironment

--- a/osu.Game/EzOsuGame/Scoring/ReplayRunRequest.cs
+++ b/osu.Game/EzOsuGame/Scoring/ReplayRunRequest.cs
@@ -15,17 +15,11 @@ namespace osu.Game.EzOsuGame.Scoring
         public IBeatmap Beatmap { get; }
         public ReplayRunPurpose Purpose { get; }
 
-        /// <summary>
-        /// Session 判定用 offset（毫秒）。0 与未传等价；Graph 落定后传当前滑条值。
-        /// </summary>
-        public double OffsetPlusMania { get; }
-
-        public ReplayRunRequest(Score score, IBeatmap beatmap, ReplayRunPurpose purpose, double offsetPlusMania = 0)
+        public ReplayRunRequest(Score score, IBeatmap beatmap, ReplayRunPurpose purpose)
         {
             Score = score;
             Beatmap = beatmap;
             Purpose = purpose;
-            OffsetPlusMania = offsetPlusMania;
         }
     }
 }

--- a/osu.Game/EzOsuGame/Statistics/EzScoreGraphBase.cs
+++ b/osu.Game/EzOsuGame/Statistics/EzScoreGraphBase.cs
@@ -452,7 +452,7 @@ namespace osu.Game.EzOsuGame.Statistics
 
         // ==================== Graph-UX: 双轨刷新机制 ====================
 
-        /// <summary>Graph Session 请求；Mania 覆写以传入当前 offset。</summary>
+        /// <summary>Graph Session 请求；ForStored 默认零 offset，ForLive Session 在 EzReplaySession 内传 ignoreOffset。</summary>
         protected virtual ReplayRunRequest CreateReplayRunRequest(Score score)
             => new ReplayRunRequest(score, Beatmap, ReplayRunPurpose.ForLive);
 


### PR DESCRIPTION
## Summary
- 新增 `ManiaJudgementRound`：开局冻结环境、策略与派生标志，Drawable 热路径不再重复解析配置
- 合并 `ResolveForDrawable` / `ResolveForSession` / `ResolveForReplay` 为统一 `ResolveEnvironment(purpose, score?, offsetPlusMania?)`
- Session / Graph / Drawable 调用方已迁移至新 API

## Test plan
- [x] `dotnet test osu.Game.Rulesets.Mania.Tests --filter FullyQualifiedName~ReplayJudge|ManiaResolve`
- [ ] 本地 Mania 游玩 + replay 回放无明显判定回归

Made with [Cursor](https://cursor.com)