### PR TITLE
feat(mania): LANE-PRECEDENCE、COLUMN-INPUT 与 miss TimeOffset parity

### DIFF
--- a/osu.Game.Benchmarks/BenchmarkManiaReplaySession.cs
+++ b/osu.Game.Benchmarks/BenchmarkManiaReplaySession.cs
@@ -18,27 +18,33 @@ namespace osu.Game.Benchmarks
 {
     /// <summary>
     /// P2-B: ManiaReplaySessionService 性能基准测试
-    /// Phase 3 备忘：默认采用 timeline + QueryAtTime（EzScoreRaceService）；
-    /// 若需对比增量 Session（方案 B），可在此增加 AdvanceTo 整局基准。
+    /// BENCH-KPS：含高密度 jack（80ms × 4K）与三档 JudgePrecedence 场景。
     /// </summary>
     public class BenchmarkManiaReplaySession : BenchmarkTest
     {
         private ManiaReplaySessionService sessionService = null!;
         private IBeatmap beatmap = null!;
+        private IBeatmap jackBeatmap = null!;
         private Score score = null!;
+        private Score jackScore = null!;
+
+        [Params(EzEnumJudgePrecedence.Earliest, EzEnumJudgePrecedence.Combo, EzEnumJudgePrecedence.Duration)]
+        public EzEnumJudgePrecedence BenchPrecedence { get; set; }
 
         public override void SetUp()
         {
             base.SetUp();
 
             sessionService = new ManiaReplaySessionService();
-            beatmap = createTestBeatmap();
+            beatmap = createTestBeatmap(noteSpacingMs: 500, noteCount: 200);
+            jackBeatmap = createTestBeatmap(noteSpacingMs: 80, noteCount: 400);
             score = createTestScore(beatmap);
+            jackScore = createTestScore(jackBeatmap);
 
             var environment = GlobalConfigStore.EzConfig.ResolveEnvironment(ReplayRunPurpose.ForStored, score.ScoreInfo);
             GlobalConfigStore.EzConfig.SetValue(Ez2Setting.ManiaHitMode, environment.ManiaHitMode);
             GlobalConfigStore.EzConfig.SetValue(Ez2Setting.ManiaHealthMode, environment.ManiaHealthMode);
-            GlobalConfigStore.EzConfig.SetValue(Ez2Setting.JudgePrecedence, environment.JudgePrecedence);
+            GlobalConfigStore.EzConfig.SetValue(Ez2Setting.JudgePrecedence, BenchPrecedence);
             GlobalConfigStore.EzConfig.SetValue(Ez2Setting.BmsPoorHitResultEnable, environment.BmsPoorHitResultEnable);
         }
 
@@ -64,7 +70,21 @@ namespace osu.Game.Benchmarks
             ).ConfigureAwait(true);
         }
 
-        private static IBeatmap createTestBeatmap()
+        /// <summary>
+        /// 高密度 jack：80ms 间距 4K，约 90 KPS 量级 Session 吞吐基线。
+        /// </summary>
+        [Benchmark]
+        public async Task<Score> BenchmarkJackRunAsync()
+        {
+            return await sessionService.RunAsync(
+                jackScore.DeepClone(),
+                jackBeatmap,
+                ReplayRunPurpose.ForStored,
+                CancellationToken.None
+            ).ConfigureAwait(true);
+        }
+
+        private static IBeatmap createTestBeatmap(int noteSpacingMs, int noteCount)
         {
             var ruleset = new ManiaRuleset();
             var beatmap = new Beatmap
@@ -80,13 +100,12 @@ namespace osu.Game.Benchmarks
                 }
             };
 
-            // 添加一些测试 note（模拟中等长度谱面）
-            for (int i = 0; i < 200; i++)
+            for (int i = 0; i < noteCount; i++)
             {
                 beatmap.HitObjects.Add(new Note
                 {
-                    StartTime = i * 500, // 每 500ms 一个 note，总共 100 秒
-                    Column = i % 4 // 4K 模式
+                    StartTime = i * noteSpacingMs,
+                    Column = i % 4
                 });
             }
 
@@ -103,15 +122,12 @@ namespace osu.Game.Benchmarks
                 TotalScore = 1000000,
             };
 
-            // 创建 replay frames（与 beatmap hit objects 对应）
             var replay = new Replay();
 
             foreach (var hitObject in beatmap.HitObjects)
             {
                 if (hitObject is Note note)
-                {
                     replay.Frames.Add(new ManiaReplayFrame(note.StartTime));
-                }
             }
 
             return new Score { ScoreInfo = scoreInfo, Replay = replay };

--- a/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/ManiaLaneControllerTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/ManiaLaneControllerTest.cs
@@ -2,9 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.Rulesets.Mania.EzMania.Helper;
 using osu.Game.Rulesets.Mania.EzMania.ReplayJudge;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mania.Objects.Drawables;
+using osu.Game.Rulesets.Mania.Scoring;
 
 namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
 {
@@ -23,8 +26,7 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
         public void TestRegisterIfNeededSkipsDuplicate()
         {
             var controller = new ManiaLaneController();
-            var drawable = new DrawableNote();
-            drawable.Apply(new Note { StartTime = 1000 });
+            var drawable = createNote(1000);
 
             controller.RegisterIfNeeded(drawable);
             controller.RegisterIfNeeded(drawable);
@@ -36,14 +38,75 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
         public void TestUnregisterByHitObject()
         {
             var controller = new ManiaLaneController();
-            var note = new Note { StartTime = 1000 };
-            var drawable = new DrawableNote();
-            drawable.Apply(note);
+            var drawable = createNote(1000);
 
             controller.Register(drawable);
-            controller.UnregisterByHitObject(note);
+            controller.UnregisterByHitObject(drawable.HitObject);
 
             Assert.That(controller.Entries, Is.Empty);
+        }
+
+        [Test]
+        public void TestSelectPressEntryComboMatchesSelectFold()
+        {
+            var controller = new ManiaLaneController();
+            var early = createNote(1000);
+            var late = createNote(1100);
+            controller.Register(early);
+            controller.Register(late);
+
+            double pressTime = 1050;
+            var overlapping = controller.CollectOverlappingEntries(pressTime);
+
+            var expected = OrderedHitPolicyHelper.SelectFold(
+                overlapping,
+                e => e.IsPressJudged,
+                e => e.StartTime,
+                e => e.PressWindows!,
+                pressTime,
+                comboAlgorithm: true);
+
+            var selected = controller.SelectPressEntry(pressTime, EzEnumJudgePrecedence.Combo, allowBmsFallbackToEarliest: false);
+
+            Assert.That(selected, Is.SameAs(expected));
+        }
+
+        [Test]
+        public void TestSelectPressEntryDurationMatchesSelectFold()
+        {
+            var controller = new ManiaLaneController();
+            var early = createNote(1000);
+            var late = createNote(1200);
+            controller.Register(early);
+            controller.Register(late);
+
+            double pressTime = 1150;
+            var overlapping = controller.CollectOverlappingEntries(pressTime);
+
+            var expected = OrderedHitPolicyHelper.SelectFold(
+                overlapping,
+                e => e.IsPressJudged,
+                e => e.StartTime,
+                e => e.PressWindows!,
+                pressTime,
+                comboAlgorithm: false);
+
+            var selected = controller.SelectPressEntry(pressTime, EzEnumJudgePrecedence.Duration, allowBmsFallbackToEarliest: false);
+
+            Assert.That(selected, Is.SameAs(expected));
+        }
+
+        private static DrawableNote createNote(double startTime)
+        {
+            var note = new Note
+            {
+                StartTime = startTime,
+                HitWindows = new ManiaHitWindows(EzEnumHitMode.Lazer)
+            };
+
+            var drawable = new DrawableNote();
+            drawable.Apply(note);
+            return drawable;
         }
     }
 }

--- a/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/ManiaReplayMissOffsetTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/ManiaReplayMissOffsetTest.cs
@@ -29,6 +29,16 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
         public void SetUp() => ReplayJudgeTestConfig.ApplyToGlobalConfig(LazerTapReplayFixtures.CreateTwoNoteColumnTap().environment);
 
         [Test]
+        public void TestOverlappingJackSessionIncludesMiddleMiss()
+        {
+            var (score, beatmap, environment) = JudgePrecedenceReplayFixtures.CreateOverlappingJack(
+                EzEnumHitMode.Lazer, EzEnumHealthMode.Lazer, EzEnumJudgePrecedence.Earliest);
+            var events = ManiaReplaySession.RunHitEvents(score, beatmap, environment);
+            Assert.That(events.Any(e => e.HitObject.StartTime == 1080 && e.Result == HitResult.Miss), Is.True,
+                () => ManiaReplayParityHelper.DescribeHitEvents(events));
+        }
+
+        [Test]
         public void TestForceMissEarlierMissesHaveDistinctStoredOffsets()
         {
             var (score, beatmap, environment) = createSkipFirstNoteTap();

--- a/osu.Game.Rulesets.Mania/EzMania/Diagnostics/ManiaJudgeHotPathTrace.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/Diagnostics/ManiaJudgeHotPathTrace.cs
@@ -1,0 +1,85 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading;
+using osu.Game.EzOsuGame.Diagnostics;
+
+namespace osu.Game.Rulesets.Mania.EzMania.Diagnostics
+{
+    /// <summary>
+    /// 高 KPS 判定热路径计数（TRACE-JUDGE）。与 <see cref="EzJudgmentDiagnostics.Enabled"/> 联动。
+    /// </summary>
+    public static class ManiaJudgeHotPathTrace
+    {
+        private static long isHittableCalls;
+        private static long checkForResultCalls;
+        private static long o2BpmLookups;
+        private static long drawableOnPressedCalls;
+        private static long columnOnPressedCalls;
+        private static long autoMissSkipped;
+
+        public static bool Enabled => EzJudgmentDiagnostics.Enabled;
+
+        public static long IsHittableCalls => Interlocked.Read(ref isHittableCalls);
+
+        public static long CheckForResultCalls => Interlocked.Read(ref checkForResultCalls);
+
+        public static long O2BpmLookups => Interlocked.Read(ref o2BpmLookups);
+
+        public static long DrawableOnPressedCalls => Interlocked.Read(ref drawableOnPressedCalls);
+
+        public static long ColumnOnPressedCalls => Interlocked.Read(ref columnOnPressedCalls);
+
+        public static long AutoMissSkipped => Interlocked.Read(ref autoMissSkipped);
+
+        public static void RecordIsHittable()
+        {
+            if (Enabled)
+                Interlocked.Increment(ref isHittableCalls);
+        }
+
+        public static void RecordCheckForResult()
+        {
+            if (Enabled)
+                Interlocked.Increment(ref checkForResultCalls);
+        }
+
+        public static void RecordO2BpmLookup()
+        {
+            if (Enabled)
+                Interlocked.Increment(ref o2BpmLookups);
+        }
+
+        public static void RecordDrawableOnPressed()
+        {
+            if (Enabled)
+                Interlocked.Increment(ref drawableOnPressedCalls);
+        }
+
+        public static void RecordColumnOnPressed()
+        {
+            if (Enabled)
+                Interlocked.Increment(ref columnOnPressedCalls);
+        }
+
+        public static void RecordAutoMissSkipped()
+        {
+            if (Enabled)
+                Interlocked.Increment(ref autoMissSkipped);
+        }
+
+        public static void Clear()
+        {
+            Interlocked.Exchange(ref isHittableCalls, 0);
+            Interlocked.Exchange(ref checkForResultCalls, 0);
+            Interlocked.Exchange(ref o2BpmLookups, 0);
+            Interlocked.Exchange(ref drawableOnPressedCalls, 0);
+            Interlocked.Exchange(ref columnOnPressedCalls, 0);
+            Interlocked.Exchange(ref autoMissSkipped, 0);
+        }
+
+        public static string FormatSummary()
+            => $"IsHittable={IsHittableCalls} CheckForResult={CheckForResultCalls} O2Bpm={O2BpmLookups} "
+               + $"ColPress={ColumnOnPressedCalls} DPress={DrawableOnPressedCalls} AutoMissSkip={AutoMissSkipped}";
+    }
+}

--- a/osu.Game.Rulesets.Mania/EzMania/Helper/OrderedHitPolicyHelper.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/Helper/OrderedHitPolicyHelper.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Logging;
 using osu.Game.EzOsuGame.Configuration;
+using osu.Game.Rulesets.Mania.EzMania.ReplayJudge;
 using osu.Game.Rulesets.Mania.Objects.Drawables;
 using osu.Game.Rulesets.Mania.Scoring;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -21,12 +22,14 @@ namespace osu.Game.Rulesets.Mania.EzMania.Helper
     public class OrderedHitPolicyHelper
     {
         private readonly HitObjectContainer hitObjectContainer;
+        private readonly ManiaLaneController? laneController;
         private readonly Ez2ConfigManager ezConfig;
         private const string log_prefix = "[JudgeDiag][PolicyHelper]";
 
-        public OrderedHitPolicyHelper(HitObjectContainer hitObjectContainer)
+        public OrderedHitPolicyHelper(HitObjectContainer hitObjectContainer, ManiaLaneController? laneController = null)
         {
             this.hitObjectContainer = hitObjectContainer;
+            this.laneController = laneController;
             ezConfig = GlobalConfigStore.EzConfig;
         }
 
@@ -40,6 +43,9 @@ namespace osu.Game.Rulesets.Mania.EzMania.Helper
         public bool IsHittableWithPrecedence(DrawableHitObject hitObject, double time)
         {
             var judgePrecedence = ezConfig.Get<EzEnumJudgePrecedence>(Ez2Setting.JudgePrecedence);
+
+            if (laneController != null && hitObject is not DrawableHoldNoteTail)
+                return laneController.IsHittable(hitObject, time, judgePrecedence, isBMS());
 
             if (isBMS())
             {

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/HIGH_KPS_JUDGE_BACKLOG.md
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/HIGH_KPS_JUDGE_BACKLOG.md
@@ -1,12 +1,12 @@
 # Mania 高 KPS 判定性能 — 代号 backlog
 
 > **定位**：高密度谱面 / 高按键吞吐（社区口径可达 ~90 KPS 量级）下的**全 HitMode**热路径优化清单。  
-> **与主题关系**：依附「局内冻结判定平面」主线（`ManiaJudgementRound` → `ManiaLaneController` → `ManiaJudgementKernel`），**不**替代架构重构；本文件只记录性能专项，方案细节以后单独开文档。  
-> **黄金标准不变**：任何优化不得破坏 `TestSceneReplaySessionParity` / `ManiaCrossSourceInvariantTest`。
+> **与主题关系**：依附「局内冻结判定平面」主线（`ManiaJudgementRound` → `ManiaLaneController` → `ManiaJudgementKernel`），**不**替代架构重构；本文件只记录性能专项。  
+> **黄金标准不变**：任何优化不得破坏 `TestSceneReplaySessionParity` / `ManiaCrossSourceInvariantTest` / `ManiaJudgePrecedenceParityTest`。
 
 ---
 
-## 已落地（主线 Phase A/B，全模式受益）
+## 已落地（主线 Phase A–C）
 
 | 代号 | 内容 | 受益 HitMode |
 |------|------|----------------|
@@ -15,71 +15,67 @@
 | **WINDOW-BAKE** | `ManiaWindowBaker.Align` 开局对齐 HitMode + 非 O2 窗口 | 全部 Ez + Session |
 | **O2-NOMUTATE** | O2 用户判定走 `ResultFor(bpm)`，去掉 per-note `updateWindows()` | O2Jam |
 | **O2-FRAME-BPM** | auto-miss 同帧共享一次 `GetBPMAtTime` | O2Jam |
-| **LANE-CURSOR** | Earliest：`ManiaLaneController` 列内有序目标 + 游标；`OrderedHitPolicy` / Session 共用 `IsHittableEarliest` | **全部**（Earliest） | Combo/Duration 仍走 `OrderedHitPolicyHelper` 全列扫描。 |
+| **LANE-CURSOR** | Earliest：`ManiaLaneController` 列内有序目标 + 游标 | 全部（Earliest） |
+| **LANE-PRECEDENCE** | Combo / Duration / BMS post-Bad：`CollectOverlappingEntries` + `SelectPressEntry`；Session `ManiaLanePressSelector` | 全部 |
+| **COLUMN-INPUT** | `Column.OnPressed` → `TryRoutePress` → 单 target；`ManiaKeyBindingContainer` 列优先队列；drawable `ShouldSkipColumnRoutedPress` 兜底 | 全部 |
+| **TRACE-JUDGE** | `ManiaJudgeHotPathTrace`（`IsHittable` / `CheckForResult` / O2 BPM / press 计数） | 观测 |
+| **BENCH-KPS** | `BenchmarkManiaReplaySession`：jack 80ms×4K + 三档 `JudgePrecedence` | 观测 |
 
 ---
 
-## 待办（按优先级，全 HitMode 视角）
+## 暂缓（Phase D — 性能回归，profile 后再议）
 
-### P0 — 与主线 Phase C 绑定（高 KPS 主瓶颈）
+| 代号 | 说明 |
+|------|------|
+| **KERNEL-ONE** | `ManiaJudgementKernel` Ez note/hold-tail 单源 |
+| **DRAWABLE-THIN** | Drawable `CheckForResult` 收敛为 kernel → ApplyResult |
+| **STATE-ONE** | O2 Pill / BMS KPoor 路由状态合并进 `ManiaReplayJudgementState` |
 
-| 代号 | TODO | 涉及 HitMode | 说明 |
-|------|------|----------------|------|
-| **COLUMN-INPUT** | [ ] 按键入口收敛到 `Column.OnPressed`：`selectTarget` → 单 drawable `UpdateResult` | **全部** | Earliest 下 `CheckHittable` 已 O(1) 拒绝非游标 note；输入仍冒泡到各 drawable。 |
-| **LANE-PRECEDENCE** | [ ] Combo / Duration：`ManiaLaneController` 列级目标选择，替代 `OrderedHitPolicyHelper` 全列 `AliveObjects` 扫描 | **全部**（Combo/Duration） | 高叠键列上 note-lock 扫描是 90 KPS 主瓶颈；依赖 `LANE-CURSOR` 列内有序结构。 |
+---
 
-### P1 — 与主线 Phase D 绑定（正确性 + 间接减负）
-
-| 代号 | TODO | 涉及 HitMode | 说明 |
-|------|------|----------------|------|
-| **KERNEL-ONE** | [ ] `ManiaJudgementKernel`：合并 `EvaluateDrawable*` / `EvaluateSession*` 为单一 `EvaluatePress` / `EvaluateTail` | 全部 Ez | 减少热路径分支与重复上下文构造；Session/Drawable 单源利于后续 profile。 |
-| **DRAWABLE-THIN** | [ ] Drawable `CheckForResult` 收敛为：`offset → kernel → ApplyResult` | 全部 Ez | 降低每 note OOP 层数。 |
-| **STATE-ONE** | [ ] O2 Pill / BMS KPoor 路由状态统一进 `ManiaReplayJudgementState`（去掉 gameplay 静态 `O2HitModeExtension` 计数） | O2 + BMS | 正确性为主；顺带减少 `ConditionalWeakTable` 查找。 |
-
-### P2 — 高 KPS 专项（可独立于 Phase C/D 排期，**以后另写方案**）
-
-| 代号 | TODO | 涉及 HitMode | 说明 |
-|------|------|----------------|------|
-| **AUTO-MISS-GATE** | [ ] 每帧 `UpdateResult(false)`：用烘焙 miss 窗早退，未进窗的存活物件跳过 Ez 判定链 | 全部 Ez | 存活 note 数 × 帧率；与按键 KPS 无关但高密度谱面极重。 |
-| **O2-PILL-1PASS** | [ ] `PillCheck` 接受已算 `bpm` 或 `GetRanges` 结果，去掉每次 press 3× `GetBPMAtTime` | O2Jam | Phase B 遗留；Pill 开时按键路径可能劣于旧实现。 |
-| **O2-COLUMN-BPM** | [ ] `NotifyO2InputAt` 挪到 `Column.OnPressed`（每列每按键 1 次） | O2Jam | 当前在 drawable `CheckForResult` 内，和弦同帧可能重复查表。 |
-| **BMS-ROUTE-COL** | [ ] BMS `BmsRouteState` 按列持有，避免 per-note `ConditionalWeakTable` | BMS | 高叠键列上 post-Bad KPoor 状态机。 |
-| **HOLD-TAIL-FAST** | [ ] Hold/Tail 释放判定：列级 holding 状态 + 单 target，避免 tail drawable 全链 `CheckForResult` | EZ2AC / Malody / O2 LN | LN 高 KPS 谱面次要热点。 |
-| **SOUND-DECOUPLE** | [ ] 评估 `Column.OnPressed` 音效与判定解耦（判定先走、音效异步/合并） | 全部 | 仅当 profile 证明音效阻塞输入时做；**不在架构重构前动**。 |
-
-### P3 — 观测与验收（排期前建议先做）
+## 待办（P2 可选后续）
 
 | 代号 | TODO | 说明 |
 |------|------|------|
-| **BENCH-KPS** | [ ] 扩展 `BenchmarkManiaReplaySession` + 新增 Drawable 侧 micro-bench（note-lock / O2 press / auto-miss） | 用数据定 P2 顺序，避免凭感觉优化。 |
-| **TRACE-JUDGE** | [ ] 复用 `EzJudgmentDiagnostics` 或轻量计数器：每帧 `IsHittable` 次数、`CheckForResult` 次数、BPM 查表次数 | 90 KPS 实机对比 Phase A/B 前后。 |
+| **AUTO-MISS-GATE** | [ ] 未进 miss 早窗跳过 auto-miss 链（`ManiaAutoMissGate` 原型在库，待 parity 验收） | 全部 Ez |
+| **O2-PILL-1PASS** | [ ] press 路径单次 BPM / `PillCheckWithBpm` | O2Jam |
+| **O2-COLUMN-BPM** | [x] `Column.OnPressed` 每列每按键 `NotifyO2InputAt` | O2Jam |
+| **BMS-ROUTE-COL** | [ ] tail `BmsRouteState` 完全列级化 | BMS |
+| **HOLD-TAIL-FAST** | [ ] `Column.OnReleased` → 列级 tail release | LN |
+| **SOUND-DECOUPLE** | [ ] 判定与 `sampleTriggerSource.Play()` 解耦 | 仅 profile 证明阻塞时做 |
+| **DRAWABLE-MICRO-BENCH** | [ ] headless Column press micro-bench | BENCH-KPS Drawable 侧补充 |
 
 ---
 
-## 明确不在本 backlog 内（别和主题搅在一起）
+## 明确不在本 backlog 内
 
-- 游戏中禁止改 HitMode/HealthMode 的 **UX**（产品层，非性能层）。
-- Lazer/Classic `Lazer*Replica` 与 ppy inline 合并（ppy 同步成本）。
-- `OffsetPlusMania` Realm 持久化（见 `REPLAY_JUDGE_MERGE.md` §1.5d follow-up）。
-- 单纯「禁止游戏中修改设置」的配置锁 UI。
-- **POLICY-PARITY**（Earliest / Combo / Duration Drawable ≡ Session）— 正确性/架构 parity，见 `REPLAY_JUDGE_MERGE.md` §4。
+- 游戏中禁止改 HitMode/HealthMode 的 **UX**
+- Lazer/Classic `Lazer*Replica` 与 ppy inline 合并
+- `OffsetPlusMania` Realm 持久化
+- **POLICY-PARITY** — 已落地测试，见 `REPLAY_JUDGE_MERGE.md` §4
 
 ---
 
-## 主线阶段对照（继续专注主题时走这条）
+## 阶段路线（E0 → C 已完成）
 
 ```mermaid
 flowchart LR
-  doneAB["Phase A/B 已完成\nROUND-FREEZE / WINDOW-BAKE"]
-  phaseC["Phase C 当前主题\nCOLUMN-INPUT + LANE-PRECEDENCE"]
-  phaseD["Phase D\nKERNEL-ONE + DRAWABLE-THIN"]
-  p2["P2 backlog\n以后另案"]
-  doneAB --> phaseC --> phaseD
-  phaseC -.-> p2
-  phaseD -.-> p2
+  E0["E0 度量\nTRACE + BENCH"]
+  C1["C1 LANE-PRECEDENCE ✓"]
+  C2["C2 COLUMN-INPUT ✓"]
+  D["Phase D\n暂缓"]
+  P2["P2 backlog"]
+  E0 --> C1 --> C2 --> D
+  C2 -.-> P2
 ```
 
-**下一步默认**：推进 **Phase C（COLUMN-INPUT + LANE-PRECEDENCE）**，P2 代号项仅在 profile 或 parity 需求明确时插入。
+**预期收益（定性）**
+
+- **C1**：Combo/Duration 叠键列 O(存活数) → O(窗口内候选数)
+- **C2**：每键 `CheckForResult` O(存活数) → O(1)
+- **整体**：Drawable 与 Session 在列级 target 选择层面对齐
+
+**下一步默认**：P2 按 profile 排期；Phase D 待帧成本问题解决后再议。
 
 ---
 
@@ -88,5 +84,4 @@ flowchart LR
 | 日期 | 说明 |
 |------|------|
 | 2026-07-06 | 初版：全 HitMode 高 KPS backlog；Phase A/B 已落地项归档 |
-| 2026-07-06 | Phase C（部分）：`LANE-CURSOR` Earliest 落地；`COLUMN-INPUT` 仍待办 |
-| 2026-07-06 | `POLICY-PARITY` 移出本 backlog；P0 新增 `LANE-PRECEDENCE`（Combo/Duration 列级扫描替代） |
+| 2026-07-06 | Phase C 完成：`LANE-PRECEDENCE` + `COLUMN-INPUT`；Phase D 标注暂缓 |

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaAutoMissGate.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaAutoMissGate.cs
@@ -1,0 +1,34 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Mania.EzMania.Diagnostics;
+using osu.Game.Rulesets.Mania.Scoring;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
+{
+    /// <summary>
+    /// auto-miss 早退：物件尚未进入 miss 早窗时不跑 Ez 判定链（AUTO-MISS-GATE）。
+    /// </summary>
+    internal static class ManiaAutoMissGate
+    {
+        internal static bool ShouldEvaluateAutoMiss(HitObject hitObject, double timeOffset)
+        {
+            if (hitObject.HitWindows is not ManiaHitWindows maniaWindows)
+                return true;
+
+            double missEarly = maniaWindows.WindowFor(HitResult.Miss, true);
+
+            if (timeOffset < -missEarly)
+            {
+                if (ManiaJudgeHotPathTrace.Enabled)
+                    ManiaJudgeHotPathTrace.RecordAutoMissSkipped();
+
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaColumnSimulator.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaColumnSimulator.cs
@@ -43,8 +43,6 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
                 if (state.Target.StartTime >= targetStartTime)
                     break;
 
-                state.Judged = true;
-                state.Result = HitResult.Miss;
                 yield return state;
             }
         }

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaDrawableMissTiming.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaDrawableMissTiming.cs
@@ -1,0 +1,37 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.Mania.Objects;
+using osu.Game.Rulesets.Mania.UI;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Objects.Types;
+
+namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
+{
+    /// <summary>
+    /// Drawable 被动 miss 的 stored TimeOffset，与 Session <c>ResolveMissStoredOffset</c> 对齐。
+    /// </summary>
+    internal static class ManiaDrawableMissTiming
+    {
+        internal static double ResolveStoredOffset(DrawableHitObject drawable)
+        {
+            if (drawable.HitObject is not IHasColumn hasColumn)
+                return drawable.Time.Current - drawable.HitObject.GetEndTime();
+
+            var column = drawable.FindClosestParent<Column>();
+
+            if (column == null)
+                return drawable.Time.Current - drawable.HitObject.GetEndTime();
+
+            var pressTimes = new Dictionary<int, List<double>>
+            {
+                [hasColumn.Column] = column.GetPressTimesSnapshot(),
+            };
+
+            return ManiaReplaySessionSimulator.ResolveMissStoredOffset(drawable.HitObject, pressTimes);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaEzDrawableJudgement.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaEzDrawableJudgement.cs
@@ -167,6 +167,20 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
                 applyFinal(result);
         }
 
+        internal static bool TryColumnHoldTailRelease(DrawableHoldNote hold, double currentTime, ManiaJudgementRound round)
+        {
+            if (!hold.IsHolding.Value)
+                return false;
+
+            if (ManiaEzDrawableJudgement.TryMalodyHoldOnReleased(hold))
+                return true;
+
+            hold.Tail.UpdateResult();
+            hold.Body.TriggerResult(hold.Tail.IsHit);
+            hold.Result.ReportHoldState(currentTime, false);
+            return true;
+        }
+
         internal static bool TryApplyEzNoteCheckForResult(DrawableNote drawable, bool userTriggered, double timeOffset)
         {
             var round = getJudgementRound(drawable);

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaEzDrawableJudgement.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaEzDrawableJudgement.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
 using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.Scoring;
+using osu.Game.Rulesets.Mania.EzMania.Diagnostics;
 using osu.Game.Rulesets.Mania.EzMania.ReplayJudge.Mappings;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mania.Objects.Drawables;
@@ -38,13 +39,24 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
             => GlobalConfigStore.EzConfig.ResolveEnvironment(ReplayRunPurpose.ForLive).ManiaHitMode == EzEnumHitMode.O2Jam;
 
         internal static BmsHitModeJudgement.BmsRouteState GetBmsState(DrawableNote note)
-            => note_bms_states.GetValue(note, _ => new BmsHitModeJudgement.BmsRouteState());
+        {
+            if (note.FindClosestParent<Column>() is Column column && column.TryGetBmsRoute(note, out var route))
+                return route;
+
+            return note_bms_states.GetValue(note, _ => new BmsHitModeJudgement.BmsRouteState());
+        }
 
         internal static BmsHitModeJudgement.BmsRouteState GetBmsState(DrawableHoldNoteTail tail)
             => tail_bms_states.GetValue(tail, _ => new BmsHitModeJudgement.BmsRouteState());
 
         private static ManiaJudgementRound getJudgementRound(DrawableHitObject? drawable = null)
         {
+            if (drawable is DrawableManiaHitObject maniaDrawable
+                && maniaDrawable.EzDrawableManiaRuleset?.JudgementRound is { } cachedRound)
+            {
+                return cachedRound;
+            }
+
             if (drawable?.FindClosestParent<DrawableManiaRuleset>() is { JudgementRound: { } round })
                 return round;
 
@@ -183,7 +195,12 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
 
         internal static bool TryApplyEzNoteCheckForResult(DrawableNote drawable, bool userTriggered, double timeOffset)
         {
+            ManiaJudgeHotPathTrace.RecordCheckForResult();
+
             var round = getJudgementRound(drawable);
+
+            if (!userTriggered && !ManiaAutoMissGate.ShouldEvaluateAutoMiss(drawable.HitObject, timeOffset))
+                return true;
 
             if (!round.IsEzHitMode)
                 return false;
@@ -209,11 +226,14 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
 
             if (hitMode is O2HitModeJudgement o2)
             {
-                (drawable.HitObject.HitWindows as ManiaHitWindows)?.UpdateO2JamBpmFromTime(drawable.Time.Current);
+                if (drawable.HitObject.HitWindows is ManiaHitWindows maniaWindows)
+                    maniaWindows.BPM = round.O2PressBpm;
 
                 if (userTriggered)
                 {
-                    bool cont = O2HitModeExtension.PillCheck(timeOffset, drawable.Time.Current, out bool _, out bool upgradeToPerfect);
+                    bool upgradeToPerfect = false;
+                    bool cont = !round.PillModeEnabled
+                                || O2HitModeExtension.PillCheckWithBpm(timeOffset, round.O2PressBpm, out bool _, out upgradeToPerfect);
                     var outcome = o2.EvaluateDrawableNotePress(timeOffset, drawable.HitObject.HitWindows!, new O2HitModeJudgement.DrawableNoteContext
                     {
                         CurrentTime = drawable.Time.Current,
@@ -255,7 +275,12 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
 
         internal static bool TryApplyEzHoldTailCheckForResult(DrawableHoldNoteTail drawable, bool userTriggered, double timeOffset)
         {
+            ManiaJudgeHotPathTrace.RecordCheckForResult();
+
             var round = getJudgementRound(drawable);
+
+            if (!userTriggered && !ManiaAutoMissGate.ShouldEvaluateAutoMiss(drawable.HitObject, timeOffset))
+                return true;
 
             if (!round.IsEzHitMode)
                 return false;

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaEzDrawableJudgement.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaEzDrawableJudgement.cs
@@ -139,12 +139,16 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
             return O2HitModeJudgement.Instance.TryO2HoldCheckForResult(hold, userTriggered, timeOffset);
         }
 
-        internal static void ApplyNoteOutcome(DrawableNote drawable, ManiaJudgementRound round, ManiaNoteJudgementOutcome outcome)
+        internal static void ApplyNoteOutcome(DrawableNote drawable, ManiaJudgementRound round, ManiaNoteJudgementOutcome outcome, bool userTriggered = true)
         {
             switch (outcome.Kind)
             {
                 case ManiaNoteJudgementOutcomeKind.Apply:
-                    drawable.EzApplyFinalResult(outcome.Result, round.Environment.ManiaHitMode);
+                    if (!userTriggered && outcome.Result == HitResult.Miss)
+                        drawable.EzApplyPassiveMissWithStoredOffset();
+                    else
+                        drawable.EzApplyFinalResult(outcome.Result, round.Environment.ManiaHitMode);
+
                     break;
 
                 case ManiaNoteJudgementOutcomeKind.DispatchExtra:
@@ -226,28 +230,29 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
 
             if (hitMode is O2HitModeJudgement o2)
             {
-                if (drawable.HitObject.HitWindows is ManiaHitWindows maniaWindows)
-                    maniaWindows.BPM = round.O2PressBpm;
-
                 if (userTriggered)
                 {
                     bool upgradeToPerfect = false;
                     bool cont = !round.PillModeEnabled
                                 || O2HitModeExtension.PillCheckWithBpm(timeOffset, round.O2PressBpm, out bool _, out upgradeToPerfect);
-                    var outcome = o2.EvaluateDrawableNotePress(timeOffset, drawable.HitObject.HitWindows!, new O2HitModeJudgement.DrawableNoteContext
+                    var outcome = o2.EvaluatePress(timeOffset, drawable.HitObject.HitWindows!, new O2HitModeJudgement.NotePressContext
                     {
-                        CurrentTime = drawable.Time.Current,
+                        RawOffset = timeOffset,
+                        Bpm = round.O2PressBpm,
+                        UsePressTimeBpmForJudgement = true,
+                        PillModeEnabled = round.PillModeEnabled,
                         PillCheckPassed = cont,
                         UpgradeToPerfect = upgradeToPerfect,
-                    }, round.MutableState);
+                        State = round.MutableState,
+                    });
 
-                    if (outcome != null)
-                        ApplyNoteOutcome(drawable, round, outcome.Value);
-
+                    ApplyNoteOutcome(drawable, round, outcome, userTriggered: true);
                     return true;
                 }
 
-                ApplyNoteOutcome(drawable, round, o2.EvaluateAutoMiss(timeOffset, drawable.HitObject.HitWindows!));
+                long frameId = (long)(drawable.Time.Current * 1000);
+                double bpm = round.GetO2BpmForAutoMiss(drawable.Time.Current, frameId);
+                ApplyNoteOutcome(drawable, round, o2.EvaluateAutoMiss(timeOffset, drawable.HitObject.HitWindows!, bpm), userTriggered: false);
                 return true;
             }
 
@@ -255,21 +260,21 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
             {
                 if (userTriggered)
                 {
-                    ApplyNoteOutcome(drawable, round, ez2Ac.EvaluateDrawablePress(timeOffset, drawable.HitObject.HitWindows!, drawable.HitObject is HeadNote));
+                    ApplyNoteOutcome(drawable, round, ez2Ac.EvaluateDrawablePress(timeOffset, drawable.HitObject.HitWindows!, drawable.HitObject is HeadNote), userTriggered: true);
                     return true;
                 }
 
-                ApplyNoteOutcome(drawable, round, ez2Ac.EvaluateAutoMiss(timeOffset, drawable.HitObject.HitWindows!));
+                ApplyNoteOutcome(drawable, round, ez2Ac.EvaluateAutoMiss(timeOffset, drawable.HitObject.HitWindows!), userTriggered: false);
                 return true;
             }
 
             if (userTriggered)
             {
-                ApplyNoteOutcome(drawable, round, hitMode.EvaluatePress(timeOffset, drawable.HitObject.HitWindows!));
+                ApplyNoteOutcome(drawable, round, hitMode.EvaluatePress(timeOffset, drawable.HitObject.HitWindows!), userTriggered: true);
                 return true;
             }
 
-            ApplyNoteOutcome(drawable, round, hitMode.EvaluateAutoMiss(timeOffset, drawable.HitObject.HitWindows!));
+            ApplyNoteOutcome(drawable, round, hitMode.EvaluateAutoMiss(timeOffset, drawable.HitObject.HitWindows!), userTriggered: false);
             return true;
         }
 

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaJudgementRound.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaJudgementRound.cs
@@ -3,6 +3,7 @@
 
 using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.Scoring;
+using osu.Game.Rulesets.Mania.EzMania.Diagnostics;
 using osu.Game.Rulesets.Mania.EzMania.Helper;
 using osu.Game.Rulesets.Mania.EzMania.ReplayJudge.Mappings;
 using osu.Game.Rulesets.Mania.Objects.EzCurrentHitObject;
@@ -68,7 +69,11 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
         /// <summary>
         /// 列级按键：缓存本按 press-time BPM（O2 每输入至多查表一次）。
         /// </summary>
-        public void NotifyO2InputAt(double time) => O2PressBpm = O2HitModeExtension.GetBPMAtTime(time);
+        public void NotifyO2InputAt(double time)
+        {
+            O2PressBpm = O2HitModeExtension.GetBPMAtTime(time);
+            ManiaJudgeHotPathTrace.RecordO2BpmLookup();
+        }
 
         public double O2PressBpm { get; private set; }
 

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaLaneController.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaLaneController.cs
@@ -3,14 +3,19 @@
 
 using System;
 using System.Collections.Generic;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.Rulesets.Mania.EzMania.Helper;
+using osu.Game.Rulesets.Mania.EzMania.ReplayJudge.Mappings;
 using osu.Game.Rulesets.Mania.Objects.Drawables;
+using osu.Game.Rulesets.Mania.Scoring;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
 {
     /// <summary>
-    /// 列内 note-lock 状态机：有序目标 + 游标。Earliest 模式下 Drawable / Session 共用判定语义。
+    /// 列内 note-lock 状态机：有序目标 + 游标。全 JudgePrecedence 下 Drawable / Session 共用判定语义。
     /// </summary>
     public sealed class ManiaLaneController
     {
@@ -70,10 +75,20 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
 
         public void NotifyJudged(DrawableHitObject drawable)
         {
+            drawable = resolveJudgedDrawable(drawable);
+
             if (!drawableIndices.ContainsKey(drawable))
                 return;
 
             advanceCursor();
+        }
+
+        private static DrawableHitObject resolveJudgedDrawable(DrawableHitObject drawable)
+        {
+            if (drawable is DrawableHoldNoteHead head && head.ParentHold != null)
+                return head.ParentHold;
+
+            return drawable;
         }
 
         /// <summary>
@@ -92,6 +107,35 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
 
         public bool IsHittableEarliestIndex(int index, double time)
             => IsHittableEarliest(entries, index, time, static e => e.IsJudged, static e => e.StartTime);
+
+        public bool IsHittable(DrawableHitObject drawable, double time, EzEnumJudgePrecedence precedence, bool bmsMode)
+        {
+            if (precedence == EzEnumJudgePrecedence.Earliest)
+                return IsHittableEarliest(drawable, time);
+
+            var entry = SelectPressEntry(time, precedence, bmsMode);
+
+            if (entry == null)
+                return true;
+
+            return ReferenceEquals(entry.RoutedObject, drawable);
+        }
+
+        public bool TryGetEntry(DrawableHitObject drawable, out ManiaLaneEntry entry)
+        {
+            if (drawableIndices.TryGetValue(drawable, out int index))
+            {
+                entry = entries[index];
+                return true;
+            }
+
+            entry = null!;
+            return false;
+        }
+
+        public DrawableHoldNote? ActiveHold { get; private set; }
+
+        internal void SetActiveHold(DrawableHoldNote? hold) => ActiveHold = hold;
 
         /// <summary>
         /// Session：<see cref="LaneTargetState"/> 列版本。
@@ -122,7 +166,7 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
         {
             foreach (var entry in entries)
             {
-                if (entry.IsJudged)
+                if (entry.IsPressJudged)
                     continue;
 
                 if (entry.StartTime >= targetStartTime)
@@ -130,6 +174,210 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
 
                 yield return entry;
             }
+        }
+
+        /// <summary>
+        /// 收集 miss 窗内、未判定的列内 press 候选（O(log n + k)）。
+        /// </summary>
+        public List<ManiaLaneEntry> CollectOverlappingEntries(double time)
+        {
+            var result = new List<ManiaLaneEntry>();
+
+            if (entries.Count == 0)
+                return result;
+
+            double maxEarly = 0;
+            double maxLate = 0;
+
+            foreach (var entry in entries)
+            {
+                if (entry.PressWindows == null)
+                    continue;
+
+                maxEarly = Math.Max(maxEarly, entry.PressWindows.WindowFor(HitResult.Miss, true));
+                maxLate = Math.Max(maxLate, entry.PressWindows.WindowFor(HitResult.Miss, false));
+            }
+
+            if (maxEarly == 0 && maxLate == 0)
+                return result;
+
+            double searchLowerBound = time - maxLate;
+            int lo = 0;
+            int hi = entries.Count;
+
+            while (lo < hi)
+            {
+                int mid = lo + (hi - lo) / 2;
+
+                if (entries[mid].StartTime < searchLowerBound)
+                    lo = mid + 1;
+                else
+                    hi = mid;
+            }
+
+            double searchUpperBound = time + maxEarly;
+
+            for (int i = lo; i < entries.Count; i++)
+            {
+                var entry = entries[i];
+
+                if (entry.StartTime > searchUpperBound)
+                    break;
+
+                if (entry.IsPressJudged || entry.PressWindows == null)
+                    continue;
+
+                double early = entry.PressWindows.WindowFor(HitResult.Miss, true);
+                double late = entry.PressWindows.WindowFor(HitResult.Miss, false);
+
+                if (time >= entry.StartTime - early && time <= entry.StartTime + late)
+                    result.Add(entry);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// 按 JudgePrecedence 选择本列 press 目标（含 BMS post-Bad KPoor）。
+        /// </summary>
+        public ManiaLaneEntry? SelectPressEntry(double time, EzEnumJudgePrecedence precedence, bool allowBmsFallbackToEarliest)
+        {
+            if (allowBmsFallbackToEarliest && trySelectPostBadEntry(time, out var postBad))
+                return postBad;
+
+            if (precedence == EzEnumJudgePrecedence.Earliest)
+            {
+                if (cursor >= entries.Count)
+                    return null;
+
+                var entry = entries[cursor];
+
+                if (entry.IsPressJudged || !isWithinMissWindow(entry, time))
+                    return null;
+
+                if (!IsHittableEarliestIndex(cursor, time))
+                    return null;
+
+                return entry;
+            }
+
+            var overlapping = CollectOverlappingEntries(time);
+
+            if (overlapping.Count == 0)
+                return null;
+
+            if (overlapping.Count == 1)
+                return overlapping[0];
+
+            overlapping.Sort((a, b) => a.StartTime.CompareTo(b.StartTime));
+
+            bool combo = precedence == EzEnumJudgePrecedence.Combo;
+
+            var picked = OrderedHitPolicyHelper.SelectFold(
+                overlapping,
+                e => e.IsPressJudged,
+                e => e.StartTime,
+                e => e.PressWindows,
+                time,
+                combo);
+
+            if (picked != null)
+                return picked;
+
+            return overlapping[0];
+        }
+
+        private bool trySelectPostBadEntry(double time, out ManiaLaneEntry? selected)
+        {
+            selected = null;
+            ManiaLaneEntry? postBadCandidate = null;
+            double postBadDistance = double.PositiveInfinity;
+
+            foreach (var entry in entries)
+            {
+                if (!isPostBadKPoorRoutable(entry) || !isWithinMissWindow(entry, time))
+                    continue;
+
+                double distance = distanceToNonBadWindow(entry.RoutedObject, time);
+
+                if (postBadCandidate == null || distance < postBadDistance
+                                             || (distance == postBadDistance && entry.StartTime < postBadCandidate.StartTime))
+                {
+                    postBadCandidate = entry;
+                    postBadDistance = distance;
+                }
+            }
+
+            if (postBadCandidate == null)
+                return false;
+
+            double unjudgedMin = double.PositiveInfinity;
+
+            foreach (var entry in entries)
+            {
+                if (entry.IsPressJudged || !isWithinMissWindow(entry, time))
+                    continue;
+
+                unjudgedMin = Math.Min(unjudgedMin, distanceToNonBadWindow(entry.RoutedObject, time));
+            }
+
+            if (postBadDistance > unjudgedMin || postBadCandidate.BmsRoute.HasLateKPoor)
+                return false;
+
+            selected = postBadCandidate;
+            return true;
+        }
+
+        private static bool isWithinMissWindow(ManiaLaneEntry entry, double time)
+        {
+            if (entry.PressWindows == null)
+                return false;
+
+            double early = entry.PressWindows.WindowFor(HitResult.Miss, true);
+            double late = entry.PressWindows.WindowFor(HitResult.Miss, false);
+            return time >= entry.StartTime - early && time <= entry.StartTime + late;
+        }
+
+        private static bool isPostBadKPoorRoutable(ManiaLaneEntry entry)
+        {
+            if (!entry.IsPressJudged || !entry.BmsRoute.CanRouteToKPoor)
+                return false;
+
+            if (entry.RoutedObject is DrawableNote note)
+                return note.CanRouteToKPoor;
+
+            if (entry.RoutedObject is DrawableHoldNote hold && hold.Tail.Judged)
+                return hold.Tail.CanRouteToKPoor;
+
+            return false;
+        }
+
+        private static double distanceToNonBadWindow(DrawableHitObject obj, double pressTime)
+        {
+            var windows = obj.HitObject.HitWindows;
+
+            if (windows == null)
+                return double.PositiveInfinity;
+
+            double early = windows.WindowFor(HitResult.Good);
+            double late = windows.WindowFor(HitResult.Good);
+
+            if (windows is ManiaHitWindows maniaWindows)
+            {
+                early = maniaWindows.WindowFor(HitResult.Good, true);
+                late = maniaWindows.WindowFor(HitResult.Good, false);
+            }
+
+            double start = obj.HitObject.StartTime - early;
+            double end = obj.HitObject.StartTime + late;
+
+            if (pressTime < start)
+                return start - pressTime;
+
+            if (pressTime > end)
+                return pressTime - end;
+
+            return 0;
         }
 
         public static bool TryCreateEntry(DrawableHitObject drawable, out ManiaLaneEntry entry)
@@ -144,14 +392,23 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
 
             if (drawable is DrawableHoldNote hold)
             {
-                entry = new ManiaLaneEntry(hold, hold.HitObject.StartTime);
+                if (hold.Judged || hold.Head.Judged)
+                    return false;
+
+                if (hold.Head.HitObject.HitWindows is not ManiaHitWindows headWindows || headWindows.WindowFor(HitResult.Miss) == 0)
+                    return false;
+
+                entry = new ManiaLaneEntry(hold, hold.Head, hold.Head.HitObject.StartTime, headWindows);
                 return true;
             }
 
             if (drawable.Judged)
                 return false;
 
-            entry = new ManiaLaneEntry(drawable, drawable.HitObject.StartTime);
+            if (drawable.HitObject.HitWindows is not ManiaHitWindows windows || windows.WindowFor(HitResult.Miss) == 0)
+                return false;
+
+            entry = new ManiaLaneEntry(drawable, drawable, drawable.HitObject.StartTime, windows);
             return true;
         }
 
@@ -174,14 +431,27 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
     {
         public DrawableHitObject Drawable { get; }
 
+        public DrawableHitObject RoutedObject { get; }
+
+        public DrawableHitObject JudgementObject { get; }
+
         public double StartTime { get; }
+
+        public ManiaHitWindows? PressWindows { get; }
+
+        public BmsHitModeJudgement.BmsRouteState BmsRoute { get; } = new BmsHitModeJudgement.BmsRouteState();
 
         public bool IsJudged => Drawable.Judged;
 
-        public ManiaLaneEntry(DrawableHitObject drawable, double startTime)
+        public bool IsPressJudged => RoutedObject.Judged || JudgementObject.Judged;
+
+        public ManiaLaneEntry(DrawableHitObject routedObject, DrawableHitObject judgementObject, double startTime, ManiaHitWindows? pressWindows)
         {
-            Drawable = drawable;
+            Drawable = routedObject;
+            RoutedObject = routedObject;
+            JudgementObject = judgementObject;
             StartTime = startTime;
+            PressWindows = pressWindows;
         }
 
         internal sealed class StartTimeComparer : IComparer<ManiaLaneEntry>

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaLaneController.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaLaneController.cs
@@ -23,6 +23,11 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
         private readonly Dictionary<DrawableHitObject, int> drawableIndices = new Dictionary<DrawableHitObject, int>();
         private int cursor;
 
+        private double lastSelectPressTime = double.NaN;
+        private EzEnumJudgePrecedence lastSelectPrecedence;
+        private bool lastSelectBmsMode;
+        private ManiaLaneEntry? lastSelectResult;
+
         public IReadOnlyList<ManiaLaneEntry> Entries => entries;
 
         public void Register(DrawableHitObject drawable)
@@ -37,11 +42,7 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
             if (insertIndex < 0)
                 insertIndex = ~insertIndex;
 
-            entries.Insert(insertIndex, entry);
-            rebuildDrawableIndices();
-
-            if (insertIndex < cursor)
-                cursor++;
+            insertEntryAt(insertIndex, entry);
         }
 
         public void RegisterIfNeeded(DrawableHitObject drawable)
@@ -58,10 +59,15 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
                 return;
 
             entries.RemoveAt(index);
-            rebuildDrawableIndices();
+            drawableIndices.Remove(drawable);
+
+            for (int i = index; i < entries.Count; i++)
+                drawableIndices[entries[i].Drawable] = i;
 
             if (index < cursor)
                 cursor--;
+
+            invalidateSelectPressCache();
         }
 
         public void UnregisterByHitObject(HitObject hitObject)
@@ -99,21 +105,24 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
             if (!drawableIndices.TryGetValue(drawable, out int index))
                 return false;
 
-            if (drawable.Judged || index != cursor)
+            if (index != cursor)
+                return false;
+
+            if (entries[index].IsPressJudged)
                 return false;
 
             return IsHittableEarliestIndex(index, time);
         }
 
         public bool IsHittableEarliestIndex(int index, double time)
-            => IsHittableEarliest(entries, index, time, static e => e.IsJudged, static e => e.StartTime);
+            => IsHittableEarliest(entries, index, time, static e => e.IsPressJudged, static e => e.StartTime);
 
         public bool IsHittable(DrawableHitObject drawable, double time, EzEnumJudgePrecedence precedence, bool bmsMode)
         {
             if (precedence == EzEnumJudgePrecedence.Earliest)
                 return IsHittableEarliest(drawable, time);
 
-            var entry = SelectPressEntry(time, precedence, bmsMode);
+            var entry = selectPressEntry(time, precedence, bmsMode);
 
             if (entry == null)
                 return true;
@@ -241,6 +250,25 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
         /// 按 JudgePrecedence 选择本列 press 目标（含 BMS post-Bad KPoor）。
         /// </summary>
         public ManiaLaneEntry? SelectPressEntry(double time, EzEnumJudgePrecedence precedence, bool allowBmsFallbackToEarliest)
+            => selectPressEntry(time, precedence, allowBmsFallbackToEarliest);
+
+        private ManiaLaneEntry? selectPressEntry(double time, EzEnumJudgePrecedence precedence, bool allowBmsFallbackToEarliest)
+        {
+            if (time == lastSelectPressTime
+                && precedence == lastSelectPrecedence
+                && allowBmsFallbackToEarliest == lastSelectBmsMode)
+            {
+                return lastSelectResult;
+            }
+
+            lastSelectPressTime = time;
+            lastSelectPrecedence = precedence;
+            lastSelectBmsMode = allowBmsFallbackToEarliest;
+            lastSelectResult = selectPressEntryCore(time, precedence, allowBmsFallbackToEarliest);
+            return lastSelectResult;
+        }
+
+        private ManiaLaneEntry? selectPressEntryCore(double time, EzEnumJudgePrecedence precedence, bool allowBmsFallbackToEarliest)
         {
             if (allowBmsFallbackToEarliest && trySelectPostBadEntry(time, out var postBad))
                 return postBad;
@@ -414,16 +442,28 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
 
         private void advanceCursor()
         {
-            while (cursor < entries.Count && entries[cursor].IsJudged)
+            while (cursor < entries.Count && entries[cursor].IsPressJudged)
                 cursor++;
         }
 
-        private void rebuildDrawableIndices()
+        private void insertEntryAt(int insertIndex, ManiaLaneEntry entry)
         {
-            drawableIndices.Clear();
+            entries.Insert(insertIndex, entry);
+            drawableIndices[entry.Drawable] = insertIndex;
 
-            for (int i = 0; i < entries.Count; i++)
+            for (int i = insertIndex + 1; i < entries.Count; i++)
                 drawableIndices[entries[i].Drawable] = i;
+
+            if (insertIndex < cursor)
+                cursor++;
+
+            invalidateSelectPressCache();
+        }
+
+        private void invalidateSelectPressCache()
+        {
+            lastSelectPressTime = double.NaN;
+            lastSelectResult = null;
         }
     }
 

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaLanePressSelector.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaLanePressSelector.cs
@@ -1,0 +1,48 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.Rulesets.Mania.EzMania.Helper;
+using osu.Game.Rulesets.Mania.Scoring;
+
+namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
+{
+    /// <summary>
+    /// Session 列级 press 目标选择（与 <see cref="ManiaLaneController.SelectPressEntry"/> 共用 fold 语义）。
+    /// </summary>
+    internal static class ManiaLanePressSelector
+    {
+        internal static LaneTargetState? SelectSessionTarget(
+            IReadOnlyList<LaneTargetState> candidates,
+            double time,
+            EzEnumJudgePrecedence precedence,
+            bool allowFallbackToEarliest)
+        {
+            if (candidates.Count == 0)
+                return null;
+
+            var overlapping = new List<LaneTargetState>(candidates);
+            overlapping.Sort((a, b) => a.Target.StartTime.CompareTo(b.Target.StartTime));
+
+            return precedence switch
+            {
+                EzEnumJudgePrecedence.Duration => OrderedHitPolicyHelper.SelectFold(
+                    overlapping,
+                    s => s.Judged,
+                    s => s.Target.StartTime,
+                    s => s.Target.HitWindows as ManiaHitWindows,
+                    time,
+                    comboAlgorithm: false) ?? overlapping[0],
+                EzEnumJudgePrecedence.Combo => OrderedHitPolicyHelper.SelectFold(
+                    overlapping,
+                    s => s.Judged,
+                    s => s.Target.StartTime,
+                    s => s.Target.HitWindows as ManiaHitWindows,
+                    time,
+                    comboAlgorithm: true) ?? overlapping[0],
+                _ => overlapping[0],
+            };
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaReplaySessionSimulator.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaReplaySessionSimulator.cs
@@ -173,6 +173,9 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
 
                 foreach (var forced in ForceMissEarlier(laneStates, target.StartTime))
                 {
+                    if (!IsWithinMissWindow(forced.Target, input.Time, useTailReleaseLenience: false))
+                        continue;
+
                     forced.Judged = true;
                     forced.Result = HitResult.Miss;
                     ApplyFinalResult(

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaReplaySessionSimulator.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaReplaySessionSimulator.cs
@@ -321,26 +321,11 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
             if (candidates.Count == 0)
                 return null;
 
-            candidates.Sort((a, b) => a.Target.StartTime.CompareTo(b.Target.StartTime));
-
-            return environment.JudgePrecedence switch
-            {
-                EzEnumJudgePrecedence.Combo => OrderedHitPolicyHelper.SelectFold(
-                    candidates,
-                    s => s.Judged,
-                    s => s.Target.StartTime,
-                    s => s.Target.HitWindows as ManiaHitWindows,
-                    inputTime,
-                    comboAlgorithm: true),
-                EzEnumJudgePrecedence.Duration => OrderedHitPolicyHelper.SelectFold(
-                    candidates,
-                    s => s.Judged,
-                    s => s.Target.StartTime,
-                    s => s.Target.HitWindows as ManiaHitWindows,
-                    inputTime,
-                    comboAlgorithm: false),
-                _ => candidates[0]
-            } ?? candidates[0];
+            return ManiaLanePressSelector.SelectSessionTarget(
+                candidates,
+                inputTime,
+                environment.JudgePrecedence,
+                HitModeHelper.IsBMSHitMode(environment.ManiaHitMode));
         }
 
         private static IEnumerable<LaneTargetState> collectCandidatesForInput(

--- a/osu.Game.Rulesets.Mania/ManiaInputManager.cs
+++ b/osu.Game.Rulesets.Mania/ManiaInputManager.cs
@@ -1,9 +1,12 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.ComponentModel;
 using osu.Framework.Allocation;
+using osu.Framework.Graphics;
 using osu.Framework.Input.Bindings;
+using osu.Game.Rulesets.Mania.UI;
 using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Rulesets.Mania
@@ -14,6 +17,46 @@ namespace osu.Game.Rulesets.Mania
         public ManiaInputManager(RulesetInfo ruleset, int variant)
             : base(ruleset, variant, SimultaneousBindingMode.Unique)
         {
+        }
+
+        protected override KeyBindingContainer<ManiaAction> CreateKeyBindingContainer(RulesetInfo ruleset, int variant, SimultaneousBindingMode unique)
+            => new ManiaKeyBindingContainer(ruleset, variant, unique);
+
+        /// <summary>
+        /// COLUMN-INPUT：列级 <see cref="Column.OnPressed"/> 优先于列内 drawable，避免每键 N 路冒泡。
+        /// </summary>
+        private partial class ManiaKeyBindingContainer : RulesetKeyBindingContainer
+        {
+            private readonly List<Drawable> columnFirstQueue = new List<Drawable>();
+            private readonly List<Drawable> nonColumnQueue = new List<Drawable>();
+
+            public ManiaKeyBindingContainer(RulesetInfo ruleset, int variant, SimultaneousBindingMode unique)
+                : base(ruleset, variant, unique)
+            {
+            }
+
+            protected override IEnumerable<Drawable> KeyBindingInputQueue
+            {
+                get
+                {
+                    columnFirstQueue.Clear();
+                    nonColumnQueue.Clear();
+
+                    foreach (var drawable in base.KeyBindingInputQueue)
+                    {
+                        if (drawable is Column)
+                            columnFirstQueue.Add(drawable);
+                        else
+                            nonColumnQueue.Add(drawable);
+                    }
+
+                    if (columnFirstQueue.Count == 0)
+                        return base.KeyBindingInputQueue;
+
+                    columnFirstQueue.AddRange(nonColumnQueue);
+                    return columnFirstQueue;
+                }
+            }
         }
     }
 

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -13,11 +13,11 @@ using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Audio;
 using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Mania.EzMania.ReplayJudge;
 using osu.Game.Rulesets.Mania.Judgements;
 using osu.Game.Rulesets.Mania.Skinning.Default;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
-using osu.Game.Rulesets.Mania.EzMania.ReplayJudge;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Screens.Play;
@@ -313,6 +313,9 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
 
         public bool OnPressed(KeyBindingPressEvent<ManiaAction> e)
         {
+            if (ShouldSkipColumnRoutedPress?.Invoke(this) == true)
+                return false;
+
             if (AllJudged)
                 return false;
 
@@ -323,16 +326,40 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             if ((Clock as IGameplayClock)?.IsRewinding == true)
                 return false;
 
-            if (CheckHittable?.Invoke(this, Time.Current) == false)
+            return TryBeginHoldPress(Time.Current);
+        }
+
+        internal bool TryBeginHoldPress(double currentTime)
+        {
+            if (CheckHittable?.Invoke(this, currentTime) == false)
                 return false;
 
             // The tail has a lenience applied to it which is factored into the miss window (i.e. the miss judgement will be delayed).
             // But the hold cannot ever be started within the late-lenience window, so we should skip trying to begin the hold during that time.
             // Note: Unlike below, we use the tail's start time to determine the time offset.
-            if (Time.Current > Tail.HitObject.StartTime && !Tail.HitObject.HitWindows.CanBeHit(Time.Current - Tail.HitObject.StartTime))
+            if (currentTime > Tail.HitObject.StartTime && !Tail.HitObject.HitWindows.CanBeHit(currentTime - Tail.HitObject.StartTime))
                 return false;
 
-            beginHoldAt(Time.Current - Head.HitObject.StartTime);
+            beginHoldAt(currentTime - Head.HitObject.StartTime);
+
+            return Head.UpdateResult();
+        }
+
+        /// <summary>
+        /// 列级路由已选中本 hold，跳过重复的 <see cref="CheckHittable"/>。
+        /// </summary>
+        internal bool TryBeginHoldPressFromColumn(double currentTime)
+        {
+            if (AllJudged)
+                return false;
+
+            if ((Clock as IGameplayClock)?.IsRewinding == true)
+                return false;
+
+            if (currentTime > Tail.HitObject.StartTime && !Tail.HitObject.HitWindows.CanBeHit(currentTime - Tail.HitObject.StartTime))
+                return false;
+
+            beginHoldAt(currentTime - Head.HitObject.StartTime);
 
             return Head.UpdateResult();
         }

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteHead.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteHead.cs
@@ -43,6 +43,8 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                 MissingStartTime.BindTo(parentHold.MissingStartTime);
         }
 
+        public DrawableHoldNote ParentHold => ParentHitObject as DrawableHoldNote;
+
         protected override void OnFree()
         {
             base.OnFree();

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableManiaHitObject.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableManiaHitObject.cs
@@ -12,7 +12,9 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Timing;
 using osu.Game.Audio;
+using osu.Game.Rulesets.Mania.EzMania.ReplayJudge;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Rulesets.Mania.UI;
 
@@ -133,6 +135,21 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                     this.FadeOut();
                     break;
             }
+        }
+
+        /// <summary>
+        /// 被动 miss：在通知 <see cref="ScoreProcessor"/> 前写入 stored TimeOffset（与 Session end-sweep 对齐）。
+        /// </summary>
+        internal void EzApplyPassiveMissWithStoredOffset()
+        {
+            ApplyResultWithStoredTiming(
+                static (r, _) =>
+                {
+                    r.Type = HitResult.Miss;
+                    r.IsComboHit = false;
+                },
+                0,
+                ManiaDrawableMissTiming.ResolveStoredOffset(this));
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableManiaHitObject.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableManiaHitObject.cs
@@ -35,6 +35,11 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
         [Resolved(canBeNull: true)]
         private ManiaPlayfield playfield { get; set; }
 
+        [Resolved(canBeNull: true)]
+        private DrawableManiaRuleset drawableManiaRuleset { get; set; }
+
+        internal DrawableManiaRuleset EzDrawableManiaRuleset => drawableManiaRuleset;
+
         protected override float SamplePlaybackPosition
         {
             get
@@ -51,6 +56,13 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
         /// If non-null, judgements will be ignored whilst the function returns false.
         /// </summary>
         public Func<DrawableHitObject, double, bool> CheckHittable;
+
+        /// <summary>
+        /// 列级按键已路由到其它 drawable 时跳过本物件的 <see cref="IKeyBindingHandler.OnPressed"/>。
+        /// </summary>
+        public Func<DrawableHitObject, bool> ShouldSkipColumnRoutedPress;
+
+        protected bool UsesColumnPressRouting => this.FindClosestParent<DrawableManiaRuleset>()?.ColumnRoutesInput == true;
 
         protected DrawableManiaHitObject(ManiaHitObject hitObject)
             : base(hitObject)

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableNote.cs
@@ -15,6 +15,7 @@ using osu.Game.EzOsuGame.Configuration;
 using osu.Game.Rulesets.Mania.Configuration;
 using osu.Game.Rulesets.Mania.Skinning.Default;
 using osu.Game.Rulesets.Mania.EzMania.Helper;
+using osu.Game.Rulesets.Mania.EzMania.Diagnostics;
 using osu.Game.Rulesets.Mania.EzMania.ReplayJudge;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI.Scrolling;
@@ -87,6 +88,9 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {
+            if (!userTriggered)
+                ManiaJudgeHotPathTrace.RecordCheckForResult();
+
             if (ManiaEzDrawableJudgement.TryHitModeCheckForResult(this, userTriggered, timeOffset))
                 return;
 
@@ -116,6 +120,9 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
 
         public virtual bool OnPressed(KeyBindingPressEvent<ManiaAction> e)
         {
+            if (ShouldSkipColumnRoutedPress?.Invoke(this) == true)
+                return false;
+
             if (e.Action == Action.Value && ManiaEzDrawableJudgement.TryBmsOnPressed(this, e))
                 return true;
 
@@ -125,8 +132,10 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             if (CheckHittable?.Invoke(this, Time.Current) == false)
                 return false;
 
-            return UpdateResult(true);
+            return ApplyColumnRoutedPress();
         }
+
+        internal bool ApplyColumnRoutedPress() => UpdateResult(true);
 
         public virtual void OnReleased(KeyBindingReleaseEvent<ManiaAction> e)
         {

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableNote.cs
@@ -99,7 +99,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             if (!userTriggered)
             {
                 if (!HitObject.HitWindows.CanBeHit(timeOffset))
-                    ApplyMinResult();
+                    EzApplyPassiveMissWithStoredOffset();
 
                 return;
             }

--- a/osu.Game.Rulesets.Mania/Objects/EzCurrentHitObject/O2HitModeExtension.cs
+++ b/osu.Game.Rulesets.Mania/Objects/EzCurrentHitObject/O2HitModeExtension.cs
@@ -108,6 +108,46 @@ namespace osu.Game.Rulesets.Mania.Objects.EzCurrentHitObject
 
         public static double SafeBpm(double bpm) => double.IsFinite(bpm) && bpm > 0 ? Math.Max(bpm, 75.0) : 75.0;
 
+        /// <summary>
+        /// Pill 逻辑：使用已算 BPM，避免 press 路径重复 <see cref="GetBPMAtTime"/>。
+        /// </summary>
+        public static bool PillCheckWithBpm(double timeOffset, double bpm, out bool applyComboBreak, out bool upgradeToPerfect)
+        {
+            applyComboBreak = false;
+            upgradeToPerfect = false;
+
+            if (!PillActivated)
+                return true;
+
+            double absOffset = Math.Abs(timeOffset);
+            GetRanges(SafeBpm(bpm), 1, out double coolRange, out double goodRange, out double badRange);
+
+            if (absOffset <= coolRange)
+            {
+                IncrementCoolCombo();
+            }
+            else if (absOffset <= goodRange)
+            {
+                CoolCombo = 0;
+            }
+            else if (absOffset <= badRange)
+            {
+                CoolCombo = 0;
+
+                if (PILL_COUNT.Value > 0)
+                {
+                    PILL_COUNT.Value = Math.Clamp(PILL_COUNT.Value - 1, 0, 5);
+                    upgradeToPerfect = true;
+                }
+                else
+                {
+                    applyComboBreak = true;
+                }
+            }
+
+            return true;
+        }
+
         public static void GetRanges(double bpm, double totalMultiplier, out double cool, out double good, out double bad)
         {
             double safe = SafeBpm(bpm);

--- a/osu.Game.Rulesets.Mania/UI/Column.cs
+++ b/osu.Game.Rulesets.Mania/UI/Column.cs
@@ -15,7 +15,10 @@ using osu.Game.Extensions;
 using osu.Game.EzOsuGame;
 using osu.Game.EzOsuGame.Audio;
 using osu.Game.EzOsuGame.Configuration;
+using osu.Game.Rulesets.Mania.EzMania.Diagnostics;
+using osu.Game.Rulesets.Mania.EzMania.Helper;
 using osu.Game.Rulesets.Mania.EzMania.ReplayJudge;
+using osu.Game.Rulesets.Mania.EzMania.ReplayJudge.Mappings;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mania.Beatmaps;
 using osu.Game.Rulesets.Mania.Configuration;
@@ -54,7 +57,8 @@ namespace osu.Game.Rulesets.Mania.UI
 
         private DrawablePool<PoolableHitExplosion> hitExplosionPool = null!;
         private OrderedHitPolicy hitPolicy = null!;
-        private ManiaLaneController? laneController;
+        private EzEnumJudgePrecedence judgePrecedence;
+        private bool bmsMode;
         public Container UnderlayElements => HitObjectArea.UnderlayElements;
 
         private GameplaySampleTriggerSource sampleTriggerSource = null!;
@@ -101,6 +105,23 @@ namespace osu.Game.Rulesets.Mania.UI
         //
         // public IEzSkinInfo EzSkinInfo => ezSkinInfo;
 
+        [Resolved(canBeNull: true)]
+        private DrawableManiaRuleset? drawableRuleset { get; set; }
+
+        internal ManiaLaneController LaneController { get; private set; } = null!;
+
+        internal bool TryGetBmsRoute(DrawableNote note, out BmsHitModeJudgement.BmsRouteState route)
+        {
+            if (LaneController.TryGetEntry(note, out var entry))
+            {
+                route = entry.BmsRoute;
+                return true;
+            }
+
+            route = null!;
+            return false;
+        }
+
         public Bindable<string> NoteSetNameBindable = null!;
         public Bindable<bool> ColorSettingsEnabledBindable = null!;
         public Bindable<Colour4> EzNoteColourBindable = null!;
@@ -132,13 +153,12 @@ namespace osu.Game.Rulesets.Mania.UI
 
             // JudgePrecedence 来自全局配置（与 ManiaJudgementRound.Create 一致）；勿 [Resolved] DrawableManiaRuleset——
             // 皮肤预览等场景会单独构造 Column，且 JudgementRound 在 ruleset LoadComplete 才冻结。
-            var judgePrecedence = ezConfig.Get<EzEnumJudgePrecedence>(Ez2Setting.JudgePrecedence);
+            judgePrecedence = ezConfig.Get<EzEnumJudgePrecedence>(Ez2Setting.JudgePrecedence);
+            var hitMode = ezConfig.Get<EzEnumHitMode>(Ez2Setting.ManiaHitMode);
+            bmsMode = HitModeHelper.IsBMSHitMode(hitMode);
 
-            // Earliest：列内有序目标 + 游标（ManiaLaneController），Drawable / Session 共用 note-lock 语义。
-            // Combo / Duration：暂不建 controller，OrderedHitPolicy 仍走 OrderedHitPolicyHelper 全列 AliveObjects 扫描。
-            // TODO(LANE-PRECEDENCE): Combo/Duration 也接入 ManiaLaneController 列级目标选择，替代热路径全列扫描（见 HIGH_KPS_JUDGE_BACKLOG.md）。
-            laneController = judgePrecedence == EzEnumJudgePrecedence.Earliest ? new ManiaLaneController() : null;
-            hitPolicy = new OrderedHitPolicy(HitObjectContainer, judgePrecedence, laneController);
+            LaneController = new ManiaLaneController();
+            hitPolicy = new OrderedHitPolicy(HitObjectContainer, judgePrecedence, LaneController, bmsMode);
 
             EzNoteTypeBindable = ezConfig.GetColumnTypeBindable(KeyMode, Index);
             EzNoteSizeBindable = ezFactory.GetNoteSizeBindable(KeyMode, Index);
@@ -272,6 +292,7 @@ namespace osu.Game.Rulesets.Mania.UI
                 hitPolicy.EnsureRegistered(d);
                 return hitPolicy.IsHittable(d, time);
             };
+            maniaObject.ShouldSkipColumnRoutedPress = hitPolicy.ShouldSkipDrawablePress;
         }
 
         private sealed partial class LaneTrackingScrollingHitObjectContainer : ScrollingHitObjectContainer
@@ -314,16 +335,46 @@ namespace osu.Game.Rulesets.Mania.UI
             if (e.Action != Action.Value)
                 return false;
 
-            // 记录延迟追踪按键输入
+            ManiaJudgeHotPathTrace.RecordColumnOnPressed();
+
             InputAudioLatencyTracker.Instance?.RecordColumnPress(Index);
+
+            bool routed = false;
+
+            if (drawableRuleset?.ColumnRoutesInput == true)
+            {
+                if (drawableRuleset.JudgementRound is { IsO2Jam: true } round)
+                    round.NotifyO2InputAt(Time.Current);
+
+                if (hitPolicy.TryRoutePress(Time.Current, out var target))
+                    routed = hitPolicy.ApplyRoutedPress(target!, Time.Current, e);
+            }
 
             if (keySoundPreviewMode != KeySoundPreviewMode.AutoPlayPlus)
                 sampleTriggerSource.Play();
-            return true;
+
+            return routed;
         }
 
         public void OnReleased(KeyBindingReleaseEvent<ManiaAction> e)
         {
+            if (e.Action != Action.Value)
+                return;
+
+            if (drawableRuleset?.ColumnRoutesInput != true)
+                return;
+
+            var activeHold = LaneController.ActiveHold;
+
+            if (activeHold == null || !activeHold.IsHolding.Value)
+                return;
+
+            var round = drawableRuleset.JudgementRound;
+
+            if (round != null)
+                ManiaEzDrawableJudgement.TryColumnHoldTailRelease(activeHold, Time.Current, round);
+
+            LaneController.SetActiveHold(null);
         }
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos)

--- a/osu.Game.Rulesets.Mania/UI/Column.cs
+++ b/osu.Game.Rulesets.Mania/UI/Column.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
@@ -109,6 +110,12 @@ namespace osu.Game.Rulesets.Mania.UI
         private DrawableManiaRuleset? drawableRuleset { get; set; }
 
         internal ManiaLaneController LaneController { get; private set; } = null!;
+
+        private readonly List<double> pressTimes = new List<double>();
+
+        internal void RecordPressTime(double time) => pressTimes.Add(time);
+
+        internal List<double> GetPressTimesSnapshot() => new List<double>(pressTimes);
 
         internal bool TryGetBmsRoute(DrawableNote note, out BmsHitModeJudgement.BmsRouteState route)
         {
@@ -338,6 +345,9 @@ namespace osu.Game.Rulesets.Mania.UI
             ManiaJudgeHotPathTrace.RecordColumnOnPressed();
 
             InputAudioLatencyTracker.Instance?.RecordColumnPress(Index);
+
+            if (e.Action == Action.Value)
+                RecordPressTime(Time.Current);
 
             bool routed = false;
 

--- a/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
@@ -103,6 +103,12 @@ namespace osu.Game.Rulesets.Mania.UI
         int IManiaGameplayModeSnapshot.HealthMode => (int)ManiaHealthProcessor.ActiveHealthMode;
 
         /// <summary>
+        /// 列级按键输入由 <see cref="UI.Column"/> 路由到单一 press 目标（C2 COLUMN-INPUT）。
+        /// 回放仍走 drawable 按键链，与 Session 输入模型一致。
+        /// </summary>
+        public bool ColumnRoutesInput => JudgementRound != null && ReplayScore == null;
+
+        /// <summary>
         /// 本局冻结的判定上下文；热路径读取此实例，禁止再解析全局配置。
         /// </summary>
         public ManiaJudgementRound? JudgementRound { get; private set; }

--- a/osu.Game.Rulesets.Mania/UI/OrderedHitPolicy.cs
+++ b/osu.Game.Rulesets.Mania/UI/OrderedHitPolicy.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
-using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Input.Events;
 using osu.Game.EzOsuGame.Configuration;
+using osu.Game.Rulesets.Mania.EzMania.Diagnostics;
 using osu.Game.Rulesets.Mania.EzMania.Helper;
 using osu.Game.Rulesets.Mania.EzMania.ReplayJudge;
 using osu.Game.Rulesets.Mania.Objects.Drawables;
@@ -20,107 +20,107 @@ namespace osu.Game.Rulesets.Mania.UI
     {
         private readonly HitObjectContainer hitObjectContainer;
         private readonly OrderedHitPolicyHelper helper;
-        private readonly bool enabledPrecedence;
-        private readonly ManiaLaneController? laneController;
+        private readonly EzEnumJudgePrecedence judgePrecedence;
+        private readonly ManiaLaneController laneController;
+        private readonly bool bmsMode;
+        private DrawableHitObject? columnRoutedPressTarget;
 
-        public OrderedHitPolicy(HitObjectContainer hitObjectContainer, EzEnumJudgePrecedence judgePrecedence, ManiaLaneController? laneController = null)
+        public OrderedHitPolicy(HitObjectContainer hitObjectContainer, EzEnumJudgePrecedence judgePrecedence, ManiaLaneController laneController, bool bmsMode)
         {
             this.hitObjectContainer = hitObjectContainer;
-            this.laneController = judgePrecedence == EzEnumJudgePrecedence.Earliest ? laneController : null;
-            helper = new OrderedHitPolicyHelper(hitObjectContainer);
-            enabledPrecedence = judgePrecedence != EzEnumJudgePrecedence.Earliest;
+            this.judgePrecedence = judgePrecedence;
+            this.laneController = laneController;
+            this.bmsMode = bmsMode;
+            helper = new OrderedHitPolicyHelper(hitObjectContainer, laneController);
         }
 
-        internal void RegisterDrawable(DrawableHitObject drawable) => laneController?.Register(drawable);
+        internal void RegisterDrawable(DrawableHitObject drawable) => laneController.Register(drawable);
 
-        internal void EnsureRegistered(DrawableHitObject drawable) => laneController?.RegisterIfNeeded(drawable);
+        internal void EnsureRegistered(DrawableHitObject drawable) => laneController.RegisterIfNeeded(drawable);
 
-        internal void UnregisterDrawable(DrawableHitObject drawable) => laneController?.Unregister(drawable);
+        internal void UnregisterDrawable(DrawableHitObject drawable) => laneController.Unregister(drawable);
 
-        internal void UnregisterByHitObject(HitObject hitObject) => laneController?.UnregisterByHitObject(hitObject);
+        internal void UnregisterByHitObject(HitObject hitObject) => laneController.UnregisterByHitObject(hitObject);
 
-        internal void NotifyJudged(DrawableHitObject drawable) => laneController?.NotifyJudged(drawable);
+        internal void NotifyJudged(DrawableHitObject drawable) => laneController.NotifyJudged(drawable);
+
+        internal bool ShouldSkipDrawablePress(DrawableHitObject drawable)
+            => columnRoutedPressTarget != null;
 
         /// <summary>
-        /// Determines whether a <see cref="DrawableHitObject"/> can be hit at a point in time.
+        /// 列级按键路由：选出本列唯一 press 目标（Combo / Duration / Earliest + BMS post-Bad）。
         /// </summary>
-        /// <remarks>
-        /// Only the most recent <see cref="DrawableHitObject"/> can be hit, a previous hitobject's window cannot extend past the next one.
-        /// </remarks>
-        /// <param name="hitObject">The <see cref="DrawableHitObject"/> to check.</param>
-        /// <param name="time">The time to check.</param>
-        /// <returns>Whether <paramref name="hitObject"/> can be hit at the given <paramref name="time"/>.</returns>
+        public bool TryRoutePress(double time, out DrawableHitObject? target)
+        {
+            columnRoutedPressTarget = null;
+            target = null;
+
+            var entry = laneController.SelectPressEntry(time, judgePrecedence, bmsMode);
+
+            if (entry == null)
+                return false;
+
+            target = entry.RoutedObject;
+            return true;
+        }
+
+        /// <summary>
+        /// 对 <see cref="TryRoutePress"/> 选中的目标执行判定（保留 Ez 判定链）。
+        /// </summary>
+        public bool ApplyRoutedPress(DrawableHitObject target, double time, KeyBindingPressEvent<ManiaAction> e)
+        {
+            switch (target)
+            {
+                case DrawableNote note when ManiaEzDrawableJudgement.TryBmsOnPressed(note, e):
+                    columnRoutedPressTarget = target;
+                    return true;
+
+                case DrawableNote note:
+                    if (!note.ApplyColumnRoutedPress())
+                        return false;
+
+                    columnRoutedPressTarget = target;
+                    return true;
+
+                case DrawableHoldNote hold:
+                    if (!hold.TryBeginHoldPressFromColumn(time))
+                        return false;
+
+                    laneController.SetActiveHold(hold);
+                    columnRoutedPressTarget = target;
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
         public bool IsHittable(DrawableHitObject hitObject, double time)
         {
-            if (enabledPrecedence)
+            ManiaJudgeHotPathTrace.RecordIsHittable();
+
+            if (hitObject is DrawableHoldNoteTail)
                 return helper.IsHittableWithPrecedence(hitObject, time);
 
-            if (laneController != null)
-                return laneController.IsHittableEarliest(hitObject, time);
+            if (judgePrecedence != EzEnumJudgePrecedence.Earliest)
+                return helper.IsHittableWithPrecedence(hitObject, time);
 
-            var nextObject = hitObjectContainer.AliveObjects.GetNext(hitObject);
-            return nextObject == null || time < nextObject.HitObject.StartTime;
+            return laneController.IsHittableEarliest(hitObject, time);
         }
 
-        /// <summary>
-        /// Handles a <see cref="HitObject"/> being hit to potentially miss all earlier <see cref="HitObject"/>s.
-        /// </summary>
-        /// <param name="hitObject">The <see cref="HitObject"/> that was hit.</param>
         public void HandleHit(DrawableHitObject hitObject)
         {
-            if (enabledPrecedence)
+            double judgementTime = hitObject.Result.TimeAbsolute;
+
+            foreach (var entry in laneController.EnumerateForceMissBefore(hitObject.HitObject.StartTime))
             {
-                double judgementTime = hitObject.Result.TimeAbsolute;
-
-                foreach (var obj in enumerateHitObjectsUpTo(hitObject.HitObject.StartTime))
-                {
-                    if (obj.Judged)
-                        continue;
-
-                    if (OrderedHitPolicyHelper.IsUserTriggerJudgeableNow(obj, judgementTime))
-                        continue;
-
-                    ((DrawableManiaHitObject)obj).MissForcefully();
-                }
-
-                return;
-            }
-
-            if (laneController != null)
-            {
-                foreach (var entry in laneController.EnumerateForceMissBefore(hitObject.HitObject.StartTime))
-                    ((DrawableManiaHitObject)entry.Drawable).MissForcefully();
-
-                laneController.NotifyJudged(hitObject);
-                return;
-            }
-
-            foreach (var obj in enumerateHitObjectsUpTo(hitObject.HitObject.StartTime))
-            {
-                if (obj.Judged)
+                if (OrderedHitPolicyHelper.IsUserTriggerJudgeableNow(entry.RoutedObject, judgementTime))
                     continue;
 
-                ((DrawableManiaHitObject)obj).MissForcefully();
+                ((DrawableManiaHitObject)entry.RoutedObject).MissForcefully();
             }
-        }
 
-        private IEnumerable<DrawableHitObject> enumerateHitObjectsUpTo(double targetTime)
-        {
-            foreach (var obj in hitObjectContainer.AliveObjects)
-            {
-                if (obj.HitObject.GetEndTime() >= targetTime)
-                    yield break;
-
-                yield return obj;
-
-                foreach (var nestedObj in obj.NestedHitObjects)
-                {
-                    if (nestedObj.HitObject.GetEndTime() >= targetTime)
-                        break;
-
-                    yield return nestedObj;
-                }
-            }
+            laneController.NotifyJudged(hitObject);
         }
     }
 }

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.EzTiming.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.EzTiming.cs
@@ -1,0 +1,46 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Game.EzOsuGame.Scoring;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Screens.Play;
+
+namespace osu.Game.Rulesets.Objects.Drawables
+{
+    public abstract partial class DrawableHitObject
+    {
+        /// <summary>
+        /// 与 <see cref="ApplyResult{T}"/> 相同，但在触发 <see cref="OnNewResult"/> 前写入 stored <paramref name="timeOffset"/>。
+        /// </summary>
+        protected void ApplyResultWithStoredTiming<T>(Action<JudgementResult, T> application, T state, double timeOffset)
+        {
+            if (Result.HasResult)
+                throw new InvalidOperationException("Cannot apply result on a hitobject that already has a result.");
+
+            application?.Invoke(Result, state);
+
+            if (!Result.HasResult)
+                throw new InvalidOperationException($"{GetType().Name} applied a {nameof(JudgementResult)} but did not update {nameof(JudgementResult.Type)}.");
+
+            HitResultExtensions.ValidateHitResultPair(Result.Judgement.MaxResult, Result.Judgement.MinResult);
+
+            if (!Result.Type.IsValidHitResult(Result.Judgement.MinResult, Result.Judgement.MaxResult))
+            {
+                throw new InvalidOperationException(
+                    $"{GetType().Name} applied an invalid hit result (was: {Result.Type}, expected: [{Result.Judgement.MinResult} ... {Result.Judgement.MaxResult}]).");
+            }
+
+            double gameplayRate = (Clock as IGameplayClock)?.GetTrueGameplayRate() ?? Clock.Rate;
+            JudgementResultTimingHelper.ApplyTiming(Result, timeOffset, gameplayRate);
+
+            autoplaySampleTriggered = true;
+
+            if (Result.HasResult)
+                UpdateState(Result.IsHit ? ArmedState.Hit : ArmedState.Miss);
+
+            OnNewResult?.Invoke(this, Result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **LANE-PRECEDENCE**：Combo/Duration 列级 note-lock（`ManiaLaneController`、`ManiaLanePressSelector`、Session 选目标）。
- **COLUMN-INPUT**：列级按键单入口、AutoMissGate、O2-NOMUTATE、idle/press 热路径减负。
- **Miss parity**：Drawable passive miss `TimeOffset` 与 Session end-sweep 对齐（stored timing、`ApplyResultWithStoredTiming`）。

## Commits

1. `feat(mania): LANE-PRECEDENCE Combo/Duration 列级 note-lock`
2. `feat(mania): COLUMN-INPUT 列级按键单入口`
3. `feat(mania): passive miss TimeOffset 与 Session parity`

## Test plan

- [x] `dotnet build osu.Game.Rulesets.Mania`
- [x] ReplayJudge / Parity / Precedence / ManiaLaneController 相关测试 124/124
