### PR TITLE
feat(mania): Phase D ManiaJudgementKernel

### DIFF
--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/HIGH_KPS_JUDGE_BACKLOG.md
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/HIGH_KPS_JUDGE_BACKLOG.md
@@ -20,6 +20,11 @@
 | **COLUMN-INPUT** | `Column.OnPressed` → `TryRoutePress` → 单 target；`ManiaKeyBindingContainer` 列优先队列；drawable `ShouldSkipColumnRoutedPress` 兜底 | 全部 |
 | **TRACE-JUDGE** | `ManiaJudgeHotPathTrace`（`IsHittable` / `CheckForResult` / O2 BPM / press 计数） | 观测 |
 | **BENCH-KPS** | `BenchmarkManiaReplaySession`：jack 80ms×4K + 三档 `JudgePrecedence` | 观测 |
+| **PERF-IDLE-PRESS** | 增量 lane index、列 press 去重、`KeyBindingInputQueue` 无 `ToList`、O2 press 无 `maniaWindows.BPM` 突变 | 全部 |
+| **AUTO-MISS-GATE** | `ManiaAutoMissGate.ShouldEvaluateAutoMiss` 未进 miss 早窗早退 | 全部 Ez |
+| **O2-PILL-1PASS** | press 路径 `PillCheckWithBpm` + `EvaluatePress(NotePressContext)` | O2Jam |
+| **MISS-STORED-OFFSET** | Drawable 被动 miss / Session end-sweep：`ResolveMissStoredOffset`（列 press 最近邻） | 全部 |
+| **FORCE-MISS-WINDOW** | Session `ForceMissEarlier` 跳过 miss 窗外物件（对齐 `IsUserTriggerJudgeableNow`）；枚举不再预写 `Judged` | Lazer/Classic + Session |
 
 ---
 
@@ -27,9 +32,15 @@
 
 | 代号 | 说明 |
 |------|------|
-| **KERNEL-ONE** | `ManiaJudgementKernel` Ez note/hold-tail 单源 |
-| **DRAWABLE-THIN** | Drawable `CheckForResult` 收敛为 kernel → ApplyResult |
 | **STATE-ONE** | O2 Pill / BMS KPoor 路由状态合并进 `ManiaReplayJudgementState` |
+
+## Phase D 进行中（`mania-judgement-kernel-d`）
+
+| 代号 | 说明 |
+|------|------|
+| **KERNEL-ONE** | [x] `ManiaJudgementKernel`：Drawable + Session 共用 note/hold-tail 判定 |
+| **DRAWABLE-THIN** | [x] `ManiaEzDrawableJudgement` 收敛为 kernel → ApplyResult（保留 AutoMissGate / stored offset） |
+| **BMS-PRESS-CORE** | [x] `evaluatePressCore` 统一 Drawable / Session BMS press |
 
 ---
 
@@ -37,8 +48,6 @@
 
 | 代号 | TODO | 说明 |
 |------|------|------|
-| **AUTO-MISS-GATE** | [ ] 未进 miss 早窗跳过 auto-miss 链（`ManiaAutoMissGate` 原型在库，待 parity 验收） | 全部 Ez |
-| **O2-PILL-1PASS** | [ ] press 路径单次 BPM / `PillCheckWithBpm` | O2Jam |
 | **O2-COLUMN-BPM** | [x] `Column.OnPressed` 每列每按键 `NotifyO2InputAt` | O2Jam |
 | **BMS-ROUTE-COL** | [ ] tail `BmsRouteState` 完全列级化 | BMS |
 | **HOLD-TAIL-FAST** | [ ] `Column.OnReleased` → 列级 tail release | LN |
@@ -63,10 +72,11 @@ flowchart LR
   E0["E0 度量\nTRACE + BENCH"]
   C1["C1 LANE-PRECEDENCE ✓"]
   C2["C2 COLUMN-INPUT ✓"]
-  D["Phase D\n暂缓"]
+  D["Phase D\nkernel-d"]
   P2["P2 backlog"]
   E0 --> C1 --> C2 --> D
   C2 -.-> P2
+  D -.-> P2
 ```
 
 **预期收益（定性）**
@@ -75,7 +85,7 @@ flowchart LR
 - **C2**：每键 `CheckForResult` O(存活数) → O(1)
 - **整体**：Drawable 与 Session 在列级 target 选择层面对齐
 
-**下一步默认**：P2 按 profile 排期；Phase D 待帧成本问题解决后再议。
+**下一步默认**：`mania-judgement-kernel-d` 实机 profile 对比 `mania-perf-fix`；`STATE-ONE` 与 P2 按 profile 排期。
 
 ---
 
@@ -85,3 +95,5 @@ flowchart LR
 |------|------|
 | 2026-07-06 | 初版：全 HitMode 高 KPS backlog；Phase A/B 已落地项归档 |
 | 2026-07-06 | Phase C 完成：`LANE-PRECEDENCE` + `COLUMN-INPUT`；Phase D 标注暂缓 |
+| 2026-07-07 | `mania-perf-fix`：idle/press 热路径减负 + 叠键 miss `TimeOffset` parity（`MISS-STORED-OFFSET` / `FORCE-MISS-WINDOW`） |
+| 2026-07-07 | `mania-judgement-kernel-d`：`KERNEL-ONE` + `DRAWABLE-THIN`；O2-NOMUTATE；BMS auto-miss stored offset |

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaDrawableMissTiming.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaDrawableMissTiming.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using osu.Framework.Graphics;
-using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mania.UI;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaEzDrawableJudgement.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaEzDrawableJudgement.cs
@@ -206,76 +206,33 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
             if (!userTriggered && !ManiaAutoMissGate.ShouldEvaluateAutoMiss(drawable.HitObject, timeOffset))
                 return true;
 
-            if (!round.IsEzHitMode)
+            if (!round.IsEzHitMode || round.Strategy == null)
                 return false;
 
-            var hitMode = round.Strategy;
-            if (hitMode == null)
-                return false;
+            bool o2PillPassed = true;
+            bool o2Upgrade = false;
 
-            if (hitMode is BmsHitModeJudgement bms)
+            if (userTriggered && round.Strategy is O2HitModeJudgement && round.PillModeEnabled)
+                o2PillPassed = O2HitModeExtension.PillCheckWithBpm(timeOffset, round.O2PressBpm, out _, out o2Upgrade);
+
+            var bmsState = round.Strategy is BmsHitModeJudgement ? GetBmsState(drawable) : null;
+
+            var result = ManiaJudgementKernel.EvaluateNote(new ManiaJudgementKernel.NoteEvaluationRequest
             {
-                if (drawable.HitObject.HitWindows is not ManiaHitWindows maniaWindows)
-                    return true;
+                Round = round,
+                TimeOffset = timeOffset,
+                HitWindows = drawable.HitObject.HitWindows!,
+                UserTriggered = userTriggered,
+                IsLnHead = drawable.HitObject is HeadNote,
+                EventTime = drawable.Time.Current,
+                FrameStableId = getFrameStableId(drawable),
+                BmsState = bmsState,
+                CheckBmsCanRouteOnPress = userTriggered,
+                O2PillCheckPassed = o2PillPassed,
+                O2UpgradeToPerfect = o2Upgrade,
+            });
 
-                var state = GetBmsState(drawable);
-
-                var action = userTriggered
-                    ? bms.EvaluateDrawablePress(maniaWindows, timeOffset, state, round.PoorEnabled)
-                    : bms.EvaluateDrawableAutoMiss(maniaWindows, timeOffset);
-
-                ApplyBmsAction(drawable, round, action, state);
-                return true;
-            }
-
-            if (hitMode is O2HitModeJudgement o2)
-            {
-                if (userTriggered)
-                {
-                    bool upgradeToPerfect = false;
-                    bool cont = !round.PillModeEnabled
-                                || O2HitModeExtension.PillCheckWithBpm(timeOffset, round.O2PressBpm, out bool _, out upgradeToPerfect);
-                    var outcome = o2.EvaluatePress(timeOffset, drawable.HitObject.HitWindows!, new O2HitModeJudgement.NotePressContext
-                    {
-                        RawOffset = timeOffset,
-                        Bpm = round.O2PressBpm,
-                        UsePressTimeBpmForJudgement = true,
-                        PillModeEnabled = round.PillModeEnabled,
-                        PillCheckPassed = cont,
-                        UpgradeToPerfect = upgradeToPerfect,
-                        State = round.MutableState,
-                    });
-
-                    ApplyNoteOutcome(drawable, round, outcome, userTriggered: true);
-                    return true;
-                }
-
-                long frameId = (long)(drawable.Time.Current * 1000);
-                double bpm = round.GetO2BpmForAutoMiss(drawable.Time.Current, frameId);
-                ApplyNoteOutcome(drawable, round, o2.EvaluateAutoMiss(timeOffset, drawable.HitObject.HitWindows!, bpm), userTriggered: false);
-                return true;
-            }
-
-            if (hitMode is Ez2AcHitModeJudgement ez2Ac)
-            {
-                if (userTriggered)
-                {
-                    ApplyNoteOutcome(drawable, round, ez2Ac.EvaluateDrawablePress(timeOffset, drawable.HitObject.HitWindows!, drawable.HitObject is HeadNote), userTriggered: true);
-                    return true;
-                }
-
-                ApplyNoteOutcome(drawable, round, ez2Ac.EvaluateAutoMiss(timeOffset, drawable.HitObject.HitWindows!), userTriggered: false);
-                return true;
-            }
-
-            if (userTriggered)
-            {
-                ApplyNoteOutcome(drawable, round, hitMode.EvaluatePress(timeOffset, drawable.HitObject.HitWindows!), userTriggered: true);
-                return true;
-            }
-
-            ApplyNoteOutcome(drawable, round, hitMode.EvaluateAutoMiss(timeOffset, drawable.HitObject.HitWindows!), userTriggered: false);
-            return true;
+            return applyNoteEvaluation(drawable, round, result, bmsState, userTriggered);
         }
 
         internal static bool TryApplyEzHoldTailCheckForResult(DrawableHoldNoteTail drawable, bool userTriggered, double timeOffset)
@@ -290,131 +247,111 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
             if (!round.IsEzHitMode)
                 return false;
 
-            var hitMode = round.Strategy;
+            bool o2PillPassed = true;
+            bool o2Upgrade = false;
 
-            if (hitMode is MalodyHitModeJudgement)
+            if (userTriggered && round.Strategy is O2HitModeJudgement && round.PillModeEnabled)
+                o2PillPassed = O2HitModeExtension.PillCheckWithBpm(timeOffset, round.O2PressBpm, out _, out o2Upgrade);
+
+            var bmsState = round.Strategy is BmsHitModeJudgement ? GetBmsState(drawable) : null;
+
+            var result = ManiaJudgementKernel.EvaluateHoldTail(new ManiaJudgementKernel.HoldTailEvaluationRequest
             {
-                if (!userTriggered && timeOffset >= 0)
-                    drawable.EzApplyFinalResult(HitResult.IgnoreHit, round.Environment.ManiaHitMode);
-
-                return true;
-            }
-
-            if (hitMode is BmsHitModeJudgement bms)
-            {
-                if (drawable.HitObject.HitWindows is not ManiaHitWindows maniaWindows)
-                    return true;
-
-                var state = GetBmsState(drawable);
-                bool forcePoor = !drawable.HoldNote.IsHolding.Value && drawable.HoldNote.Body.HasHoldBreak;
-
-                var action = userTriggered
-                    ? bms.EvaluateDrawablePress(maniaWindows, timeOffset, state, round.PoorEnabled, forcePoorOnTailHoldBreak: forcePoor)
-                    : bms.EvaluateDrawableAutoMiss(maniaWindows, timeOffset);
-
-                ApplyBmsAction(drawable, round, action, state);
-                return true;
-            }
-
-            if (hitMode is O2HitModeJudgement o2)
-            {
-                (drawable.HitObject.HitWindows as ManiaHitWindows)?.UpdateO2JamBpmFromTime(drawable.Time.Current);
-
-                if (!userTriggered)
-                {
-                    if (drawable.HoldNote.Body.HasHoldBreak)
-                    {
-                        if (timeOffset < 0)
-                            return true;
-
-                        drawable.EzApplyFinalResult(O2HitModeJudgement.MapTo(O2Judge.Miss), round.Environment.ManiaHitMode);
-                        return true;
-                    }
-
-                    if (!drawable.HitObject.HitWindows!.CanBeHit(timeOffset))
-                        drawable.EzApplyMinResult();
-
-                    return true;
-                }
-
-                bool cont = O2HitModeExtension.PillCheck(timeOffset, drawable.Time.Current, out bool _, out bool upgradeToPerfect);
-                var result = o2.EvaluateDrawableTailPress(timeOffset, drawable.HitObject.HitWindows!, new O2HitModeJudgement.DrawableTailContext
-                {
-                    CurrentTime = drawable.Time.Current,
-                    PillCheckPassed = cont,
-                    UpgradeToPerfect = upgradeToPerfect,
-                    HeadHit = drawable.HoldNote.Head.IsHit,
-                    HoldBroken = drawable.HoldNote.Body.HasHoldBreak,
-                    WasHolding = drawable.HoldNote.IsHolding.Value,
-                    PillModeEnabled = round.PillModeEnabled,
-                }, round.MutableState);
-
-                if (result != null)
-                    drawable.EzApplyFinalResult(result.Value, round.Environment.ManiaHitMode);
-
-                return true;
-            }
-
-            if (hitMode is Ez2AcHitModeJudgement ez2Ac)
-            {
-                bool headMissOrBreak = !drawable.HoldNote.Head.IsHit || drawable.HoldNote.Body.HasHoldBreak;
-
-                if (!userTriggered)
-                {
-                    if (timeOffset < 0)
-                        return true;
-
-                    if (headMissOrBreak)
-                    {
-                        if (!drawable.HitObject.HitWindows!.CanBeHit(timeOffset))
-                            drawable.EzApplyMinResult();
-
-                        return true;
-                    }
-                }
-
-                var tailJudge = ez2Ac.EvaluateTailJudge(new HoldTailEvaluationContext
-                {
-                    RawOffset = timeOffset,
-                    TimeOffsetForJudgement = timeOffset,
-                    HitWindows = drawable.HitObject.HitWindows!,
-                    HeadHit = drawable.HoldNote.Head.IsHit,
-                    HoldBreak = ez2Ac.IsHoldBreak(timeOffset, drawable.HitObject.HitWindows!),
-                    HoldBroken = drawable.HoldNote.Body.HasHoldBreak,
-                    WasHoldingBeforeRelease = drawable.HoldNote.IsHolding.Value,
-                });
-
-                if (tailJudge == Ez2AcJudge.None)
-                {
-                    if (!userTriggered && !drawable.HitObject.HitWindows!.CanBeHit(timeOffset))
-                        drawable.EzApplyMinResult();
-
-                    return true;
-                }
-
-                drawable.EzApplyFinalResult(Ez2AcHitModeJudgement.MapTo(tailJudge), round.Environment.ManiaHitMode);
-                return true;
-            }
-
-            if (hitMode == null)
-                return false;
-
-            var genericResult = hitMode.EvaluateTail(new HoldTailEvaluationContext
-            {
+                Round = round,
+                TimeOffset = timeOffset,
                 RawOffset = timeOffset,
-                TimeOffsetForJudgement = timeOffset,
                 HitWindows = drawable.HitObject.HitWindows!,
+                UserTriggered = userTriggered,
                 HeadHit = drawable.HoldNote.Head.IsHit,
-                HoldBreak = hitMode.IsHoldBreak(timeOffset, drawable.HitObject.HitWindows!),
                 HoldBroken = drawable.HoldNote.Body.HasHoldBreak,
-                WasHoldingBeforeRelease = drawable.HoldNote.IsHolding.Value,
+                WasHolding = drawable.HoldNote.IsHolding.Value,
+                HasHoldBreak = drawable.HoldNote.Body.HasHoldBreak,
+                EventTime = drawable.Time.Current,
+                FrameStableId = getFrameStableId(drawable),
+                BmsState = bmsState,
+                O2PillCheckPassed = o2PillPassed,
+                O2UpgradeToPerfect = o2Upgrade,
             });
 
-            if (genericResult == HitResult.None)
-                return true;
+            if (!result.Handled)
+                return false;
 
-            drawable.EzApplyFinalResult(genericResult, round.Environment.ManiaHitMode);
+            if (result.ApplyMinResult)
+            {
+                if (!userTriggered)
+                    drawable.EzApplyPassiveMissWithStoredOffset();
+                else
+                    drawable.EzApplyMinResult();
+
+                return true;
+            }
+
+            if (result.BmsAction.Handled)
+            {
+                if (!userTriggered && result.BmsAction.ApplyFinal)
+                    applyBmsAutoMissFinal(drawable, round, result.BmsAction, bmsState!);
+                else
+                    ApplyBmsAction(drawable, round, result.BmsAction, bmsState!);
+
+                return true;
+            }
+
+            if (result.FinalResult != null)
+            {
+                drawable.EzApplyFinalResult(result.FinalResult.Value, round.Environment.ManiaHitMode);
+                return true;
+            }
+
             return true;
         }
+
+        private static bool applyNoteEvaluation(
+            DrawableNote drawable,
+            ManiaJudgementRound round,
+            ManiaJudgementKernel.NoteEvaluationResult result,
+            BmsHitModeJudgement.BmsRouteState? bmsState,
+            bool userTriggered)
+        {
+            switch (result.Kind)
+            {
+                case ManiaJudgementKernel.NoteEvaluationKind.NotHandled:
+                    return false;
+
+                case ManiaJudgementKernel.NoteEvaluationKind.Ignore:
+                    return true;
+
+                case ManiaJudgementKernel.NoteEvaluationKind.ApplyBmsAction:
+                    if (!userTriggered && result.BmsAction.ApplyFinal)
+                        applyBmsAutoMissFinal(drawable, round, result.BmsAction, bmsState!);
+                    else
+                        ApplyBmsAction(drawable, round, result.BmsAction, bmsState!);
+
+                    return true;
+
+                case ManiaJudgementKernel.NoteEvaluationKind.ApplyNoteOutcome:
+                    ApplyNoteOutcome(drawable, round, result.NoteOutcome, userTriggered);
+                    return true;
+
+                default:
+                    return true;
+            }
+        }
+
+        private static void applyBmsAutoMissFinal(
+            DrawableManiaHitObject drawable,
+            ManiaJudgementRound round,
+            BmsHitModeJudgement.DrawableAction action,
+            BmsHitModeJudgement.BmsRouteState state)
+        {
+            if (!action.Handled || !action.ApplyFinal)
+                return;
+
+            BmsHitModeJudgement.ApplyRouteState(state, action);
+            var result = BmsHitModeJudgement.MapTo(action.Judge);
+            drawable.EzApplyBmsAutoMissFinalWithStoredOffset(result, round.Environment.ManiaHitMode);
+        }
+
+        private static long getFrameStableId(DrawableHitObject drawable)
+            => (long)(drawable.Time.Current * 1000);
     }
 }

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaJudgementKernel.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaJudgementKernel.cs
@@ -1,0 +1,354 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Mania.EzMania.ReplayJudge.Mappings;
+using osu.Game.Rulesets.Mania.Objects.EzCurrentHitObject;
+using osu.Game.Rulesets.Mania.Scoring;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
+{
+    /// <summary>
+    /// Drawable 与 Session 共用的 note / hold-tail 判定内核（Phase D KERNEL-ONE）。
+    /// O2 热路径遵守 O2-NOMUTATE：不调用 <c>UpdateO2JamBpmFromTime</c>。
+    /// </summary>
+    internal static class ManiaJudgementKernel
+    {
+        public enum NoteEvaluationKind
+        {
+            NotHandled,
+            Ignore,
+            ApplyNoteOutcome,
+            ApplyBmsAction,
+        }
+
+        public readonly struct NoteEvaluationRequest
+        {
+            public ManiaJudgementRound Round { get; init; }
+
+            public double TimeOffset { get; init; }
+
+            public HitWindows HitWindows { get; init; }
+
+            public bool UserTriggered { get; init; }
+
+            public bool IsLnHead { get; init; }
+
+            public double EventTime { get; init; }
+
+            /// <summary>Session 等无列级 BPM 缓存时显式传入 press-time BPM。</summary>
+            public double? PressBpm { get; init; }
+
+            public long FrameStableId { get; init; }
+
+            public BmsHitModeJudgement.BmsRouteState? BmsState { get; init; }
+
+            public bool ForcePoorOnTailHoldBreak { get; init; }
+
+            public bool CheckBmsCanRouteOnPress { get; init; }
+
+            /// <summary>Drawable O2 press：已由 <c>PillCheckWithBpm</c> 预检时为 true。</summary>
+            public bool O2PillCheckPassed { get; init; }
+
+            public bool O2UpgradeToPerfect { get; init; }
+        }
+
+        public readonly struct NoteEvaluationResult
+        {
+            public NoteEvaluationKind Kind { get; init; }
+
+            public ManiaNoteJudgementOutcome NoteOutcome { get; init; }
+
+            public BmsHitModeJudgement.DrawableAction BmsAction { get; init; }
+
+            public static NoteEvaluationResult NotHandled => new NoteEvaluationResult { Kind = NoteEvaluationKind.NotHandled };
+
+            public static NoteEvaluationResult Ignore => new NoteEvaluationResult { Kind = NoteEvaluationKind.Ignore };
+
+            public static NoteEvaluationResult FromNoteOutcome(ManiaNoteJudgementOutcome outcome)
+                => new NoteEvaluationResult { Kind = NoteEvaluationKind.ApplyNoteOutcome, NoteOutcome = outcome };
+
+            public static NoteEvaluationResult FromBmsAction(BmsHitModeJudgement.DrawableAction action)
+                => new NoteEvaluationResult { Kind = NoteEvaluationKind.ApplyBmsAction, BmsAction = action };
+        }
+
+        public readonly struct HoldTailEvaluationRequest
+        {
+            public ManiaJudgementRound Round { get; init; }
+
+            public double TimeOffset { get; init; }
+
+            public double RawOffset { get; init; }
+
+            public HitWindows HitWindows { get; init; }
+
+            public bool UserTriggered { get; init; }
+
+            public bool HeadHit { get; init; }
+
+            public bool HoldBroken { get; init; }
+
+            public bool WasHolding { get; init; }
+
+            public bool HasHoldBreak { get; init; }
+
+            public double EventTime { get; init; }
+
+            public double? PressBpm { get; init; }
+
+            public long FrameStableId { get; init; }
+
+            public BmsHitModeJudgement.BmsRouteState? BmsState { get; init; }
+
+            public bool O2PillCheckPassed { get; init; }
+
+            public bool O2UpgradeToPerfect { get; init; }
+        }
+
+        public readonly struct HoldTailEvaluationResult
+        {
+            public bool Handled { get; init; }
+
+            public bool ApplyMinResult { get; init; }
+
+            public HitResult? FinalResult { get; init; }
+
+            public BmsHitModeJudgement.DrawableAction BmsAction { get; init; }
+
+            public static HoldTailEvaluationResult Unhandled => default;
+
+            public static HoldTailEvaluationResult HandledNoOp => new HoldTailEvaluationResult { Handled = true };
+
+            public static HoldTailEvaluationResult MinResult => new HoldTailEvaluationResult { Handled = true, ApplyMinResult = true };
+
+            public static HoldTailEvaluationResult FromResult(HitResult result)
+                => new HoldTailEvaluationResult { Handled = true, FinalResult = result };
+
+            public static HoldTailEvaluationResult FromBmsAction(BmsHitModeJudgement.DrawableAction action)
+                => new HoldTailEvaluationResult { Handled = true, BmsAction = action };
+        }
+
+        public static NoteEvaluationResult EvaluateNote(in NoteEvaluationRequest request)
+        {
+            var round = request.Round;
+            var strategy = round.Strategy;
+
+            if (strategy == null || !round.IsEzHitMode)
+                return NoteEvaluationResult.NotHandled;
+
+            if (strategy is BmsHitModeJudgement bms)
+            {
+                if (request.HitWindows is not ManiaHitWindows maniaWindows || request.BmsState == null)
+                    return NoteEvaluationResult.Ignore;
+
+                var action = request.UserTriggered
+                    ? bms.EvaluatePressAction(
+                        maniaWindows,
+                        request.TimeOffset,
+                        request.BmsState,
+                        round.PoorEnabled,
+                        checkCanRouteOnPress: request.CheckBmsCanRouteOnPress,
+                        forcePoorOnTailHoldBreak: request.ForcePoorOnTailHoldBreak)
+                    : bms.EvaluateAutoMissAction(maniaWindows, request.TimeOffset);
+
+                return NoteEvaluationResult.FromBmsAction(action);
+            }
+
+            if (strategy is O2HitModeJudgement o2)
+            {
+                double pressBpm = resolveO2PressBpm(request);
+
+                if (request.UserTriggered)
+                {
+                    if (round.PillModeEnabled && !request.O2PillCheckPassed)
+                        return NoteEvaluationResult.Ignore;
+
+                    var outcome = o2.EvaluatePress(request.TimeOffset, request.HitWindows, new O2HitModeJudgement.NotePressContext
+                    {
+                        RawOffset = request.TimeOffset,
+                        Bpm = pressBpm,
+                        UsePressTimeBpmForJudgement = true,
+                        PillModeEnabled = round.PillModeEnabled,
+                        PillCheckPassed = !round.PillModeEnabled || request.O2PillCheckPassed,
+                        UpgradeToPerfect = request.O2UpgradeToPerfect,
+                        State = round.MutableState,
+                    });
+
+                    syncO2HudPillCount(round.MutableState);
+                    return NoteEvaluationResult.FromNoteOutcome(outcome);
+                }
+
+                double autoMissBpm = request.PressBpm ?? round.GetO2BpmForAutoMiss(request.EventTime, request.FrameStableId);
+
+                return NoteEvaluationResult.FromNoteOutcome(o2.EvaluateAutoMiss(request.TimeOffset, request.HitWindows, autoMissBpm));
+            }
+
+            if (strategy is Ez2AcHitModeJudgement ez2Ac)
+            {
+                var outcome = request.UserTriggered
+                    ? ez2Ac.EvaluatePress(request.TimeOffset, request.HitWindows, request.IsLnHead)
+                    : ez2Ac.EvaluateAutoMiss(request.TimeOffset, request.HitWindows);
+
+                return NoteEvaluationResult.FromNoteOutcome(outcome);
+            }
+
+            var genericOutcome = request.UserTriggered
+                ? strategy.EvaluatePress(request.TimeOffset, request.HitWindows)
+                : strategy.EvaluateAutoMiss(request.TimeOffset, request.HitWindows);
+
+            return NoteEvaluationResult.FromNoteOutcome(genericOutcome);
+        }
+
+        public static HoldTailEvaluationResult EvaluateHoldTail(in HoldTailEvaluationRequest request)
+        {
+            var round = request.Round;
+            var strategy = round.Strategy;
+
+            if (strategy == null || !round.IsEzHitMode)
+                return HoldTailEvaluationResult.Unhandled;
+
+            if (strategy is MalodyHitModeJudgement)
+            {
+                if (!request.UserTriggered && request.TimeOffset >= 0)
+                    return HoldTailEvaluationResult.FromResult(HitResult.IgnoreHit);
+
+                return HoldTailEvaluationResult.HandledNoOp;
+            }
+
+            if (strategy is BmsHitModeJudgement bms)
+            {
+                if (request.HitWindows is not ManiaHitWindows maniaWindows || request.BmsState == null)
+                    return HoldTailEvaluationResult.HandledNoOp;
+
+                var action = request.UserTriggered
+                    ? bms.EvaluatePressAction(
+                        maniaWindows,
+                        request.TimeOffset,
+                        request.BmsState,
+                        round.PoorEnabled,
+                        checkCanRouteOnPress: false,
+                        forcePoorOnTailHoldBreak: request.HoldBroken && !request.WasHolding)
+                    : bms.EvaluateAutoMissAction(maniaWindows, request.TimeOffset);
+
+                return HoldTailEvaluationResult.FromBmsAction(action);
+            }
+
+            if (strategy is O2HitModeJudgement o2)
+            {
+                double pressBpm = resolveO2PressBpm(request);
+
+                if (!request.UserTriggered)
+                {
+                    if (request.HasHoldBreak)
+                    {
+                        if (request.TimeOffset < 0)
+                            return HoldTailEvaluationResult.HandledNoOp;
+
+                        return HoldTailEvaluationResult.FromResult(O2HitModeJudgement.MapTo(O2Judge.Miss));
+                    }
+
+                    double mult = ManiaJudgementRound.GetTotalMultiplier(request.HitWindows);
+
+                    if (!O2HitModeExtension.CanBeHit(request.TimeOffset, pressBpm, mult))
+                        return HoldTailEvaluationResult.MinResult;
+
+                    return HoldTailEvaluationResult.HandledNoOp;
+                }
+
+                if (round.PillModeEnabled && !request.O2PillCheckPassed)
+                    return HoldTailEvaluationResult.HandledNoOp;
+
+                var judge = o2.EvaluateTailJudge(new HoldTailEvaluationContext
+                {
+                    RawOffset = request.RawOffset,
+                    TimeOffsetForJudgement = request.TimeOffset,
+                    HitWindows = request.HitWindows,
+                    HeadHit = request.HeadHit,
+                    HoldBreak = o2.IsHoldBreak(request.RawOffset, request.HitWindows),
+                    HoldBroken = request.HoldBroken,
+                    WasHoldingBeforeRelease = request.WasHolding,
+                    PillModeEnabled = round.PillModeEnabled,
+                    Bpm = pressBpm,
+                    UsePressTimeBpmForJudgement = true,
+                    State = round.MutableState,
+                });
+
+                syncO2HudPillCount(round.MutableState);
+
+                if (judge == O2Judge.None)
+                    return HoldTailEvaluationResult.HandledNoOp;
+
+                if (request.O2UpgradeToPerfect)
+                    return HoldTailEvaluationResult.FromResult(O2HitModeJudgement.MapTo(O2Judge.Cool));
+
+                return HoldTailEvaluationResult.FromResult(O2HitModeJudgement.MapTo(judge));
+            }
+
+            if (strategy is Ez2AcHitModeJudgement ez2Ac)
+            {
+                bool headMissOrBreak = !request.HeadHit || request.HasHoldBreak;
+
+                if (!request.UserTriggered)
+                {
+                    if (request.TimeOffset < 0)
+                        return HoldTailEvaluationResult.HandledNoOp;
+
+                    if (headMissOrBreak && !request.HitWindows.CanBeHit(request.TimeOffset))
+                        return HoldTailEvaluationResult.MinResult;
+
+                    return HoldTailEvaluationResult.HandledNoOp;
+                }
+
+                var tailJudge = ez2Ac.EvaluateTailJudge(new HoldTailEvaluationContext
+                {
+                    RawOffset = request.RawOffset,
+                    TimeOffsetForJudgement = request.TimeOffset,
+                    HitWindows = request.HitWindows,
+                    HeadHit = request.HeadHit,
+                    HoldBreak = ez2Ac.IsHoldBreak(request.RawOffset, request.HitWindows),
+                    HoldBroken = request.HoldBroken,
+                    WasHoldingBeforeRelease = request.WasHolding,
+                });
+
+                if (tailJudge == Ez2AcJudge.None)
+                {
+                    if (!request.UserTriggered && !request.HitWindows.CanBeHit(request.TimeOffset))
+                        return HoldTailEvaluationResult.MinResult;
+
+                    return HoldTailEvaluationResult.HandledNoOp;
+                }
+
+                return HoldTailEvaluationResult.FromResult(Ez2AcHitModeJudgement.MapTo(tailJudge));
+            }
+
+            var genericResult = strategy.EvaluateTail(new HoldTailEvaluationContext
+            {
+                RawOffset = request.RawOffset,
+                TimeOffsetForJudgement = request.TimeOffset,
+                HitWindows = request.HitWindows,
+                HeadHit = request.HeadHit,
+                HoldBreak = strategy.IsHoldBreak(request.RawOffset, request.HitWindows),
+                HoldBroken = request.HoldBroken,
+                WasHoldingBeforeRelease = request.WasHolding,
+                State = round.MutableState,
+                EventTime = request.EventTime,
+                Bpm = round.O2PressBpm,
+                PillModeEnabled = round.PillModeEnabled,
+            });
+
+            if (genericResult == HitResult.None)
+                return HoldTailEvaluationResult.HandledNoOp;
+
+            return HoldTailEvaluationResult.FromResult(genericResult);
+        }
+
+        private static double resolveO2PressBpm(in NoteEvaluationRequest request)
+            => request.PressBpm ?? request.Round.O2PressBpm;
+
+        private static double resolveO2PressBpm(in HoldTailEvaluationRequest request)
+            => request.PressBpm ?? request.Round.O2PressBpm;
+
+        private static void syncO2HudPillCount(ManiaReplayJudgementState state)
+            => O2HitModeExtension.PILL_COUNT.Value = state.O2PillCount;
+    }
+}

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaReplaySessionSimulator.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaReplaySessionSimulator.cs
@@ -42,6 +42,7 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
 
             bool pillModeEnabled = environment.ManiaHealthMode.ToString().Contains("O2Jam");
             var bms = noteStrategy as BmsHitModeJudgement;
+            var judgementRound = createJudgementRound(environment);
 
             var hitWindowHelper = new HitModeHelper(environment.ManiaHitMode)
             {
@@ -49,7 +50,6 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
                 BPM = getBpmAtTime(beatmap, 0),
             };
 
-            var judgementState = new ManiaReplayJudgementState();
             var headWasHit = new Dictionary<HeadNote, bool>();
             var keyHeldByColumn = new Dictionary<int, bool>();
 
@@ -120,24 +120,54 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
 
                 if (isTail)
                 {
-                    result = holdStrategy.EvaluateTail(new HoldTailEvaluationContext
+                    if (judgementRound.IsEzHitMode)
                     {
-                        RawOffset = rawOffset,
-                        TimeOffsetForJudgement = timeOffsetForJudgement,
-                        HitWindows = target.HitWindows!,
-                        HeadHit = headHit,
-                        HoldBreak = holdBreak,
-                        HoldBroken = selected.HoldBroken,
-                        WasHoldingBeforeRelease = wasHoldingBeforeEvent,
-                        State = judgementState,
-                        EventTime = input.Time,
-                        Bpm = hitWindowHelper.BPM,
-                        PillModeEnabled = pillModeEnabled,
-                        UsePressTimeBpmForJudgement = environment.ManiaHitMode == EzEnumHitMode.O2Jam,
-                    });
+                        var tailEval = ManiaJudgementKernel.EvaluateHoldTail(new ManiaJudgementKernel.HoldTailEvaluationRequest
+                        {
+                            Round = judgementRound,
+                            TimeOffset = timeOffsetForJudgement,
+                            RawOffset = rawOffset,
+                            HitWindows = target.HitWindows!,
+                            UserTriggered = true,
+                            HeadHit = headHit,
+                            HoldBroken = selected.HoldBroken,
+                            WasHolding = wasHoldingBeforeEvent,
+                            HasHoldBreak = holdBreak,
+                            EventTime = input.Time,
+                            PressBpm = hitWindowHelper.BPM,
+                            FrameStableId = (long)(input.Time * 1000),
+                            BmsState = bms != null ? selected.BmsRoute : null,
+                            O2PillCheckPassed = true,
+                        });
 
-                    if (environment.ManiaHitMode == EzEnumHitMode.Lazer && result == HitResult.None)
-                        continue;
+                        if (!tryMapTailEvaluation(tailEval, out result))
+                        {
+                            if (environment.ManiaHitMode == EzEnumHitMode.Lazer)
+                                continue;
+
+                            result = HitResult.None;
+                        }
+                    }
+                    else
+                    {
+                        result = holdStrategy.EvaluateTail(new HoldTailEvaluationContext
+                        {
+                            RawOffset = rawOffset,
+                            TimeOffsetForJudgement = timeOffsetForJudgement,
+                            HitWindows = target.HitWindows!,
+                            HeadHit = headHit,
+                            HoldBreak = holdBreak,
+                            HoldBroken = selected.HoldBroken,
+                            WasHoldingBeforeRelease = wasHoldingBeforeEvent,
+                            State = judgementRound.MutableState,
+                            EventTime = input.Time,
+                            Bpm = hitWindowHelper.BPM,
+                            PillModeEnabled = pillModeEnabled,
+                        });
+
+                        if (environment.ManiaHitMode == EzEnumHitMode.Lazer && result == HitResult.None)
+                            continue;
+                    }
                 }
                 else if (bms != null && target.HitWindows is ManiaHitWindows bmsWindows)
                 {
@@ -162,13 +192,33 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
                     result = BmsHitModeJudgement.MapTo(sessionOutcome.Judge);
                     selected.BmsRoute.CanRouteToKPoor = sessionOutcome.EnableCanRouteToKPoor;
                 }
+                else if (judgementRound.IsEzHitMode)
+                {
+                    var noteEval = ManiaJudgementKernel.EvaluateNote(new ManiaJudgementKernel.NoteEvaluationRequest
+                    {
+                        Round = judgementRound,
+                        TimeOffset = timeOffsetForJudgement,
+                        HitWindows = target.HitWindows!,
+                        UserTriggered = true,
+                        IsLnHead = target is HeadNote,
+                        EventTime = input.Time,
+                        PressBpm = hitWindowHelper.BPM,
+                        FrameStableId = (long)(input.Time * 1000),
+                        BmsState = bms != null ? selected.BmsRoute : null,
+                        O2PillCheckPassed = true,
+                    });
+
+                    if (!tryMapNoteEvaluation(noteEval, out result))
+                        continue;
+                }
                 else
                 {
-                    result = evaluateNotePress(
-                        target, noteStrategy, timeOffsetForJudgement, rawOffset, judgementState, hitWindowHelper.BPM, pillModeEnabled, environment.ManiaHitMode);
+                    var outcome = noteStrategy.EvaluatePress(timeOffsetForJudgement, target.HitWindows!);
 
-                    if (result == HitResult.None)
+                    if (outcome.Kind != ManiaNoteJudgementOutcomeKind.Apply)
                         continue;
+
+                    result = outcome.Result;
                 }
 
                 foreach (var forced in ForceMissEarlier(laneStates, target.StartTime))
@@ -229,42 +279,71 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
             }
         }
 
-        private static HitResult evaluateNotePress(
-            HitObject target,
-            IManiaNoteJudgementStrategy noteStrategy,
-            double timeOffsetForJudgement,
-            double rawOffset,
-            ManiaReplayJudgementState state,
-            double bpm,
-            bool pillModeEnabled,
-            EzEnumHitMode hitMode)
+        private static ManiaJudgementRound createJudgementRound(IGameplayEnvironment environment)
         {
-            ManiaNoteJudgementOutcome outcome;
-
-            if (hitMode == EzEnumHitMode.O2Jam && noteStrategy is O2HitModeJudgement o2)
+            GameplayEnvironment gameplay = environment as GameplayEnvironment ?? new GameplayEnvironment
             {
-                outcome = o2.EvaluatePress(timeOffsetForJudgement, target.HitWindows!, new O2HitModeJudgement.NotePressContext
-                {
-                    RawOffset = rawOffset,
-                    Bpm = bpm,
-                    UsePressTimeBpmForJudgement = true,
-                    PillModeEnabled = pillModeEnabled,
-                    State = state,
-                });
-            }
-            else if (hitMode == EzEnumHitMode.EZ2AC && noteStrategy is Ez2AcHitModeJudgement ez2Ac)
+                ManiaHitMode = environment.ManiaHitMode,
+                ManiaHealthMode = environment.ManiaHealthMode,
+                JudgePrecedence = environment.JudgePrecedence,
+                OffsetPlusMania = environment.OffsetPlusMania,
+                BmsPoorHitResultEnable = environment.BmsPoorHitResultEnable,
+            };
+
+            return ManiaJudgementRound.Create(gameplay);
+        }
+
+        private static bool tryMapNoteEvaluation(ManiaJudgementKernel.NoteEvaluationResult evaluation, out HitResult result)
+        {
+            result = default;
+
+            switch (evaluation.Kind)
             {
-                outcome = ez2Ac.EvaluatePress(timeOffsetForJudgement, target.HitWindows!, target is HeadNote);
+                case ManiaJudgementKernel.NoteEvaluationKind.ApplyNoteOutcome:
+                    if (evaluation.NoteOutcome.Kind != ManiaNoteJudgementOutcomeKind.Apply)
+                        return false;
+
+                    result = evaluation.NoteOutcome.Result;
+                    return true;
+
+                case ManiaJudgementKernel.NoteEvaluationKind.ApplyBmsAction:
+                    if (!evaluation.BmsAction.Handled || !evaluation.BmsAction.ApplyFinal)
+                        return false;
+
+                    result = BmsHitModeJudgement.MapTo(evaluation.BmsAction.Judge);
+                    return result != HitResult.None;
+
+                default:
+                    return false;
             }
-            else
+        }
+
+        private static bool tryMapTailEvaluation(ManiaJudgementKernel.HoldTailEvaluationResult evaluation, out HitResult result)
+        {
+            result = default;
+
+            if (!evaluation.Handled)
+                return false;
+
+            if (evaluation.ApplyMinResult)
             {
-                outcome = noteStrategy.EvaluatePress(timeOffsetForJudgement, target.HitWindows!);
+                result = HitResult.Miss;
+                return true;
             }
 
-            if (outcome.Kind == ManiaNoteJudgementOutcomeKind.None)
-                return HitResult.None;
+            if (evaluation.FinalResult != null)
+            {
+                result = evaluation.FinalResult.Value;
+                return result != HitResult.None;
+            }
 
-            return outcome.Result;
+            if (evaluation.BmsAction.Handled && evaluation.BmsAction.ApplyFinal)
+            {
+                result = BmsHitModeJudgement.MapTo(evaluation.BmsAction.Judge);
+                return result != HitResult.None;
+            }
+
+            return false;
         }
 
         private static LaneTargetState? selectCandidate(

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/Mappings/BmsHitModeJudgement.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/Mappings/BmsHitModeJudgement.cs
@@ -136,46 +136,23 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge.Mappings
             return DrawableAction.Extra(BmsJudge.KPoor, clearCanRouteToKPoor: true);
         }
 
+        public DrawableAction EvaluateAutoMissAction(ManiaHitWindows windows, double timeOffset)
+            => toDrawableAction(evaluatePressCore(windows, timeOffset, state: null, poorEnabled: false, autoMiss: true, forcePoorOnTailHoldBreak: false, checkCanRouteOnPress: false));
+
+        public DrawableAction EvaluatePressAction(
+            ManiaHitWindows windows,
+            double timeOffset,
+            BmsRouteState state,
+            bool poorEnabled,
+            bool checkCanRouteOnPress,
+            bool forcePoorOnTailHoldBreak = false)
+            => toDrawableAction(evaluatePressCore(windows, timeOffset, state, poorEnabled, autoMiss: false, forcePoorOnTailHoldBreak, checkCanRouteOnPress));
+
         public DrawableAction EvaluateDrawableAutoMiss(ManiaHitWindows windows, double timeOffset)
-        {
-            double badLate = WindowFor(windows, BmsJudge.Bad, false);
-
-            if (shouldAutoMiss(windows, timeOffset, badLate))
-                return DrawableAction.Final(BmsJudge.Poor);
-
-            return DrawableAction.Ignore;
-        }
+            => EvaluateAutoMissAction(windows, timeOffset);
 
         public DrawableAction EvaluateDrawablePress(ManiaHitWindows windows, double timeOffset, BmsRouteState state, bool poorEnabled, bool forcePoorOnTailHoldBreak = false)
-        {
-            double badLate = WindowFor(windows, BmsJudge.Bad, false);
-
-            if (poorEnabled && state.CanRouteToKPoor && windows.IsHitResultAllowed(MapTo(BmsJudge.KPoor)))
-                return DrawableAction.Extra(BmsJudge.KPoor, clearCanRouteToKPoor: true);
-
-            var judge = resolvePressedJudge(windows, timeOffset, badLate);
-
-            if (judge == BmsJudge.None)
-                return DrawableAction.Ignore;
-
-            if (forcePoorOnTailHoldBreak)
-                judge = BmsJudge.Poor;
-
-            if (judge == BmsJudge.KPoor)
-            {
-                if (!poorEnabled || !windows.IsHitResultAllowed(MapTo(BmsJudge.KPoor)))
-                    return DrawableAction.Ignore;
-
-                bool isLatePress = IsLateOutsideBad(timeOffset, badLate);
-
-                if (!isLatePress || !state.HasLateKPoor)
-                    return DrawableAction.Extra(BmsJudge.KPoor, setHasLateKPoor: isLatePress);
-
-                return DrawableAction.Ignore;
-            }
-
-            return DrawableAction.Final(judge, setCanRouteToKPoor: judge == BmsJudge.Bad && timeOffset < 0 && poorEnabled);
-        }
+            => EvaluatePressAction(windows, timeOffset, state, poorEnabled, checkCanRouteOnPress: true, forcePoorOnTailHoldBreak: forcePoorOnTailHoldBreak);
 
         public static void ApplyRouteState(BmsRouteState state, DrawableAction action)
         {
@@ -190,35 +167,7 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge.Mappings
         }
 
         internal SessionPressOutcome EvaluateSessionPress(ManiaHitWindows windows, double timeOffset, BmsRouteState state, bool poorEnabled)
-        {
-            var outcome = EvaluatePress(timeOffset, windows);
-
-            if (outcome.Kind == ManiaNoteJudgementOutcomeKind.None)
-                return default;
-
-            var judge = FromHitResult(outcome.Result);
-
-            if (outcome.Kind == ManiaNoteJudgementOutcomeKind.DispatchExtra)
-            {
-                double badLate = WindowFor(windows, BmsJudge.Bad, false);
-                bool isLatePress = IsLateOutsideBad(timeOffset, badLate);
-
-                if (isLatePress && state.HasLateKPoor)
-                    return default;
-
-                if (isLatePress)
-                    state.HasLateKPoor = true;
-
-                return new SessionPressOutcome { Kind = SessionPressKind.DispatchExtra, Judge = judge };
-            }
-
-            return new SessionPressOutcome
-            {
-                Kind = SessionPressKind.ApplyFinal,
-                Judge = judge,
-                EnableCanRouteToKPoor = judge == BmsJudge.Bad && timeOffset < 0 && poorEnabled,
-            };
-        }
+            => toSessionOutcome(evaluatePressCore(windows, timeOffset, state, poorEnabled, autoMiss: false, forcePoorOnTailHoldBreak: false, checkCanRouteOnPress: false), state);
 
         internal bool TryRoutePostBadKPoor(
             IReadOnlyList<LaneTargetState> laneStates,
@@ -338,6 +287,124 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge.Mappings
 
         private static bool shouldAutoMiss(ManiaHitWindows windows, double timeOffset, double badLate)
             => windows.ResultFor(timeOffset) == HitResult.None && IsLateOutsideBad(timeOffset, badLate);
+
+        private enum BmsPressCoreKind
+        {
+            None,
+            Ignore,
+            ApplyFinal,
+            DispatchExtra,
+        }
+
+        private readonly struct BmsPressCoreResult
+        {
+            public BmsPressCoreKind Kind { get; init; }
+
+            public BmsJudge Judge { get; init; }
+
+            public bool? SetCanRouteToKPoor { get; init; }
+
+            public bool? SetHasLateKPoor { get; init; }
+
+            public bool ClearCanRouteToKPoor { get; init; }
+        }
+
+        private static BmsPressCoreResult evaluatePressCore(
+            ManiaHitWindows windows,
+            double timeOffset,
+            BmsRouteState? state,
+            bool poorEnabled,
+            bool autoMiss,
+            bool forcePoorOnTailHoldBreak,
+            bool checkCanRouteOnPress)
+        {
+            double badLate = WindowFor(windows, BmsJudge.Bad, false);
+
+            if (autoMiss)
+            {
+                if (shouldAutoMiss(windows, timeOffset, badLate))
+                    return new BmsPressCoreResult { Kind = BmsPressCoreKind.ApplyFinal, Judge = BmsJudge.Poor };
+
+                return new BmsPressCoreResult { Kind = BmsPressCoreKind.Ignore };
+            }
+
+            if (checkCanRouteOnPress && state != null && poorEnabled && state.CanRouteToKPoor && windows.IsHitResultAllowed(MapTo(BmsJudge.KPoor)))
+                return new BmsPressCoreResult { Kind = BmsPressCoreKind.DispatchExtra, Judge = BmsJudge.KPoor, ClearCanRouteToKPoor = true };
+
+            var judge = resolvePressedJudge(windows, timeOffset, badLate);
+
+            if (judge == BmsJudge.None)
+                return new BmsPressCoreResult { Kind = BmsPressCoreKind.Ignore };
+
+            if (forcePoorOnTailHoldBreak)
+                judge = BmsJudge.Poor;
+
+            if (judge == BmsJudge.KPoor)
+            {
+                if (!poorEnabled || !windows.IsHitResultAllowed(MapTo(BmsJudge.KPoor)))
+                    return new BmsPressCoreResult { Kind = BmsPressCoreKind.Ignore };
+
+                bool isLatePress = IsLateOutsideBad(timeOffset, badLate);
+
+                if (state != null && isLatePress && state.HasLateKPoor)
+                    return new BmsPressCoreResult { Kind = BmsPressCoreKind.None };
+
+                return new BmsPressCoreResult
+                {
+                    Kind = BmsPressCoreKind.DispatchExtra,
+                    Judge = BmsJudge.KPoor,
+                    SetHasLateKPoor = isLatePress,
+                };
+            }
+
+            return new BmsPressCoreResult
+            {
+                Kind = BmsPressCoreKind.ApplyFinal,
+                Judge = judge,
+                SetCanRouteToKPoor = judge == BmsJudge.Bad && timeOffset < 0 && poorEnabled,
+            };
+        }
+
+        private static DrawableAction toDrawableAction(BmsPressCoreResult core)
+        {
+            switch (core.Kind)
+            {
+                case BmsPressCoreKind.Ignore:
+                    return DrawableAction.Ignore;
+
+                case BmsPressCoreKind.ApplyFinal:
+                    return DrawableAction.Final(core.Judge, setCanRouteToKPoor: core.SetCanRouteToKPoor);
+
+                case BmsPressCoreKind.DispatchExtra:
+                    return DrawableAction.Extra(core.Judge, setHasLateKPoor: core.SetHasLateKPoor, clearCanRouteToKPoor: core.ClearCanRouteToKPoor);
+
+                default:
+                    return DrawableAction.NotHandled;
+            }
+        }
+
+        private static SessionPressOutcome toSessionOutcome(BmsPressCoreResult core, BmsRouteState state)
+        {
+            switch (core.Kind)
+            {
+                case BmsPressCoreKind.ApplyFinal:
+                    return new SessionPressOutcome
+                    {
+                        Kind = SessionPressKind.ApplyFinal,
+                        Judge = core.Judge,
+                        EnableCanRouteToKPoor = core.SetCanRouteToKPoor == true,
+                    };
+
+                case BmsPressCoreKind.DispatchExtra:
+                    if (core.SetHasLateKPoor == true)
+                        state.HasLateKPoor = true;
+
+                    return new SessionPressOutcome { Kind = SessionPressKind.DispatchExtra, Judge = core.Judge };
+
+                default:
+                    return default;
+            }
+        }
 
         private static BmsJudge resolvePressedJudge(ManiaHitWindows windows, double timeOffset, double badLate)
         {

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableManiaHitObject.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableManiaHitObject.cs
@@ -12,6 +12,8 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Timing;
 using osu.Game.Audio;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.Rulesets.Mania.EzMania.Helper;
 using osu.Game.Rulesets.Mania.EzMania.ReplayJudge;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
@@ -149,6 +151,23 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                     r.IsComboHit = false;
                 },
                 0,
+                ManiaDrawableMissTiming.ResolveStoredOffset(this));
+        }
+
+        internal void EzApplyBmsAutoMissFinalWithStoredOffset(HitResult result, EzEnumHitMode hitMode)
+        {
+            ApplyResultWithStoredTiming(
+                static (r, data) =>
+                {
+                    r.Type = data.result;
+
+                    if (data.result == HitResult.Miss
+                        || (data.result == HitResult.Meh && HitModeHelper.MehBreaksCombo(data.hitMode)))
+                    {
+                        r.IsComboHit = false;
+                    }
+                },
+                (result, hitMode),
                 ManiaDrawableMissTiming.ResolveStoredOffset(this));
         }
 

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.EzTiming.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.EzTiming.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
             if (Result.HasResult)
                 throw new InvalidOperationException("Cannot apply result on a hitobject that already has a result.");
 
-            application?.Invoke(Result, state);
+            application.Invoke(Result, state);
 
             if (!Result.HasResult)
                 throw new InvalidOperationException($"{GetType().Name} applied a {nameof(JudgementResult)} but did not update {nameof(JudgementResult.Type)}.");


### PR DESCRIPTION
## Summary

- 引入 `ManiaJudgementKernel`：Drawable / Session 共用 note 与 hold-tail 判定路径。
- `ManiaEzDrawableJudgement` 收敛为 kernel 薄封装；Session simulator 走 kernel。
- `BmsHitModeJudgement` 抽出 `evaluatePressCore` / `EvaluatePressAction`。
- **无** `syncO2HitWindowsBpm`（O2 press BPM 来自 `round.O2PressBpm`）。
- IIDX 叠键 BMS auto-miss 保留 stored offset parity。

## Commits

1. `feat(mania): Phase D ManiaJudgementKernel`

> 建议在 #77（mania-perf-fix）合并后再合本 PR；合入前 diff 含 perf-fix 3 提交 + 本提交。

## Test plan

- [x] `dotnet build osu.Game.Rulesets.Mania`
- [x] ReplayJudge / Parity / Precedence / ManiaLaneController 相关测试 124/124
