### PR TITLE
Mania 判定轻量化 Phase B：窗口烘焙与 O2 列级 BPM

### DIFF
--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaEzDrawableJudgement.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaEzDrawableJudgement.cs
@@ -195,14 +195,15 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
 
             if (hitMode is O2HitModeJudgement o2)
             {
-                (drawable.HitObject.HitWindows as ManiaHitWindows)?.UpdateO2JamBpmFromTime(drawable.Time.Current);
-
                 if (userTriggered)
                 {
+                    round.NotifyO2InputAt(drawable.Time.Current);
+                    double bpm = round.O2PressBpm;
                     bool cont = O2HitModeExtension.PillCheck(timeOffset, drawable.Time.Current, out bool _, out bool upgradeToPerfect);
                     var outcome = o2.EvaluateDrawableNotePress(timeOffset, drawable.HitObject.HitWindows!, new O2HitModeJudgement.DrawableNoteContext
                     {
                         CurrentTime = drawable.Time.Current,
+                        Bpm = bpm,
                         PillCheckPassed = cont,
                         UpgradeToPerfect = upgradeToPerfect,
                     }, round.MutableState);
@@ -213,7 +214,8 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
                     return true;
                 }
 
-                ApplyNoteOutcome(drawable, round, o2.EvaluateAutoMiss(timeOffset, drawable.HitObject.HitWindows!));
+                double autoMissBpm = round.GetO2BpmForAutoMiss(drawable.Time.Current, getFrameStableId(drawable));
+                ApplyNoteOutcome(drawable, round, o2.EvaluateAutoMiss(timeOffset, drawable.HitObject.HitWindows!, autoMissBpm));
                 return true;
             }
 
@@ -274,7 +276,7 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
 
             if (hitMode is O2HitModeJudgement o2)
             {
-                (drawable.HitObject.HitWindows as ManiaHitWindows)?.UpdateO2JamBpmFromTime(drawable.Time.Current);
+                double mult = ManiaJudgementRound.GetTotalMultiplier(drawable.HitObject.HitWindows!);
 
                 if (!userTriggered)
                 {
@@ -287,16 +289,21 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
                         return true;
                     }
 
-                    if (!drawable.HitObject.HitWindows!.CanBeHit(timeOffset))
+                    double autoMissBpm = round.GetO2BpmForAutoMiss(drawable.Time.Current, getFrameStableId(drawable));
+
+                    if (!O2HitModeExtension.CanBeHit(timeOffset, autoMissBpm, mult))
                         drawable.EzApplyMinResult();
 
                     return true;
                 }
 
+                round.NotifyO2InputAt(drawable.Time.Current);
+                double bpm = round.O2PressBpm;
                 bool cont = O2HitModeExtension.PillCheck(timeOffset, drawable.Time.Current, out bool _, out bool upgradeToPerfect);
                 var result = o2.EvaluateDrawableTailPress(timeOffset, drawable.HitObject.HitWindows!, new O2HitModeJudgement.DrawableTailContext
                 {
                     CurrentTime = drawable.Time.Current,
+                    Bpm = bpm,
                     PillCheckPassed = cont,
                     UpgradeToPerfect = upgradeToPerfect,
                     HeadHit = drawable.HoldNote.Head.IsHit,
@@ -372,5 +379,8 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
             drawable.EzApplyFinalResult(genericResult, round.Environment.ManiaHitMode);
             return true;
         }
+
+        private static long getFrameStableId(DrawableHitObject drawable)
+            => (long)(drawable.Time.Current * 1000);
     }
 }

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaJudgementRound.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaJudgementRound.cs
@@ -5,6 +5,9 @@ using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.Scoring;
 using osu.Game.Rulesets.Mania.EzMania.Helper;
 using osu.Game.Rulesets.Mania.EzMania.ReplayJudge.Mappings;
+using osu.Game.Rulesets.Mania.Objects.EzCurrentHitObject;
+using osu.Game.Rulesets.Mania.Scoring;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
 {
@@ -25,6 +28,11 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
 
         public ManiaReplayJudgementState MutableState { get; }
 
+        public bool IsO2Jam { get; }
+
+        private long o2AutoMissFrame = -1;
+        private double o2AutoMissBpm;
+
         private ManiaJudgementRound(
             GameplayEnvironment environment,
             IManiaHitModeJudgement? strategy,
@@ -38,6 +46,7 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
             PillModeEnabled = pillModeEnabled;
             JudgePrecedence = environment.JudgePrecedence;
             MutableState = mutableState;
+            IsO2Jam = environment.ManiaHitMode == EzEnumHitMode.O2Jam;
         }
 
         public static ManiaJudgementRound Create(GameplayEnvironment environment)
@@ -55,5 +64,29 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
         }
 
         public bool IsEzHitMode => ManiaJudgementRegistry.IsEzHitMode(Environment.ManiaHitMode);
+
+        /// <summary>
+        /// 列级按键：缓存本按 press-time BPM（O2 每输入至多查表一次）。
+        /// </summary>
+        public void NotifyO2InputAt(double time) => O2PressBpm = O2HitModeExtension.GetBPMAtTime(time);
+
+        public double O2PressBpm { get; private set; }
+
+        /// <summary>
+        /// 每帧 auto-miss：同帧共享一次 BPM 查表。
+        /// </summary>
+        public double GetO2BpmForAutoMiss(double time, long frameStableId)
+        {
+            if (frameStableId != o2AutoMissFrame)
+            {
+                o2AutoMissBpm = O2HitModeExtension.GetBPMAtTime(time);
+                o2AutoMissFrame = frameStableId;
+            }
+
+            return o2AutoMissBpm;
+        }
+
+        public static double GetTotalMultiplier(HitWindows hitWindows)
+            => hitWindows is ManiaHitWindows mania ? mania.TotalMultiplier : 1;
     }
 }

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaReplaySession.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaReplaySession.cs
@@ -100,7 +100,7 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
             recorder?.RecordInitial(scoreProcessor, gameplayRate);
 
             var targets = buildTargets(beatmap);
-            alignHitWindows(beatmap, environment);
+            ManiaWindowBaker.Align(beatmap, environment);
 
             var holdByHead = new Dictionary<HeadNote, HoldNote>();
             var headByTail = new Dictionary<TailNote, HeadNote>();
@@ -235,30 +235,6 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
                 list.Sort();
 
             return new ManiaReplayInputData(inputEvents, pressTimes);
-        }
-
-        private static void alignHitWindows(IBeatmap beatmap, IGameplayEnvironment environment)
-        {
-            bool isO2Jam = environment.ManiaHitMode == EzEnumHitMode.O2Jam;
-
-            foreach (var hitObject in beatmap.HitObjects)
-                alignHitWindowsRecursive(hitObject, beatmap, environment, isO2Jam);
-        }
-
-        private static void alignHitWindowsRecursive(HitObject hitObject, IBeatmap beatmap, IGameplayEnvironment environment, bool isO2Jam)
-        {
-            if (hitObject.HitWindows is ManiaHitWindows maniaHitWindows)
-            {
-                maniaHitWindows.SetHitMode(environment.ManiaHitMode);
-
-                // O2Jam 判定窗口依赖 BPM 缩放，必须按 hitObject 时间查谱面 BPM 写入。
-                // 不设 BPM 则 ManiaHitWindows 默认 BPM=0 → safeBpm=75 → 窗口加倍，误判严重。
-                if (isO2Jam)
-                    maniaHitWindows.UpdateO2JamBpmFromTime(hitObject.StartTime);
-            }
-
-            foreach (var nested in hitObject.NestedHitObjects)
-                alignHitWindowsRecursive(nested, beatmap, environment, isO2Jam);
         }
 
         private static void applyForcedMisses(

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaWindowBaker.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaWindowBaker.cs
@@ -1,0 +1,42 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Scoring;
+using osu.Game.Rulesets.Mania.Scoring;
+using osu.Game.Rulesets.Objects;
+
+namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
+{
+    /// <summary>
+    /// 开局一次性对齐谱面物件 <see cref="ManiaHitWindows"/>（HitMode / 非 O2 窗口 / O2 StartTime BPM 基线）。
+    /// Session 与 Drawable 共用。
+    /// </summary>
+    public static class ManiaWindowBaker
+    {
+        public static void Align(IBeatmap beatmap, IGameplayEnvironment environment)
+        {
+            bool isO2Jam = environment.ManiaHitMode == EzEnumHitMode.O2Jam;
+
+            foreach (var hitObject in beatmap.HitObjects)
+                alignRecursive(hitObject, environment, isO2Jam);
+        }
+
+        private static void alignRecursive(HitObject hitObject, IGameplayEnvironment environment, bool isO2Jam)
+        {
+            if (hitObject.HitWindows is ManiaHitWindows maniaHitWindows)
+            {
+                maniaHitWindows.SetHitMode(environment.ManiaHitMode);
+
+                // O2Jam：按物件 StartTime 写入基线 BPM（auto-miss / note-lock 扫描用）。
+                // 用户触发判定走 press-time BPM，不 mutate 物件窗口。
+                if (isO2Jam)
+                    maniaHitWindows.UpdateO2JamBpmFromTime(hitObject.StartTime);
+            }
+
+            foreach (var nested in hitObject.NestedHitObjects)
+                alignRecursive(nested, environment, isO2Jam);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/Mappings/O2HitModeJudgement.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/Mappings/O2HitModeJudgement.cs
@@ -72,6 +72,8 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge.Mappings
         {
             public double CurrentTime { get; init; }
 
+            public double Bpm { get; init; }
+
             public bool PillCheckPassed { get; init; }
 
             public bool UpgradeToPerfect { get; init; }
@@ -80,6 +82,8 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge.Mappings
         public readonly struct DrawableTailContext
         {
             public double CurrentTime { get; init; }
+
+            public double Bpm { get; init; }
 
             public bool PillCheckPassed { get; init; }
 
@@ -107,7 +111,7 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge.Mappings
             var outcome = EvaluatePress(timeOffset, hitWindows, new NotePressContext
             {
                 RawOffset = timeOffset,
-                Bpm = O2HitModeExtension.GetBPMAtTime(context.CurrentTime),
+                Bpm = context.Bpm,
                 PillModeEnabled = true,
                 PillCheckPassed = true,
                 UpgradeToPerfect = context.UpgradeToPerfect,
@@ -132,7 +136,7 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge.Mappings
                 HoldBroken = context.HoldBroken,
                 WasHoldingBeforeRelease = context.WasHolding,
                 PillModeEnabled = context.PillModeEnabled,
-                Bpm = O2HitModeExtension.GetBPMAtTime(context.CurrentTime),
+                Bpm = context.Bpm,
                 State = state,
             });
 
@@ -146,8 +150,15 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge.Mappings
         }
 
         public ManiaNoteJudgementOutcome EvaluateAutoMiss(double timeOffset, HitWindows hitWindows)
+            => EvaluateAutoMiss(timeOffset, hitWindows, bpm: 0);
+
+        public ManiaNoteJudgementOutcome EvaluateAutoMiss(double timeOffset, HitWindows hitWindows, double bpm)
         {
-            if (!hitWindows.CanBeHit(timeOffset))
+            bool canHit = bpm > 0
+                ? O2HitModeExtension.CanBeHit(timeOffset, bpm, ManiaJudgementRound.GetTotalMultiplier(hitWindows))
+                : hitWindows.CanBeHit(timeOffset);
+
+            if (!canHit)
                 return ManiaNoteJudgementOutcome.ApplyResult(MapTo(O2Judge.Miss));
 
             return ManiaNoteJudgementOutcome.Ignore;
@@ -157,7 +168,7 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge.Mappings
 
         public ManiaNoteJudgementOutcome EvaluatePress(double timeOffset, HitWindows hitWindows, in NotePressContext context)
         {
-            var judge = FromHitResult(hitWindows.ResultFor(timeOffset));
+            var judge = FromHitResult(resolveResult(timeOffset, hitWindows, context.Bpm));
 
             if (judge == O2Judge.None)
                 return ManiaNoteJudgementOutcome.Ignore;
@@ -175,7 +186,7 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge.Mappings
 
         public O2Judge EvaluateTailJudge(in HoldTailEvaluationContext context)
         {
-            var judge = FromHitResult(context.HitWindows.ResultFor(context.TimeOffsetForJudgement));
+            var judge = FromHitResult(resolveResult(context.TimeOffsetForJudgement, context.HitWindows, context.Bpm));
 
             if (context.PillModeEnabled)
                 ApplyPillLogic(Math.Abs(context.RawOffset), context.Bpm, context.State, ref judge);
@@ -220,6 +231,14 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge.Mappings
         public bool CanBeginHoldAt(double time, TailNote tail) => LazerHoldJudgementReplica.Instance.CanBeginHoldAt(time, tail);
 
         public bool IsHoldBreak(double rawOffset, HitWindows hitWindows) => LazerHoldJudgementReplica.Instance.IsHoldBreak(rawOffset, hitWindows);
+
+        private static HitResult resolveResult(double timeOffset, HitWindows hitWindows, double bpm)
+        {
+            if (bpm > 0)
+                return O2HitModeExtension.ResultFor(timeOffset, bpm, ManiaJudgementRound.GetTotalMultiplier(hitWindows));
+
+            return hitWindows.ResultFor(timeOffset);
+        }
 
         public HitResult RejudgeHitEvent(HitEvent hitEvent, HitWindows hitWindows)
         {

--- a/osu.Game.Rulesets.Mania/Objects/EzCurrentHitObject/O2HitModeExtension.cs
+++ b/osu.Game.Rulesets.Mania/Objects/EzCurrentHitObject/O2HitModeExtension.cs
@@ -92,6 +92,46 @@ namespace osu.Game.Rulesets.Mania.Objects.EzCurrentHitObject
         /// <returns>Bad 判定范围</returns>
         public static double GetBadRangeAtTime(double time) => BASE_BAD / GetBPMAtTime(time);
 
+        public static double SafeBpm(double bpm) => double.IsFinite(bpm) && bpm > 0 ? Math.Max(bpm, 75.0) : 75.0;
+
+        public static void GetRanges(double bpm, double totalMultiplier, out double cool, out double good, out double bad)
+        {
+            double safe = SafeBpm(bpm);
+            cool = BASE_COOL / safe * totalMultiplier;
+            good = BASE_GOOD / safe * totalMultiplier;
+            bad = BASE_BAD / safe * totalMultiplier;
+        }
+
+        /// O2Jam 判定：按 press-time BPM 计算，不 mutate 物件 HitWindows 可变状态。
+        public static HitResult ResultFor(double timeOffset, double bpm, double totalMultiplier = 1)
+        {
+            GetRanges(bpm, totalMultiplier, out double cool, out double good, out double bad);
+            double absOffset = Math.Abs(timeOffset);
+
+            if (absOffset <= cool)
+                return HitResult.Perfect;
+
+            if (absOffset <= good)
+                return HitResult.Good;
+
+            if (absOffset <= bad)
+                return HitResult.Meh;
+
+            return HitResult.None;
+        }
+
+        public static bool CanBeHit(double timeOffset, double bpm, double totalMultiplier = 1)
+        {
+            GetRanges(bpm, totalMultiplier, out _, out _, out double bad);
+            return Math.Abs(timeOffset) <= bad;
+        }
+
+        public static double MissWindow(double bpm, double totalMultiplier = 1)
+        {
+            GetRanges(bpm, totalMultiplier, out _, out _, out double bad);
+            return bad;
+        }
+
         /// <summary>
         /// 更新 CoolCombo 值，自动处理溢出逻辑
         /// </summary>

--- a/osu.Game.Rulesets.Mania/Scoring/ManiaHitWindows.cs
+++ b/osu.Game.Rulesets.Mania/Scoring/ManiaHitWindows.cs
@@ -79,6 +79,11 @@ namespace osu.Game.Rulesets.Mania.Scoring
 
         private double totalMultiplier => speedMultiplier / difficultyMultiplier;
 
+        /// <summary>
+        /// Speed / difficulty 合成乘数（O2 press-time 判定用）。
+        /// </summary>
+        public double TotalMultiplier => totalMultiplier;
+
         private double overallDifficulty;
 
         private bool classicModActive;

--- a/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
@@ -194,6 +194,7 @@ namespace osu.Game.Rulesets.Mania.UI
 
             var purpose = ReplayScore != null ? ReplayRunPurpose.ForStored : ReplayRunPurpose.ForLive;
             JudgementRound = ManiaJudgementRound.Create(ezConfig.ResolveEnvironment(purpose, ReplayScore?.ScoreInfo));
+            ManiaWindowBaker.Align(Beatmap, JudgementRound.Environment);
 
             hitModeBindable.BindValueChanged(h =>
             {


### PR DESCRIPTION
## Summary
- 新增 `ManiaWindowBaker.Align`：开局对齐 HitMode，非 O2 模式窗口在局内不再重算
- O2Jam 用户判定改走 `ResultFor(bpm)`，移除 `CheckForResult` 内 per-note `updateWindows()`
- auto-miss 同帧共享一次 `GetBPMAtTime`，减少 O2 热路径开销
- 依赖 Phase A（#73）已合并的 `ManiaJudgementRound` / `ResolveEnvironment`

## Test plan
- [x] `dotnet test osu.Game.Rulesets.Mania.Tests --filter FullyQualifiedName~ReplayJudge|ManiaResolve`
- [ ] O2Jam 谱面本地游玩：BPM 变化段判定与 Phase A 行为一致
- [x] 非 O2 HitMode 高密度谱面按键响应无明显回退

Made with [Cursor](https://cursor.com)