### PR TITLE
mania: Phase C LANE-CURSOR (Earliest) + POLICY-PARITY

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/JudgePrecedenceReplayFixtures.cs
+++ b/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/JudgePrecedenceReplayFixtures.cs
@@ -1,0 +1,73 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Scoring;
+using osu.Game.Replays;
+using osu.Game.Rulesets.Mania.Objects;
+using osu.Game.Rulesets.Mania.Replays;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Replays;
+using osu.Game.Scoring;
+using osu.Game.Tests.Beatmaps;
+
+namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
+{
+    /// <summary>
+    /// 叠键 / JudgePrecedence 专用 replay 夹具（POLICY-PARITY）。
+    /// </summary>
+    internal static class JudgePrecedenceReplayFixtures
+    {
+        /// <summary>
+        /// 同列 80ms 叠键 + 第三次 note 作间隔；第一次按键落在双 note 窗口重叠区（1040ms）。
+        /// </summary>
+        public static (Score score, IBeatmap beatmap, GameplayEnvironment environment) CreateOverlappingJack(
+            EzEnumHitMode hitMode,
+            EzEnumHealthMode healthMode,
+            EzEnumJudgePrecedence judgePrecedence)
+        {
+            var ruleset = new ManiaRuleset();
+            var beatmap = new TestBeatmap(ruleset.RulesetInfo)
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new Note { StartTime = 1000, Column = 0 },
+                    new Note { StartTime = 1080, Column = 0 },
+                    new Note { StartTime = 2500, Column = 0 },
+                },
+                ControlPointInfo = new ControlPointInfo(),
+            };
+
+            foreach (var obj in beatmap.HitObjects)
+                obj.ApplyDefaults(beatmap.ControlPointInfo, beatmap.Difficulty);
+
+            var replay = new Replay
+            {
+                Frames = new List<ReplayFrame>
+                {
+                    new ManiaReplayFrame(1040, ManiaAction.Key1),
+                    new ManiaReplayFrame(1200),
+                    new ManiaReplayFrame(2500, ManiaAction.Key1),
+                    new ManiaReplayFrame(2600),
+                    new ManiaReplayFrame(5000),
+                },
+            };
+
+            var environment = ReplayJudgeTestConfig.Create(hitMode, healthMode, judgePrecedence);
+            var score = createScore(ruleset, replay);
+            ReplayJudgeTestConfig.ApplyEmbeddedModes(score, environment);
+            return (score, beatmap, environment);
+        }
+
+        private static Score createScore(ManiaRuleset ruleset, Replay replay) => new Score
+        {
+            ScoreInfo = new ScoreInfo { Ruleset = ruleset.RulesetInfo, Mods = Array.Empty<Mod>() },
+            Replay = replay,
+        };
+    }
+}

--- a/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/ManiaJudgePrecedenceParityTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/ManiaJudgePrecedenceParityTest.cs
@@ -1,0 +1,70 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.Rulesets.Mania.EzMania.ReplayJudge;
+
+namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
+{
+    /// <summary>
+    /// POLICY-PARITY：叠键谱面下 Earliest / Combo / Duration Session 路径确定性；
+    /// Drawable ≡ Session 见 <c>TestSceneReplaySessionParity</c> 同名用例。
+    /// </summary>
+    [TestFixture]
+    public class ManiaJudgePrecedenceParityTest
+    {
+        [TearDown]
+        public void TearDown()
+        {
+            GlobalConfigStore.EzConfig.SetValue(Ez2Setting.JudgePrecedence, EzEnumJudgePrecedence.Earliest);
+        }
+
+        [TestCase(EzEnumJudgePrecedence.Earliest)]
+        [TestCase(EzEnumJudgePrecedence.Combo)]
+        [TestCase(EzEnumJudgePrecedence.Duration)]
+        public void TestLazerOverlappingJackSessionIsDeterministic(EzEnumJudgePrecedence precedence)
+        {
+            var (score, beatmap, environment) = JudgePrecedenceReplayFixtures.CreateOverlappingJack(
+                EzEnumHitMode.Lazer, EzEnumHealthMode.Lazer, precedence);
+
+            var first = ManiaReplaySession.RunHitEvents(score, beatmap, environment);
+            var second = ManiaReplaySession.RunHitEvents(score, beatmap, environment);
+
+            Assert.That(ManiaReplayParityHelper.AreHitEventsEquivalent(first, second), Is.True,
+                () => $"Lazer precedence={precedence} session not deterministic: [{ManiaReplayParityHelper.DescribeHitEvents(first)}]");
+        }
+
+        [TestCase(EzEnumJudgePrecedence.Earliest)]
+        [TestCase(EzEnumJudgePrecedence.Combo)]
+        [TestCase(EzEnumJudgePrecedence.Duration)]
+        public void TestIidxOverlappingJackSessionIsDeterministic(EzEnumJudgePrecedence precedence)
+        {
+            var (score, beatmap, environment) = JudgePrecedenceReplayFixtures.CreateOverlappingJack(
+                EzEnumHitMode.IIDX_HD, EzEnumHealthMode.IIDX_HD, precedence);
+
+            var first = ManiaReplaySession.RunHitEvents(score, beatmap, environment);
+            var second = ManiaReplaySession.RunHitEvents(score, beatmap, environment);
+
+            Assert.That(ManiaReplayParityHelper.AreHitEventsEquivalent(first, second), Is.True,
+                () => $"IIDX precedence={precedence} session not deterministic: [{ManiaReplayParityHelper.DescribeHitEvents(first)}]");
+        }
+
+        [Test]
+        public void TestComboAndDurationMayDifferOnOverlappingPress()
+        {
+            var (score, beatmap, _) = JudgePrecedenceReplayFixtures.CreateOverlappingJack(
+                EzEnumHitMode.Lazer, EzEnumHealthMode.Lazer, EzEnumJudgePrecedence.Earliest);
+
+            var comboEnv = ReplayJudgeTestConfig.Create(EzEnumHitMode.Lazer, EzEnumHealthMode.Lazer, EzEnumJudgePrecedence.Combo);
+            var durationEnv = ReplayJudgeTestConfig.Create(EzEnumHitMode.Lazer, EzEnumHealthMode.Lazer, EzEnumJudgePrecedence.Duration);
+
+            var comboEvents = ManiaReplaySession.RunHitEvents(score, beatmap, comboEnv);
+            var durationEvents = ManiaReplaySession.RunHitEvents(score, beatmap, durationEnv);
+
+            // 叠键重叠区按键：Combo 与 Duration 至少应产生可判定的首击（路由逻辑不同，但均需稳定输出）。
+            Assert.That(comboEvents, Is.Not.Empty);
+            Assert.That(durationEvents, Is.Not.Empty);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/ManiaLaneControllerTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/ManiaLaneControllerTest.cs
@@ -1,0 +1,49 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Rulesets.Mania.EzMania.ReplayJudge;
+using osu.Game.Rulesets.Mania.Objects;
+using osu.Game.Rulesets.Mania.Objects.Drawables;
+
+namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
+{
+    [TestFixture]
+    public class ManiaLaneControllerTest
+    {
+        [Test]
+        public void TestTryCreateEntryRejectsNullHitObject()
+        {
+            var drawable = new DrawableNote();
+
+            Assert.That(ManiaLaneController.TryCreateEntry(drawable, out _), Is.False);
+        }
+
+        [Test]
+        public void TestRegisterIfNeededSkipsDuplicate()
+        {
+            var controller = new ManiaLaneController();
+            var drawable = new DrawableNote();
+            drawable.Apply(new Note { StartTime = 1000 });
+
+            controller.RegisterIfNeeded(drawable);
+            controller.RegisterIfNeeded(drawable);
+
+            Assert.That(controller.Entries, Has.Count.EqualTo(1));
+        }
+
+        [Test]
+        public void TestUnregisterByHitObject()
+        {
+            var controller = new ManiaLaneController();
+            var note = new Note { StartTime = 1000 };
+            var drawable = new DrawableNote();
+            drawable.Apply(note);
+
+            controller.Register(drawable);
+            controller.UnregisterByHitObject(note);
+
+            Assert.That(controller.Entries, Is.Empty);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania.Tests/TestSceneReplaySessionParity.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneReplaySessionParity.cs
@@ -221,6 +221,28 @@ namespace osu.Game.Rulesets.Mania.Tests
                 });
         }
 
+        // ==================== POLICY-PARITY: JudgePrecedence × 叠键 ====================
+
+        [TestCase(EzEnumJudgePrecedence.Earliest)]
+        [TestCase(EzEnumJudgePrecedence.Combo)]
+        [TestCase(EzEnumJudgePrecedence.Duration)]
+        public void TestLazerOverlappingJackDrawableMatchesSession(EzEnumJudgePrecedence precedence)
+        {
+            var fixture = JudgePrecedenceReplayFixtures.CreateOverlappingJack(
+                EzEnumHitMode.Lazer, EzEnumHealthMode.Lazer, precedence);
+            runDrawableParityTestFromFixture(fixture);
+        }
+
+        [TestCase(EzEnumJudgePrecedence.Earliest)]
+        [TestCase(EzEnumJudgePrecedence.Combo)]
+        [TestCase(EzEnumJudgePrecedence.Duration)]
+        public void TestIidxOverlappingJackDrawableMatchesSession(EzEnumJudgePrecedence precedence)
+        {
+            var fixture = JudgePrecedenceReplayFixtures.CreateOverlappingJack(
+                EzEnumHitMode.IIDX_HD, EzEnumHealthMode.IIDX_HD, precedence);
+            runDrawableParityTestFromFixture(fixture);
+        }
+
         // ==================== P2-B: Parity 扩到完整 Score ====================
 
         [Test]
@@ -270,6 +292,14 @@ namespace osu.Game.Rulesets.Mania.Tests
                     new ManiaReplayFrame(5000, ManiaAction.Key2),
                     new ManiaReplayFrame(5100),
                 });
+        }
+
+        private void runDrawableParityTestFromFixture((Score score, IBeatmap beatmap, GameplayEnvironment environment) fixture)
+        {
+            parityEnvironment = fixture.environment;
+            runDrawableParityTest(
+                fixture.beatmap.HitObjects.Cast<ManiaHitObject>().ToList(),
+                fixture.score.Replay.Frames);
         }
 
         private void runDrawableParityTest(List<ManiaHitObject> hitObjects, List<ReplayFrame> frames)

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/HIGH_KPS_JUDGE_BACKLOG.md
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/HIGH_KPS_JUDGE_BACKLOG.md
@@ -1,0 +1,89 @@
+# Mania 高 KPS 判定性能 — 代号 backlog
+
+> **定位**：高密度谱面 / 高按键吞吐（社区口径可达 ~90 KPS 量级）下的**全 HitMode**热路径优化清单。  
+> **与主题关系**：依附「局内冻结判定平面」主线（`ManiaJudgementRound` → `ManiaLaneController` → `ManiaJudgementKernel`），**不**替代架构重构；本文件只记录性能专项，方案细节以后单独开文档。  
+> **黄金标准不变**：任何优化不得破坏 `TestSceneReplaySessionParity` / `ManiaCrossSourceInvariantTest`。
+
+---
+
+## 已落地（主线 Phase A/B，全模式受益）
+
+| 代号 | 内容 | 受益 HitMode |
+|------|------|----------------|
+| **ROUND-FREEZE** | `ManiaJudgementRound` 开局冻结 env / strategy / flags | 全部 Ez |
+| **ENV-ONE** | `ResolveEnvironment(purpose, score?, offset?)` 统一解析 | 全部 |
+| **WINDOW-BAKE** | `ManiaWindowBaker.Align` 开局对齐 HitMode + 非 O2 窗口 | 全部 Ez + Session |
+| **O2-NOMUTATE** | O2 用户判定走 `ResultFor(bpm)`，去掉 per-note `updateWindows()` | O2Jam |
+| **O2-FRAME-BPM** | auto-miss 同帧共享一次 `GetBPMAtTime` | O2Jam |
+
+---
+
+## 待办（按优先级，全 HitMode 视角）
+
+### P0 — 与主线 Phase C 绑定（高 KPS 主瓶颈）
+
+| 代号 | TODO | 涉及 HitMode | 说明 |
+|------|------|----------------|------|
+| **LANE-CURSOR** | [ ] 实现 `ManiaLaneController`：列内目标序列 + 游标，替代 `OrderedHitPolicyHelper` 每次 `OnPressed` 扫 `AliveObjects` | **全部**（Earliest 先落地；Combo/Duration 次之） | Session 已有 `ManiaColumnSimulator` 思路；Drawable 列级共用。90 KPS 下 note-lock 扫描通常为最大单项开销。 |
+| **COLUMN-INPUT** | [ ] 按键入口收敛到 `Column.OnPressed`：`selectTarget` → 单 drawable `UpdateResult`；减少冒泡链上重复 `CheckHittable` | **全部** | 与 **LANE-CURSOR** 同批交付。 |
+| **POLICY-PARITY** | [ ] Earliest / Combo / Duration 三路 Drawable ≡ Session 回归测试补齐 | BMS 尤甚 | 重构 note-lock 前的安全网。 |
+
+### P1 — 与主线 Phase D 绑定（正确性 + 间接减负）
+
+| 代号 | TODO | 涉及 HitMode | 说明 |
+|------|------|----------------|------|
+| **KERNEL-ONE** | [ ] `ManiaJudgementKernel`：合并 `EvaluateDrawable*` / `EvaluateSession*` 为单一 `EvaluatePress` / `EvaluateTail` | 全部 Ez | 减少热路径分支与重复上下文构造；Session/Drawable 单源利于后续 profile。 |
+| **DRAWABLE-THIN** | [ ] Drawable `CheckForResult` 收敛为：`offset → kernel → ApplyResult` | 全部 Ez | 降低每 note OOP 层数。 |
+| **STATE-ONE** | [ ] O2 Pill / BMS KPoor 路由状态统一进 `ManiaReplayJudgementState`（去掉 gameplay 静态 `O2HitModeExtension` 计数） | O2 + BMS | 正确性为主；顺带减少 `ConditionalWeakTable` 查找。 |
+
+### P2 — 高 KPS 专项（可独立于 Phase C/D 排期，**以后另写方案**）
+
+| 代号 | TODO | 涉及 HitMode | 说明 |
+|------|------|----------------|------|
+| **AUTO-MISS-GATE** | [ ] 每帧 `UpdateResult(false)`：用烘焙 miss 窗早退，未进窗的存活物件跳过 Ez 判定链 | 全部 Ez | 存活 note 数 × 帧率；与按键 KPS 无关但高密度谱面极重。 |
+| **O2-PILL-1PASS** | [ ] `PillCheck` 接受已算 `bpm` 或 `GetRanges` 结果，去掉每次 press 3× `GetBPMAtTime` | O2Jam | Phase B 遗留；Pill 开时按键路径可能劣于旧实现。 |
+| **O2-COLUMN-BPM** | [ ] `NotifyO2InputAt` 挪到 `Column.OnPressed`（每列每按键 1 次） | O2Jam | 当前在 drawable `CheckForResult` 内，和弦同帧可能重复查表。 |
+| **BMS-ROUTE-COL** | [ ] BMS `BmsRouteState` 按列持有，避免 per-note `ConditionalWeakTable` | BMS | 高叠键列上 post-Bad KPoor 状态机。 |
+| **HOLD-TAIL-FAST** | [ ] Hold/Tail 释放判定：列级 holding 状态 + 单 target，避免 tail drawable 全链 `CheckForResult` | EZ2AC / Malody / O2 LN | LN 高 KPS 谱面次要热点。 |
+| **SOUND-DECOUPLE** | [ ] 评估 `Column.OnPressed` 音效与判定解耦（判定先走、音效异步/合并） | 全部 | 仅当 profile 证明音效阻塞输入时做；**不在架构重构前动**。 |
+
+### P3 — 观测与验收（排期前建议先做）
+
+| 代号 | TODO | 说明 |
+|------|------|------|
+| **BENCH-KPS** | [ ] 扩展 `BenchmarkManiaReplaySession` + 新增 Drawable 侧 micro-bench（note-lock / O2 press / auto-miss） | 用数据定 P2 顺序，避免凭感觉优化。 |
+| **TRACE-JUDGE** | [ ] 复用 `EzJudgmentDiagnostics` 或轻量计数器：每帧 `IsHittable` 次数、`CheckForResult` 次数、BPM 查表次数 | 90 KPS 实机对比 Phase A/B 前后。 |
+
+---
+
+## 明确不在本 backlog 内（别和主题搅在一起）
+
+- 游戏中禁止改 HitMode/HealthMode 的 **UX**（产品层，非性能层）。
+- Lazer/Classic `Lazer*Replica` 与 ppy inline 合并（ppy 同步成本）。
+- `OffsetPlusMania` Realm 持久化（见 `REPLAY_JUDGE_MERGE.md` §1.5d follow-up）。
+- 单纯「禁止游戏中修改设置」的配置锁 UI。
+
+---
+
+## 主线阶段对照（继续专注主题时走这条）
+
+```mermaid
+flowchart LR
+  doneAB["Phase A/B 已完成\nROUND-FREEZE / WINDOW-BAKE"]
+  phaseC["Phase C 当前主题\nLANE-CURSOR + COLUMN-INPUT"]
+  phaseD["Phase D\nKERNEL-ONE + DRAWABLE-THIN"]
+  p2["P2 backlog\n以后另案"]
+  doneAB --> phaseC --> phaseD
+  phaseC -.-> p2
+  phaseD -.-> p2
+```
+
+**下一步默认**：推进 **Phase C（LANE-CURSOR）**，P2 代号项仅在 profile 或 parity 需求明确时插入。
+
+---
+
+## 修订记录
+
+| 日期 | 说明 |
+|------|------|
+| 2026-07-06 | 初版：全 HitMode 高 KPS backlog；Phase A/B 已落地项归档 |

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/HIGH_KPS_JUDGE_BACKLOG.md
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/HIGH_KPS_JUDGE_BACKLOG.md
@@ -24,9 +24,9 @@
 
 | 代号 | TODO | 涉及 HitMode | 说明 |
 |------|------|----------------|------|
-| **LANE-CURSOR** | [ ] 实现 `ManiaLaneController`：列内目标序列 + 游标，替代 `OrderedHitPolicyHelper` 每次 `OnPressed` 扫 `AliveObjects` | **全部**（Earliest 先落地；Combo/Duration 次之） | Session 已有 `ManiaColumnSimulator` 思路；Drawable 列级共用。90 KPS 下 note-lock 扫描通常为最大单项开销。 |
-| **COLUMN-INPUT** | [ ] 按键入口收敛到 `Column.OnPressed`：`selectTarget` → 单 drawable `UpdateResult`；减少冒泡链上重复 `CheckHittable` | **全部** | 与 **LANE-CURSOR** 同批交付。 |
-| **POLICY-PARITY** | [ ] Earliest / Combo / Duration 三路 Drawable ≡ Session 回归测试补齐 | BMS 尤甚 | 重构 note-lock 前的安全网。 |
+| **LANE-CURSOR** | [x] Earliest：`ManiaLaneController` 列内有序目标 + 游标；`OrderedHitPolicy` / Session 共用 `IsHittableEarliest` | **全部**（Earliest） | Combo/Duration 仍走 `OrderedHitPolicyHelper` 全列扫描。 |
+| **COLUMN-INPUT** | [ ] 按键入口收敛到 `Column.OnPressed`：`selectTarget` → 单 drawable `UpdateResult` | **全部** | Earliest 下 `CheckHittable` 已 O(1) 拒绝非游标 note；输入仍冒泡到各 drawable。 |
+| **POLICY-PARITY** | [ ] Earliest / Combo / Duration 三路 Drawable ≡ Session 回归测试补齐 | BMS 尤甚 | 现有 ReplayJudge 68 项已过；专用 policy 用例待补。 |
 
 ### P1 — 与主线 Phase D 绑定（正确性 + 间接减负）
 
@@ -87,3 +87,4 @@ flowchart LR
 | 日期 | 说明 |
 |------|------|
 | 2026-07-06 | 初版：全 HitMode 高 KPS backlog；Phase A/B 已落地项归档 |
+| 2026-07-06 | Phase C（部分）：`LANE-CURSOR` Earliest 落地；`COLUMN-INPUT` 仍待办 |

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/HIGH_KPS_JUDGE_BACKLOG.md
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/HIGH_KPS_JUDGE_BACKLOG.md
@@ -15,6 +15,7 @@
 | **WINDOW-BAKE** | `ManiaWindowBaker.Align` 开局对齐 HitMode + 非 O2 窗口 | 全部 Ez + Session |
 | **O2-NOMUTATE** | O2 用户判定走 `ResultFor(bpm)`，去掉 per-note `updateWindows()` | O2Jam |
 | **O2-FRAME-BPM** | auto-miss 同帧共享一次 `GetBPMAtTime` | O2Jam |
+| **LANE-CURSOR** | Earliest：`ManiaLaneController` 列内有序目标 + 游标；`OrderedHitPolicy` / Session 共用 `IsHittableEarliest` | **全部**（Earliest） | Combo/Duration 仍走 `OrderedHitPolicyHelper` 全列扫描。 |
 
 ---
 
@@ -24,9 +25,8 @@
 
 | 代号 | TODO | 涉及 HitMode | 说明 |
 |------|------|----------------|------|
-| **LANE-CURSOR** | [x] Earliest：`ManiaLaneController` 列内有序目标 + 游标；`OrderedHitPolicy` / Session 共用 `IsHittableEarliest` | **全部**（Earliest） | Combo/Duration 仍走 `OrderedHitPolicyHelper` 全列扫描。 |
 | **COLUMN-INPUT** | [ ] 按键入口收敛到 `Column.OnPressed`：`selectTarget` → 单 drawable `UpdateResult` | **全部** | Earliest 下 `CheckHittable` 已 O(1) 拒绝非游标 note；输入仍冒泡到各 drawable。 |
-| **POLICY-PARITY** | [ ] Earliest / Combo / Duration 三路 Drawable ≡ Session 回归测试补齐 | BMS 尤甚 | 现有 ReplayJudge 68 项已过；专用 policy 用例待补。 |
+| **LANE-PRECEDENCE** | [ ] Combo / Duration：`ManiaLaneController` 列级目标选择，替代 `OrderedHitPolicyHelper` 全列 `AliveObjects` 扫描 | **全部**（Combo/Duration） | 高叠键列上 note-lock 扫描是 90 KPS 主瓶颈；依赖 `LANE-CURSOR` 列内有序结构。 |
 
 ### P1 — 与主线 Phase D 绑定（正确性 + 间接减负）
 
@@ -62,6 +62,7 @@
 - Lazer/Classic `Lazer*Replica` 与 ppy inline 合并（ppy 同步成本）。
 - `OffsetPlusMania` Realm 持久化（见 `REPLAY_JUDGE_MERGE.md` §1.5d follow-up）。
 - 单纯「禁止游戏中修改设置」的配置锁 UI。
+- **POLICY-PARITY**（Earliest / Combo / Duration Drawable ≡ Session）— 正确性/架构 parity，见 `REPLAY_JUDGE_MERGE.md` §4。
 
 ---
 
@@ -70,7 +71,7 @@
 ```mermaid
 flowchart LR
   doneAB["Phase A/B 已完成\nROUND-FREEZE / WINDOW-BAKE"]
-  phaseC["Phase C 当前主题\nLANE-CURSOR + COLUMN-INPUT"]
+  phaseC["Phase C 当前主题\nCOLUMN-INPUT + LANE-PRECEDENCE"]
   phaseD["Phase D\nKERNEL-ONE + DRAWABLE-THIN"]
   p2["P2 backlog\n以后另案"]
   doneAB --> phaseC --> phaseD
@@ -78,7 +79,7 @@ flowchart LR
   phaseD -.-> p2
 ```
 
-**下一步默认**：推进 **Phase C（LANE-CURSOR）**，P2 代号项仅在 profile 或 parity 需求明确时插入。
+**下一步默认**：推进 **Phase C（COLUMN-INPUT + LANE-PRECEDENCE）**，P2 代号项仅在 profile 或 parity 需求明确时插入。
 
 ---
 
@@ -88,3 +89,4 @@ flowchart LR
 |------|------|
 | 2026-07-06 | 初版：全 HitMode 高 KPS backlog；Phase A/B 已落地项归档 |
 | 2026-07-06 | Phase C（部分）：`LANE-CURSOR` Earliest 落地；`COLUMN-INPUT` 仍待办 |
+| 2026-07-06 | `POLICY-PARITY` 移出本 backlog；P0 新增 `LANE-PRECEDENCE`（Combo/Duration 列级扫描替代） |

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaColumnSimulator.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaColumnSimulator.cs
@@ -31,18 +31,7 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
     internal static class ManiaColumnSimulator
     {
         internal static bool IsHittableEarliest(IReadOnlyList<LaneTargetState> column, int index, double time)
-        {
-            for (int i = index + 1; i < column.Count; i++)
-            {
-                if (column[i].Judged)
-                    continue;
-
-                if (time >= column[i].Target.StartTime)
-                    return false;
-            }
-
-            return true;
-        }
+            => ManiaLaneController.IsHittableEarliest(column, index, time);
 
         internal static IEnumerable<LaneTargetState> ForceMissEarlier(IReadOnlyList<LaneTargetState> column, double targetStartTime)
         {

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaLaneController.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaLaneController.cs
@@ -1,0 +1,206 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Game.Rulesets.Mania.Objects.Drawables;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
+
+namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
+{
+    /// <summary>
+    /// 列内 note-lock 状态机：有序目标 + 游标。Earliest 模式下 Drawable / Session 共用判定语义。
+    /// </summary>
+    public sealed class ManiaLaneController
+    {
+        private readonly List<ManiaLaneEntry> entries = new List<ManiaLaneEntry>();
+        private readonly Dictionary<DrawableHitObject, int> drawableIndices = new Dictionary<DrawableHitObject, int>();
+        private int cursor;
+
+        public IReadOnlyList<ManiaLaneEntry> Entries => entries;
+
+        public void Register(DrawableHitObject drawable)
+        {
+            if (!TryCreateEntry(drawable, out var entry))
+                return;
+
+            if (drawableIndices.ContainsKey(drawable))
+                Unregister(drawable);
+
+            int insertIndex = entries.BinarySearch(entry, ManiaLaneEntry.StartTimeComparer.INSTANCE);
+            if (insertIndex < 0)
+                insertIndex = ~insertIndex;
+
+            entries.Insert(insertIndex, entry);
+            rebuildDrawableIndices();
+
+            if (insertIndex < cursor)
+                cursor++;
+        }
+
+        public void RegisterIfNeeded(DrawableHitObject drawable)
+        {
+            if (drawableIndices.ContainsKey(drawable))
+                return;
+
+            Register(drawable);
+        }
+
+        public void Unregister(DrawableHitObject drawable)
+        {
+            if (!drawableIndices.TryGetValue(drawable, out int index))
+                return;
+
+            entries.RemoveAt(index);
+            rebuildDrawableIndices();
+
+            if (index < cursor)
+                cursor--;
+        }
+
+        public void UnregisterByHitObject(HitObject hitObject)
+        {
+            for (int i = entries.Count - 1; i >= 0; i--)
+            {
+                if (entries[i].Drawable.HitObject == hitObject)
+                    Unregister(entries[i].Drawable);
+            }
+        }
+
+        public void NotifyJudged(DrawableHitObject drawable)
+        {
+            if (!drawableIndices.ContainsKey(drawable))
+                return;
+
+            advanceCursor();
+        }
+
+        /// <summary>
+        /// Earliest note-lock：仅游标处未判定物件可击打，且不得越过更晚物件的 StartTime。
+        /// </summary>
+        public bool IsHittableEarliest(DrawableHitObject drawable, double time)
+        {
+            if (!drawableIndices.TryGetValue(drawable, out int index))
+                return false;
+
+            if (drawable.Judged || index != cursor)
+                return false;
+
+            return IsHittableEarliestIndex(index, time);
+        }
+
+        public bool IsHittableEarliestIndex(int index, double time)
+            => IsHittableEarliest(entries, index, time, static e => e.IsJudged, static e => e.StartTime);
+
+        /// <summary>
+        /// Session：<see cref="LaneTargetState"/> 列版本。
+        /// </summary>
+        internal static bool IsHittableEarliest(IReadOnlyList<LaneTargetState> column, int index, double time)
+            => IsHittableEarliest(column, index, time, static s => s.Judged, static s => s.Target.StartTime);
+
+        internal static bool IsHittableEarliest<T>(
+            IReadOnlyList<T> column,
+            int index,
+            double time,
+            Func<T, bool> isJudged,
+            Func<T, double> startTime)
+        {
+            for (int i = index + 1; i < column.Count; i++)
+            {
+                if (isJudged(column[i]))
+                    continue;
+
+                if (time >= startTime(column[i]))
+                    return false;
+            }
+
+            return true;
+        }
+
+        public IEnumerable<ManiaLaneEntry> EnumerateForceMissBefore(double targetStartTime)
+        {
+            foreach (var entry in entries)
+            {
+                if (entry.IsJudged)
+                    continue;
+
+                if (entry.StartTime >= targetStartTime)
+                    break;
+
+                yield return entry;
+            }
+        }
+
+        public static bool TryCreateEntry(DrawableHitObject drawable, out ManiaLaneEntry entry)
+        {
+            entry = null!;
+
+            if (drawable.HitObject == null)
+                return false;
+
+            if (drawable is DrawableHoldNoteHead or DrawableHoldNoteTail)
+                return false;
+
+            if (drawable is DrawableHoldNote hold)
+            {
+                entry = new ManiaLaneEntry(hold, hold.HitObject.StartTime);
+                return true;
+            }
+
+            if (drawable.Judged)
+                return false;
+
+            entry = new ManiaLaneEntry(drawable, drawable.HitObject.StartTime);
+            return true;
+        }
+
+        private void advanceCursor()
+        {
+            while (cursor < entries.Count && entries[cursor].IsJudged)
+                cursor++;
+        }
+
+        private void rebuildDrawableIndices()
+        {
+            drawableIndices.Clear();
+
+            for (int i = 0; i < entries.Count; i++)
+                drawableIndices[entries[i].Drawable] = i;
+        }
+    }
+
+    public sealed class ManiaLaneEntry
+    {
+        public DrawableHitObject Drawable { get; }
+
+        public double StartTime { get; }
+
+        public bool IsJudged => Drawable.Judged;
+
+        public ManiaLaneEntry(DrawableHitObject drawable, double startTime)
+        {
+            Drawable = drawable;
+            StartTime = startTime;
+        }
+
+        internal sealed class StartTimeComparer : IComparer<ManiaLaneEntry>
+        {
+            public static readonly StartTimeComparer INSTANCE = new StartTimeComparer();
+
+            public int Compare(ManiaLaneEntry? x, ManiaLaneEntry? y)
+            {
+                if (ReferenceEquals(x, y))
+                    return 0;
+
+                if (x is null)
+                    return -1;
+
+                if (y is null)
+                    return 1;
+
+                return x.StartTime.CompareTo(y.StartTime);
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaReplaySessionSimulator.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaReplaySessionSimulator.cs
@@ -291,7 +291,7 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
 
             foreach (var candidate in candidates)
             {
-                int index = laneStates.ToList().FindIndex(s => ReferenceEquals(s, candidate));
+                int index = indexOf(laneStates, candidate);
                 if (index < 0 || !IsHittableEarliest(laneStates, index, time))
                     continue;
 
@@ -538,6 +538,17 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
 
             double reference = target.GetEndTime();
             return candidateList.MinBy(t => Math.Abs(t - reference));
+        }
+
+        private static int indexOf(IReadOnlyList<LaneTargetState> laneStates, LaneTargetState candidate)
+        {
+            for (int i = 0; i < laneStates.Count; i++)
+            {
+                if (ReferenceEquals(laneStates[i], candidate))
+                    return i;
+            }
+
+            return -1;
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/REPLAY_JUDGE_MERGE.md
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/REPLAY_JUDGE_MERGE.md
@@ -19,7 +19,7 @@
 
 **禁止**恢复 drawable 分析 fallback；Session 做到等价即可。
 
-Parity 测试：`TestSceneReplaySessionParity`（Drawable replay vs Session，完整 HitEvent 字段）。
+Parity 测试：`TestSceneReplaySessionParity`（Drawable replay vs Session，完整 HitEvent 字段）；**POLICY-PARITY** 叠键 × Earliest/Combo/Duration 见 `ManiaJudgePrecedenceParityTest` + `TestSceneReplaySessionParity.Test*OverlappingJack*`。
 
 ---
 
@@ -278,5 +278,6 @@ flowchart LR
 4. **跑 parity**
    - `ManiaCrossSourceInvariantTest`（Run：HitEvents 聚合 ≡ Statistics、同环境 FromScore ≡ FromLive）
    - `TestSceneReplaySessionParity`（Drawable vs Session：Lazer tap/hold、IIDX tap/hold、O2 tap/hold/pill、Ez2AC hold、Malody hold）
-   - `JudgePrecedenceRoutingRegressionTest`
+   - **`POLICY-PARITY`**：`ManiaJudgePrecedenceParityTest` + `TestSceneReplaySessionParity` 叠键用例 — Earliest / Combo / Duration × Lazer + IIDX，Drawable `ScoreProcessor` HitEvents ≡ `ManiaReplaySession.RunHitEvents`
+   - `JudgePrecedenceRoutingRegressionTest`（helper 级路由，非 Drawable parity）
    - `dotnet test osu.Game.Rulesets.Mania.Tests`（全量）

--- a/osu.Game.Rulesets.Mania/UI/Column.cs
+++ b/osu.Game.Rulesets.Mania/UI/Column.cs
@@ -15,6 +15,7 @@ using osu.Game.Extensions;
 using osu.Game.EzOsuGame;
 using osu.Game.EzOsuGame.Audio;
 using osu.Game.EzOsuGame.Configuration;
+using osu.Game.Rulesets.Mania.EzMania.ReplayJudge;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mania.Beatmaps;
 using osu.Game.Rulesets.Mania.Configuration;
@@ -22,6 +23,7 @@ using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mania.Objects.Drawables;
 using osu.Game.Rulesets.Mania.Skinning;
 using osu.Game.Rulesets.Mania.UI.Components;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.UI;
 using osu.Game.Rulesets.UI.Scrolling;
@@ -51,7 +53,8 @@ namespace osu.Game.Rulesets.Mania.UI
         internal readonly Container TopLevelContainer = new Container { RelativeSizeAxes = Axes.Both };
 
         private DrawablePool<PoolableHitExplosion> hitExplosionPool = null!;
-        private readonly OrderedHitPolicy hitPolicy;
+        private OrderedHitPolicy hitPolicy = null!;
+        private ManiaLaneController? laneController;
         public Container UnderlayElements => HitObjectArea.UnderlayElements;
 
         private GameplaySampleTriggerSource sampleTriggerSource = null!;
@@ -76,7 +79,6 @@ namespace osu.Game.Rulesets.Mania.UI
             RelativeSizeAxes = Axes.Y;
             Width = COLUMN_WIDTH;
 
-            hitPolicy = new OrderedHitPolicy(HitObjectContainer);
             HitObjectArea = new ColumnHitObjectArea
             {
                 RelativeSizeAxes = Axes.Both,
@@ -116,10 +118,28 @@ namespace osu.Game.Rulesets.Mania.UI
         public int KeyMode;
         public bool ConfigTimingBasedNoteColouring;
 
+        protected override ScrollingHitObjectContainer CreateScrollingHitObjectContainer()
+            => new LaneTrackingScrollingHitObjectContainer(this);
+
+        internal void RegisterLaneDrawable(DrawableHitObject drawable) => hitPolicy.RegisterDrawable(drawable);
+
+        internal void UnregisterLaneDrawable(DrawableHitObject drawable) => hitPolicy.UnregisterDrawable(drawable);
+
         [BackgroundDependencyLoader]
         private void load(GameHost host, ManiaRulesetConfigManager? rulesetConfig, StageDefinition stageDefinition)
         {
             KeyMode = stageDefinition.Columns;
+
+            // JudgePrecedence 来自全局配置（与 ManiaJudgementRound.Create 一致）；勿 [Resolved] DrawableManiaRuleset——
+            // 皮肤预览等场景会单独构造 Column，且 JudgementRound 在 ruleset LoadComplete 才冻结。
+            var judgePrecedence = ezConfig.Get<EzEnumJudgePrecedence>(Ez2Setting.JudgePrecedence);
+
+            // Earliest：列内有序目标 + 游标（ManiaLaneController），Drawable / Session 共用 note-lock 语义。
+            // Combo / Duration：暂不建 controller，OrderedHitPolicy 仍走 OrderedHitPolicyHelper 全列 AliveObjects 扫描。
+            // TODO(LANE-PRECEDENCE): Combo/Duration 也接入 ManiaLaneController 列级目标选择，替代热路径全列扫描（见 HIGH_KPS_JUDGE_BACKLOG.md）。
+            laneController = judgePrecedence == EzEnumJudgePrecedence.Earliest ? new ManiaLaneController() : null;
+            hitPolicy = new OrderedHitPolicy(HitObjectContainer, judgePrecedence, laneController);
+
             EzNoteTypeBindable = ezConfig.GetColumnTypeBindable(KeyMode, Index);
             EzNoteSizeBindable = ezFactory.GetNoteSizeBindable(KeyMode, Index);
             EzNoteColourBindable = ezConfig.GetColumnColorBindable(KeyMode, Index);
@@ -247,13 +267,41 @@ namespace osu.Game.Rulesets.Mania.UI
             DrawableManiaHitObject maniaObject = (DrawableManiaHitObject)drawableHitObject;
 
             maniaObject.AccentColour.BindTo(AccentColour);
-            maniaObject.CheckHittable = hitPolicy.IsHittable;
+            maniaObject.CheckHittable = (d, time) =>
+            {
+                hitPolicy.EnsureRegistered(d);
+                return hitPolicy.IsHittable(d, time);
+            };
+        }
+
+        private sealed partial class LaneTrackingScrollingHitObjectContainer : ScrollingHitObjectContainer
+        {
+            private readonly Column column;
+
+            public LaneTrackingScrollingHitObjectContainer(Column column)
+            {
+                this.column = column;
+            }
+
+            protected override void AddDrawable(HitObjectLifetimeEntry entry, DrawableHitObject drawable)
+            {
+                base.AddDrawable(entry, drawable);
+                column.RegisterLaneDrawable(drawable);
+            }
+
+            protected override void RemoveDrawable(HitObjectLifetimeEntry entry, DrawableHitObject drawable)
+            {
+                column.UnregisterLaneDrawable(drawable);
+                base.RemoveDrawable(entry, drawable);
+            }
         }
 
         internal void OnNewResult(DrawableHitObject judgedObject, JudgementResult result)
         {
             if (result.IsHit)
                 hitPolicy.HandleHit(judgedObject);
+            else
+                hitPolicy.NotifyJudged(judgedObject);
 
             if (!result.IsHit || !judgedObject.DisplayResult || !DisplayJudgements.Value)
                 return;

--- a/osu.Game.Rulesets.Mania/UI/OrderedHitPolicy.cs
+++ b/osu.Game.Rulesets.Mania/UI/OrderedHitPolicy.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Game.EzOsuGame.Configuration;
 using osu.Game.Rulesets.Mania.EzMania.Helper;
+using osu.Game.Rulesets.Mania.EzMania.ReplayJudge;
 using osu.Game.Rulesets.Mania.Objects.Drawables;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -20,17 +21,25 @@ namespace osu.Game.Rulesets.Mania.UI
         private readonly HitObjectContainer hitObjectContainer;
         private readonly OrderedHitPolicyHelper helper;
         private readonly bool enabledPrecedence;
+        private readonly ManiaLaneController? laneController;
 
-        public OrderedHitPolicy(HitObjectContainer hitObjectContainer)
+        public OrderedHitPolicy(HitObjectContainer hitObjectContainer, EzEnumJudgePrecedence judgePrecedence, ManiaLaneController? laneController = null)
         {
             this.hitObjectContainer = hitObjectContainer;
+            this.laneController = judgePrecedence == EzEnumJudgePrecedence.Earliest ? laneController : null;
             helper = new OrderedHitPolicyHelper(hitObjectContainer);
-
-            if (GlobalConfigStore.EzConfig.Get<EzEnumJudgePrecedence>(Ez2Setting.JudgePrecedence) != EzEnumJudgePrecedence.Earliest)
-                enabledPrecedence = true;
-            else
-                enabledPrecedence = false;
+            enabledPrecedence = judgePrecedence != EzEnumJudgePrecedence.Earliest;
         }
+
+        internal void RegisterDrawable(DrawableHitObject drawable) => laneController?.Register(drawable);
+
+        internal void EnsureRegistered(DrawableHitObject drawable) => laneController?.RegisterIfNeeded(drawable);
+
+        internal void UnregisterDrawable(DrawableHitObject drawable) => laneController?.Unregister(drawable);
+
+        internal void UnregisterByHitObject(HitObject hitObject) => laneController?.UnregisterByHitObject(hitObject);
+
+        internal void NotifyJudged(DrawableHitObject drawable) => laneController?.NotifyJudged(drawable);
 
         /// <summary>
         /// Determines whether a <see cref="DrawableHitObject"/> can be hit at a point in time.
@@ -43,9 +52,11 @@ namespace osu.Game.Rulesets.Mania.UI
         /// <returns>Whether <paramref name="hitObject"/> can be hit at the given <paramref name="time"/>.</returns>
         public bool IsHittable(DrawableHitObject hitObject, double time)
         {
-            // 非Earliest模式下，允许独立的优先级算法。
             if (enabledPrecedence)
                 return helper.IsHittableWithPrecedence(hitObject, time);
+
+            if (laneController != null)
+                return laneController.IsHittableEarliest(hitObject, time);
 
             var nextObject = hitObjectContainer.AliveObjects.GetNext(hitObject);
             return nextObject == null || time < nextObject.HitObject.StartTime;
@@ -71,16 +82,25 @@ namespace osu.Game.Rulesets.Mania.UI
 
                     ((DrawableManiaHitObject)obj).MissForcefully();
                 }
-            }
-            else
-            {
-                foreach (var obj in enumerateHitObjectsUpTo(hitObject.HitObject.StartTime))
-                {
-                    if (obj.Judged)
-                        continue;
 
-                    ((DrawableManiaHitObject)obj).MissForcefully();
-                }
+                return;
+            }
+
+            if (laneController != null)
+            {
+                foreach (var entry in laneController.EnumerateForceMissBefore(hitObject.HitObject.StartTime))
+                    ((DrawableManiaHitObject)entry.Drawable).MissForcefully();
+
+                laneController.NotifyJudged(hitObject);
+                return;
+            }
+
+            foreach (var obj in enumerateHitObjectsUpTo(hitObject.HitObject.StartTime))
+            {
+                if (obj.Judged)
+                    continue;
+
+                ((DrawableManiaHitObject)obj).MissForcefully();
             }
         }
 


### PR DESCRIPTION
## Summary
- **LANE-CURSOR**：\ManiaLaneController\ 列内有序目标 + 游标，Earliest note-lock 在 Drawable（池化 \AddDrawable\ 注册）与 Session 路径共用语义。
- **POLICY-PARITY**：叠键谱面 Earliest/Combo/Duration × Lazer+IIDX 回归（\ManiaJudgePrecedenceParityTest\ + \TestSceneReplaySessionParity\）。
- **文档**：\HIGH_KPS_JUDGE_BACKLOG\ 归档已落地项；\LANE-PRECEDENCE\（Combo/Duration 列级扫描）与 \COLUMN-INPUT\ 留待后续；parity 清单更新 \REPLAY_JUDGE_MERGE.md\。

## Test plan
- [x] \dotnet test osu.Game.Rulesets.Mania.Tests --filter ReplayJudge|JudgePrecedence\
- [x] 进局 Earliest 模式 tap/hold 可正常判定
- [ ] Combo/Duration 叠键谱面 Drawable 与 Session parity（visual \TestSceneReplaySessionParity\）

Made with [Cursor](https://cursor.com)