### PR TITLE
feat(mania): L/R turntable scratch axis

### DIFF
--- a/Ez2Lazer.Dependencies.props
+++ b/Ez2Lazer.Dependencies.props
@@ -1,7 +1,7 @@
 ﻿<!-- Ez2Lazer：Framework / Resources 依赖。版本仅在此文件维护。 -->
 <Project>
   <PropertyGroup Label="Ez2Lazer">
-    <Ez2LazerFrameworkVersion>2026.703.1-ez2lazer</Ez2LazerFrameworkVersion>
+    <Ez2LazerFrameworkVersion>2026.722.0-ez2lazer</Ez2LazerFrameworkVersion>
     <Ez2LazerGameResourcesVersion>2026.711.0-ez2lazer</Ez2LazerGameResourcesVersion>
     <Ez2LazerFrameworkProjectPath>$(MSBuildThisFileDirectory)..\osu-framework\osu.Framework\osu.Framework.csproj</Ez2LazerFrameworkProjectPath>
     <Ez2LazerResourcesProjectPath>$(MSBuildThisFileDirectory)..\osu-resources\osu.Game.Resources\osu.Game.Resources.csproj</Ez2LazerResourcesProjectPath>

--- a/osu.Game.Rulesets.Mania/EzMania/Input/ManiaScratchColumnTemplate.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/Input/ManiaScratchColumnTemplate.cs
@@ -1,0 +1,43 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Mania.EzMania.Input
+{
+    /// <summary>
+    /// 转盘轴模板：将 L/R scratch 映射到 12/14/16K 首尾列。
+    /// </summary>
+    public static class ManiaScratchColumnTemplate
+    {
+        /// <summary>
+        /// 解析当前键数下的 (L列, R列)。无匹配时返回 false。
+        /// </summary>
+        /// <param name="variant">Mania variant（= 逻辑键数）。</param>
+        /// <param name="skipEmptyEdgeColumns">10k2s1p / <c>ManiaSkipEmptyEdgeColumns</c>。</param>
+        /// <param name="leftColumn">L-Scratch 对应列下标。</param>
+        /// <param name="rightColumn">R-Scratch 对应列下标。</param>
+        public static bool TryResolve(int variant, bool skipEmptyEdgeColumns, out int leftColumn, out int rightColumn)
+        {
+            switch (variant)
+            {
+                case 12:
+                    leftColumn = 0;
+                    rightColumn = 11;
+                    return true;
+
+                case 14:
+                    leftColumn = 0;
+                    rightColumn = skipEmptyEdgeColumns ? 12 : 13;
+                    return true;
+
+                case 16:
+                    leftColumn = 0;
+                    rightColumn = 15;
+                    return true;
+
+                default:
+                    leftColumn = rightColumn = -1;
+                    return false;
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/ManiaInputManager.ScratchAxis.cs
+++ b/osu.Game.Rulesets.Mania/ManiaInputManager.ScratchAxis.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Platform;
 using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.Input;
 using osu.Game.Rulesets.Mania.EzMania.Input;
@@ -14,6 +15,7 @@ namespace osu.Game.Rulesets.Mania
         private readonly ScratchAxisPair scratchAxes = new ScratchAxisPair();
 
         private ScratchAxisDeviceTracker scratchTracker = null!;
+        private GameHost host = null!;
 
         private Bindable<bool> scratchEnabled = null!;
         private Bindable<bool> skipEmptyEdge = null!;
@@ -28,9 +30,10 @@ namespace osu.Game.Rulesets.Mania
         private ManiaAction rightInjectedAction;
 
         [BackgroundDependencyLoader]
-        private void loadScratchAxis(Ez2ConfigManager ezConfig, ScratchAxisDeviceTracker tracker)
+        private void loadScratchAxis(Ez2ConfigManager ezConfig, ScratchAxisDeviceTracker tracker, GameHost gameHost)
         {
             scratchTracker = tracker;
+            host = gameHost;
 
             scratchEnabled = ezConfig.GetBindable<bool>(Ez2Setting.ManiaScratchAxisEnabled);
             skipEmptyEdge = ezConfig.GetBindable<bool>(Ez2Setting.ManiaSkipEmptyEdgeColumns);
@@ -69,25 +72,30 @@ namespace osu.Game.Rulesets.Mania
                 return;
             }
 
-            bool leftWas = scratchAxes.Left.IsPressed.Value;
-            bool rightWas = scratchAxes.Right.IsPressed.Value;
+            // FrameStable 的 Time.Current 在追帧/进图停表时可能长时间不变，停转阈值永远到不了 → 列一直按住。
+            double wallTime = host.UpdateThread.Clock.CurrentTime;
+            scratchAxes.UpdateFrom(scratchTracker, wallTime);
 
-            scratchAxes.UpdateFrom(scratchTracker, Time.Current);
-
-            syncInjection(scratchAxes.Left.IsPressed.Value, leftWas, ManiaAction.Key1 + leftCol, ref leftInjected, ref leftInjectedAction);
-            syncInjection(scratchAxes.Right.IsPressed.Value, rightWas, ManiaAction.Key1 + rightCol, ref rightInjected, ref rightInjectedAction);
+            syncInjection(scratchAxes.Left.IsPressed.Value, ManiaAction.Key1 + leftCol, ref leftInjected, ref leftInjectedAction);
+            syncInjection(scratchAxes.Right.IsPressed.Value, ManiaAction.Key1 + rightCol, ref rightInjected, ref rightInjectedAction);
         }
 
-        private void syncInjection(bool nowPressed, bool wasPressed, ManiaAction action, ref bool injected, ref ManiaAction injectedAction)
+        private void syncInjection(bool nowPressed, ManiaAction action, ref bool injected, ref ManiaAction injectedAction)
         {
-            if (nowPressed == wasPressed)
-                return;
-
             if (nowPressed)
             {
-                KeyBindingContainer.TriggerPressed(action);
-                injected = true;
-                injectedAction = action;
+                if (!injected)
+                {
+                    KeyBindingContainer.TriggerPressed(action);
+                    injected = true;
+                    injectedAction = action;
+                }
+                else if (injectedAction != action)
+                {
+                    KeyBindingContainer.TriggerReleased(injectedAction);
+                    KeyBindingContainer.TriggerPressed(action);
+                    injectedAction = action;
+                }
             }
             else if (injected)
             {

--- a/osu.Game.Rulesets.Mania/ManiaInputManager.ScratchAxis.cs
+++ b/osu.Game.Rulesets.Mania/ManiaInputManager.ScratchAxis.cs
@@ -1,0 +1,112 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Input;
+using osu.Game.Rulesets.Mania.EzMania.Input;
+
+namespace osu.Game.Rulesets.Mania
+{
+    public partial class ManiaInputManager
+    {
+        private readonly ScratchAxisPair scratchAxes = new ScratchAxisPair();
+
+        private Bindable<bool> scratchEnabled = null!;
+        private Bindable<bool> skipEmptyEdge = null!;
+        private Bindable<int> leftAxisIndex = null!;
+        private Bindable<int> rightAxisIndex = null!;
+        private Bindable<double> deadzone = null!;
+        private Bindable<int> stopThreshold = null!;
+
+        private bool leftInjected;
+        private bool rightInjected;
+        private ManiaAction leftInjectedAction;
+        private ManiaAction rightInjectedAction;
+
+        [BackgroundDependencyLoader]
+        private void loadScratchAxis(Ez2ConfigManager ezConfig)
+        {
+            scratchEnabled = ezConfig.GetBindable<bool>(Ez2Setting.ManiaScratchAxisEnabled);
+            skipEmptyEdge = ezConfig.GetBindable<bool>(Ez2Setting.ManiaSkipEmptyEdgeColumns);
+            leftAxisIndex = ezConfig.GetBindable<int>(Ez2Setting.ScratchAxisL);
+            rightAxisIndex = ezConfig.GetBindable<int>(Ez2Setting.ScratchAxisR);
+            deadzone = ezConfig.GetBindable<double>(Ez2Setting.ScratchAxisDeadzone);
+            stopThreshold = ezConfig.GetBindable<int>(Ez2Setting.ScratchAxisStopThreshold);
+
+            scratchAxes.LeftAxisIndex.BindTo(leftAxisIndex);
+            scratchAxes.RightAxisIndex.BindTo(rightAxisIndex);
+            scratchAxes.BindTuning(deadzone, stopThreshold);
+
+            scratchEnabled.BindValueChanged(_ => releaseInjected(), true);
+            skipEmptyEdge.BindValueChanged(_ => releaseInjected());
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+            pollScratchAxes();
+        }
+
+        private void pollScratchAxes()
+        {
+            if (ReplayInputHandler != null || !scratchEnabled.Value)
+            {
+                if (leftInjected || rightInjected)
+                    releaseInjected();
+                return;
+            }
+
+            if (!ManiaScratchColumnTemplate.TryResolve(variant, skipEmptyEdge.Value, out int leftCol, out int rightCol))
+            {
+                if (leftInjected || rightInjected)
+                    releaseInjected();
+                return;
+            }
+
+            bool leftWas = scratchAxes.Left.IsPressed.Value;
+            bool rightWas = scratchAxes.Right.IsPressed.Value;
+
+            scratchAxes.UpdateFrom(CurrentState.Joystick);
+
+            syncInjection(scratchAxes.Left.IsPressed.Value, leftWas, ManiaAction.Key1 + leftCol, ref leftInjected, ref leftInjectedAction);
+            syncInjection(scratchAxes.Right.IsPressed.Value, rightWas, ManiaAction.Key1 + rightCol, ref rightInjected, ref rightInjectedAction);
+        }
+
+        private void syncInjection(bool nowPressed, bool wasPressed, ManiaAction action, ref bool injected, ref ManiaAction injectedAction)
+        {
+            if (nowPressed == wasPressed)
+                return;
+
+            if (nowPressed)
+            {
+                KeyBindingContainer.TriggerPressed(action);
+                injected = true;
+                injectedAction = action;
+            }
+            else if (injected)
+            {
+                KeyBindingContainer.TriggerReleased(injectedAction);
+                injected = false;
+            }
+        }
+
+        private void releaseInjected()
+        {
+            if (leftInjected)
+            {
+                KeyBindingContainer.TriggerReleased(leftInjectedAction);
+                leftInjected = false;
+            }
+
+            if (rightInjected)
+            {
+                KeyBindingContainer.TriggerReleased(rightInjectedAction);
+                rightInjected = false;
+            }
+
+            scratchAxes.Reset();
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/ManiaInputManager.ScratchAxis.cs
+++ b/osu.Game.Rulesets.Mania/ManiaInputManager.ScratchAxis.cs
@@ -13,10 +13,12 @@ namespace osu.Game.Rulesets.Mania
     {
         private readonly ScratchAxisPair scratchAxes = new ScratchAxisPair();
 
+        private ScratchAxisDeviceTracker scratchTracker = null!;
+
         private Bindable<bool> scratchEnabled = null!;
         private Bindable<bool> skipEmptyEdge = null!;
-        private Bindable<int> leftAxisIndex = null!;
-        private Bindable<int> rightAxisIndex = null!;
+        private Bindable<string> leftBinding = null!;
+        private Bindable<string> rightBinding = null!;
         private Bindable<double> deadzone = null!;
         private Bindable<int> stopThreshold = null!;
 
@@ -26,17 +28,19 @@ namespace osu.Game.Rulesets.Mania
         private ManiaAction rightInjectedAction;
 
         [BackgroundDependencyLoader]
-        private void loadScratchAxis(Ez2ConfigManager ezConfig)
+        private void loadScratchAxis(Ez2ConfigManager ezConfig, ScratchAxisDeviceTracker tracker)
         {
+            scratchTracker = tracker;
+
             scratchEnabled = ezConfig.GetBindable<bool>(Ez2Setting.ManiaScratchAxisEnabled);
             skipEmptyEdge = ezConfig.GetBindable<bool>(Ez2Setting.ManiaSkipEmptyEdgeColumns);
-            leftAxisIndex = ezConfig.GetBindable<int>(Ez2Setting.ScratchAxisL);
-            rightAxisIndex = ezConfig.GetBindable<int>(Ez2Setting.ScratchAxisR);
+            leftBinding = ezConfig.GetBindable<string>(Ez2Setting.ScratchAxisL);
+            rightBinding = ezConfig.GetBindable<string>(Ez2Setting.ScratchAxisR);
             deadzone = ezConfig.GetBindable<double>(Ez2Setting.ScratchAxisDeadzone);
             stopThreshold = ezConfig.GetBindable<int>(Ez2Setting.ScratchAxisStopThreshold);
 
-            scratchAxes.LeftAxisIndex.BindTo(leftAxisIndex);
-            scratchAxes.RightAxisIndex.BindTo(rightAxisIndex);
+            scratchAxes.LeftBinding.BindTo(leftBinding);
+            scratchAxes.RightBinding.BindTo(rightBinding);
             scratchAxes.BindTuning(deadzone, stopThreshold);
 
             scratchEnabled.BindValueChanged(_ => releaseInjected(), true);
@@ -68,7 +72,7 @@ namespace osu.Game.Rulesets.Mania
             bool leftWas = scratchAxes.Left.IsPressed.Value;
             bool rightWas = scratchAxes.Right.IsPressed.Value;
 
-            scratchAxes.UpdateFrom(CurrentState.Joystick);
+            scratchAxes.UpdateFrom(scratchTracker, Time.Current);
 
             syncInjection(scratchAxes.Left.IsPressed.Value, leftWas, ManiaAction.Key1 + leftCol, ref leftInjected, ref leftInjectedAction);
             syncInjection(scratchAxes.Right.IsPressed.Value, rightWas, ManiaAction.Key1 + rightCol, ref rightInjected, ref rightInjectedAction);

--- a/osu.Game.Rulesets.Mania/ManiaInputManager.cs
+++ b/osu.Game.Rulesets.Mania/ManiaInputManager.cs
@@ -15,9 +15,12 @@ namespace osu.Game.Rulesets.Mania
     [Cached] // Used for touch input, see Column.OnTouchDown/OnTouchUp.
     public partial class ManiaInputManager : RulesetInputManager<ManiaAction>
     {
+        private readonly int variant;
+
         public ManiaInputManager(RulesetInfo ruleset, int variant)
             : base(ruleset, variant, SimultaneousBindingMode.Unique)
         {
+            this.variant = variant;
         }
 
         protected override KeyBindingContainer<ManiaAction> CreateKeyBindingContainer(RulesetInfo ruleset, int variant, SimultaneousBindingMode unique)

--- a/osu.Game.Tests/NonVisual/ScratchAxisProcessorTest.cs
+++ b/osu.Game.Tests/NonVisual/ScratchAxisProcessorTest.cs
@@ -11,16 +11,34 @@ namespace osu.Game.Tests.NonVisual
     public class ScratchAxisProcessorTest
     {
         [Test]
+        public void RestAtNonZeroPositionIsIdle()
+        {
+            var processor = new ScratchAxisProcessor();
+            processor.Deadzone.Value = 0.04;
+            processor.StopThresholdMs.Value = 50;
+
+            // 停靠在 60%，不是按下
+            processor.Update(0.6f, 0);
+            Assert.That(processor.IsPressed.Value, Is.False);
+
+            for (int t = 1; t <= 200; t++)
+            {
+                processor.Update(0.6f, t);
+                Assert.That(processor.IsPressed.Value, Is.False, $"t={t}");
+            }
+        }
+
+        [Test]
         public void SpinAboveDeadzonePressesAndSetsDirection()
         {
             var processor = new ScratchAxisProcessor();
             processor.Deadzone.Value = 0.02;
-            processor.StopThreshold.Value = 5;
+            processor.StopThresholdMs.Value = 50;
 
-            processor.Update(0f);
+            processor.Update(0f, 0);
             Assert.That(processor.IsPressed.Value, Is.False);
 
-            processor.Update(0.1f);
+            processor.Update(0.1f, 16);
             Assert.That(processor.IsPressed.Value, Is.True);
             Assert.That(processor.Direction.Value, Is.EqualTo(ScratchAxisDirection.Clockwise));
         }
@@ -30,36 +48,50 @@ namespace osu.Game.Tests.NonVisual
         {
             var processor = new ScratchAxisProcessor();
             processor.Deadzone.Value = 0.05;
-            processor.StopThreshold.Value = 5;
+            processor.StopThresholdMs.Value = 50;
 
-            processor.Update(0f);
-            processor.Update(0.01f);
-            processor.Update(-0.01f);
-            processor.Update(0.02f);
+            processor.Update(0.5f, 0);
+            processor.Update(0.51f, 16);
+            processor.Update(0.49f, 32);
+            processor.Update(0.52f, 48);
 
             Assert.That(processor.IsPressed.Value, Is.False);
             Assert.That(processor.Direction.Value, Is.EqualTo(ScratchAxisDirection.None));
         }
 
         [Test]
-        public void StopAfterIdleFramesReleases()
+        public void StopAfterIdleMsReleases()
         {
             var processor = new ScratchAxisProcessor();
             processor.Deadzone.Value = 0.02;
-            processor.StopThreshold.Value = 3;
+            processor.StopThresholdMs.Value = 50;
 
-            processor.Update(0f);
-            processor.Update(0.1f);
+            processor.Update(0f, 0);
+            processor.Update(0.1f, 10);
             Assert.That(processor.IsPressed.Value, Is.True);
 
-            processor.Update(0.1f);
-            processor.Update(0.1f);
-            processor.Update(0.1f);
+            processor.Update(0.1f, 40);
             Assert.That(processor.IsPressed.Value, Is.True);
 
-            processor.Update(0.1f);
+            processor.Update(0.1f, 70);
             Assert.That(processor.IsPressed.Value, Is.False);
             Assert.That(processor.Direction.Value, Is.EqualTo(ScratchAxisDirection.None));
+        }
+
+        [Test]
+        public void MissingSampleDoesNotTreatAsZero()
+        {
+            var processor = new ScratchAxisProcessor();
+            processor.Deadzone.Value = 0.02;
+            processor.StopThresholdMs.Value = 50;
+
+            processor.Update(0.7f, 0);
+            processor.UpdateMissing(100);
+            Assert.That(processor.IsPressed.Value, Is.False);
+
+            // 再次出现同一停靠点，不应因「相对 0」而按下
+            processor.Update(0.7f, 116);
+            Assert.That(processor.IsPressed.Value, Is.False);
         }
 
         [Test]
@@ -68,8 +100,8 @@ namespace osu.Game.Tests.NonVisual
             var processor = new ScratchAxisProcessor();
             processor.Deadzone.Value = 0.02;
 
-            processor.Update(0.95f);
-            processor.Update(-0.95f);
+            processor.Update(0.95f, 0);
+            processor.Update(-0.95f, 16);
 
             Assert.That(processor.IsPressed.Value, Is.True);
             Assert.That(processor.Direction.Value, Is.EqualTo(ScratchAxisDirection.Clockwise));
@@ -81,11 +113,30 @@ namespace osu.Game.Tests.NonVisual
             var processor = new ScratchAxisProcessor();
             processor.Deadzone.Value = 0.02;
 
-            processor.Update(0f);
-            processor.Update(-0.1f);
+            processor.Update(0f, 0);
+            processor.Update(-0.1f, 16);
 
             Assert.That(processor.IsPressed.Value, Is.True);
             Assert.That(processor.Direction.Value, Is.EqualTo(ScratchAxisDirection.CounterClockwise));
+        }
+
+        [Test]
+        public void BindingRoundTripsGuidAndAxis()
+        {
+            var binding = new ScratchAxisBinding("abcd-ef", 2, "TT-L");
+            Assert.That(binding.ToString(), Is.EqualTo("abcd-ef|2"));
+
+            var parsed = ScratchAxisBinding.Parse(binding.ToString());
+            Assert.That(parsed.DeviceGuid, Is.EqualTo("abcd-ef"));
+            Assert.That(parsed.AxisIndex, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void BindingParsesLegacyAxisIndex()
+        {
+            var parsed = ScratchAxisBinding.Parse("3");
+            Assert.That(parsed.DeviceGuid, Is.Empty);
+            Assert.That(parsed.AxisIndex, Is.EqualTo(3));
         }
 
         [TestCase(12, false, 0, 11)]

--- a/osu.Game.Tests/NonVisual/ScratchAxisProcessorTest.cs
+++ b/osu.Game.Tests/NonVisual/ScratchAxisProcessorTest.cs
@@ -13,9 +13,17 @@ namespace osu.Game.Tests.NonVisual
         [Test]
         public void RestAtNonZeroPositionIsIdle()
         {
-            var processor = new ScratchAxisProcessor();
-            processor.Deadzone.Value = 0.04;
-            processor.StopThresholdMs.Value = 50;
+            var processor = new ScratchAxisProcessor
+            {
+                Deadzone =
+                {
+                    Value = 0.04
+                },
+                StopThresholdMs =
+                {
+                    Value = 50
+                }
+            };
 
             // 停靠在 60%，不是按下
             processor.Update(0.6f, 0);
@@ -29,26 +37,134 @@ namespace osu.Game.Tests.NonVisual
         }
 
         [Test]
-        public void SpinAboveDeadzonePressesAndSetsDirection()
+        public void TwoSameDirectionDeltasRequiredToPress()
         {
-            var processor = new ScratchAxisProcessor();
-            processor.Deadzone.Value = 0.02;
-            processor.StopThresholdMs.Value = 50;
+            var processor = new ScratchAxisProcessor
+            {
+                Deadzone =
+                {
+                    Value = 0.02
+                },
+                StopThresholdMs =
+                {
+                    Value = 50
+                }
+            };
 
             processor.Update(0f, 0);
             Assert.That(processor.IsPressed.Value, Is.False);
 
             processor.Update(0.1f, 16);
+            Assert.That(processor.IsPressed.Value, Is.False);
+
+            processor.Update(0.2f, 32);
             Assert.That(processor.IsPressed.Value, Is.True);
             Assert.That(processor.Direction.Value, Is.EqualTo(ScratchAxisDirection.Clockwise));
         }
 
         [Test]
+        public void SingleSpikeDoesNotPress()
+        {
+            var processor = new ScratchAxisProcessor
+            {
+                Deadzone =
+                {
+                    Value = 0.02
+                },
+                StopThresholdMs =
+                {
+                    Value = 50
+                }
+            };
+
+            processor.Update(0f, 0);
+            processor.Update(0.1f, 16);
+            Assert.That(processor.IsPressed.Value, Is.False);
+
+            processor.Update(0.1f, 80);
+            Assert.That(processor.IsPressed.Value, Is.False);
+        }
+
+        [Test]
+        public void ContinuousSameDirectionStaysPressed()
+        {
+            var processor = new ScratchAxisProcessor
+            {
+                Deadzone =
+                {
+                    Value = 0.04
+                },
+                StopThresholdMs =
+                {
+                    Value = 100
+                }
+            };
+
+            processor.Update(0f, 0);
+            processor.Update(0.1f, 10);
+            processor.Update(0.2f, 20);
+            Assert.That(processor.IsPressed.Value, Is.True);
+
+            processor.Update(0.3f, 40);
+            Assert.That(processor.IsPressed.Value, Is.True);
+
+            // 亚死区慢移续按住
+            processor.Update(0.31f, 60);
+            Assert.That(processor.IsPressed.Value, Is.True);
+
+            // 采样空隙未超阈值
+            processor.Update(0.31f, 120);
+            Assert.That(processor.IsPressed.Value, Is.True);
+
+            processor.Update(0.31f, 180);
+            Assert.That(processor.IsPressed.Value, Is.False);
+        }
+
+        [Test]
+        public void DirectionReverseClearsAndRequiresReactivation()
+        {
+            var processor = new ScratchAxisProcessor
+            {
+                Deadzone =
+                {
+                    Value = 0.02
+                },
+                StopThresholdMs =
+                {
+                    Value = 200
+                }
+            };
+
+            processor.Update(0f, 0);
+            processor.Update(0.1f, 10);
+            processor.Update(0.2f, 20);
+            Assert.That(processor.IsPressed.Value, Is.True);
+
+            // 转向：清空；反向位移记 pending=1，本帧不激活
+            processor.Update(0.05f, 30);
+            Assert.That(processor.IsPressed.Value, Is.False);
+            Assert.That(processor.Direction.Value, Is.EqualTo(ScratchAxisDirection.None));
+
+            // 再一次同向（逆时针）→ 第二次有效位移，重新按下
+            processor.Update(-0.05f, 40);
+            Assert.That(processor.IsPressed.Value, Is.True);
+            Assert.That(processor.Direction.Value, Is.EqualTo(ScratchAxisDirection.CounterClockwise));
+        }
+
+        [Test]
         public void JitterBelowDeadzoneDoesNotPress()
         {
-            var processor = new ScratchAxisProcessor();
-            processor.Deadzone.Value = 0.05;
-            processor.StopThresholdMs.Value = 50;
+            var processor = new ScratchAxisProcessor
+            {
+                Deadzone =
+                {
+                    Value = 0.05
+                },
+                StopThresholdMs =
+                {
+                    Value = 50
+                }
+            };
 
             processor.Update(0.5f, 0);
             processor.Update(0.51f, 16);
@@ -62,28 +178,71 @@ namespace osu.Game.Tests.NonVisual
         [Test]
         public void StopAfterIdleMsReleases()
         {
-            var processor = new ScratchAxisProcessor();
-            processor.Deadzone.Value = 0.02;
-            processor.StopThresholdMs.Value = 50;
+            var processor = new ScratchAxisProcessor
+            {
+                Deadzone =
+                {
+                    Value = 0.02
+                },
+                StopThresholdMs =
+                {
+                    Value = 50
+                }
+            };
 
             processor.Update(0f, 0);
             processor.Update(0.1f, 10);
+            processor.Update(0.2f, 20);
             Assert.That(processor.IsPressed.Value, Is.True);
 
-            processor.Update(0.1f, 40);
+            processor.Update(0.2f, 40);
             Assert.That(processor.IsPressed.Value, Is.True);
 
-            processor.Update(0.1f, 70);
+            processor.Update(0.2f, 80);
             Assert.That(processor.IsPressed.Value, Is.False);
             Assert.That(processor.Direction.Value, Is.EqualTo(ScratchAxisDirection.None));
         }
 
         [Test]
+        public void FrozenClockDoesNotReleaseWhilePressed()
+        {
+            var processor = new ScratchAxisProcessor
+            {
+                Deadzone =
+                {
+                    Value = 0.02
+                },
+                StopThresholdMs =
+                {
+                    Value = 50
+                }
+            };
+
+            processor.Update(0f, 100);
+            processor.Update(0.1f, 100);
+            processor.Update(0.2f, 100);
+            Assert.That(processor.IsPressed.Value, Is.True);
+
+            for (int i = 0; i < 20; i++)
+                processor.Update(0.2f, 100);
+
+            Assert.That(processor.IsPressed.Value, Is.True);
+        }
+
+        [Test]
         public void MissingSampleDoesNotTreatAsZero()
         {
-            var processor = new ScratchAxisProcessor();
-            processor.Deadzone.Value = 0.02;
-            processor.StopThresholdMs.Value = 50;
+            var processor = new ScratchAxisProcessor
+            {
+                Deadzone =
+                {
+                    Value = 0.02
+                },
+                StopThresholdMs =
+                {
+                    Value = 50
+                }
+            };
 
             processor.Update(0.7f, 0);
             processor.UpdateMissing(100);
@@ -97,12 +256,19 @@ namespace osu.Game.Tests.NonVisual
         [Test]
         public void WrapAroundUsesShortestArc()
         {
-            var processor = new ScratchAxisProcessor();
-            processor.Deadzone.Value = 0.02;
+            var processor = new ScratchAxisProcessor
+            {
+                Deadzone =
+                {
+                    Value = 0.02
+                }
+            };
 
             processor.Update(0.95f, 0);
             processor.Update(-0.95f, 16);
+            Assert.That(processor.IsPressed.Value, Is.False);
 
+            processor.Update(-0.85f, 32);
             Assert.That(processor.IsPressed.Value, Is.True);
             Assert.That(processor.Direction.Value, Is.EqualTo(ScratchAxisDirection.Clockwise));
         }
@@ -110,11 +276,17 @@ namespace osu.Game.Tests.NonVisual
         [Test]
         public void CounterClockwiseDirection()
         {
-            var processor = new ScratchAxisProcessor();
-            processor.Deadzone.Value = 0.02;
+            var processor = new ScratchAxisProcessor
+            {
+                Deadzone =
+                {
+                    Value = 0.02
+                }
+            };
 
             processor.Update(0f, 0);
             processor.Update(-0.1f, 16);
+            processor.Update(-0.2f, 32);
 
             Assert.That(processor.IsPressed.Value, Is.True);
             Assert.That(processor.Direction.Value, Is.EqualTo(ScratchAxisDirection.CounterClockwise));

--- a/osu.Game.Tests/NonVisual/ScratchAxisProcessorTest.cs
+++ b/osu.Game.Tests/NonVisual/ScratchAxisProcessorTest.cs
@@ -1,0 +1,109 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.EzOsuGame.Input;
+using osu.Game.Rulesets.Mania.EzMania.Input;
+
+namespace osu.Game.Tests.NonVisual
+{
+    [TestFixture]
+    public class ScratchAxisProcessorTest
+    {
+        [Test]
+        public void SpinAboveDeadzonePressesAndSetsDirection()
+        {
+            var processor = new ScratchAxisProcessor();
+            processor.Deadzone.Value = 0.02;
+            processor.StopThreshold.Value = 5;
+
+            processor.Update(0f);
+            Assert.That(processor.IsPressed.Value, Is.False);
+
+            processor.Update(0.1f);
+            Assert.That(processor.IsPressed.Value, Is.True);
+            Assert.That(processor.Direction.Value, Is.EqualTo(ScratchAxisDirection.Clockwise));
+        }
+
+        [Test]
+        public void JitterBelowDeadzoneDoesNotPress()
+        {
+            var processor = new ScratchAxisProcessor();
+            processor.Deadzone.Value = 0.05;
+            processor.StopThreshold.Value = 5;
+
+            processor.Update(0f);
+            processor.Update(0.01f);
+            processor.Update(-0.01f);
+            processor.Update(0.02f);
+
+            Assert.That(processor.IsPressed.Value, Is.False);
+            Assert.That(processor.Direction.Value, Is.EqualTo(ScratchAxisDirection.None));
+        }
+
+        [Test]
+        public void StopAfterIdleFramesReleases()
+        {
+            var processor = new ScratchAxisProcessor();
+            processor.Deadzone.Value = 0.02;
+            processor.StopThreshold.Value = 3;
+
+            processor.Update(0f);
+            processor.Update(0.1f);
+            Assert.That(processor.IsPressed.Value, Is.True);
+
+            processor.Update(0.1f);
+            processor.Update(0.1f);
+            processor.Update(0.1f);
+            Assert.That(processor.IsPressed.Value, Is.True);
+
+            processor.Update(0.1f);
+            Assert.That(processor.IsPressed.Value, Is.False);
+            Assert.That(processor.Direction.Value, Is.EqualTo(ScratchAxisDirection.None));
+        }
+
+        [Test]
+        public void WrapAroundUsesShortestArc()
+        {
+            var processor = new ScratchAxisProcessor();
+            processor.Deadzone.Value = 0.02;
+
+            processor.Update(0.95f);
+            processor.Update(-0.95f);
+
+            Assert.That(processor.IsPressed.Value, Is.True);
+            Assert.That(processor.Direction.Value, Is.EqualTo(ScratchAxisDirection.Clockwise));
+        }
+
+        [Test]
+        public void CounterClockwiseDirection()
+        {
+            var processor = new ScratchAxisProcessor();
+            processor.Deadzone.Value = 0.02;
+
+            processor.Update(0f);
+            processor.Update(-0.1f);
+
+            Assert.That(processor.IsPressed.Value, Is.True);
+            Assert.That(processor.Direction.Value, Is.EqualTo(ScratchAxisDirection.CounterClockwise));
+        }
+
+        [TestCase(12, false, 0, 11)]
+        [TestCase(14, false, 0, 13)]
+        [TestCase(14, true, 0, 12)]
+        [TestCase(16, false, 0, 15)]
+        public void ManiaTemplateResolvesColumns(int variant, bool skipEmpty, int left, int right)
+        {
+            Assert.That(ManiaScratchColumnTemplate.TryResolve(variant, skipEmpty, out int l, out int r), Is.True);
+            Assert.That(l, Is.EqualTo(left));
+            Assert.That(r, Is.EqualTo(right));
+        }
+
+        [Test]
+        public void ManiaTemplateRejectsUnsupportedVariants()
+        {
+            Assert.That(ManiaScratchColumnTemplate.TryResolve(8, false, out _, out _), Is.False);
+            Assert.That(ManiaScratchColumnTemplate.TryResolve(10, true, out _, out _), Is.False);
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Configuration/Ez2ConfigManager.cs
+++ b/osu.Game/EzOsuGame/Configuration/Ez2ConfigManager.cs
@@ -104,7 +104,7 @@ namespace osu.Game.EzOsuGame.Configuration
             SetDefault(Ez2Setting.ScratchAxisL, string.Empty);
             SetDefault(Ez2Setting.ScratchAxisR, string.Empty);
             SetDefault(Ez2Setting.ScratchAxisDeadzone, 0.04, 0.0, 0.2, 0.005);
-            SetDefault(Ez2Setting.ScratchAxisStopThreshold, 80, 10, 1000);
+            SetDefault(Ez2Setting.ScratchAxisStopThreshold, 150, 10, 1000);
             SetDefault(Ez2Setting.SkipWithGameplayKeys, true);
 
             SetDefault(Ez2Setting.StoryboardAutoVideoSize, false);

--- a/osu.Game/EzOsuGame/Configuration/Ez2ConfigManager.cs
+++ b/osu.Game/EzOsuGame/Configuration/Ez2ConfigManager.cs
@@ -10,7 +10,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Configuration;
 using osu.Framework.Development;
 using osu.Framework.Graphics;
-using osu.Framework.Input;
 using osu.Framework.Platform;
 using osu.Game.Configuration;
 using osu.Game.EzOsuGame.HUD;
@@ -101,11 +100,11 @@ namespace osu.Game.EzOsuGame.Configuration
             SetDefault(Ez2Setting.HitObjectLifetimeUsesOwnTime, !DebugUtils.IsNUnitRunning);
             SetDefault(Ez2Setting.ManiaSkipEmptyEdgeColumns, false);
             SetDefault(Ez2Setting.ManiaScratchAxisEnabled, false);
-            // BindableInt 无 precision 参数；多传会误匹配 BindableFloat 重载。
-            SetDefault(Ez2Setting.ScratchAxisL, (int)JoystickAxisSource.GamePadLeftStickX, 0, (int)JoystickAxisSource.Axis16);
-            SetDefault(Ez2Setting.ScratchAxisR, (int)JoystickAxisSource.GamePadLeftStickY, 0, (int)JoystickAxisSource.Axis16);
-            SetDefault(Ez2Setting.ScratchAxisDeadzone, 0.02, 0.0, 0.2, 0.005);
-            SetDefault(Ez2Setting.ScratchAxisStopThreshold, 100, 10, 500);
+            // 格式：guid|axisIndex（多设备）；兼容旧版纯数字轴下标
+            SetDefault(Ez2Setting.ScratchAxisL, string.Empty);
+            SetDefault(Ez2Setting.ScratchAxisR, string.Empty);
+            SetDefault(Ez2Setting.ScratchAxisDeadzone, 0.04, 0.0, 0.2, 0.005);
+            SetDefault(Ez2Setting.ScratchAxisStopThreshold, 80, 10, 1000);
             SetDefault(Ez2Setting.SkipWithGameplayKeys, true);
 
             SetDefault(Ez2Setting.StoryboardAutoVideoSize, false);
@@ -871,13 +870,12 @@ namespace osu.Game.EzOsuGame.Configuration
         ManiaScratchAxisEnabled,
 
         /// <summary>
-        /// L 转盘绑定的 <see cref="JoystickAxisSource"/> 索引（0–15）。
-        /// 规则集无关；Mania 作 scratch，未来 Catch 等可复用。
+        /// L 转盘绑定（<c>guid|axisIndex</c>）。规则集无关。
         /// </summary>
         ScratchAxisL,
 
         /// <summary>
-        /// R 转盘绑定的 <see cref="JoystickAxisSource"/> 索引（0–15）。
+        /// R 转盘绑定（<c>guid|axisIndex</c>）。
         /// </summary>
         ScratchAxisR,
 
@@ -887,7 +885,7 @@ namespace osu.Game.EzOsuGame.Configuration
         ScratchAxisDeadzone,
 
         /// <summary>
-        /// 停转判定：连续多少帧无有效位移后视为松开（对齐 beatoraja AnalogScratch 轮询计数）。
+        /// 停转判定：距上次有效转动超过多少毫秒后松开。
         /// </summary>
         ScratchAxisStopThreshold,
 

--- a/osu.Game/EzOsuGame/Configuration/Ez2ConfigManager.cs
+++ b/osu.Game/EzOsuGame/Configuration/Ez2ConfigManager.cs
@@ -10,6 +10,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Configuration;
 using osu.Framework.Development;
 using osu.Framework.Graphics;
+using osu.Framework.Input;
 using osu.Framework.Platform;
 using osu.Game.Configuration;
 using osu.Game.EzOsuGame.HUD;
@@ -99,6 +100,12 @@ namespace osu.Game.EzOsuGame.Configuration
             SetDefault(Ez2Setting.ScreenshotAction, EzScreenshotAction.SaveAndCopy);
             SetDefault(Ez2Setting.HitObjectLifetimeUsesOwnTime, !DebugUtils.IsNUnitRunning);
             SetDefault(Ez2Setting.ManiaSkipEmptyEdgeColumns, false);
+            SetDefault(Ez2Setting.ManiaScratchAxisEnabled, false);
+            // BindableInt 无 precision 参数；多传会误匹配 BindableFloat 重载。
+            SetDefault(Ez2Setting.ScratchAxisL, (int)JoystickAxisSource.GamePadLeftStickX, 0, (int)JoystickAxisSource.Axis16);
+            SetDefault(Ez2Setting.ScratchAxisR, (int)JoystickAxisSource.GamePadLeftStickY, 0, (int)JoystickAxisSource.Axis16);
+            SetDefault(Ez2Setting.ScratchAxisDeadzone, 0.02, 0.0, 0.2, 0.005);
+            SetDefault(Ez2Setting.ScratchAxisStopThreshold, 100, 10, 500);
             SetDefault(Ez2Setting.SkipWithGameplayKeys, true);
 
             SetDefault(Ez2Setting.StoryboardAutoVideoSize, false);
@@ -857,6 +864,33 @@ namespace osu.Game.EzOsuGame.Configuration
         NotificationBehaviour,
         ScreenshotAction,
         ManiaSkipEmptyEdgeColumns,
+
+        /// <summary>
+        /// 开启后按 12/14/16K 模板将 L/R 转盘轴运行时注入首尾列（不改写 Realm 键位）。
+        /// </summary>
+        ManiaScratchAxisEnabled,
+
+        /// <summary>
+        /// L 转盘绑定的 <see cref="JoystickAxisSource"/> 索引（0–15）。
+        /// 规则集无关；Mania 作 scratch，未来 Catch 等可复用。
+        /// </summary>
+        ScratchAxisL,
+
+        /// <summary>
+        /// R 转盘绑定的 <see cref="JoystickAxisSource"/> 索引（0–15）。
+        /// </summary>
+        ScratchAxisR,
+
+        /// <summary>
+        /// 转盘轴位移死区：|Δ| 低于此值视为抖动，不触发按下。
+        /// </summary>
+        ScratchAxisDeadzone,
+
+        /// <summary>
+        /// 停转判定：连续多少帧无有效位移后视为松开（对齐 beatoraja AnalogScratch 轮询计数）。
+        /// </summary>
+        ScratchAxisStopThreshold,
+
         SkipWithGameplayKeys,
         StoryboardAutoVideoSize,
         AcrylicUiEnabled,

--- a/osu.Game/EzOsuGame/Input/ScratchAxisBinding.cs
+++ b/osu.Game/EzOsuGame/Input/ScratchAxisBinding.cs
@@ -1,0 +1,84 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Game.EzOsuGame.Input
+{
+    /// <summary>
+    /// 转盘轴绑定：设备 GUID + 该设备上的轴下标（支持多设备 / 同设备多轴）。
+    /// 序列化格式：<c>guid|axisIndex</c>；兼容旧版纯数字轴下标。
+    /// </summary>
+    public readonly struct ScratchAxisBinding : IEquatable<ScratchAxisBinding>
+    {
+        public string DeviceGuid { get; }
+        public int AxisIndex { get; }
+        public string DeviceName { get; }
+
+        public bool IsEmpty => string.IsNullOrEmpty(DeviceGuid) && AxisIndex < 0;
+
+        public ScratchAxisBinding(string deviceGuid, int axisIndex, string deviceName = "")
+        {
+            DeviceGuid = deviceGuid;
+            AxisIndex = axisIndex;
+            DeviceName = deviceName;
+        }
+
+        public static ScratchAxisBinding Empty => new ScratchAxisBinding(string.Empty, -1);
+
+        public static ScratchAxisBinding Parse(string? stored)
+        {
+            if (string.IsNullOrWhiteSpace(stored))
+                return Empty;
+
+            // legacy: plain axis index
+            if (int.TryParse(stored, out int legacyAxis))
+                return new ScratchAxisBinding(string.Empty, legacyAxis);
+
+            int sep = stored.LastIndexOf('|');
+            if (sep <= 0 || sep >= stored.Length - 1)
+                return Empty;
+
+            string guid = stored[..sep];
+            if (!int.TryParse(stored[(sep + 1)..], out int axis))
+                return Empty;
+
+            return new ScratchAxisBinding(guid, axis);
+        }
+
+        public override string ToString()
+        {
+            if (IsEmpty)
+                return string.Empty;
+
+            if (string.IsNullOrEmpty(DeviceGuid))
+                return AxisIndex.ToString();
+
+            return $"{DeviceGuid}|{AxisIndex}";
+        }
+
+        public string ToDisplayString()
+        {
+            if (IsEmpty)
+                return "(none)";
+
+            string name = string.IsNullOrEmpty(DeviceName) ? DeviceGuid : DeviceName;
+            if (string.IsNullOrEmpty(name))
+                return $"Axis {AxisIndex}";
+
+            // GUID 过长时截断显示
+            if (name.Length > 24 && string.IsNullOrEmpty(DeviceName))
+                name = name[..8] + "…" + name[^4..];
+
+            return $"{name} / Axis {AxisIndex}";
+        }
+
+        public bool Equals(ScratchAxisBinding other) =>
+            string.Equals(DeviceGuid, other.DeviceGuid, StringComparison.OrdinalIgnoreCase)
+            && AxisIndex == other.AxisIndex;
+
+        public override bool Equals(object? obj) => obj is ScratchAxisBinding other && Equals(other);
+
+        public override int GetHashCode() => HashCode.Combine(DeviceGuid.ToLowerInvariant(), AxisIndex);
+    }
+}

--- a/osu.Game/EzOsuGame/Input/ScratchAxisDeviceTracker.cs
+++ b/osu.Game/EzOsuGame/Input/ScratchAxisDeviceTracker.cs
@@ -1,0 +1,91 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Input;
+using osu.Framework.Input.Handlers.Joystick;
+using osu.Framework.Platform;
+using osu.Framework.Threading;
+
+namespace osu.Game.EzOsuGame.Input
+{
+    /// <summary>
+    /// 订阅 <see cref="JoystickHandler.DeviceAxisChanged"/>，维护多设备轴值表，供转盘绑定与游玩读取。
+    /// </summary>
+    /// <remarks>
+    /// TODO(Catch)：可由此读取绑定轴的 Direction 做左右移动。
+    /// </remarks>
+    [Cached]
+    public partial class ScratchAxisDeviceTracker : Component
+    {
+        private readonly ConcurrentDictionary<(string guid, int axis), float> valuesByGuid =
+            new ConcurrentDictionary<(string, int), float>();
+
+        private readonly ConcurrentDictionary<string, string> namesByGuid =
+            new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// 任意设备轴发生变化时（已调度到更新线程）。
+        /// </summary>
+        public event Action<JoystickDeviceAxis>? AxisMoved;
+
+        private JoystickHandler? joystickHandler;
+        private Scheduler? scheduler;
+
+        [BackgroundDependencyLoader]
+        private void load(GameHost host)
+        {
+            scheduler = host.UpdateThread.Scheduler;
+            joystickHandler = host.AvailableInputHandlers.OfType<JoystickHandler>().FirstOrDefault();
+
+            if (joystickHandler != null)
+                joystickHandler.DeviceAxisChanged += onDeviceAxisChanged;
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (joystickHandler != null)
+                joystickHandler.DeviceAxisChanged -= onDeviceAxisChanged;
+
+            base.Dispose(isDisposing);
+        }
+
+        /// <summary>
+        /// 读取绑定对应的当前轴值。尚无该设备轴采样时返回 false（不要用 0 冒充）。
+        /// </summary>
+        public bool TryGetValue(ScratchAxisBinding binding, out float value)
+        {
+            value = 0;
+
+            if (binding.IsEmpty || string.IsNullOrEmpty(binding.DeviceGuid))
+                return false;
+
+            return valuesByGuid.TryGetValue((binding.DeviceGuid, binding.AxisIndex), out value);
+        }
+
+        /// <summary>
+        /// 仅在已有采样时返回轴值；否则返回 0（不应用于转动检测）。
+        /// </summary>
+        public float GetValue(ScratchAxisBinding binding) =>
+            TryGetValue(binding, out float value) ? value : 0;
+
+        public string? GetDeviceName(string guid) =>
+            namesByGuid.TryGetValue(guid, out string? name) ? name : null;
+
+        private void onDeviceAxisChanged(JoystickDeviceAxis axis)
+        {
+            if (!string.IsNullOrEmpty(axis.Guid))
+            {
+                valuesByGuid[(axis.Guid, axis.AxisIndex)] = axis.Value;
+                namesByGuid[axis.Guid] = axis.Name;
+            }
+
+            var captured = axis;
+            scheduler?.Add(() => AxisMoved?.Invoke(captured), false);
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Input/ScratchAxisDeviceTracker.cs
+++ b/osu.Game/EzOsuGame/Input/ScratchAxisDeviceTracker.cs
@@ -78,11 +78,12 @@ namespace osu.Game.EzOsuGame.Input
 
         private void onDeviceAxisChanged(JoystickDeviceAxis axis)
         {
-            if (!string.IsNullOrEmpty(axis.Guid))
-            {
-                valuesByGuid[(axis.Guid, axis.AxisIndex)] = axis.Value;
-                namesByGuid[axis.Guid] = axis.Name;
-            }
+            string deviceKey = !string.IsNullOrEmpty(axis.Guid)
+                ? axis.Guid
+                : $"id:{axis.InstanceId}";
+
+            valuesByGuid[(deviceKey, axis.AxisIndex)] = axis.Value;
+            namesByGuid[deviceKey] = string.IsNullOrEmpty(axis.Name) ? deviceKey : axis.Name;
 
             var captured = axis;
             scheduler?.Add(() => AxisMoved?.Invoke(captured), false);

--- a/osu.Game/EzOsuGame/Input/ScratchAxisDirection.cs
+++ b/osu.Game/EzOsuGame/Input/ScratchAxisDirection.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.EzOsuGame.Input
+{
+    /// <summary>
+    /// 转盘/编码器轴的转动方向。
+    /// Mania：顺逆均视为按下；选歌滚动与 Catch 左右移动可据此区分。
+    /// </summary>
+    /// <remarks>
+    /// TODO(Catch)：逆时针→左、顺时针→右，作为 Catch 移动输入时再接消费方。
+    /// TODO(SongSelect)：类滚轮滚动选歌时按方向消费。
+    /// </remarks>
+    public enum ScratchAxisDirection
+    {
+        None,
+        Clockwise,
+        CounterClockwise,
+    }
+}

--- a/osu.Game/EzOsuGame/Input/ScratchAxisPair.cs
+++ b/osu.Game/EzOsuGame/Input/ScratchAxisPair.cs
@@ -2,46 +2,32 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Bindables;
-using osu.Framework.Input;
-using osu.Framework.Input.States;
 
 namespace osu.Game.EzOsuGame.Input
 {
     /// <summary>
-    /// L/R 双转盘状态对，从 <see cref="JoystickState"/> 按配置轴索引取样。
+    /// L/R 双转盘状态对，从 <see cref="ScratchAxisDeviceTracker"/> 按设备绑定取样。
     /// </summary>
     public class ScratchAxisPair
     {
         public ScratchAxisProcessor Left { get; } = new ScratchAxisProcessor();
         public ScratchAxisProcessor Right { get; } = new ScratchAxisProcessor();
 
-        public BindableInt LeftAxisIndex { get; } = new BindableInt((int)JoystickAxisSource.GamePadLeftStickX)
-        {
-            MinValue = 0,
-            MaxValue = (int)JoystickAxisSource.Axis16,
-        };
+        public Bindable<string> LeftBinding { get; } = new Bindable<string>(string.Empty);
+        public Bindable<string> RightBinding { get; } = new Bindable<string>(string.Empty);
 
-        public BindableInt RightAxisIndex { get; } = new BindableInt((int)JoystickAxisSource.GamePadLeftStickY)
-        {
-            MinValue = 0,
-            MaxValue = (int)JoystickAxisSource.Axis16,
-        };
-
-        /// <summary>
-        /// 将死区/停转阈值同步到左右处理器。
-        /// </summary>
-        public void BindTuning(Bindable<double> deadzone, Bindable<int> stopThreshold)
+        public void BindTuning(Bindable<double> deadzone, Bindable<int> stopThresholdMs)
         {
             Left.Deadzone.BindTo(deadzone);
             Right.Deadzone.BindTo(deadzone);
-            Left.StopThreshold.BindTo(stopThreshold);
-            Right.StopThreshold.BindTo(stopThreshold);
+            Left.StopThresholdMs.BindTo(stopThresholdMs);
+            Right.StopThresholdMs.BindTo(stopThresholdMs);
         }
 
-        public void UpdateFrom(JoystickState joystick)
+        public void UpdateFrom(ScratchAxisDeviceTracker tracker, double currentTime)
         {
-            Left.Update(readAxis(joystick, LeftAxisIndex.Value));
-            Right.Update(readAxis(joystick, RightAxisIndex.Value));
+            updateOne(Left, ScratchAxisBinding.Parse(LeftBinding.Value), tracker, currentTime);
+            updateOne(Right, ScratchAxisBinding.Parse(RightBinding.Value), tracker, currentTime);
         }
 
         public void Reset()
@@ -50,12 +36,12 @@ namespace osu.Game.EzOsuGame.Input
             Right.Reset();
         }
 
-        private static float readAxis(JoystickState joystick, int index)
+        private static void updateOne(ScratchAxisProcessor processor, ScratchAxisBinding binding, ScratchAxisDeviceTracker tracker, double currentTime)
         {
-            if (index < 0 || index >= joystick.AxesValues.Length)
-                return 0;
-
-            return joystick.AxesValues[index];
+            if (tracker.TryGetValue(binding, out float value))
+                processor.Update(value, currentTime);
+            else
+                processor.UpdateMissing(currentTime);
         }
     }
 }

--- a/osu.Game/EzOsuGame/Input/ScratchAxisPair.cs
+++ b/osu.Game/EzOsuGame/Input/ScratchAxisPair.cs
@@ -1,0 +1,61 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Framework.Input;
+using osu.Framework.Input.States;
+
+namespace osu.Game.EzOsuGame.Input
+{
+    /// <summary>
+    /// L/R 双转盘状态对，从 <see cref="JoystickState"/> 按配置轴索引取样。
+    /// </summary>
+    public class ScratchAxisPair
+    {
+        public ScratchAxisProcessor Left { get; } = new ScratchAxisProcessor();
+        public ScratchAxisProcessor Right { get; } = new ScratchAxisProcessor();
+
+        public BindableInt LeftAxisIndex { get; } = new BindableInt((int)JoystickAxisSource.GamePadLeftStickX)
+        {
+            MinValue = 0,
+            MaxValue = (int)JoystickAxisSource.Axis16,
+        };
+
+        public BindableInt RightAxisIndex { get; } = new BindableInt((int)JoystickAxisSource.GamePadLeftStickY)
+        {
+            MinValue = 0,
+            MaxValue = (int)JoystickAxisSource.Axis16,
+        };
+
+        /// <summary>
+        /// 将死区/停转阈值同步到左右处理器。
+        /// </summary>
+        public void BindTuning(Bindable<double> deadzone, Bindable<int> stopThreshold)
+        {
+            Left.Deadzone.BindTo(deadzone);
+            Right.Deadzone.BindTo(deadzone);
+            Left.StopThreshold.BindTo(stopThreshold);
+            Right.StopThreshold.BindTo(stopThreshold);
+        }
+
+        public void UpdateFrom(JoystickState joystick)
+        {
+            Left.Update(readAxis(joystick, LeftAxisIndex.Value));
+            Right.Update(readAxis(joystick, RightAxisIndex.Value));
+        }
+
+        public void Reset()
+        {
+            Left.Reset();
+            Right.Reset();
+        }
+
+        private static float readAxis(JoystickState joystick, int index)
+        {
+            if (index < 0 || index >= joystick.AxesValues.Length)
+                return 0;
+
+            return joystick.AxesValues[index];
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Input/ScratchAxisProcessor.cs
+++ b/osu.Game/EzOsuGame/Input/ScratchAxisProcessor.cs
@@ -1,0 +1,113 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Bindables;
+
+namespace osu.Game.EzOsuGame.Input
+{
+    /// <summary>
+    /// 规则集无关的模拟转盘轴处理器（beatoraja AnalogScratch Ver1 + 位移死区）。
+    /// 轴范围假定为 [-1, 1]；有有效位移→按下，连续无位移达阈值→松开。
+    /// </summary>
+    /// <remarks>
+    /// 供 Mania scratch、未来 Catch 左右移动、选歌滚动等复用；不要绑到具体 <c>ManiaAction</c>。
+    /// </remarks>
+    public class ScratchAxisProcessor
+    {
+        /// <summary>
+        /// 位移死区：|Δ|（环绕最短弧）低于此值视为抖动。
+        /// </summary>
+        public BindableDouble Deadzone { get; } = new BindableDouble(0.02)
+        {
+            MinValue = 0,
+            MaxValue = 0.5,
+        };
+
+        /// <summary>
+        /// 停转帧阈值：连续多少次 <see cref="Update"/> 无有效位移后松开。
+        /// </summary>
+        public BindableInt StopThreshold { get; } = new BindableInt(100)
+        {
+            MinValue = 1,
+            MaxValue = 1000,
+        };
+
+        public BindableBool IsPressed { get; } = new BindableBool();
+
+        public Bindable<ScratchAxisDirection> Direction { get; } = new Bindable<ScratchAxisDirection>();
+
+        private float lastValue;
+        private bool hasSample;
+        private int idleFrames;
+
+        /// <summary>
+        /// 喂入当前轴绝对值（通常每帧一次）。返回是否发生按下/松开边沿。
+        /// </summary>
+        public bool Update(float axisValue)
+        {
+            bool wasPressed = IsPressed.Value;
+
+            if (!hasSample)
+            {
+                lastValue = axisValue;
+                hasSample = true;
+                return false;
+            }
+
+            float delta = shortestDelta(lastValue, axisValue);
+            float absDelta = Math.Abs(delta);
+
+            if (absDelta >= Deadzone.Value)
+            {
+                lastValue = axisValue;
+                idleFrames = 0;
+
+                var dir = delta > 0 ? ScratchAxisDirection.Clockwise : ScratchAxisDirection.CounterClockwise;
+                Direction.Value = dir;
+                IsPressed.Value = true;
+            }
+            else
+            {
+                // 跟随微抖动，避免慢漂移累积后一次越过死区
+                lastValue = axisValue;
+                idleFrames++;
+
+                if (IsPressed.Value && idleFrames > StopThreshold.Value)
+                {
+                    IsPressed.Value = false;
+                    Direction.Value = ScratchAxisDirection.None;
+                    idleFrames = 0;
+                }
+            }
+
+            return wasPressed != IsPressed.Value;
+        }
+
+        public void Reset()
+        {
+            hasSample = false;
+            lastValue = 0;
+            idleFrames = 0;
+            IsPressed.Value = false;
+            Direction.Value = ScratchAxisDirection.None;
+        }
+
+        /// <summary>
+        /// [-1,1] 环上的最短有符号位移（全周长 2）。
+        /// </summary>
+        public static float ShortestDelta(float from, float to) => shortestDelta(from, to);
+
+        private static float shortestDelta(float from, float to)
+        {
+            float delta = to - from;
+
+            if (delta > 1f)
+                delta -= 2f;
+            else if (delta < -1f)
+                delta += 2f;
+
+            return delta;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Input/ScratchAxisProcessor.cs
+++ b/osu.Game/EzOsuGame/Input/ScratchAxisProcessor.cs
@@ -8,15 +8,17 @@ namespace osu.Game.EzOsuGame.Input
 {
     /// <summary>
     /// 规则集无关的模拟转盘轴处理器：只认位移，不认停靠绝对值。
-    /// 轴可停在 [-1,1] 任意位置；有有效 |Δ|→按下，停止超过阈值→松开。
+    /// 轴可停在 [-1,1] 任意位置；连续同向有效位移→按下并保持；转向清空后需重新激活；停止超过阈值→松开。
     /// </summary>
     /// <remarks>
+    /// 对齐 beatoraja Analog Scratch V2（死区 + 墙钟时间阈值；无 tick 量化）：
+    /// 两次同向过死区才激活；转向清空视为另一次打击；顺逆在 Mania 仍注入同一列。
     /// 供 Mania scratch、未来 Catch 左右移动、选歌滚动等复用。
     /// </remarks>
     public class ScratchAxisProcessor
     {
         /// <summary>
-        /// 位移死区：环绕最短弧 |Δ| 低于此值视为静止/抖动（不是“离中心多远”）。
+        /// 激活死区：环绕最短弧 |Δ| 低于此值不视为开始转动（不是“离中心多远”）。
         /// </summary>
         public BindableDouble Deadzone { get; } = new BindableDouble(0.04)
         {
@@ -27,7 +29,7 @@ namespace osu.Game.EzOsuGame.Input
         /// <summary>
         /// 停转判定：距上次有效位移超过多少毫秒后松开。
         /// </summary>
-        public BindableInt StopThresholdMs { get; } = new BindableInt(80)
+        public BindableInt StopThresholdMs { get; } = new BindableInt(150)
         {
             MinValue = 10,
             MaxValue = 1000,
@@ -44,9 +46,13 @@ namespace osu.Game.EzOsuGame.Input
         private bool hasSample;
         private double lastMotionTime = double.NegativeInfinity;
 
+        /// <summary>激活前连续同向有效位移次数（替代 beatoraja V2 的 2-tick，无量化步进）。</summary>
+        private int pendingTicks;
+
+        private ScratchAxisDirection pendingDirection = ScratchAxisDirection.None;
+
         /// <summary>
-        /// 喂入当前轴绝对值与当前时间（通常为 <c>Time.Current</c>）。
-        /// 仅位移超过死区视为转动；停靠在任意绝对值都不是按下。
+        /// 喂入当前轴绝对值与<strong>墙钟时间</strong>（勿用 gameplay / FrameStable 的 <c>Time.Current</c>，暂停或追帧时会卡住导致永不松开）。
         /// </summary>
         public bool Update(float axisValue, double currentTime)
         {
@@ -58,6 +64,7 @@ namespace osu.Game.EzOsuGame.Input
                 lastValue = axisValue;
                 hasSample = true;
                 lastMotionTime = double.NegativeInfinity;
+                clearPending();
                 return false;
             }
 
@@ -68,18 +75,49 @@ namespace osu.Game.EzOsuGame.Input
             {
                 lastValue = axisValue;
                 lastMotionTime = currentTime;
-                Direction.Value = delta > 0 ? ScratchAxisDirection.Clockwise : ScratchAxisDirection.CounterClockwise;
-                IsPressed.Value = true;
+
+                var dir = delta > 0 ? ScratchAxisDirection.Clockwise : ScratchAxisDirection.CounterClockwise;
+
+                if (IsPressed.Value)
+                {
+                    if (Direction.Value != ScratchAxisDirection.None && Direction.Value != dir)
+                    {
+                        // V2：转向清空，本帧反向位移只记 pending=1，不立刻再激活
+                        IsPressed.Value = false;
+                        Direction.Value = ScratchAxisDirection.None;
+                        pendingTicks = 1;
+                        pendingDirection = dir;
+                    }
+                    else
+                    {
+                        Direction.Value = dir;
+                    }
+                }
+                else
+                {
+                    accumulatePending(dir);
+                }
+            }
+            else if (IsPressed.Value && absDelta > 1e-5f)
+            {
+                // 已按下：亚死区同向慢移续按住（不改方向语义）
+                lastValue = axisValue;
+                lastMotionTime = currentTime;
             }
             else
             {
-                // 微抖动跟随，避免慢漂移一次越过死区；不刷新 lastMotionTime
+                // 微抖动跟随；不刷新 lastMotionTime
                 lastValue = axisValue;
 
-                if (IsPressed.Value && currentTime - lastMotionTime >= StopThresholdMs.Value)
+                if (currentTime - lastMotionTime >= StopThresholdMs.Value)
                 {
-                    IsPressed.Value = false;
-                    Direction.Value = ScratchAxisDirection.None;
+                    clearPending();
+
+                    if (IsPressed.Value)
+                    {
+                        IsPressed.Value = false;
+                        Direction.Value = ScratchAxisDirection.None;
+                    }
                 }
             }
 
@@ -91,19 +129,19 @@ namespace osu.Game.EzOsuGame.Input
         /// </summary>
         public bool UpdateMissing(double currentTime)
         {
-            if (!IsPressed.Value)
+            if (!IsPressed.Value && pendingTicks == 0)
                 return false;
-
-            bool wasPressed = true;
 
             if (currentTime - lastMotionTime >= StopThresholdMs.Value)
             {
+                bool wasPressed = IsPressed.Value;
+                clearPending();
                 IsPressed.Value = false;
                 Direction.Value = ScratchAxisDirection.None;
-                return true;
+                return wasPressed;
             }
 
-            return wasPressed != IsPressed.Value;
+            return false;
         }
 
         public void Reset()
@@ -111,8 +149,33 @@ namespace osu.Game.EzOsuGame.Input
             hasSample = false;
             lastValue = 0;
             lastMotionTime = double.NegativeInfinity;
+            clearPending();
             IsPressed.Value = false;
             Direction.Value = ScratchAxisDirection.None;
+        }
+
+        private void accumulatePending(ScratchAxisDirection dir)
+        {
+            if (pendingDirection == dir)
+                pendingTicks++;
+            else
+            {
+                pendingTicks = 1;
+                pendingDirection = dir;
+            }
+
+            if (pendingTicks >= 2)
+            {
+                IsPressed.Value = true;
+                Direction.Value = dir;
+                clearPending();
+            }
+        }
+
+        private void clearPending()
+        {
+            pendingTicks = 0;
+            pendingDirection = ScratchAxisDirection.None;
         }
 
         public static float ShortestDelta(float from, float to) => shortestDelta(from, to);

--- a/osu.Game/EzOsuGame/Input/ScratchAxisProcessor.cs
+++ b/osu.Game/EzOsuGame/Input/ScratchAxisProcessor.cs
@@ -7,31 +7,34 @@ using osu.Framework.Bindables;
 namespace osu.Game.EzOsuGame.Input
 {
     /// <summary>
-    /// 规则集无关的模拟转盘轴处理器（beatoraja AnalogScratch Ver1 + 位移死区）。
-    /// 轴范围假定为 [-1, 1]；有有效位移→按下，连续无位移达阈值→松开。
+    /// 规则集无关的模拟转盘轴处理器：只认位移，不认停靠绝对值。
+    /// 轴可停在 [-1,1] 任意位置；有有效 |Δ|→按下，停止超过阈值→松开。
     /// </summary>
     /// <remarks>
-    /// 供 Mania scratch、未来 Catch 左右移动、选歌滚动等复用；不要绑到具体 <c>ManiaAction</c>。
+    /// 供 Mania scratch、未来 Catch 左右移动、选歌滚动等复用。
     /// </remarks>
     public class ScratchAxisProcessor
     {
         /// <summary>
-        /// 位移死区：|Δ|（环绕最短弧）低于此值视为抖动。
+        /// 位移死区：环绕最短弧 |Δ| 低于此值视为静止/抖动（不是“离中心多远”）。
         /// </summary>
-        public BindableDouble Deadzone { get; } = new BindableDouble(0.02)
+        public BindableDouble Deadzone { get; } = new BindableDouble(0.04)
         {
             MinValue = 0,
             MaxValue = 0.5,
         };
 
         /// <summary>
-        /// 停转帧阈值：连续多少次 <see cref="Update"/> 无有效位移后松开。
+        /// 停转判定：距上次有效位移超过多少毫秒后松开。
         /// </summary>
-        public BindableInt StopThreshold { get; } = new BindableInt(100)
+        public BindableInt StopThresholdMs { get; } = new BindableInt(80)
         {
-            MinValue = 1,
+            MinValue = 10,
             MaxValue = 1000,
         };
+
+        /// <summary>兼容旧绑定名，等同 <see cref="StopThresholdMs"/>。</summary>
+        public BindableInt StopThreshold => StopThresholdMs;
 
         public BindableBool IsPressed { get; } = new BindableBool();
 
@@ -39,19 +42,22 @@ namespace osu.Game.EzOsuGame.Input
 
         private float lastValue;
         private bool hasSample;
-        private int idleFrames;
+        private double lastMotionTime = double.NegativeInfinity;
 
         /// <summary>
-        /// 喂入当前轴绝对值（通常每帧一次）。返回是否发生按下/松开边沿。
+        /// 喂入当前轴绝对值与当前时间（通常为 <c>Time.Current</c>）。
+        /// 仅位移超过死区视为转动；停靠在任意绝对值都不是按下。
         /// </summary>
-        public bool Update(float axisValue)
+        public bool Update(float axisValue, double currentTime)
         {
             bool wasPressed = IsPressed.Value;
 
             if (!hasSample)
             {
+                // 记录静止停靠点，绝不把「当前位置相对 0」当成转动
                 lastValue = axisValue;
                 hasSample = true;
+                lastMotionTime = double.NegativeInfinity;
                 return false;
             }
 
@@ -61,24 +67,40 @@ namespace osu.Game.EzOsuGame.Input
             if (absDelta >= Deadzone.Value)
             {
                 lastValue = axisValue;
-                idleFrames = 0;
-
-                var dir = delta > 0 ? ScratchAxisDirection.Clockwise : ScratchAxisDirection.CounterClockwise;
-                Direction.Value = dir;
+                lastMotionTime = currentTime;
+                Direction.Value = delta > 0 ? ScratchAxisDirection.Clockwise : ScratchAxisDirection.CounterClockwise;
                 IsPressed.Value = true;
             }
             else
             {
-                // 跟随微抖动，避免慢漂移累积后一次越过死区
+                // 微抖动跟随，避免慢漂移一次越过死区；不刷新 lastMotionTime
                 lastValue = axisValue;
-                idleFrames++;
 
-                if (IsPressed.Value && idleFrames > StopThreshold.Value)
+                if (IsPressed.Value && currentTime - lastMotionTime >= StopThresholdMs.Value)
                 {
                     IsPressed.Value = false;
                     Direction.Value = ScratchAxisDirection.None;
-                    idleFrames = 0;
                 }
+            }
+
+            return wasPressed != IsPressed.Value;
+        }
+
+        /// <summary>
+        /// 本帧没有有效采样（设备未上报）时调用：仅推进停转计时，不把缺失当成回到 0。
+        /// </summary>
+        public bool UpdateMissing(double currentTime)
+        {
+            if (!IsPressed.Value)
+                return false;
+
+            bool wasPressed = true;
+
+            if (currentTime - lastMotionTime >= StopThresholdMs.Value)
+            {
+                IsPressed.Value = false;
+                Direction.Value = ScratchAxisDirection.None;
+                return true;
             }
 
             return wasPressed != IsPressed.Value;
@@ -88,14 +110,11 @@ namespace osu.Game.EzOsuGame.Input
         {
             hasSample = false;
             lastValue = 0;
-            idleFrames = 0;
+            lastMotionTime = double.NegativeInfinity;
             IsPressed.Value = false;
             Direction.Value = ScratchAxisDirection.None;
         }
 
-        /// <summary>
-        /// [-1,1] 环上的最短有符号位移（全周长 2）。
-        /// </summary>
         public static float ShortestDelta(float from, float to) => shortestDelta(from, to);
 
         private static float shortestDelta(float from, float to)

--- a/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
@@ -260,8 +260,16 @@ namespace osu.Game.EzOsuGame.Localization
         public static readonly LocalisableString SCRATCH_AXIS_R = new EzLocalizationManager.EzLocalisableString("R-Scratch 轴", "R-Scratch Axis");
 
         public static readonly LocalisableString SCRATCH_AXIS_BIND_HINT = new EzLocalizationManager.EzLocalisableString(
-            "点击后转动目标转盘以绑定（按设备区分，同轴多设备可分别绑定）",
-            "Click, then spin the target turntable to bind (per-device; same axis on different devices can bind separately)");
+            "转动转盘以绑定…（再点取消 / Esc）",
+            "Spin turntable to bind… (click again / Esc to cancel)");
+
+        public static readonly LocalisableString SCRATCH_AXIS_BIND_IDLE_HINT = new EzLocalizationManager.EzLocalisableString(
+            "点击 L/R 后转动对应转盘；仅累计位移，停靠位置不会触发绑定。",
+            "Click L/R then spin the turntable; only movement is counted, resting position does not bind.");
+
+        public static readonly LocalisableString SCRATCH_AXIS_BIND_LISTENING_HINT = new EzLocalizationManager.EzLocalisableString(
+            "正在听轴… 累计位移 {0} / {1}",
+            "Listening… travel {0} / {1}");
 
         public static readonly LocalisableString SCRATCH_AXIS_DEADZONE = new EzLocalizationManager.EzLocalisableString(
             "转盘轴死区",

--- a/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
@@ -241,6 +241,50 @@ namespace osu.Game.EzOsuGame.Localization
             "When enabled, 14K beatmaps display as 13K (last column hidden) for Ez2Ac arcade maps with an empty last column."
             + "\nDisable this if the last column contains notes.");
 
+        public static readonly LocalisableString MANIA_SCRATCH_AXIS_ENABLED = new EzLocalizationManager.EzLocalisableString(
+            "启用转盘轴模板（L/R Scratch）",
+            "Enable turntable axis template (L/R Scratch)");
+
+        public static readonly LocalisableString MANIA_SCRATCH_AXIS_ENABLED_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "开启后，按键数模板将 L/R 转盘轴运行时注入首尾列（不改写键位配置）："
+            + "\n12K：列 0 / 11；16K：列 0 / 15；"
+            + "\n14K：列 0 / 13；开启 10k2s1p 时为列 0 / 12。"
+            + "\n转动=按下，停止转动=松开。请勿把同一轴再绑到其它 Mania 键。",
+            "When enabled, L/R turntable axes are injected into edge columns at runtime (key bindings are not rewritten):"
+            + "\n12K: cols 0 / 11; 16K: cols 0 / 15;"
+            + "\n14K: cols 0 / 13; with 10k2s1p: cols 0 / 12."
+            + "\nSpinning = pressed, stop = released. Do not also bind the same axis to other Mania keys.");
+
+        public static readonly LocalisableString SCRATCH_AXIS_L = new EzLocalizationManager.EzLocalisableString("L-Scratch 轴", "L-Scratch Axis");
+
+        public static readonly LocalisableString SCRATCH_AXIS_R = new EzLocalizationManager.EzLocalisableString("R-Scratch 轴", "R-Scratch Axis");
+
+        public static readonly LocalisableString SCRATCH_AXIS_BIND_HINT = new EzLocalizationManager.EzLocalisableString(
+            "点击后转动目标轴以绑定",
+            "Click, then move the target axis to bind");
+
+        public static readonly LocalisableString SCRATCH_AXIS_DEADZONE = new EzLocalizationManager.EzLocalisableString(
+            "转盘轴死区",
+            "Turntable axis deadzone");
+
+        public static readonly LocalisableString SCRATCH_AXIS_DEADZONE_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "忽略小于此阈值的轴位移，减少转盘/摇杆抖动误触。",
+            "Ignore axis deltas below this threshold to reduce turntable/stick jitter.");
+
+        public static readonly LocalisableString SCRATCH_AXIS_STOP_THRESHOLD = new EzLocalizationManager.EzLocalisableString(
+            "停转判定（帧）",
+            "Stop threshold (frames)");
+
+        public static readonly LocalisableString SCRATCH_AXIS_STOP_THRESHOLD_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "连续多少帧没有有效转动后视为松开。",
+            "Release after this many frames without significant spin.");
+
+        public static readonly LocalisableString SCRATCH_AXIS_STATUS_IDLE = new EzLocalizationManager.EzLocalisableString("状态：空闲", "Status: Idle");
+
+        public static readonly LocalisableString SCRATCH_AXIS_STATUS_CW = new EzLocalizationManager.EzLocalisableString("状态：顺时针（按下）", "Status: Clockwise (pressed)");
+
+        public static readonly LocalisableString SCRATCH_AXIS_STATUS_CCW = new EzLocalizationManager.EzLocalisableString("状态：逆时针（按下）", "Status: Counter-clockwise (pressed)");
+
         public static readonly LocalisableString SKIP_WITH_GAMEPLAY_KEYS = new EzLocalizationManager.EzLocalisableString(
             "跳过可由游戏按键触发",
             "Allow gameplay keys to trigger skip");

--- a/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
@@ -260,24 +260,24 @@ namespace osu.Game.EzOsuGame.Localization
         public static readonly LocalisableString SCRATCH_AXIS_R = new EzLocalizationManager.EzLocalisableString("R-Scratch 轴", "R-Scratch Axis");
 
         public static readonly LocalisableString SCRATCH_AXIS_BIND_HINT = new EzLocalizationManager.EzLocalisableString(
-            "点击后转动目标轴以绑定",
-            "Click, then move the target axis to bind");
+            "点击后转动目标转盘以绑定（按设备区分，同轴多设备可分别绑定）",
+            "Click, then spin the target turntable to bind (per-device; same axis on different devices can bind separately)");
 
         public static readonly LocalisableString SCRATCH_AXIS_DEADZONE = new EzLocalizationManager.EzLocalisableString(
             "转盘轴死区",
             "Turntable axis deadzone");
 
-        public static readonly LocalisableString SCRATCH_AXIS_DEADZONE_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
-            "忽略小于此阈值的轴位移，减少转盘/摇杆抖动误触。",
-            "Ignore axis deltas below this threshold to reduce turntable/stick jitter.");
-
         public static readonly LocalisableString SCRATCH_AXIS_STOP_THRESHOLD = new EzLocalizationManager.EzLocalisableString(
-            "停转判定（帧）",
-            "Stop threshold (frames)");
+            "停转判定（毫秒）",
+            "Stop threshold (ms)");
 
         public static readonly LocalisableString SCRATCH_AXIS_STOP_THRESHOLD_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
-            "连续多少帧没有有效转动后视为松开。",
-            "Release after this many frames without significant spin.");
+            "距上次有效转动超过此时长后视为松开。停靠在任意轴位置都不是按下，只有转动位移才算。",
+            "Release after this many milliseconds without significant spin. Resting at any axis position is idle; only movement counts.");
+
+        public static readonly LocalisableString SCRATCH_AXIS_DEADZONE_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "忽略小于此阈值的轴位移（不是离中心的距离）。转盘可停在任意位置，只有转动才触发。",
+            "Ignore axis deltas below this threshold (not distance from center). The turntable may rest anywhere; only spinning triggers.");
 
         public static readonly LocalisableString SCRATCH_AXIS_STATUS_IDLE = new EzLocalizationManager.EzLocalisableString("状态：空闲", "Status: Idle");
 

--- a/osu.Game/EzOsuGame/Overlays/EzGameSettings.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzGameSettings.cs
@@ -144,6 +144,7 @@ namespace osu.Game.EzOsuGame.Overlays
                 {
                     Keywords = new[] { "ez", "skip", "empty", "column" }
                 },
+                new EzManiaScratchAxisSettings(),
             };
 
             maniaHealthModeBindable.BindValueChanged(e =>

--- a/osu.Game/EzOsuGame/Overlays/EzManiaScratchAxisSettings.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzManiaScratchAxisSettings.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -22,18 +23,21 @@ using osuTK;
 namespace osu.Game.EzOsuGame.Overlays
 {
     /// <summary>
-    /// Mania L/R 转盘轴设置：开关、轴绑定、死区、实时顺逆状态。
+    /// Mania L/R 转盘轴设置：按设备 GUID+轴绑定，支持多设备/同设备多轴。
     /// </summary>
     public partial class EzManiaScratchAxisSettings : FillFlowContainer
     {
         private readonly ScratchAxisProcessor leftMonitor = new ScratchAxisProcessor();
         private readonly ScratchAxisProcessor rightMonitor = new ScratchAxisProcessor();
+        private readonly Dictionary<(string guid, int axis), float> bindSampleLast = new Dictionary<(string, int), float>();
 
         private Bindable<bool> enabled = null!;
-        private Bindable<int> leftAxis = null!;
-        private Bindable<int> rightAxis = null!;
+        private Bindable<string> leftBinding = null!;
+        private Bindable<string> rightBinding = null!;
         private Bindable<double> deadzone = null!;
         private Bindable<int> stopThreshold = null!;
+
+        private ScratchAxisDeviceTracker tracker = null!;
 
         private SettingsButtonV2 leftBindButton = null!;
         private SettingsButtonV2 rightBindButton = null!;
@@ -41,6 +45,7 @@ namespace osu.Game.EzOsuGame.Overlays
         private OsuSpriteText rightStatusText = null!;
 
         private BindTarget? bindTarget;
+        private (string guid, int axis, string name, float score)? bestBindCandidate;
 
         public EzManiaScratchAxisSettings()
         {
@@ -51,11 +56,13 @@ namespace osu.Game.EzOsuGame.Overlays
         }
 
         [BackgroundDependencyLoader]
-        private void load(Ez2ConfigManager ezConfig)
+        private void load(Ez2ConfigManager ezConfig, ScratchAxisDeviceTracker scratchTracker)
         {
+            tracker = scratchTracker;
+
             enabled = ezConfig.GetBindable<bool>(Ez2Setting.ManiaScratchAxisEnabled);
-            leftAxis = ezConfig.GetBindable<int>(Ez2Setting.ScratchAxisL);
-            rightAxis = ezConfig.GetBindable<int>(Ez2Setting.ScratchAxisR);
+            leftBinding = ezConfig.GetBindable<string>(Ez2Setting.ScratchAxisL);
+            rightBinding = ezConfig.GetBindable<string>(Ez2Setting.ScratchAxisR);
             deadzone = ezConfig.GetBindable<double>(Ez2Setting.ScratchAxisDeadzone);
             stopThreshold = ezConfig.GetBindable<int>(Ez2Setting.ScratchAxisStopThreshold);
 
@@ -111,19 +118,30 @@ namespace osu.Game.EzOsuGame.Overlays
                 },
             };
 
-            leftAxis.BindValueChanged(_ => refreshBindLabels(), true);
-            rightAxis.BindValueChanged(_ => refreshBindLabels(), true);
+            leftBinding.BindValueChanged(_ => refreshBindLabels(), true);
+            rightBinding.BindValueChanged(_ => refreshBindLabels(), true);
 
             leftMonitor.IsPressed.BindValueChanged(_ => refreshStatus(leftMonitor, leftStatusText), true);
             leftMonitor.Direction.BindValueChanged(_ => refreshStatus(leftMonitor, leftStatusText));
             rightMonitor.IsPressed.BindValueChanged(_ => refreshStatus(rightMonitor, rightStatusText), true);
             rightMonitor.Direction.BindValueChanged(_ => refreshStatus(rightMonitor, rightStatusText));
+
+            tracker.AxisMoved += onAxisMoved;
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (tracker != null)
+                tracker.AxisMoved -= onAxisMoved;
+
+            base.Dispose(isDisposing);
         }
 
         public override bool AcceptsFocus => bindTarget != null;
 
         protected override void OnFocusLost(FocusLostEvent e)
         {
+            commitBindIfPossible();
             endBind();
             base.OnFocusLost(e);
         }
@@ -132,38 +150,25 @@ namespace osu.Game.EzOsuGame.Overlays
         {
             base.Update();
 
-            var joystick = GetContainingInputManager()?.CurrentState.Joystick;
-            if (joystick == null)
-                return;
+            double t = Time.Current;
 
-            leftMonitor.Update(readAxis(joystick.AxesValues, leftAxis.Value));
-            rightMonitor.Update(readAxis(joystick.AxesValues, rightAxis.Value));
-        }
-
-        protected override bool OnJoystickAxisMove(JoystickAxisMoveEvent e)
-        {
-            if (bindTarget == null)
-                return false;
-
-            if (Math.Abs(e.Delta) < Math.Max(0.05, deadzone.Value))
-                return false;
-
-            int axisIndex = (int)e.Axis.Source;
-            if (bindTarget == BindTarget.Left)
-                leftAxis.Value = axisIndex;
+            if (tracker.TryGetValue(decorate(leftBinding.Value), out float leftValue))
+                leftMonitor.Update(leftValue, t);
             else
-                rightAxis.Value = axisIndex;
+                leftMonitor.UpdateMissing(t);
 
-            endBind();
-            return true;
+            if (tracker.TryGetValue(decorate(rightBinding.Value), out float rightValue))
+                rightMonitor.Update(rightValue, t);
+            else
+                rightMonitor.UpdateMissing(t);
         }
 
         protected override bool OnClick(ClickEvent e)
         {
-            // 点击空白处取消绑定等待
             if (bindTarget != null && !leftBindButton.ReceivePositionalInputAt(e.ScreenSpaceMousePosition)
                                    && !rightBindButton.ReceivePositionalInputAt(e.ScreenSpaceMousePosition))
             {
+                commitBindIfPossible();
                 endBind();
                 return true;
             }
@@ -171,33 +176,88 @@ namespace osu.Game.EzOsuGame.Overlays
             return base.OnClick(e);
         }
 
+        private void onAxisMoved(JoystickDeviceAxis axis)
+        {
+            if (string.IsNullOrEmpty(axis.Guid))
+                return;
+
+            var key = (axis.Guid, axis.AxisIndex);
+            float last = bindSampleLast.GetValueOrDefault(key, axis.Value);
+            float delta = Math.Abs(ScratchAxisProcessor.ShortestDelta(last, axis.Value));
+            bindSampleLast[key] = axis.Value;
+
+            float threshold = (float)Math.Max(0.02, deadzone.Value);
+
+            if (bindTarget == null)
+                return;
+
+            if (delta < threshold)
+                return;
+
+            if (bestBindCandidate == null || delta > bestBindCandidate.Value.score)
+                bestBindCandidate = (axis.Guid, axis.AxisIndex, axis.Name, delta);
+
+            // 累计足够位移后立即确认，避免必须失焦才生效
+            if (bestBindCandidate.Value.score >= threshold * 2)
+            {
+                commitBindIfPossible();
+                endBind();
+            }
+        }
+
         private void beginBind(BindTarget target)
         {
             bindTarget = target;
+            bestBindCandidate = null;
+            bindSampleLast.Clear();
             refreshBindLabels();
             GetContainingFocusManager()?.ChangeFocus(this);
+        }
+
+        private void commitBindIfPossible()
+        {
+            if (bindTarget == null || bestBindCandidate == null)
+                return;
+
+            var binding = new ScratchAxisBinding(bestBindCandidate.Value.guid, bestBindCandidate.Value.axis, bestBindCandidate.Value.name);
+
+            if (bindTarget == BindTarget.Left)
+                leftBinding.Value = binding.ToString();
+            else
+                rightBinding.Value = binding.ToString();
         }
 
         private void endBind()
         {
             bindTarget = null;
+            bestBindCandidate = null;
             refreshBindLabels();
         }
 
         private void refreshBindLabels()
         {
-            leftBindButton.Text = formatBindLabel("L-Scratch", leftAxis.Value, bindTarget == BindTarget.Left);
-            rightBindButton.Text = formatBindLabel("R-Scratch", rightAxis.Value, bindTarget == BindTarget.Right);
+            leftBindButton.Text = formatBindLabel("L-Scratch", decorate(leftBinding.Value), bindTarget == BindTarget.Left);
+            rightBindButton.Text = formatBindLabel("R-Scratch", decorate(rightBinding.Value), bindTarget == BindTarget.Right);
         }
 
-        private static LocalisableString formatBindLabel(string caption, int axisIndex, bool waiting)
+        private ScratchAxisBinding decorate(string stored)
         {
-            string axisName = ((JoystickAxisSource)axisIndex).ToString();
+            var binding = ScratchAxisBinding.Parse(stored);
+            if (binding.IsEmpty || !string.IsNullOrEmpty(binding.DeviceName))
+                return binding;
 
+            string? name = tracker.GetDeviceName(binding.DeviceGuid);
+            return string.IsNullOrEmpty(name)
+                ? binding
+                : new ScratchAxisBinding(binding.DeviceGuid, binding.AxisIndex, name);
+        }
+
+        private static LocalisableString formatBindLabel(string caption, ScratchAxisBinding binding, bool waiting)
+        {
             if (waiting)
                 return $"{caption}: [{EzSettingsStrings.SCRATCH_AXIS_BIND_HINT}]";
 
-            return $"{caption}: {axisName}";
+            return $"{caption}: {binding.ToDisplayString()}";
         }
 
         private static void refreshStatus(ScratchAxisProcessor processor, OsuSpriteText text)
@@ -228,14 +288,6 @@ namespace osu.Game.EzOsuGame.Overlays
                 Padding = SettingsPanel.CONTENT_PADDING,
                 Child = statusText,
             };
-        }
-
-        private static float readAxis(float[] values, int index)
-        {
-            if (index < 0 || index >= values.Length)
-                return 0;
-
-            return values[index];
         }
 
         private enum BindTarget

--- a/osu.Game/EzOsuGame/Overlays/EzManiaScratchAxisSettings.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzManiaScratchAxisSettings.cs
@@ -15,10 +15,14 @@ using osu.Game.EzOsuGame.Input;
 using osu.Game.EzOsuGame.Localization;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Localisation;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Settings;
 using osuTK;
+using osuTK.Input;
+using CommonStrings = osu.Game.Resources.Localisation.Web.CommonStrings;
 
 namespace osu.Game.EzOsuGame.Overlays
 {
@@ -27,9 +31,13 @@ namespace osu.Game.EzOsuGame.Overlays
     /// </summary>
     public partial class EzManiaScratchAxisSettings : FillFlowContainer
     {
+        /// <summary>绑定捕获用的累计位移阈值（与游玩死区独立，避免绑不上）。</summary>
+        private const float bind_travel_threshold = 0.03f;
+
         private readonly ScratchAxisProcessor leftMonitor = new ScratchAxisProcessor();
         private readonly ScratchAxisProcessor rightMonitor = new ScratchAxisProcessor();
-        private readonly Dictionary<(string guid, int axis), float> bindSampleLast = new Dictionary<(string, int), float>();
+        private readonly Dictionary<(string device, int axis), float> bindLastValue = new Dictionary<(string, int), float>();
+        private readonly Dictionary<(string device, int axis), float> bindTravel = new Dictionary<(string, int), float>();
 
         private Bindable<bool> enabled = null!;
         private Bindable<string> leftBinding = null!;
@@ -43,9 +51,11 @@ namespace osu.Game.EzOsuGame.Overlays
         private SettingsButtonV2 rightBindButton = null!;
         private OsuSpriteText leftStatusText = null!;
         private OsuSpriteText rightStatusText = null!;
+        private OsuSpriteText bindHintText = null!;
+        private FillFlowContainer cancelAndClearButtons = null!;
 
         private BindTarget? bindTarget;
-        private (string guid, int axis, string name, float score)? bestBindCandidate;
+        private (string device, int axis, string name, float travel)? bestBindCandidate;
 
         public EzManiaScratchAxisSettings()
         {
@@ -71,7 +81,7 @@ namespace osu.Game.EzOsuGame.Overlays
             leftMonitor.StopThreshold.BindTo(stopThreshold);
             rightMonitor.StopThreshold.BindTo(stopThreshold);
 
-            Children = new Drawable[]
+            Children = new[]
             {
                 new SettingsItemV2(new FormCheckBox
                 {
@@ -85,15 +95,46 @@ namespace osu.Game.EzOsuGame.Overlays
                 leftBindButton = new SettingsButtonV2
                 {
                     Keywords = new[] { "ez", "mania", "scratch", "l", "axis" },
-                    Action = () => beginBind(BindTarget.Left),
+                    Action = () => toggleBind(BindTarget.Left),
                 },
                 createStatusRow(out leftStatusText),
                 rightBindButton = new SettingsButtonV2
                 {
                     Keywords = new[] { "ez", "mania", "scratch", "r", "axis" },
-                    Action = () => beginBind(BindTarget.Right),
+                    Action = () => toggleBind(BindTarget.Right),
                 },
                 createStatusRow(out rightStatusText),
+                createHintRow(out bindHintText),
+                cancelAndClearButtons = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Full,
+                    Anchor = Anchor.TopRight,
+                    Origin = Anchor.TopRight,
+                    Spacing = new Vector2(5),
+                    Padding = SettingsPanel.CONTENT_PADDING,
+                    Alpha = 0,
+                    Children = new Drawable[]
+                    {
+                        new RoundedButton
+                        {
+                            Anchor = Anchor.TopRight,
+                            Origin = Anchor.TopRight,
+                            Text = CommonStrings.ButtonsCancel,
+                            Size = new Vector2(120, 30),
+                            Action = cancelBind,
+                        },
+                        new DangerousRoundedButton
+                        {
+                            Anchor = Anchor.TopRight,
+                            Origin = Anchor.TopRight,
+                            Text = InputSettingsStrings.ClearBindingButton,
+                            Size = new Vector2(120, 30),
+                            Action = clearBinding,
+                        },
+                    },
+                },
                 new SettingsItemV2(new FormSliderBar<double>
                 {
                     Caption = EzSettingsStrings.SCRATCH_AXIS_DEADZONE,
@@ -127,23 +168,26 @@ namespace osu.Game.EzOsuGame.Overlays
             rightMonitor.Direction.BindValueChanged(_ => refreshStatus(rightMonitor, rightStatusText));
 
             tracker.AxisMoved += onAxisMoved;
+            refreshBindHint();
         }
 
         protected override void Dispose(bool isDisposing)
         {
-            if (tracker != null)
-                tracker.AxisMoved -= onAxisMoved;
-
             base.Dispose(isDisposing);
+
+            if (isDisposing && tracker != null)
+                tracker.AxisMoved -= onAxisMoved;
         }
 
-        public override bool AcceptsFocus => bindTarget != null;
-
-        protected override void OnFocusLost(FocusLostEvent e)
+        protected override bool OnKeyDown(KeyDownEvent e)
         {
-            commitBindIfPossible();
-            endBind();
-            base.OnFocusLost(e);
+            if (bindTarget != null && e.Key == Key.Escape)
+            {
+                cancelBind();
+                return true;
+            }
+
+            return base.OnKeyDown(e);
         }
 
         protected override void Update()
@@ -163,55 +207,89 @@ namespace osu.Game.EzOsuGame.Overlays
                 rightMonitor.UpdateMissing(t);
         }
 
-        protected override bool OnClick(ClickEvent e)
-        {
-            if (bindTarget != null && !leftBindButton.ReceivePositionalInputAt(e.ScreenSpaceMousePosition)
-                                   && !rightBindButton.ReceivePositionalInputAt(e.ScreenSpaceMousePosition))
-            {
-                commitBindIfPossible();
-                endBind();
-                return true;
-            }
-
-            return base.OnClick(e);
-        }
-
         private void onAxisMoved(JoystickDeviceAxis axis)
         {
-            if (string.IsNullOrEmpty(axis.Guid))
-                return;
+            string deviceKey = !string.IsNullOrEmpty(axis.Guid) ? axis.Guid : $"id:{axis.InstanceId}";
+            var key = (deviceKey, axis.AxisIndex);
 
-            var key = (axis.Guid, axis.AxisIndex);
-            float last = bindSampleLast.GetValueOrDefault(key, axis.Value);
-            float delta = Math.Abs(ScratchAxisProcessor.ShortestDelta(last, axis.Value));
-            bindSampleLast[key] = axis.Value;
-
-            float threshold = (float)Math.Max(0.02, deadzone.Value);
-
+            // 始终更新 tracker 侧已有逻辑；绑定窗口内累计位移
             if (bindTarget == null)
                 return;
 
-            if (delta < threshold)
+            if (!bindLastValue.TryGetValue(key, out float last))
+            {
+                // 首帧只记停靠点，不算位移（避免把绝对值当转动）
+                bindLastValue[key] = axis.Value;
+                bindTravel[key] = 0;
+                refreshBindHint();
+                return;
+            }
+
+            float delta = Math.Abs(ScratchAxisProcessor.ShortestDelta(last, axis.Value));
+            bindLastValue[key] = axis.Value;
+
+            if (delta < 0.001f)
                 return;
 
-            if (bestBindCandidate == null || delta > bestBindCandidate.Value.score)
-                bestBindCandidate = (axis.Guid, axis.AxisIndex, axis.Name, delta);
+            float travel = bindTravel.GetValueOrDefault(key) + delta;
+            bindTravel[key] = travel;
 
-            // 累计足够位移后立即确认，避免必须失焦才生效
-            if (bestBindCandidate.Value.score >= threshold * 2)
+            if (bestBindCandidate == null || travel > bestBindCandidate.Value.travel)
+                bestBindCandidate = (deviceKey, axis.AxisIndex, axis.Name, travel);
+
+            refreshBindHint();
+
+            if (travel >= bind_travel_threshold)
             {
                 commitBindIfPossible();
                 endBind();
             }
+        }
+
+        private void toggleBind(BindTarget target)
+        {
+            if (bindTarget == target)
+            {
+                cancelBind();
+                return;
+            }
+
+            beginBind(target);
         }
 
         private void beginBind(BindTarget target)
         {
             bindTarget = target;
             bestBindCandidate = null;
-            bindSampleLast.Clear();
+            bindLastValue.Clear();
+            bindTravel.Clear();
             refreshBindLabels();
-            GetContainingFocusManager()?.ChangeFocus(this);
+            refreshBindHint();
+            showClearButtons(true);
+        }
+
+        private void cancelBind()
+        {
+            bindTarget = null;
+            bestBindCandidate = null;
+            bindLastValue.Clear();
+            bindTravel.Clear();
+            refreshBindLabels();
+            refreshBindHint();
+            showClearButtons(false);
+        }
+
+        private void clearBinding()
+        {
+            if (bindTarget == null)
+                return;
+
+            if (bindTarget == BindTarget.Left)
+                leftBinding.Value = string.Empty;
+            else
+                rightBinding.Value = string.Empty;
+
+            endBind();
         }
 
         private void commitBindIfPossible()
@@ -219,7 +297,10 @@ namespace osu.Game.EzOsuGame.Overlays
             if (bindTarget == null || bestBindCandidate == null)
                 return;
 
-            var binding = new ScratchAxisBinding(bestBindCandidate.Value.guid, bestBindCandidate.Value.axis, bestBindCandidate.Value.name);
+            var binding = new ScratchAxisBinding(
+                bestBindCandidate.Value.device,
+                bestBindCandidate.Value.axis,
+                bestBindCandidate.Value.name);
 
             if (bindTarget == BindTarget.Left)
                 leftBinding.Value = binding.ToString();
@@ -231,13 +312,37 @@ namespace osu.Game.EzOsuGame.Overlays
         {
             bindTarget = null;
             bestBindCandidate = null;
+            bindLastValue.Clear();
+            bindTravel.Clear();
             refreshBindLabels();
+            refreshBindHint();
+            showClearButtons(false);
+        }
+
+        private void showClearButtons(bool show)
+        {
+            if (show)
+                cancelAndClearButtons.FadeIn(200, Easing.OutQuint);
+            else
+                cancelAndClearButtons.FadeOut(200, Easing.OutQuint);
         }
 
         private void refreshBindLabels()
         {
             leftBindButton.Text = formatBindLabel("L-Scratch", decorate(leftBinding.Value), bindTarget == BindTarget.Left);
             rightBindButton.Text = formatBindLabel("R-Scratch", decorate(rightBinding.Value), bindTarget == BindTarget.Right);
+        }
+
+        private void refreshBindHint()
+        {
+            if (bindTarget == null)
+            {
+                bindHintText.Text = EzSettingsStrings.SCRATCH_AXIS_BIND_IDLE_HINT;
+                return;
+            }
+
+            float travel = bestBindCandidate?.travel ?? 0;
+            bindHintText.Text = $"Listening… travel {travel:0.###} / {bind_travel_threshold:0.###}  |  Move {travel:0.###} / {bind_travel_threshold:0.###}";
         }
 
         private ScratchAxisBinding decorate(string stored)
@@ -287,6 +392,23 @@ namespace osu.Game.EzOsuGame.Overlays
                 AutoSizeAxes = Axes.Y,
                 Padding = SettingsPanel.CONTENT_PADDING,
                 Child = statusText,
+            };
+        }
+
+        private static Drawable createHintRow(out OsuSpriteText hintText)
+        {
+            hintText = new OsuSpriteText
+            {
+                Font = OsuFont.GetFont(size: 12),
+                Colour = Colour4.Gray,
+            };
+
+            return new Container
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Padding = SettingsPanel.CONTENT_PADDING,
+                Child = hintText,
             };
         }
 

--- a/osu.Game/EzOsuGame/Overlays/EzManiaScratchAxisSettings.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzManiaScratchAxisSettings.cs
@@ -1,0 +1,247 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Input;
+using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Input;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Settings;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.Overlays
+{
+    /// <summary>
+    /// Mania L/R 转盘轴设置：开关、轴绑定、死区、实时顺逆状态。
+    /// </summary>
+    public partial class EzManiaScratchAxisSettings : FillFlowContainer
+    {
+        private readonly ScratchAxisProcessor leftMonitor = new ScratchAxisProcessor();
+        private readonly ScratchAxisProcessor rightMonitor = new ScratchAxisProcessor();
+
+        private Bindable<bool> enabled = null!;
+        private Bindable<int> leftAxis = null!;
+        private Bindable<int> rightAxis = null!;
+        private Bindable<double> deadzone = null!;
+        private Bindable<int> stopThreshold = null!;
+
+        private SettingsButtonV2 leftBindButton = null!;
+        private SettingsButtonV2 rightBindButton = null!;
+        private OsuSpriteText leftStatusText = null!;
+        private OsuSpriteText rightStatusText = null!;
+
+        private BindTarget? bindTarget;
+
+        public EzManiaScratchAxisSettings()
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            Direction = FillDirection.Vertical;
+            Spacing = new Vector2(0, SettingsSection.ITEM_SPACING_V2);
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(Ez2ConfigManager ezConfig)
+        {
+            enabled = ezConfig.GetBindable<bool>(Ez2Setting.ManiaScratchAxisEnabled);
+            leftAxis = ezConfig.GetBindable<int>(Ez2Setting.ScratchAxisL);
+            rightAxis = ezConfig.GetBindable<int>(Ez2Setting.ScratchAxisR);
+            deadzone = ezConfig.GetBindable<double>(Ez2Setting.ScratchAxisDeadzone);
+            stopThreshold = ezConfig.GetBindable<int>(Ez2Setting.ScratchAxisStopThreshold);
+
+            leftMonitor.Deadzone.BindTo(deadzone);
+            rightMonitor.Deadzone.BindTo(deadzone);
+            leftMonitor.StopThreshold.BindTo(stopThreshold);
+            rightMonitor.StopThreshold.BindTo(stopThreshold);
+
+            Children = new Drawable[]
+            {
+                new SettingsItemV2(new FormCheckBox
+                {
+                    Caption = EzSettingsStrings.MANIA_SCRATCH_AXIS_ENABLED,
+                    HintText = EzSettingsStrings.MANIA_SCRATCH_AXIS_ENABLED_TOOLTIP,
+                    Current = enabled,
+                })
+                {
+                    Keywords = new[] { "ez", "mania", "scratch", "turntable", "axis", "joystick", "转盘" }
+                },
+                leftBindButton = new SettingsButtonV2
+                {
+                    Keywords = new[] { "ez", "mania", "scratch", "l", "axis" },
+                    Action = () => beginBind(BindTarget.Left),
+                },
+                createStatusRow(out leftStatusText),
+                rightBindButton = new SettingsButtonV2
+                {
+                    Keywords = new[] { "ez", "mania", "scratch", "r", "axis" },
+                    Action = () => beginBind(BindTarget.Right),
+                },
+                createStatusRow(out rightStatusText),
+                new SettingsItemV2(new FormSliderBar<double>
+                {
+                    Caption = EzSettingsStrings.SCRATCH_AXIS_DEADZONE,
+                    HintText = EzSettingsStrings.SCRATCH_AXIS_DEADZONE_TOOLTIP,
+                    RelativeSizeAxes = Axes.X,
+                    Current = deadzone,
+                    KeyboardStep = 0.005f,
+                })
+                {
+                    Keywords = new[] { "ez", "scratch", "deadzone", "jitter", "死区" }
+                },
+                new SettingsItemV2(new FormSliderBar<int>
+                {
+                    Caption = EzSettingsStrings.SCRATCH_AXIS_STOP_THRESHOLD,
+                    HintText = EzSettingsStrings.SCRATCH_AXIS_STOP_THRESHOLD_TOOLTIP,
+                    RelativeSizeAxes = Axes.X,
+                    Current = stopThreshold,
+                    KeyboardStep = 1,
+                })
+                {
+                    Keywords = new[] { "ez", "scratch", "stop", "threshold" }
+                },
+            };
+
+            leftAxis.BindValueChanged(_ => refreshBindLabels(), true);
+            rightAxis.BindValueChanged(_ => refreshBindLabels(), true);
+
+            leftMonitor.IsPressed.BindValueChanged(_ => refreshStatus(leftMonitor, leftStatusText), true);
+            leftMonitor.Direction.BindValueChanged(_ => refreshStatus(leftMonitor, leftStatusText));
+            rightMonitor.IsPressed.BindValueChanged(_ => refreshStatus(rightMonitor, rightStatusText), true);
+            rightMonitor.Direction.BindValueChanged(_ => refreshStatus(rightMonitor, rightStatusText));
+        }
+
+        public override bool AcceptsFocus => bindTarget != null;
+
+        protected override void OnFocusLost(FocusLostEvent e)
+        {
+            endBind();
+            base.OnFocusLost(e);
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            var joystick = GetContainingInputManager()?.CurrentState.Joystick;
+            if (joystick == null)
+                return;
+
+            leftMonitor.Update(readAxis(joystick.AxesValues, leftAxis.Value));
+            rightMonitor.Update(readAxis(joystick.AxesValues, rightAxis.Value));
+        }
+
+        protected override bool OnJoystickAxisMove(JoystickAxisMoveEvent e)
+        {
+            if (bindTarget == null)
+                return false;
+
+            if (Math.Abs(e.Delta) < Math.Max(0.05, deadzone.Value))
+                return false;
+
+            int axisIndex = (int)e.Axis.Source;
+            if (bindTarget == BindTarget.Left)
+                leftAxis.Value = axisIndex;
+            else
+                rightAxis.Value = axisIndex;
+
+            endBind();
+            return true;
+        }
+
+        protected override bool OnClick(ClickEvent e)
+        {
+            // 点击空白处取消绑定等待
+            if (bindTarget != null && !leftBindButton.ReceivePositionalInputAt(e.ScreenSpaceMousePosition)
+                                   && !rightBindButton.ReceivePositionalInputAt(e.ScreenSpaceMousePosition))
+            {
+                endBind();
+                return true;
+            }
+
+            return base.OnClick(e);
+        }
+
+        private void beginBind(BindTarget target)
+        {
+            bindTarget = target;
+            refreshBindLabels();
+            GetContainingFocusManager()?.ChangeFocus(this);
+        }
+
+        private void endBind()
+        {
+            bindTarget = null;
+            refreshBindLabels();
+        }
+
+        private void refreshBindLabels()
+        {
+            leftBindButton.Text = formatBindLabel("L-Scratch", leftAxis.Value, bindTarget == BindTarget.Left);
+            rightBindButton.Text = formatBindLabel("R-Scratch", rightAxis.Value, bindTarget == BindTarget.Right);
+        }
+
+        private static LocalisableString formatBindLabel(string caption, int axisIndex, bool waiting)
+        {
+            string axisName = ((JoystickAxisSource)axisIndex).ToString();
+
+            if (waiting)
+                return $"{caption}: [{EzSettingsStrings.SCRATCH_AXIS_BIND_HINT}]";
+
+            return $"{caption}: {axisName}";
+        }
+
+        private static void refreshStatus(ScratchAxisProcessor processor, OsuSpriteText text)
+        {
+            if (!processor.IsPressed.Value || processor.Direction.Value == ScratchAxisDirection.None)
+            {
+                text.Text = EzSettingsStrings.SCRATCH_AXIS_STATUS_IDLE;
+                return;
+            }
+
+            text.Text = processor.Direction.Value == ScratchAxisDirection.Clockwise
+                ? EzSettingsStrings.SCRATCH_AXIS_STATUS_CW
+                : EzSettingsStrings.SCRATCH_AXIS_STATUS_CCW;
+        }
+
+        private static Drawable createStatusRow(out OsuSpriteText statusText)
+        {
+            statusText = new OsuSpriteText
+            {
+                Font = OsuFont.GetFont(size: 14),
+                Text = EzSettingsStrings.SCRATCH_AXIS_STATUS_IDLE,
+            };
+
+            return new Container
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Padding = SettingsPanel.CONTENT_PADDING,
+                Child = statusText,
+            };
+        }
+
+        private static float readAxis(float[] values, int index)
+        {
+            if (index < 0 || index >= values.Length)
+                return 0;
+
+            return values[index];
+        }
+
+        private enum BindTarget
+        {
+            Left,
+            Right,
+        }
+    }
+}

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -50,6 +50,7 @@ using osu.Game.IO;
 using osu.Game.EzOsuGame;
 using osu.Game.EzOsuGame.Analysis;
 using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Input;
 using osu.Game.EzOsuGame.Online;
 using osu.Game.EzOsuGame.Scoring;
 using osu.Game.Localisation;
@@ -507,6 +508,10 @@ namespace osu.Game
 
             base.Content.Add(new TouchInputInterceptor());
             base.Content.Add(hitErrorTracker);
+
+            var scratchAxisTracker = new ScratchAxisDeviceTracker();
+            dependencies.Cache(scratchAxisTracker);
+            base.Content.Add(scratchAxisTracker);
 
             KeyBindingStore = new RealmKeyBindingStore(realm, keyCombinationProvider);
             KeyBindingStore.Register(globalBindings, RulesetStore.AvailableRulesets);


### PR DESCRIPTION
## Summary
- Add Mania L/R turntable axis binding (per-device GUID + axis), settings UI, and template mapping for 12/14/16K edge columns.
- Scratch detection: delta-only spin, deadzone, wall-clock stop threshold; **beatoraja Analog V2** semantics (two same-direction deltas to press; reverse clears for a new hit).
- Bump framework package ref to `2026.722.0-ez2lazer` (needs per-device `JoystickDeviceAxis` / SDL3 joy value fix from framework).

## Test plan
- [x] Bind L/R axes in Ez settings; Cancel / Clear binding work while listening.
- [x] Settings status: idle at rest; CW/CCW while spinning.
- [x] 12/14/16K: edge columns hold during continuous same-direction spin; reverse releases then re-presses (new hit).
- [ ] Stop spinning: release after stop threshold; enter gameplay does not leave columns stuck pressed.
- [ ] Replay path does not inject scratch.


Made with [Cursor](https://cursor.com)