### PR TITLE
用 APIState.LocalOnline 表达「登录到本机/局域网」

### DIFF
--- a/osu.Game.Tests/Beatmaps/APIBeatmapMetadataSourceTest.cs
+++ b/osu.Game.Tests/Beatmaps/APIBeatmapMetadataSourceTest.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Moq;
+using NUnit.Framework;
+using osu.Framework.Bindables;
+using osu.Game.Beatmaps;
+using osu.Game.Online.API;
+
+namespace osu.Game.Tests.Beatmaps
+{
+    [TestFixture]
+    public class APIBeatmapMetadataSourceTest
+    {
+        [Test]
+        public void TestAvailableWhenOnline()
+        {
+            Assert.That(createSource(APIState.Online).Available, Is.True);
+        }
+
+        /// <summary>
+        /// <see cref="APIState.LocalOnline"/> is an Ez-only state which upstream has no test for, so a merge could
+        /// silently fold it back into the "online" branch. A local account cannot serve lookups, and pretending
+        /// otherwise makes every beatmap pay for a request that is bound to fail.
+        /// </summary>
+        [Test]
+        public void TestUnavailableWhenLocalOnline()
+        {
+            Assert.That(createSource(APIState.LocalOnline).Available, Is.False);
+        }
+
+        [Test]
+        public void TestUnavailableWhenNotOnline([Values(APIState.Offline, APIState.Failing, APIState.Connecting)] APIState state)
+        {
+            Assert.That(createSource(state).Available, Is.False);
+        }
+
+        private static APIBeatmapMetadataSource createSource(APIState state)
+        {
+            var api = new Mock<IAPIProvider>();
+
+            api.Setup(a => a.State).Returns(new Bindable<APIState>(state));
+
+            return new APIBeatmapMetadataSource(api.Object);
+        }
+    }
+}

--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -92,6 +92,11 @@ namespace osu.Game.Database
 
         protected virtual int TimeToSleepDuringGameplay => 30000;
 
+        /// <summary>
+        /// How long to wait for the API to finish connecting before giving up on online metadata lookups for this run.
+        /// </summary>
+        protected virtual int APISettleTimeout => 30000;
+
         protected virtual bool SkipProcessing => DebugUtils.IsNUnitRunning;
 
         /// <summary>
@@ -912,23 +917,47 @@ namespace osu.Game.Database
 
         private void processOnlineBeatmapSetsWithNoUpdate()
         {
+            // BeatmapProcessor is responsible for both online and local processing, so a set queued here pays for a
+            // full difficulty recalculation whether or not the online lookup ends up resolving. A lookup that cannot
+            // resolve also leaves LastOnlineUpdate null, which re-queues the very same sets on the next startup.
+            //
+            // Deciding this up front rather than per set is therefore what keeps the redundant work from recurring.
+            // Note that no login is required: the local cache is downloaded from assets.ppy.sh anonymously, same as
+            // the user tag backpopulation below.
+            bool apiAvailable = waitForAPIToSettle();
+            bool cacheAvailable = localMetadataSource.Available;
+
+            // the cache is the only source that works without a login, so it's worth fetching when the API can't
+            // serve lookups by itself. Otherwise leave the (sizeable) download alone.
+            if (!cacheAvailable && !apiAvailable)
+                cacheAvailable = fetchLocalMetadataCache();
+
+            if (!apiAvailable && !cacheAvailable)
+            {
+                Logger.Log("Skipping online beatmap updates because no metadata source is available.");
+                return;
+            }
+
             HashSet<Guid> beatmapSetIds = new HashSet<Guid>();
 
             Logger.Log("Querying for beatmap sets to reprocess...");
 
             realmAccess.Run(r =>
             {
-                // BeatmapProcessor is responsible for both online and local processing.
-                // In the case a user isn't logged in, it won't update LastOnlineUpdate and therefore re-queue,
-                // causing overhead from the non-online processing to redundantly run every startup.
-                //
-                // We may eventually consider making the Process call more specific (or avoid this in any number
-                // of other possible ways), but for now avoid queueing if the user isn't logged in at startup.
-                if (api.IsLoggedIn)
+                var candidates = r.All<BeatmapInfo>().Where(b => b.OnlineID > 0 && b.LastOnlineUpdate == null && b.BeatmapSet != null);
+
+                // The local cache only holds ranked/approved/loved beatmaps, so with no API to give a definitive
+                // answer, nothing else can ever resolve. Queueing those anyway would repeat a full difficulty
+                // recalculation on every startup for no possible gain.
+                if (!apiAvailable)
                 {
-                    foreach (var b in r.All<BeatmapInfo>().Where(b => b.OnlineID > 0 && b.LastOnlineUpdate == null && b.BeatmapSet != null))
-                        beatmapSetIds.Add(b.BeatmapSet!.ID);
+                    candidates = candidates.Where(b => b.StatusInt == (int)BeatmapOnlineStatus.Ranked
+                                                       || b.StatusInt == (int)BeatmapOnlineStatus.Approved
+                                                       || b.StatusInt == (int)BeatmapOnlineStatus.Loved);
                 }
+
+                foreach (var b in candidates)
+                    beatmapSetIds.Add(b.BeatmapSet!.ID);
             });
 
             if (beatmapSetIds.Count == 0)
@@ -968,9 +997,51 @@ namespace osu.Game.Database
                         }
                     }
                 });
+
+                updateNotificationProgress(notification, processedCount, beatmapSetIds.Count);
             }
 
             completeNotification(notification, processedCount, beatmapSetIds.Count, failedCount);
+        }
+
+        /// <summary>
+        /// Blocks until the API has settled into a state which tells us whether online lookups can be performed.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="IAPIProvider.IsLoggedIn"/> is not usable for this, as it becomes <see langword="true"/> at
+        /// <see cref="APIState.Connecting"/>, while <see cref="APIBeatmapMetadataSource"/> requires
+        /// <see cref="APIState.Online"/>. Acting on the former during startup means every lookup fails inconclusively.
+        /// </remarks>
+        /// <returns>Whether the API can serve lookups.</returns>
+        private bool waitForAPIToSettle()
+        {
+            var timeout = Stopwatch.StartNew();
+
+            while (api.State.Value == APIState.Connecting && timeout.ElapsedMilliseconds < APISettleTimeout)
+                Thread.Sleep(500);
+
+            // matches APIBeatmapMetadataSource.Available.
+            if (api.State.Value == APIState.Online)
+                return true;
+
+            Logger.Log($"API is unavailable for online metadata lookups (state: {api.State.Value}).");
+            return false;
+        }
+
+        /// <summary>
+        /// Fetches the local metadata cache. Requires no login, as it is downloaded anonymously.
+        /// </summary>
+        /// <returns>Whether the local cache can serve lookups.</returns>
+        private bool fetchLocalMetadataCache()
+        {
+            Logger.Log("Local metadata cache doesn't exist, attempting refetch...");
+            localMetadataSource.FetchCache().WaitSafely();
+
+            if (localMetadataSource.Available)
+                return true;
+
+            Logger.Log("Local metadata cache refetch failed.");
+            return false;
         }
 
         private void processBeatmapsWithMissingObjectCounts()
@@ -1666,9 +1737,13 @@ namespace osu.Game.Database
             if (notification == null)
                 return;
 
+            // a fixed interval means batches smaller than it never report anything between the initial 0 and
+            // completion, which reads as a permanently stuck progress bar.
+            int updateInterval = Math.Max(1, Math.Min(notification_progress_update_interval, totalCount / 20));
+
             bool shouldUpdate = processedCount == 0 ||
                                 processedCount >= totalCount ||
-                                processedCount - lastNotificationProgressReported >= notification_progress_update_interval;
+                                processedCount - lastNotificationProgressReported >= updateInterval;
 
             if (!shouldUpdate)
                 return;

--- a/osu.Game/EzOsuGame/Online/APIStateExtensions.cs
+++ b/osu.Game/EzOsuGame/Online/APIStateExtensions.cs
@@ -1,0 +1,16 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Online.API;
+
+namespace osu.Game.EzOsuGame.Online
+{
+    public static class APIStateExtensions
+    {
+        /// <summary>
+        /// 会话可用：用户已登录且可以进入需要身份的功能，包含本地 / 局域网账号。
+        /// 与 <c>== <see cref="APIState.Online"/></c> 的区别在于后者要求能真正访问 osu! 服务器。
+        /// </summary>
+        public static bool IsSessionActive(this APIState state) => state == APIState.Online || state == APIState.LocalOnline;
+    }
+}

--- a/osu.Game/EzOsuGame/Online/ILocalOnlyRequestHandler.cs
+++ b/osu.Game/EzOsuGame/Online/ILocalOnlyRequestHandler.cs
@@ -1,0 +1,22 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Online.API;
+
+namespace osu.Game.EzOsuGame.Online
+{
+    /// <summary>
+    /// 在 <see cref="APIState.LocalOnline"/> 下就地应答 API 请求，使本地账号不必联网也能满足 UI 的数据依赖。
+    /// </summary>
+    public interface ILocalOnlyRequestHandler
+    {
+        /// <summary>
+        /// 尝试在本地应答请求。
+        /// </summary>
+        /// <returns>
+        /// <see langword="true"/> 表示请求已被处理（无论成功或失败）；
+        /// <see langword="false"/> 表示无法在本地应答，调用方应让请求失败。
+        /// </returns>
+        bool Handle(APIRequest request);
+    }
+}

--- a/osu.Game/EzOsuGame/Online/LocalOnlyRequestHandler.cs
+++ b/osu.Game/EzOsuGame/Online/LocalOnlyRequestHandler.cs
@@ -1,0 +1,57 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Extensions.TypeExtensions;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Game.Online.API.Requests.Responses;
+
+namespace osu.Game.EzOsuGame.Online
+{
+    /// <summary>
+    /// 本地账号模式的默认请求应答器。
+    /// 只应答那些不应答就会让 UI 无限等待的请求，其余交由调用方失败。
+    /// </summary>
+    public class LocalOnlyRequestHandler : ILocalOnlyRequestHandler
+    {
+        public virtual bool Handle(APIRequest request)
+        {
+            switch (request)
+            {
+                // 登录后由 LocalUserState 无条件发出，本地账号没有社交关系，返回空集合。
+                case GetFriendsRequest friends:
+                    friends.TriggerSuccess(new List<APIRelation>());
+                    return true;
+
+                case GetBlocksRequest blocks:
+                    blocks.TriggerSuccess(new List<APIRelation>());
+                    return true;
+
+                case GetMyFavouriteBeatmapSetsRequest favourites:
+                    favourites.TriggerSuccess(new GetMyFavouriteBeatmapSetsResponse());
+                    return true;
+
+                // 聊天心跳非常频繁，静默成功以免刷满日志。
+                case ChatAckRequest ack:
+                    ack.TriggerSuccess(new ChatAckResponse());
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+    }
+
+    /// <summary>
+    /// 请求需要访问 osu! 服务器，但当前处于本地账号模式。
+    /// </summary>
+    public class LocalOnlyUnavailableException : InvalidOperationException
+    {
+        public LocalOnlyUnavailableException(APIRequest request)
+            : base($@"{request.GetType().ReadableName()} is not available while logged in with a local account.")
+        {
+        }
+    }
+}

--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -21,6 +21,7 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Logging;
 using osu.Game.Configuration;
+using osu.Game.EzOsuGame.Online;
 using osu.Game.Localisation;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
@@ -112,14 +113,12 @@ namespace osu.Game.Online.API
 
             if (!DebugUtils.IsNUnitRunning && isPersistedLocalSession(ProvidedUsername, configuredToken))
             {
+                // Restore the local account session without any network activity.
                 password = local_token_marker;
-                IsLocalOnly = true;
-                state.Value = APIState.Online;
+                state.Value = APIState.LocalOnline;
                 localUserState.SetPlaceholderLocalUser(ProvidedUsername, true);
-                return;
             }
-
-            if (HasLogin)
+            else if (HasLogin)
             {
                 // Early call to ensure the local user / "logged in" state is correct immediately.
                 localUserState.SetPlaceholderLocalUser(ProvidedUsername);
@@ -158,8 +157,7 @@ namespace osu.Game.Online.API
                         break;
 
                     case @"logout":
-                        // 在本地-only 模式下忽略来自服务器的 logout 事件，避免远程推送导致本地实验性登录被撤销。
-                        if (state.Value == APIState.Online && !IsLocalOnly)
+                        if (state.Value == APIState.Online)
                             Logout();
 
                         break;
@@ -214,6 +212,13 @@ namespace osu.Game.Online.API
 
                 Debug.Assert(HasLogin);
 
+                // 本地账号不需要连接、access token 或存活探测，请求已在 Queue() 中就地应答。
+                if (state.Value == APIState.LocalOnline)
+                {
+                    Thread.Sleep(50);
+                    continue;
+                }
+
                 // Ensure that we are in an online state. If not, attempt to connect.
                 if (state.Value != APIState.Online)
                 {
@@ -226,15 +231,11 @@ namespace osu.Game.Online.API
                     }
                 }
 
-                // 如果无法获取有效的 access token，则通常会强制登出。
-                // 对于本地-only 模式不需要 access token，因此在该模式下应避免登出操作。
+                // Ensure that we have a valid access token. If not, force a logout to require user interaction.
                 if (authentication.RequestAccessToken() == null)
                 {
-                    if (!IsLocalOnly)
-                    {
-                        Logout();
-                        continue;
-                    }
+                    Logout();
+                    continue;
                 }
 
                 if (livenessStopwatch.Elapsed.TotalMinutes >= 1)
@@ -480,10 +481,14 @@ namespace osu.Game.Online.API
         {
             try
             {
-                if (IsLocalOnly)
-                    return;
-
                 request.AttachAPI(this);
+
+                if (state.Value == APIState.LocalOnline)
+                {
+                    handleLocally(request);
+                    return;
+                }
+
                 request.Perform();
             }
             catch (Exception e)
@@ -502,7 +507,6 @@ namespace osu.Game.Online.API
 
             ProvidedUsername = username;
             this.password = password;
-            IsLocalOnly = false;
         }
 
         public void LoginLocal(string username)
@@ -511,7 +515,6 @@ namespace osu.Game.Online.API
 
             ProvidedUsername = username;
             password = local_token_marker;
-            IsLocalOnly = true;
 
             // Persist local account session so restart can directly restore local login state.
             config.SetValue(OsuSetting.Username, ProvidedUsername);
@@ -519,7 +522,7 @@ namespace osu.Game.Online.API
 
             Schedule(() => localUserState.SetPlaceholderLocalUser(ProvidedUsername, true));
             LastLoginError = null;
-            state.Value = APIState.Online;
+            state.Value = APIState.LocalOnline;
         }
 
         public void AuthenticateSecondFactor(string code)
@@ -691,7 +694,18 @@ namespace osu.Game.Online.API
 
         public bool IsLoggedIn => State.Value > APIState.Offline;
 
-        public bool IsLocalOnly { get; private set; }
+        public bool IsLocalOnly => State.Value == APIState.LocalOnline;
+
+        /// <summary>
+        /// Responds to requests locally while in <see cref="APIState.LocalOnline"/>.
+        /// </summary>
+        public ILocalOnlyRequestHandler LocalRequestHandler { get; set; } = new LocalOnlyRequestHandler();
+
+        private void handleLocally(APIRequest request)
+        {
+            if (!LocalRequestHandler.Handle(request))
+                request.Fail(new LocalOnlyUnavailableException(request));
+        }
 
         public void Queue(APIRequest request)
         {
@@ -699,8 +713,12 @@ namespace osu.Game.Online.API
             {
                 request.AttachAPI(this);
 
-                if (IsLocalOnly)
+                if (state.Value == APIState.LocalOnline)
+                {
+                    // Schedule to avoid running completion callbacks from within the caller's stack.
+                    Schedule(() => handleLocally(request));
                     return;
+                }
 
                 if (state.Value == APIState.Offline)
                 {
@@ -735,7 +753,6 @@ namespace osu.Game.Online.API
             authentication.Clear();
 
             localUserState.ClearLocalUser();
-            IsLocalOnly = false;
 
             state.Value = APIState.Offline;
             flushQueue();
@@ -806,6 +823,13 @@ namespace osu.Game.Online.API
         /// <summary>
         /// We are online.
         /// </summary>
-        Online
+        Online,
+
+        /// <summary>
+        /// 已登录到本机（未来的局域网 / P2P）账号，不与 osu! 服务器通信。
+        /// 视作「已登录」（排在 <see cref="Offline"/> 之后使 <see cref="IAPIProvider.IsLoggedIn"/> 成立），
+        /// 但任何 <c>== <see cref="Online"/></c> 的判断都不会成立，因此需要真实网络的功能会自动被排除。
+        /// </summary>
+        LocalOnline
     }
 }

--- a/osu.Game/Online/API/DummyAPIAccess.cs
+++ b/osu.Game/Online/API/DummyAPIAccess.cs
@@ -73,8 +73,8 @@ namespace osu.Game.Online.API
 
         public IBindable<string?> UserFacingOutageMessage { get; } = new Bindable<string?>();
 
-        // Match IAPIProvider.IsLocalOnly
-        public bool IsLocalOnly { get; private set; }
+        /// <seealso cref="APIAccess.IsLocalOnly"/>
+        public bool IsLocalOnly => State.Value == APIState.LocalOnline;
 
         public virtual void Queue(APIRequest request)
         {
@@ -144,8 +144,6 @@ namespace osu.Game.Online.API
                 Id = DUMMY_USER_ID,
             };
 
-            IsLocalOnly = false;
-
             if (SessionVerificationMethod != null)
             {
                 state.Value = APIState.RequiresSecondFactorAuth;
@@ -167,9 +165,7 @@ namespace osu.Game.Online.API
             };
 
             LastLoginError = null;
-            state.Value = APIState.Online;
-
-            IsLocalOnly = true;
+            state.Value = APIState.LocalOnline;
         }
 
         public void AuthenticateSecondFactor(string code)
@@ -215,8 +211,6 @@ namespace osu.Game.Online.API
             // must happen after `state.Value` is changed such that subscribers to that bindable's value changes see the correct user.
             // compare: `APIAccess.Logout()`.
             LocalUser.Value = new GuestUser();
-
-            IsLocalOnly = false;
         }
 
         public void UpdateLocalFriends()

--- a/osu.Game/Online/API/IAPIProvider.cs
+++ b/osu.Game/Online/API/IAPIProvider.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Online.API
         bool IsLoggedIn { get; }
 
         /// <summary>
-        /// 本地模式，启用后不提交成绩
+        /// 本地账号模式（<see cref="APIState.LocalOnline"/>）：已登录但不与 osu! 服务器通信，也不提交成绩。
         /// </summary>
         bool IsLocalOnly { get; }
 

--- a/osu.Game/Online/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Online/Leaderboards/Leaderboard.cs
@@ -136,6 +136,7 @@ namespace osu.Game.Online.Leaderboards
                     {
                         case APIState.Online:
                         case APIState.Offline:
+                        case APIState.LocalOnline:
                             if (IsOnlineScope)
                                 RefetchScores();
 

--- a/osu.Game/Online/OnlineViewContainer.cs
+++ b/osu.Game/Online/OnlineViewContainer.cs
@@ -73,6 +73,7 @@ namespace osu.Game.Online
                     break;
 
                 case APIState.Online:
+                case APIState.LocalOnline:
                     PopContentIn(Content);
                     placeholder.FadeOut(transform_duration / 2, Easing.OutQuint);
                     LoadingSpinner.Hide();

--- a/osu.Game/Online/PersistentEndpointClientConnector.cs
+++ b/osu.Game/Online/PersistentEndpointClientConnector.cs
@@ -56,10 +56,6 @@ namespace osu.Game.Online
             if (started)
                 return;
 
-            // 在本地-only 模式下不要自动启动连接器（统一门控，避免子类重复检查）。
-            if (API.IsLocalOnly)
-                return;
-
             apiState.BindValueChanged(_ => Task.Run(connectIfPossible), true);
             started = true;
         }
@@ -72,17 +68,12 @@ namespace osu.Game.Online
 
         private async Task connectIfPossible()
         {
-            // 在本地-only 模式下避免任何网络活动（实验性本地账户）。
-            if (API.IsLocalOnly)
-            {
-                await disconnect(true).ConfigureAwait(true);
-                return;
-            }
-
             switch (apiState.Value)
             {
                 case APIState.Failing:
                 case APIState.Offline:
+                // 本地账号不与 osu! 服务器通信，未来的本地多人客户端不走这条通路。
+                case APIState.LocalOnline:
                     await disconnect(true).ConfigureAwait(true);
                     break;
 

--- a/osu.Game/Overlays/AccountCreationOverlay.cs
+++ b/osu.Game/Overlays/AccountCreationOverlay.cs
@@ -121,6 +121,7 @@ namespace osu.Game.Overlays
                     break;
 
                 case APIState.Online:
+                case APIState.LocalOnline:
                     scheduledHide?.Cancel();
                     scheduledHide = Schedule(Hide);
                     break;

--- a/osu.Game/Overlays/Login/LoginPanel.cs
+++ b/osu.Game/Overlays/Login/LoginPanel.cs
@@ -150,6 +150,7 @@ namespace osu.Game.Overlays.Login
                     break;
 
                 case APIState.Online:
+                case APIState.LocalOnline:
                     Child = new FillFlowContainer
                     {
                         RelativeSizeAxes = Axes.X,

--- a/osu.Game/Overlays/Toolbar/ToolbarUserButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarUserButton.cs
@@ -135,6 +135,7 @@ namespace osu.Game.Overlays.Toolbar
 
                 case APIState.Offline:
                 case APIState.Online:
+                case APIState.LocalOnline:
                     TooltipText = string.Empty;
                     spinner.Hide();
                     break;

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -19,6 +19,7 @@ using osu.Framework.Input.Events;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Framework.Threading;
+using osu.Game.EzOsuGame.Online;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Input;
@@ -211,7 +212,8 @@ namespace osu.Game.Screens.Menu
 
         private void onMultiplayer(MainMenuButton mainMenuButton, UIEvent uiEvent)
         {
-            if (api.State.Value != APIState.Online)
+            // 本地账号视为已登录（面向局域网 / P2P 对战），不要求真实网络。
+            if (!api.State.Value.IsSessionActive())
             {
                 loginOverlay?.Show();
                 return;

--- a/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
@@ -7,6 +7,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Logging;
 using osu.Framework.Screens;
+using osu.Game.EzOsuGame.Online;
 using osu.Game.Graphics.Containers;
 using osu.Game.Online.API;
 using osu.Game.Overlays;
@@ -73,7 +74,7 @@ namespace osu.Game.Screens.OnlinePlay
 
         private void onlineStateChanged(ValueChangedEvent<APIState> state) => Schedule(() =>
         {
-            if (state.NewValue != APIState.Online)
+            if (!state.NewValue.IsSessionActive())
                 Schedule(forcefullyExit);
         });
 


### PR DESCRIPTION
## 背景

本地登录的语义是「已登录到本机（未来的局域网 / P2P）」，不是「离线」。但此前的实现是把本地会话强行伪装成 `APIState.Online`，再靠一个正交的 `IsLocalOnly` 布尔在 `Queue()` / `Perform()` / 连接器里静默丢弃请求。

这带来两个问题：

1. 请求被丢弃后既不 Success 也不 Fail，调用方的 task 永不完成，UI 永久转圈，只能逐处打「隐藏转圈」这类补丁。
2. 所有 `== APIState.Online` 的判断在本地模式下都成立，于是需要真实网络的功能会进入空转状态。

## 改动

### 1. 新增 `APIState.LocalOnline`

排在 `Online` 之后（最大值），因此 `IsLoggedIn => State.Value > APIState.Offline` 依然成立，而任何 `== APIState.Online` 的判断都自动排除本地账号。以后上游新增的在线判断在本地模式下**默认就是正确的**，不需要再补 `IsLocalOnly`。

`IsLocalOnly` 随之从存储字段降级为 `=> State.Value == APIState.LocalOnline` 的计算属性，7 处赋值全部删除，状态只有一个来源。

顺带删掉了两处仅为本地模式而存在的例外：`run()` 里「拿不到 access token 也不要登出」的分支，以及通知客户端 `logout` 事件的 guard，均改为一处状态早退。

### 2. 按语义把 API 状态判断分成两类

新增 `APIStateExtensions.IsSessionActive()`（`Online || LocalOnline`），只用在「用户已登录、功能可进入」的站点：

- `ButtonSystem.onMultiplayer` —— 本地模式不再弹登录窗（面向局域网 / P2P 对战）
- `OnlinePlayScreen` —— 本地模式进入多人界面不再被 `forcefullyExit()` 立刻踢出
- `Leaderboard` 的刷新触发追加 `LocalOnline`，切到本地登录后本地成绩正常重取

**互联网专属判断一律保持 `== APIState.Online` 不动**，那些文件零改动：聊天、个人主页、编辑器上传、每日挑战、快速游戏、排位、歌单、成绩提交、谱面在线元数据。

### 3. 本地请求改为应答或明确失败

`Queue()` / `Perform()` 在 `LocalOnline` 下交给新的 `ILocalOnlyRequestHandler`，能本地应答的就应答，其余抛 `LocalOnlyUnavailableException` 让上游既有的错误路径收尾，不再静默丢弃。

这个 handler 是可替换属性，下一轮的本地房间应答会挂在这里。

### 4. 显式处理新枚举值，避免崩溃 / 空白

`OnlineViewContainer`、`ToolbarUserButton`、`AccountCreationOverlay` 三处 `switch` 都有 `default: throw new ArgumentOutOfRangeException`，`LoginPanel` 则会因缺 case 导致设置面板登录区一片空白。四处均与现有 `case APIState.Online:` 并列，视觉行为不变。

`PersistentEndpointClientConnector` 把 `LocalOnline` 并入断开分支，移除 2 处 `IsLocalOnly` guard——本地模式仍然不连 ppy 的 hub。

### 5. 修掉两个既存 bug

- 恢复本地会话时构造函数会提前 `return`，导致 API 线程根本没启动，从本地会话登出后无法再登录官方账号。改为 `else if` 后线程正常启动，并在 `run()` 里对 `LocalOnline` 早退。
- `ServerSwitchManager` 的 `== Online || == Connecting` 会在本地模式下切服务器时把本地账号踢登出。`LocalOnline` 不再匹配该条件，无需改代码即修复。

### 6. 在线元数据查询（含 cherry-pick 的修复）

`BackgroundDataStoreProcessor.processOnlineBeatmapSetsWithNoUpdate` 原先只看 `api.IsLoggedIn`，而 `IsLoggedIn` 在 `Connecting` 时就为真，`APIBeatmapMetadataSource` 却要求 `Online`，于是启动期每次查询都「无定论」地失败，`LastOnlineUpdate` 不写入，同一批谱面每次启动重新排队做完整难度重算。

现在改为 `waitForAPIToSettle()` 等 API 落定后一次性决定；API 不可用时只排队 Ranked / Approved / Loved（本地缓存唯一可能命中的范围），并在必要时补下 `fetchLocalMetadataCache()`（匿名下载，无需登录）。进度更新间隔改为按批量缩放，避免小批量看起来卡在 0。

新增 `APIBeatmapMetadataSourceTest` 锁定 `LocalOnline` 时 `Available == false`。这是 Ez 独有状态，上游没有对应测试，合并时容易被悄悄折回 online 分支。

## 本地模式的当前预期表现

多人入口可进入大厅且不被踢出，但房间列表为空（`GetRoomsRequest` 被 Fail）。这是有意的中间态。

真正「不联网也能开多人局」留待下一轮：仓库里已有完整的进程内实现 `osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs`（1109 行，`IsConnected` 恒真，建房 / 加入 / 改设置 / 开始比赛 / 玩家状态机齐备），且位于 `osu.Game` 主程序集而非测试项目，可直接派生复用；房间请求应答可参照 `TestRoomRequestsHandler` 接入本 PR 的 `ILocalOnlyRequestHandler`。

## 性能

无实质影响。唯一新增的常驻开销是本地模式下 API 线程每 50ms 唤醒后立即 continue（零网络、零分配，与在线空闲循环等价）。

选歌界面的在线查询从「永久停在 `InProgress` 且同一 set 每次重选都重发」变为「失败一次后写入缓存跳过」，代价是每个新 set 两行日志，受 `max_online_lookup_sets_per_session = 120` 上限约束。

`PollingComponent` 无论成败都按 `TimeBetweenPolls` 延迟调度，失败不会造成忙循环；反而修正了此前请求被丢弃导致 `pollingActive` 永久为真、轮询彻底冻死的问题。

## 验证

- `dotnet build osu.Game/osu.Game.csproj` 与 `osu.Game.Tests` 均 0 错误
- `APIBeatmapMetadataSourceTest` 5 个 case 全部通过
- 已复核全部 `APIState` 使用点，确认没有遗漏的 `default: throw`
- 未启动游戏、未触碰 `client.realm`（不涉及 Realm schema）
