### PR TITLE
极速模式：压制非皮肤开销以提高游戏内帧数

### DIFF
--- a/osu.Game.Rulesets.Mania/UI/Stage.cs
+++ b/osu.Game.Rulesets.Mania/UI/Stage.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Performance;
 using osu.Game.Rulesets.Judgements;
 using osu.Framework.Logging;
 using osu.Game.Rulesets.Mania.Beatmaps;
@@ -74,6 +75,7 @@ namespace osu.Game.Rulesets.Mania.UI
         // private Bindable<double> osuConfigDim = null!;
         private Bindable<double> columnDim = null!;
         private Bindable<double> columnBlur = null!;
+        private Bindable<bool> turboMode = null!;
         private bool blurEnabledByConfig;
 
         private readonly Box dimBox;
@@ -218,17 +220,12 @@ namespace osu.Game.Rulesets.Mania.UI
             }, true);
 
             columnBlur = ezSkinConfig.GetBindable<double>(Ez2Setting.ColumnBlur);
-            columnBlur.BindValueChanged(v =>
-            {
-                float sigma = (float)v.NewValue * 50;
-                blurEnabledByConfig = sigma > 0.01f;
+            columnBlur.BindValueChanged(_ => updateColumnBlur(), true);
 
-                if (stageBackdropBlur != null)
-                {
-                    stageBackdropBlur.BlurSigma = new Vector2(sigma);
-                    updateBackdropBlurState();
-                }
-            }, true);
+            // [Ez] 列模糊在极速模式下不走配置压制：它是皮肤 JSON 的一部分，换皮肤会经 EzSkinJsonBridge
+            // 写回配置，压制值会被覆盖、还原时又会反过来污染皮肤设置。所以只在这个唯一的消费点跳过。
+            turboMode = ezSkinConfig.GetBindable<bool>(Ez2Setting.TurboMode);
+            turboMode.BindValueChanged(_ => updateColumnBlur());
 
             var stagePanelEnabled = ezSkinConfig.GetBindable<bool>(Ez2Setting.StagePanelEnabled);
             stagePanelEnabled.BindValueChanged(e =>
@@ -238,6 +235,18 @@ namespace osu.Game.Rulesets.Mania.UI
                 else
                     stageForeground.Hide();
             }, true);
+        }
+
+        private void updateColumnBlur()
+        {
+            float sigma = EzTurboMode.Active ? 0 : (float)columnBlur.Value * 50;
+            blurEnabledByConfig = sigma > 0.01f;
+
+            if (stageBackdropBlur != null)
+            {
+                stageBackdropBlur.BlurSigma = new Vector2(sigma);
+                updateBackdropBlurState();
+            }
         }
 
         private void onSkinChanged()

--- a/osu.Game.Tests/EzOsuGame/Performance/EzTurboModeTest.cs
+++ b/osu.Game.Tests/EzOsuGame/Performance/EzTurboModeTest.cs
@@ -3,12 +3,10 @@
 
 using System;
 using NUnit.Framework;
-using osu.Framework.Bindables;
 using osu.Framework.Testing;
 using osu.Game.Configuration;
 using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.Performance;
-using osu.Game.Screens.Play;
 
 namespace osu.Game.Tests.EzOsuGame.Performance
 {
@@ -16,25 +14,23 @@ namespace osu.Game.Tests.EzOsuGame.Performance
     public class EzTurboModeTest
     {
         [Test]
-        public void TestGlobalModeOverridesAndRestores()
+        public void TestOverridesAndRestores()
         {
             using var storage = new TemporaryNativeStorage($"ez-turbo-{Guid.NewGuid()}");
             var osuConfig = new OsuConfigManager(storage);
             var ezConfig = new Ez2ConfigManager(storage);
-            var playingState = new Bindable<LocalUserPlayingState>();
 
             osuConfig.SetValue(OsuSetting.DimLevel, 0.7);
             osuConfig.SetValue(OsuSetting.ShowStoryboard, true);
-            ezConfig.SetValue(Ez2Setting.TurboModeGameplayOnly, false);
 
-            using (new EzTurboMode(osuConfig, ezConfig, playingState))
+            using (new EzTurboMode(osuConfig, ezConfig))
             {
                 ezConfig.SetValue(Ez2Setting.TurboMode, true);
 
                 Assert.That(EzTurboMode.Active, Is.True);
                 Assert.That(osuConfig.Get<double>(OsuSetting.DimLevel), Is.EqualTo(1.0));
                 Assert.That(osuConfig.Get<bool>(OsuSetting.ShowStoryboard), Is.False);
-                // 仅全局模式的项也应生效。
+                // 压制全程生效，选歌与主菜单的项也一并改写。
                 Assert.That(osuConfig.Get<SeasonalBackgroundMode>(OsuSetting.SeasonalBackgroundMode), Is.EqualTo(SeasonalBackgroundMode.Never));
 
                 ezConfig.SetValue(Ez2Setting.TurboMode, false);
@@ -42,44 +38,89 @@ namespace osu.Game.Tests.EzOsuGame.Performance
                 Assert.That(EzTurboMode.Active, Is.False);
                 Assert.That(osuConfig.Get<double>(OsuSetting.DimLevel), Is.EqualTo(0.7));
                 Assert.That(osuConfig.Get<bool>(OsuSetting.ShowStoryboard), Is.True);
+                Assert.That(osuConfig.Get<SeasonalBackgroundMode>(OsuSetting.SeasonalBackgroundMode), Is.EqualTo(SeasonalBackgroundMode.Sometimes));
                 Assert.That(ezConfig.Get<string>(Ez2Setting.TurboModeSnapshot), Is.Empty);
             }
         }
 
+        /// <summary>
+        /// 被接管的项在生效期间应置灰，使设置面板显示为不可改，并挡住外部写入。
+        /// </summary>
         [Test]
-        public void TestGameplayOnlyModeFollowsPlayingState()
+        public void TestManagedSettingsAreLockedWhileActive()
         {
             using var storage = new TemporaryNativeStorage($"ez-turbo-{Guid.NewGuid()}");
             var osuConfig = new OsuConfigManager(storage);
             var ezConfig = new Ez2ConfigManager(storage);
-            var playingState = new Bindable<LocalUserPlayingState>();
 
             osuConfig.SetValue(OsuSetting.DimLevel, 0.7);
-            ezConfig.SetValue(Ez2Setting.TurboModeGameplayOnly, true);
 
-            using (new EzTurboMode(osuConfig, ezConfig, playingState))
+            using (new EzTurboMode(osuConfig, ezConfig))
             {
                 ezConfig.SetValue(Ez2Setting.TurboMode, true);
 
-                // 总开关已开，但还没进入游玩，不应压制。
-                Assert.That(EzTurboMode.Active, Is.False);
+                Assert.That(osuConfig.GetBindable<double>(OsuSetting.DimLevel).Disabled, Is.True);
+                Assert.Throws<InvalidOperationException>(() => osuConfig.SetValue(OsuSetting.DimLevel, 0.2));
+
+                ezConfig.SetValue(Ez2Setting.TurboMode, false);
+
+                // 解锁必须发生在写回之前，否则还原本身就会抛。
+                Assert.That(osuConfig.GetBindable<double>(OsuSetting.DimLevel).Disabled, Is.False);
                 Assert.That(osuConfig.Get<double>(OsuSetting.DimLevel), Is.EqualTo(0.7));
+                Assert.DoesNotThrow(() => osuConfig.SetValue(OsuSetting.DimLevel, 0.2));
+            }
+        }
 
-                playingState.Value = LocalUserPlayingState.Playing;
+        /// <summary>
+        /// 有运行时写入方的项只压值、不置灰：<see cref="OsuSetting.GameplayLeaderboard"/> 有游玩中可按的快捷键
+        /// （<c>HUDOverlay</c> 直接写 bindable），<see cref="OsuSetting.MenuParallaxScale"/> 有一次性配置迁移会写。
+        /// 锁上它们会让那些写入抛异常。
+        /// </summary>
+        [Test]
+        public void TestSettingsWithRuntimeWritersStayWritable()
+        {
+            using var storage = new TemporaryNativeStorage($"ez-turbo-{Guid.NewGuid()}");
+            var osuConfig = new OsuConfigManager(storage);
+            var ezConfig = new Ez2ConfigManager(storage);
 
-                Assert.That(EzTurboMode.Active, Is.True);
-                Assert.That(osuConfig.Get<double>(OsuSetting.DimLevel), Is.EqualTo(1.0));
-                // 仅全局模式的项不应在游玩压制中被改写。
-                Assert.That(osuConfig.Get<SeasonalBackgroundMode>(OsuSetting.SeasonalBackgroundMode), Is.EqualTo(SeasonalBackgroundMode.Sometimes));
+            using (new EzTurboMode(osuConfig, ezConfig))
+            {
+                ezConfig.SetValue(Ez2Setting.TurboMode, true);
 
-                // 休息段仍算游玩，不应来回还原造成抖动。
-                playingState.Value = LocalUserPlayingState.Break;
-                Assert.That(EzTurboMode.Active, Is.True);
+                Assert.That(osuConfig.Get<bool>(OsuSetting.GameplayLeaderboard), Is.False);
+                Assert.That(osuConfig.GetBindable<bool>(OsuSetting.GameplayLeaderboard).Disabled, Is.False);
+                Assert.DoesNotThrow(() => osuConfig.SetValue(OsuSetting.GameplayLeaderboard, true));
 
-                playingState.Value = LocalUserPlayingState.NotPlaying;
+                Assert.That(osuConfig.GetBindable<float>(OsuSetting.MenuParallaxScale).Disabled, Is.False);
+                Assert.DoesNotThrow(() => osuConfig.SetValue(OsuSetting.MenuParallaxScale, 1f));
 
-                Assert.That(EzTurboMode.Active, Is.False);
-                Assert.That(osuConfig.Get<double>(OsuSetting.DimLevel), Is.EqualTo(0.7));
+                ezConfig.SetValue(Ez2Setting.TurboMode, false);
+            }
+        }
+
+        /// <summary>
+        /// 列模糊与 Ez 分析都不再走配置压制：前者是皮肤 JSON 的一部分（换皮肤会写回，改成消费点 gate），
+        /// 后者只影响选歌流畅度，不值得用功能数据换。
+        /// </summary>
+        [Test]
+        public void TestSettingsOutsideOverrideListAreUntouched()
+        {
+            using var storage = new TemporaryNativeStorage($"ez-turbo-{Guid.NewGuid()}");
+            var osuConfig = new OsuConfigManager(storage);
+            var ezConfig = new Ez2ConfigManager(storage);
+
+            ezConfig.SetValue(Ez2Setting.ColumnBlur, 0.3);
+
+            using (new EzTurboMode(osuConfig, ezConfig))
+            {
+                ezConfig.SetValue(Ez2Setting.TurboMode, true);
+
+                Assert.That(ezConfig.Get<double>(Ez2Setting.ColumnBlur), Is.EqualTo(0.3));
+                Assert.That(ezConfig.GetBindable<double>(Ez2Setting.ColumnBlur).Disabled, Is.False);
+                Assert.That(ezConfig.Get<bool>(Ez2Setting.EzAnalysisRecEnabled), Is.True);
+                Assert.That(ezConfig.Get<bool>(Ez2Setting.EzAnalysisSqliteEnabled), Is.True);
+
+                ezConfig.SetValue(Ez2Setting.TurboMode, false);
             }
         }
 
@@ -89,11 +130,8 @@ namespace osu.Game.Tests.EzOsuGame.Performance
             using var storage = new TemporaryNativeStorage($"ez-turbo-{Guid.NewGuid()}");
             var osuConfig = new OsuConfigManager(storage);
             var ezConfig = new Ez2ConfigManager(storage);
-            var playingState = new Bindable<LocalUserPlayingState>();
 
-            ezConfig.SetValue(Ez2Setting.TurboModeGameplayOnly, false);
-
-            using (new EzTurboMode(osuConfig, ezConfig, playingState))
+            using (new EzTurboMode(osuConfig, ezConfig))
             {
                 ezConfig.SetValue(Ez2Setting.TurboMode, true);
 
@@ -112,7 +150,6 @@ namespace osu.Game.Tests.EzOsuGame.Performance
             using var storage = new TemporaryNativeStorage($"ez-turbo-{Guid.NewGuid()}");
             var osuConfig = new OsuConfigManager(storage);
             var ezConfig = new Ez2ConfigManager(storage);
-            var playingState = new Bindable<LocalUserPlayingState>();
 
             // 模拟上次在压制生效期间异常退出：磁盘上留着压制值与一份原值快照。
             osuConfig.SetValue(OsuSetting.DimLevel, 1.0);
@@ -120,7 +157,7 @@ namespace osu.Game.Tests.EzOsuGame.Performance
             ezConfig.SetValue(Ez2Setting.TurboModeSnapshot,
                 $"{{\"{nameof(OsuSetting)}.{nameof(OsuSetting.DimLevel)}\":\"0.55\",\"{nameof(OsuSetting)}.{nameof(OsuSetting.ShowStoryboard)}\":\"True\"}}");
 
-            using (new EzTurboMode(osuConfig, ezConfig, playingState))
+            using (new EzTurboMode(osuConfig, ezConfig))
             {
                 Assert.That(osuConfig.Get<double>(OsuSetting.DimLevel), Is.EqualTo(0.55));
                 Assert.That(osuConfig.Get<bool>(OsuSetting.ShowStoryboard), Is.True);
@@ -135,14 +172,13 @@ namespace osu.Game.Tests.EzOsuGame.Performance
             using var storage = new TemporaryNativeStorage($"ez-turbo-{Guid.NewGuid()}");
             var osuConfig = new OsuConfigManager(storage);
             var ezConfig = new Ez2ConfigManager(storage);
-            var playingState = new Bindable<LocalUserPlayingState>();
 
             osuConfig.SetValue(OsuSetting.DimLevel, 1.0);
             ezConfig.SetValue(Ez2Setting.TurboModeSnapshot, "not json at all");
 
             Assert.DoesNotThrow(() =>
             {
-                using (new EzTurboMode(osuConfig, ezConfig, playingState))
+                using (new EzTurboMode(osuConfig, ezConfig))
                 {
                 }
             });
@@ -151,40 +187,15 @@ namespace osu.Game.Tests.EzOsuGame.Performance
         }
 
         [Test]
-        public void TestSwitchingToGameplayOnlyWhileActiveRestoresGlobalOverrides()
-        {
-            using var storage = new TemporaryNativeStorage($"ez-turbo-{Guid.NewGuid()}");
-            var osuConfig = new OsuConfigManager(storage);
-            var ezConfig = new Ez2ConfigManager(storage);
-            var playingState = new Bindable<LocalUserPlayingState>();
-
-            ezConfig.SetValue(Ez2Setting.TurboModeGameplayOnly, false);
-
-            using (new EzTurboMode(osuConfig, ezConfig, playingState))
-            {
-                ezConfig.SetValue(Ez2Setting.TurboMode, true);
-                Assert.That(osuConfig.Get<SeasonalBackgroundMode>(OsuSetting.SeasonalBackgroundMode), Is.EqualTo(SeasonalBackgroundMode.Never));
-
-                // 切成仅游玩中生效、且当前不在游玩：压制应整体撤销，含仅全局那一组。
-                ezConfig.SetValue(Ez2Setting.TurboModeGameplayOnly, true);
-
-                Assert.That(EzTurboMode.Active, Is.False);
-                Assert.That(osuConfig.Get<SeasonalBackgroundMode>(OsuSetting.SeasonalBackgroundMode), Is.EqualTo(SeasonalBackgroundMode.Sometimes));
-            }
-        }
-
-        [Test]
         public void TestDisposeRestoresWhileActive()
         {
             using var storage = new TemporaryNativeStorage($"ez-turbo-{Guid.NewGuid()}");
             var osuConfig = new OsuConfigManager(storage);
             var ezConfig = new Ez2ConfigManager(storage);
-            var playingState = new Bindable<LocalUserPlayingState>();
 
             osuConfig.SetValue(OsuSetting.DimLevel, 0.4);
-            ezConfig.SetValue(Ez2Setting.TurboModeGameplayOnly, false);
 
-            var turboMode = new EzTurboMode(osuConfig, ezConfig, playingState);
+            var turboMode = new EzTurboMode(osuConfig, ezConfig);
             ezConfig.SetValue(Ez2Setting.TurboMode, true);
             Assert.That(osuConfig.Get<double>(OsuSetting.DimLevel), Is.EqualTo(1.0));
 
@@ -192,6 +203,7 @@ namespace osu.Game.Tests.EzOsuGame.Performance
 
             Assert.That(EzTurboMode.Active, Is.False);
             Assert.That(osuConfig.Get<double>(OsuSetting.DimLevel), Is.EqualTo(0.4));
+            Assert.That(osuConfig.GetBindable<double>(OsuSetting.DimLevel).Disabled, Is.False);
         }
     }
 }

--- a/osu.Game.Tests/EzOsuGame/Performance/EzTurboModeTest.cs
+++ b/osu.Game.Tests/EzOsuGame/Performance/EzTurboModeTest.cs
@@ -1,0 +1,197 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using NUnit.Framework;
+using osu.Framework.Bindables;
+using osu.Framework.Testing;
+using osu.Game.Configuration;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Performance;
+using osu.Game.Screens.Play;
+
+namespace osu.Game.Tests.EzOsuGame.Performance
+{
+    [TestFixture]
+    public class EzTurboModeTest
+    {
+        [Test]
+        public void TestGlobalModeOverridesAndRestores()
+        {
+            using var storage = new TemporaryNativeStorage($"ez-turbo-{Guid.NewGuid()}");
+            var osuConfig = new OsuConfigManager(storage);
+            var ezConfig = new Ez2ConfigManager(storage);
+            var playingState = new Bindable<LocalUserPlayingState>();
+
+            osuConfig.SetValue(OsuSetting.DimLevel, 0.7);
+            osuConfig.SetValue(OsuSetting.ShowStoryboard, true);
+            ezConfig.SetValue(Ez2Setting.TurboModeGameplayOnly, false);
+
+            using (new EzTurboMode(osuConfig, ezConfig, playingState))
+            {
+                ezConfig.SetValue(Ez2Setting.TurboMode, true);
+
+                Assert.That(EzTurboMode.Active, Is.True);
+                Assert.That(osuConfig.Get<double>(OsuSetting.DimLevel), Is.EqualTo(1.0));
+                Assert.That(osuConfig.Get<bool>(OsuSetting.ShowStoryboard), Is.False);
+                // 仅全局模式的项也应生效。
+                Assert.That(osuConfig.Get<SeasonalBackgroundMode>(OsuSetting.SeasonalBackgroundMode), Is.EqualTo(SeasonalBackgroundMode.Never));
+
+                ezConfig.SetValue(Ez2Setting.TurboMode, false);
+
+                Assert.That(EzTurboMode.Active, Is.False);
+                Assert.That(osuConfig.Get<double>(OsuSetting.DimLevel), Is.EqualTo(0.7));
+                Assert.That(osuConfig.Get<bool>(OsuSetting.ShowStoryboard), Is.True);
+                Assert.That(ezConfig.Get<string>(Ez2Setting.TurboModeSnapshot), Is.Empty);
+            }
+        }
+
+        [Test]
+        public void TestGameplayOnlyModeFollowsPlayingState()
+        {
+            using var storage = new TemporaryNativeStorage($"ez-turbo-{Guid.NewGuid()}");
+            var osuConfig = new OsuConfigManager(storage);
+            var ezConfig = new Ez2ConfigManager(storage);
+            var playingState = new Bindable<LocalUserPlayingState>();
+
+            osuConfig.SetValue(OsuSetting.DimLevel, 0.7);
+            ezConfig.SetValue(Ez2Setting.TurboModeGameplayOnly, true);
+
+            using (new EzTurboMode(osuConfig, ezConfig, playingState))
+            {
+                ezConfig.SetValue(Ez2Setting.TurboMode, true);
+
+                // 总开关已开，但还没进入游玩，不应压制。
+                Assert.That(EzTurboMode.Active, Is.False);
+                Assert.That(osuConfig.Get<double>(OsuSetting.DimLevel), Is.EqualTo(0.7));
+
+                playingState.Value = LocalUserPlayingState.Playing;
+
+                Assert.That(EzTurboMode.Active, Is.True);
+                Assert.That(osuConfig.Get<double>(OsuSetting.DimLevel), Is.EqualTo(1.0));
+                // 仅全局模式的项不应在游玩压制中被改写。
+                Assert.That(osuConfig.Get<SeasonalBackgroundMode>(OsuSetting.SeasonalBackgroundMode), Is.EqualTo(SeasonalBackgroundMode.Sometimes));
+
+                // 休息段仍算游玩，不应来回还原造成抖动。
+                playingState.Value = LocalUserPlayingState.Break;
+                Assert.That(EzTurboMode.Active, Is.True);
+
+                playingState.Value = LocalUserPlayingState.NotPlaying;
+
+                Assert.That(EzTurboMode.Active, Is.False);
+                Assert.That(osuConfig.Get<double>(OsuSetting.DimLevel), Is.EqualTo(0.7));
+            }
+        }
+
+        [Test]
+        public void TestSnapshotPersistsWhileActive()
+        {
+            using var storage = new TemporaryNativeStorage($"ez-turbo-{Guid.NewGuid()}");
+            var osuConfig = new OsuConfigManager(storage);
+            var ezConfig = new Ez2ConfigManager(storage);
+            var playingState = new Bindable<LocalUserPlayingState>();
+
+            ezConfig.SetValue(Ez2Setting.TurboModeGameplayOnly, false);
+
+            using (new EzTurboMode(osuConfig, ezConfig, playingState))
+            {
+                ezConfig.SetValue(Ez2Setting.TurboMode, true);
+
+                string snapshot = ezConfig.Get<string>(Ez2Setting.TurboModeSnapshot);
+
+                Assert.That(snapshot, Is.Not.Empty);
+                Assert.That(snapshot, Does.Contain(nameof(OsuSetting.DimLevel)));
+
+                ezConfig.SetValue(Ez2Setting.TurboMode, false);
+            }
+        }
+
+        [Test]
+        public void TestStaleSnapshotIsRestoredOnConstruction()
+        {
+            using var storage = new TemporaryNativeStorage($"ez-turbo-{Guid.NewGuid()}");
+            var osuConfig = new OsuConfigManager(storage);
+            var ezConfig = new Ez2ConfigManager(storage);
+            var playingState = new Bindable<LocalUserPlayingState>();
+
+            // 模拟上次在压制生效期间异常退出：磁盘上留着压制值与一份原值快照。
+            osuConfig.SetValue(OsuSetting.DimLevel, 1.0);
+            osuConfig.SetValue(OsuSetting.ShowStoryboard, false);
+            ezConfig.SetValue(Ez2Setting.TurboModeSnapshot,
+                $"{{\"{nameof(OsuSetting)}.{nameof(OsuSetting.DimLevel)}\":\"0.55\",\"{nameof(OsuSetting)}.{nameof(OsuSetting.ShowStoryboard)}\":\"True\"}}");
+
+            using (new EzTurboMode(osuConfig, ezConfig, playingState))
+            {
+                Assert.That(osuConfig.Get<double>(OsuSetting.DimLevel), Is.EqualTo(0.55));
+                Assert.That(osuConfig.Get<bool>(OsuSetting.ShowStoryboard), Is.True);
+                Assert.That(ezConfig.Get<string>(Ez2Setting.TurboModeSnapshot), Is.Empty);
+                Assert.That(EzTurboMode.Active, Is.False);
+            }
+        }
+
+        [Test]
+        public void TestCorruptSnapshotIsDiscardedWithoutThrowing()
+        {
+            using var storage = new TemporaryNativeStorage($"ez-turbo-{Guid.NewGuid()}");
+            var osuConfig = new OsuConfigManager(storage);
+            var ezConfig = new Ez2ConfigManager(storage);
+            var playingState = new Bindable<LocalUserPlayingState>();
+
+            osuConfig.SetValue(OsuSetting.DimLevel, 1.0);
+            ezConfig.SetValue(Ez2Setting.TurboModeSnapshot, "not json at all");
+
+            Assert.DoesNotThrow(() =>
+            {
+                using (new EzTurboMode(osuConfig, ezConfig, playingState))
+                {
+                }
+            });
+
+            Assert.That(ezConfig.Get<string>(Ez2Setting.TurboModeSnapshot), Is.Empty);
+        }
+
+        [Test]
+        public void TestSwitchingToGameplayOnlyWhileActiveRestoresGlobalOverrides()
+        {
+            using var storage = new TemporaryNativeStorage($"ez-turbo-{Guid.NewGuid()}");
+            var osuConfig = new OsuConfigManager(storage);
+            var ezConfig = new Ez2ConfigManager(storage);
+            var playingState = new Bindable<LocalUserPlayingState>();
+
+            ezConfig.SetValue(Ez2Setting.TurboModeGameplayOnly, false);
+
+            using (new EzTurboMode(osuConfig, ezConfig, playingState))
+            {
+                ezConfig.SetValue(Ez2Setting.TurboMode, true);
+                Assert.That(osuConfig.Get<SeasonalBackgroundMode>(OsuSetting.SeasonalBackgroundMode), Is.EqualTo(SeasonalBackgroundMode.Never));
+
+                // 切成仅游玩中生效、且当前不在游玩：压制应整体撤销，含仅全局那一组。
+                ezConfig.SetValue(Ez2Setting.TurboModeGameplayOnly, true);
+
+                Assert.That(EzTurboMode.Active, Is.False);
+                Assert.That(osuConfig.Get<SeasonalBackgroundMode>(OsuSetting.SeasonalBackgroundMode), Is.EqualTo(SeasonalBackgroundMode.Sometimes));
+            }
+        }
+
+        [Test]
+        public void TestDisposeRestoresWhileActive()
+        {
+            using var storage = new TemporaryNativeStorage($"ez-turbo-{Guid.NewGuid()}");
+            var osuConfig = new OsuConfigManager(storage);
+            var ezConfig = new Ez2ConfigManager(storage);
+            var playingState = new Bindable<LocalUserPlayingState>();
+
+            osuConfig.SetValue(OsuSetting.DimLevel, 0.4);
+            ezConfig.SetValue(Ez2Setting.TurboModeGameplayOnly, false);
+
+            var turboMode = new EzTurboMode(osuConfig, ezConfig, playingState);
+            ezConfig.SetValue(Ez2Setting.TurboMode, true);
+            Assert.That(osuConfig.Get<double>(OsuSetting.DimLevel), Is.EqualTo(1.0));
+
+            turboMode.Dispose();
+
+            Assert.That(EzTurboMode.Active, Is.False);
+            Assert.That(osuConfig.Get<double>(OsuSetting.DimLevel), Is.EqualTo(0.4));
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Configuration/Ez2ConfigManager.cs
+++ b/osu.Game/EzOsuGame/Configuration/Ez2ConfigManager.cs
@@ -107,6 +107,10 @@ namespace osu.Game.EzOsuGame.Configuration
             SetDefault(Ez2Setting.ScratchAxisStopThreshold, 30, 10, 150);
             SetDefault(Ez2Setting.SkipWithGameplayKeys, true);
 
+            SetDefault(Ez2Setting.TurboMode, false);
+            SetDefault(Ez2Setting.TurboModeGameplayOnly, true);
+            SetDefault(Ez2Setting.TurboModeSnapshot, string.Empty);
+
             SetDefault(Ez2Setting.StoryboardAutoVideoSize, false);
             SetDefault(Ez2Setting.AcrylicUiEnabled, false);
             SetDefault(Ez2Setting.AcrylicUiBlurStrength, 16.0, 0.0, 40.0, 1.0);
@@ -890,6 +894,24 @@ namespace osu.Game.EzOsuGame.Configuration
         ScratchAxisStopThreshold,
 
         SkipWithGameplayKeys,
+
+        /// <summary>
+        /// 极速模式总开关：压制非皮肤相关的每帧开销（背景、故事板、模糊、HUD 特效等）以提高帧数。
+        /// 开启时把一组官方与 Ez 设置改写为低开销值，关闭时按 <see cref="TurboModeSnapshot"/> 还原。
+        /// </summary>
+        TurboMode,
+
+        /// <summary>
+        /// 极速模式仅在游玩中生效；关闭则选歌与主菜单也一并压制。
+        /// </summary>
+        TurboModeGameplayOnly,
+
+        /// <summary>
+        /// 极速模式生效前的原始设置快照（JSON）。非空表示压制正在生效，
+        /// 启动时若发现它非空即为上次异常退出，需立即还原。不面向用户。
+        /// </summary>
+        TurboModeSnapshot,
+
         StoryboardAutoVideoSize,
         AcrylicUiEnabled,
         AcrylicUiBlurStrength,

--- a/osu.Game/EzOsuGame/Configuration/Ez2ConfigManager.cs
+++ b/osu.Game/EzOsuGame/Configuration/Ez2ConfigManager.cs
@@ -108,7 +108,6 @@ namespace osu.Game.EzOsuGame.Configuration
             SetDefault(Ez2Setting.SkipWithGameplayKeys, true);
 
             SetDefault(Ez2Setting.TurboMode, false);
-            SetDefault(Ez2Setting.TurboModeGameplayOnly, true);
             SetDefault(Ez2Setting.TurboModeSnapshot, string.Empty);
 
             SetDefault(Ez2Setting.StoryboardAutoVideoSize, false);
@@ -900,11 +899,6 @@ namespace osu.Game.EzOsuGame.Configuration
         /// 开启时把一组官方与 Ez 设置改写为低开销值，关闭时按 <see cref="TurboModeSnapshot"/> 还原。
         /// </summary>
         TurboMode,
-
-        /// <summary>
-        /// 极速模式仅在游玩中生效；关闭则选歌与主菜单也一并压制。
-        /// </summary>
-        TurboModeGameplayOnly,
 
         /// <summary>
         /// 极速模式生效前的原始设置快照（JSON）。非空表示压制正在生效，

--- a/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
@@ -57,6 +57,34 @@ namespace osu.Game.EzOsuGame.Localization
             "开启后将隐藏主界面底部的在线新闻/广告轮播图。",
             "When enabled, the online news/advertisement banner at the bottom of the main menu will be hidden.");
 
+        public static readonly EzLocalizationManager.EzLocalisableString TURBO_MODE =
+            new EzLocalizationManager.EzLocalisableString("极速模式", "Turbo mode");
+
+        public static readonly EzLocalizationManager.EzLocalisableString TURBO_MODE_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "压制皮肤以外的每帧开销以提高帧数：关闭故事板与视频、背景不再绘制、关闭背景与列模糊、"
+            + "毛玻璃 UI、打击闪光、星星喷泉、连击特效、按键显示与游戏内排行榜，并让角逐服务空转。"
+            + "\n不会降低任何线程频率，也不会锁帧——提高帧数的目的是降低延迟。"
+            + "\n开启期间上述设置项会被改写成低开销值，关闭后自动还原；因此不要在开启期间手动改这些项，否则改动会在还原时被覆盖。"
+            + "\n注意：列模糊属于舞台外观，是本模式唯一会改变皮肤观感的一项。",
+            "Suppresses per-frame cost outside the skin to raise frame rate: disables storyboard and video, stops drawing the background, "
+            + "turns off background and column blur, acrylic UI, hit lighting, star fountains, combo effects, key overlay and the gameplay leaderboard, "
+            + "and makes the score race service inert."
+            + "\nDoes not lower any thread rate and does not cap frames — the point of more frames is lower latency."
+            + "\nThe listed settings are rewritten to low-cost values while active and restored when turned off, so avoid editing them by hand in the meantime."
+            + "\nNote: column blur is part of the stage look, and is the only item here that changes skin appearance.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString TURBO_MODE_GAMEPLAY_ONLY =
+            new EzLocalizationManager.EzLocalisableString("极速模式仅在游玩中生效", "Turbo mode during gameplay only");
+
+        public static readonly EzLocalizationManager.EzLocalisableString TURBO_MODE_GAMEPLAY_ONLY_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "开启后只在游玩期间压制，退出后立刻还原，选歌与主菜单保持原样。"
+            + "\n关闭则全程压制，并额外关掉季节背景、选歌背景虚化与 Ez 分析的即时计算与 SQLite 读写。"
+            + "\n观看回放不算游玩，仅游玩中生效时不会压制；需要压制回放请关掉本项。",
+            "When enabled, suppression only applies during gameplay and is reverted on exit, leaving song select and the main menu untouched."
+            + "\nWhen disabled, suppression stays on everywhere and additionally disables seasonal backgrounds, song select background blur, "
+            + "and Ez analysis on-the-fly calculation and SQLite access."
+            + "\nWatching a replay does not count as gameplay, so it is not suppressed in this mode; turn this off if you want replays suppressed too.");
+
         public static readonly EzLocalizationManager.EzLocalisableString ACRYLIC_UI_ENABLED =
             new EzLocalizationManager.EzLocalisableString("毛玻璃 UI", "Acrylic UI");
 

--- a/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
@@ -62,28 +62,21 @@ namespace osu.Game.EzOsuGame.Localization
 
         public static readonly EzLocalizationManager.EzLocalisableString TURBO_MODE_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
             "压制皮肤以外的每帧开销以提高帧数：关闭故事板与视频、背景不再绘制、关闭背景与列模糊、"
-            + "毛玻璃 UI、打击闪光、星星喷泉、连击特效、按键显示与游戏内排行榜，并让角逐服务空转。"
+            + "毛玻璃 UI、打击闪光、星星喷泉、按键显示、游戏内排行榜、季节背景与选歌背景虚化，并让角逐服务空转。"
             + "\n不会降低任何线程频率，也不会锁帧——提高帧数的目的是降低延迟。"
-            + "\n开启期间上述设置项会被改写成低开销值，关闭后自动还原；因此不要在开启期间手动改这些项，否则改动会在还原时被覆盖。"
+            + "\n开启后全程生效，不随进出游玩切换。被压制的设置项会在设置里变灰，关闭本项后自动还原成你原来的值。"
             + "\n注意：列模糊属于舞台外观，是本模式唯一会改变皮肤观感的一项。",
             "Suppresses per-frame cost outside the skin to raise frame rate: disables storyboard and video, stops drawing the background, "
-            + "turns off background and column blur, acrylic UI, hit lighting, star fountains, combo effects, key overlay and the gameplay leaderboard, "
-            + "and makes the score race service inert."
+            + "turns off background and column blur, acrylic UI, hit lighting, star fountains, key overlay, the gameplay leaderboard, "
+            + "seasonal backgrounds and song select background blur, and makes the score race service inert."
             + "\nDoes not lower any thread rate and does not cap frames — the point of more frames is lower latency."
-            + "\nThe listed settings are rewritten to low-cost values while active and restored when turned off, so avoid editing them by hand in the meantime."
+            + "\nStays active everywhere rather than toggling as you enter and leave gameplay. Suppressed settings appear greyed out, "
+            + "and your original values are restored when this is turned off."
             + "\nNote: column blur is part of the stage look, and is the only item here that changes skin appearance.");
 
-        public static readonly EzLocalizationManager.EzLocalisableString TURBO_MODE_GAMEPLAY_ONLY =
-            new EzLocalizationManager.EzLocalisableString("极速模式仅在游玩中生效", "Turbo mode during gameplay only");
-
-        public static readonly EzLocalizationManager.EzLocalisableString TURBO_MODE_GAMEPLAY_ONLY_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
-            "开启后只在游玩期间压制，退出后立刻还原，选歌与主菜单保持原样。"
-            + "\n关闭则全程压制，并额外关掉季节背景、选歌背景虚化与 Ez 分析的即时计算与 SQLite 读写。"
-            + "\n观看回放不算游玩，仅游玩中生效时不会压制；需要压制回放请关掉本项。",
-            "When enabled, suppression only applies during gameplay and is reverted on exit, leaving song select and the main menu untouched."
-            + "\nWhen disabled, suppression stays on everywhere and additionally disables seasonal backgrounds, song select background blur, "
-            + "and Ez analysis on-the-fly calculation and SQLite access."
-            + "\nWatching a replay does not count as gameplay, so it is not suppressed in this mode; turn this off if you want replays suppressed too.");
+        public static readonly EzLocalizationManager.EzLocalisableString TURBO_MODE_MANAGED_NOTE = new EzLocalizationManager.EzLocalisableString(
+            "由极速模式接管。关闭极速模式后会还原成你原来的值。",
+            "Managed by turbo mode. Your original value is restored when turbo mode is turned off.");
 
         public static readonly EzLocalizationManager.EzLocalisableString ACRYLIC_UI_ENABLED =
             new EzLocalizationManager.EzLocalisableString("毛玻璃 UI", "Acrylic UI");

--- a/osu.Game/EzOsuGame/Overlays/EzUISettings.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzUISettings.cs
@@ -40,6 +40,24 @@ namespace osu.Game.EzOsuGame.Overlays
                 },
                 new SettingsItemV2(new FormCheckBox
                 {
+                    Caption = EzSettingsStrings.TURBO_MODE,
+                    HintText = EzSettingsStrings.TURBO_MODE_TOOLTIP,
+                    Current = ezConfig.GetBindable<bool>(Ez2Setting.TurboMode),
+                })
+                {
+                    Keywords = new[] { "turbo", "performance", "fps", "frame rate", "low spec", "极速", "帧数" }
+                },
+                new SettingsItemV2(new FormCheckBox
+                {
+                    Caption = EzSettingsStrings.TURBO_MODE_GAMEPLAY_ONLY,
+                    HintText = EzSettingsStrings.TURBO_MODE_GAMEPLAY_ONLY_TOOLTIP,
+                    Current = ezConfig.GetBindable<bool>(Ez2Setting.TurboModeGameplayOnly),
+                })
+                {
+                    Keywords = new[] { "turbo", "performance", "fps", "gameplay", "极速" }
+                },
+                new SettingsItemV2(new FormCheckBox
+                {
                     Caption = EzSettingsStrings.ACRYLIC_UI_ENABLED,
                     HintText = EzSettingsStrings.ACRYLIC_UI_ENABLED_TOOLTIP,
                     Current = ezConfig.GetBindable<bool>(Ez2Setting.AcrylicUiEnabled),

--- a/osu.Game/EzOsuGame/Overlays/EzUISettings.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzUISettings.cs
@@ -49,15 +49,6 @@ namespace osu.Game.EzOsuGame.Overlays
                 },
                 new SettingsItemV2(new FormCheckBox
                 {
-                    Caption = EzSettingsStrings.TURBO_MODE_GAMEPLAY_ONLY,
-                    HintText = EzSettingsStrings.TURBO_MODE_GAMEPLAY_ONLY_TOOLTIP,
-                    Current = ezConfig.GetBindable<bool>(Ez2Setting.TurboModeGameplayOnly),
-                })
-                {
-                    Keywords = new[] { "turbo", "performance", "fps", "gameplay", "极速" }
-                },
-                new SettingsItemV2(new FormCheckBox
-                {
                     Caption = EzSettingsStrings.ACRYLIC_UI_ENABLED,
                     HintText = EzSettingsStrings.ACRYLIC_UI_ENABLED_TOOLTIP,
                     Current = ezConfig.GetBindable<bool>(Ez2Setting.AcrylicUiEnabled),

--- a/osu.Game/EzOsuGame/Performance/EzTurboMode.cs
+++ b/osu.Game/EzOsuGame/Performance/EzTurboMode.cs
@@ -1,0 +1,288 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Newtonsoft.Json;
+using osu.Framework.Bindables;
+using osu.Framework.Configuration;
+using osu.Framework.Logging;
+using osu.Game.Configuration;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.Screens.Play;
+
+namespace osu.Game.EzOsuGame.Performance
+{
+    /// <summary>
+    /// 极速模式：压制非皮肤相关的每帧开销（背景、故事板、模糊、HUD 特效、后台分析等）以提高游戏内帧数。
+    /// </summary>
+    /// <remarks>
+    /// 做法是把一组已有的官方与 Ez 设置改写为低开销值，改写前先把原值快照落盘，关闭时按快照还原。
+    /// 少数没有对应设置的开销（背景整棵子树的绘制、Kiai 喷泉、视差）由各自的调用点查询 <see cref="Active"/> 跳过。
+    /// <para>
+    /// 刻意不做的事：不降低任何线程频率（update / draw / audio），也不把 <c>FrameSync</c> 改成 VSync。
+    /// 提高帧数的目的是降低延迟，而降频与锁帧都与该目的相反；音频线程更是判定时间的锚点
+    /// （<c>TrackBass.CurrentTime</c> 只在音频线程每帧刷新），降它会直接影响判定与键音时机。
+    /// </para>
+    /// </remarks>
+    public class EzTurboMode : IDisposable
+    {
+        private static volatile bool active;
+
+        /// <summary>
+        /// 压制当前是否生效。供每帧热路径以零成本查询，因此是静态的。
+        /// </summary>
+        public static bool Active => active;
+
+        /// <summary>
+        /// 压制是否会在接下来的一局游玩中生效。
+        /// </summary>
+        /// <remarks>
+        /// 「仅游玩中生效」模式下 <see cref="Active"/> 要等 <c>UserPlayingState</c> 转入游玩才置位，
+        /// 而那晚于 <c>Player</c> 建树。因此建树期决定要不要构造某个组件时必须直接看总开关。
+        /// </remarks>
+        public static bool ActiveForGameplay => active || GlobalConfigStore.EzConfig.Get<bool>(Ez2Setting.TurboMode);
+
+        private readonly OsuConfigManager osuConfig;
+        private readonly Ez2ConfigManager ezConfig;
+
+        private readonly Bindable<bool> enabled;
+        private readonly Bindable<bool> gameplayOnly;
+        private readonly IBindable<LocalUserPlayingState> playingState;
+
+        /// <summary>
+        /// 当前生效的压制是否包含「仅全局模式」那一组；用于在子开关变化时判断需不需要重建压制。
+        /// </summary>
+        private bool appliedGlobalOverrides;
+
+        public EzTurboMode(OsuConfigManager osuConfig, Ez2ConfigManager ezConfig, IBindable<LocalUserPlayingState> playingState)
+        {
+            this.osuConfig = osuConfig;
+            this.ezConfig = ezConfig;
+
+            // 先处理上次异常退出遗留的快照，再开始跟踪开关，避免把被改写过的值当成用户原值。
+            restoreFromSnapshot(recovery: true);
+
+            enabled = ezConfig.GetBindable<bool>(Ez2Setting.TurboMode);
+            gameplayOnly = ezConfig.GetBindable<bool>(Ez2Setting.TurboModeGameplayOnly);
+            this.playingState = playingState.GetBoundCopy();
+
+            enabled.BindValueChanged(_ => updateState());
+            gameplayOnly.BindValueChanged(_ => updateState());
+            this.playingState.BindValueChanged(_ => updateState(), true);
+        }
+
+        private void updateState()
+        {
+            bool globalMode = enabled.Value && !gameplayOnly.Value;
+            bool shouldBeActive = enabled.Value && (globalMode || playingState.Value != LocalUserPlayingState.NotPlaying);
+
+            if (shouldBeActive == active && globalMode == appliedGlobalOverrides)
+                return;
+
+            if (active)
+                restore();
+
+            if (shouldBeActive)
+                apply(globalMode);
+        }
+
+        private void apply(bool includeGlobalOverrides)
+        {
+            var overrides = buildOverrides(includeGlobalOverrides);
+
+            var snapshot = new Dictionary<string, string>();
+
+            foreach (var setting in overrides)
+                snapshot[setting.Key] = setting.CaptureCurrent();
+
+            // 原值必须先落盘再改写：否则进程在改写后崩溃就再也找不回用户设置。
+            ezConfig.SetValue(Ez2Setting.TurboModeSnapshot, JsonConvert.SerializeObject(snapshot));
+            ezConfig.Save();
+
+            // 先置位再改写，让 DimLevel 等改写触发的 UpdateVisuals 能看到已生效的状态。
+            active = true;
+            appliedGlobalOverrides = includeGlobalOverrides;
+
+            foreach (var setting in overrides)
+                setting.ApplyTurboValue();
+        }
+
+        private void restore()
+        {
+            // 先复位再写回，理由同 apply()。
+            active = false;
+            appliedGlobalOverrides = false;
+
+            restoreFromSnapshot(recovery: false);
+        }
+
+        /// <summary>
+        /// 按快照里记录的键逐项写回。按键还原（而不是按当前压制清单还原）使得
+        /// 上次异常退出、且期间压制清单已改动的情况也能正确恢复。
+        /// </summary>
+        private void restoreFromSnapshot(bool recovery)
+        {
+            string raw = ezConfig.Get<string>(Ez2Setting.TurboModeSnapshot);
+
+            if (string.IsNullOrEmpty(raw))
+                return;
+
+            Dictionary<string, string>? snapshot = null;
+
+            try
+            {
+                snapshot = JsonConvert.DeserializeObject<Dictionary<string, string>>(raw);
+            }
+            catch (Exception e)
+            {
+                Logger.Log($"[Ez] 极速模式快照无法解析，已丢弃：{e.Message}", level: LogLevel.Important);
+            }
+
+            if (snapshot?.Count > 0)
+            {
+                var byKey = new Dictionary<string, SettingOverride>();
+
+                foreach (var setting in buildOverrides(includeGlobalOverrides: true))
+                    byKey[setting.Key] = setting;
+
+                int restored = 0;
+
+                foreach ((string key, string value) in snapshot)
+                {
+                    if (byKey.TryGetValue(key, out var setting) && setting.RestoreFrom(value))
+                        restored++;
+                }
+
+                if (recovery)
+                    Logger.Log($"[Ez] 极速模式上次未正常退出，已还原 {restored}/{snapshot.Count} 项设置。");
+            }
+
+            ezConfig.SetValue(Ez2Setting.TurboModeSnapshot, string.Empty);
+            ezConfig.Save();
+        }
+
+        /// <summary>
+        /// 压制清单。<paramref name="includeGlobalOverrides"/> 为 false 时只保留游玩中真正会生效的项，
+        /// 避免为了一局游戏去动选歌与主菜单的外观。
+        /// </summary>
+        private IReadOnlyList<SettingOverride> buildOverrides(bool includeGlobalOverrides)
+        {
+            var overrides = new List<SettingOverride>
+            {
+                // 直接跳过 GameplayDrawableStoryboard 与视频层的创建，不只是隐藏。
+                osu(OsuSetting.ShowStoryboard, false),
+                // 关掉背景的模糊 pass；配合 DimLevel = 1 让 UserDimContainer 整棵子树不参与绘制。
+                osu(OsuSetting.BlurLevel, 0.0),
+                osu(OsuSetting.DimLevel, 1.0),
+                osu(OsuSetting.LightenDuringBreaks, false),
+                osu(OsuSetting.HitLighting, false),
+                osu(OsuSetting.StarFountains, false),
+                osu(OsuSetting.GameplayLeaderboard, false),
+                osu(OsuSetting.KeyOverlay, false),
+                osu(OsuSetting.FloatingComments, false),
+                // 0 同时让 ParallaxContainer 不再产生位移。
+                osu(OsuSetting.MenuParallaxScale, 0f),
+
+                // 每帧一次全屏毛玻璃 pass。
+                ez(Ez2Setting.AcrylicUiEnabled, false),
+                ez(Ez2Setting.ColumnBlur, 0.0),
+                // 服务实例仍在，但会 no-op，不再做元数据查询与 timeline 构建。
+                ez(Ez2Setting.EzScoreRaceServiceEnabled, false),
+            };
+
+            if (includeGlobalOverrides)
+            {
+                overrides.AddRange(new[]
+                {
+                    osu(OsuSetting.SeasonalBackgroundMode, SeasonalBackgroundMode.Never),
+                    osu(OsuSetting.SongSelectBackgroundBlur, false),
+                    osu(OsuSetting.MenuBackgroundSource, BackgroundSource.Skin),
+
+                    // 选歌时的即时计算与 SQLite 读写；游玩中本来就不跑，只有全局模式才有意义。
+                    ez(Ez2Setting.EzAnalysisRecEnabled, false),
+                    ez(Ez2Setting.EzAnalysisSqliteEnabled, false),
+                });
+            }
+
+            return overrides;
+        }
+
+        private SettingOverride osu<TValue>(OsuSetting lookup, TValue turboValue) =>
+            new SettingOverride<OsuSetting, TValue>(osuConfig, lookup, turboValue);
+
+        private SettingOverride ez<TValue>(Ez2Setting lookup, TValue turboValue) =>
+            new SettingOverride<Ez2Setting, TValue>(ezConfig, lookup, turboValue);
+
+        public void Dispose()
+        {
+            if (active)
+                restore();
+        }
+
+        private abstract class SettingOverride
+        {
+            public abstract string Key { get; }
+
+            public abstract string CaptureCurrent();
+
+            public abstract void ApplyTurboValue();
+
+            /// <returns>是否成功写回。</returns>
+            public abstract bool RestoreFrom(string serialised);
+        }
+
+        private sealed class SettingOverride<TLookup, TValue> : SettingOverride
+            where TLookup : struct, Enum
+        {
+            private readonly ConfigManager<TLookup> config;
+            private readonly TLookup lookup;
+            private readonly TValue turboValue;
+
+            public SettingOverride(ConfigManager<TLookup> config, TLookup lookup, TValue turboValue)
+            {
+                this.config = config;
+                this.lookup = lookup;
+                this.turboValue = turboValue;
+            }
+
+            public override string Key => $"{typeof(TLookup).Name}.{lookup}";
+
+            public override string CaptureCurrent() => serialise(config.Get<TValue>(lookup));
+
+            public override void ApplyTurboValue() => config.SetValue(lookup, turboValue);
+
+            public override bool RestoreFrom(string serialised)
+            {
+                if (!tryDeserialise(serialised, out TValue value))
+                {
+                    Logger.Log($"[Ez] 极速模式无法还原 {Key}（快照值 \"{serialised}\"）。", level: LogLevel.Important);
+                    return false;
+                }
+
+                config.SetValue(lookup, value);
+                return true;
+            }
+
+            private static string serialise(TValue value) =>
+                value is Enum ? value.ToString()! : Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
+
+            private static bool tryDeserialise(string serialised, out TValue value)
+            {
+                try
+                {
+                    value = typeof(TValue).IsEnum
+                        ? (TValue)Enum.Parse(typeof(TValue), serialised)
+                        : (TValue)Convert.ChangeType(serialised, typeof(TValue), CultureInfo.InvariantCulture);
+                    return true;
+                }
+                catch (Exception)
+                {
+                    value = default!;
+                    return false;
+                }
+            }
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Performance/EzTurboMode.cs
+++ b/osu.Game/EzOsuGame/Performance/EzTurboMode.cs
@@ -10,16 +10,20 @@ using osu.Framework.Configuration;
 using osu.Framework.Logging;
 using osu.Game.Configuration;
 using osu.Game.EzOsuGame.Configuration;
-using osu.Game.Screens.Play;
 
 namespace osu.Game.EzOsuGame.Performance
 {
     /// <summary>
-    /// 极速模式：压制非皮肤相关的每帧开销（背景、故事板、模糊、HUD 特效、后台分析等）以提高游戏内帧数。
+    /// 极速模式：压制非皮肤相关的每帧开销（背景、故事板、模糊、HUD 特效等）以提高游戏内帧数。
     /// </summary>
     /// <remarks>
     /// 做法是把一组已有的官方与 Ez 设置改写为低开销值，改写前先把原值快照落盘，关闭时按快照还原。
-    /// 少数没有对应设置的开销（背景整棵子树的绘制、Kiai 喷泉、视差）由各自的调用点查询 <see cref="Active"/> 跳过。
+    /// 少数没有对应设置的开销（背景整棵子树的绘制、Kiai 喷泉、列模糊）由各自的调用点查询 <see cref="Active"/> 跳过。
+    /// <para>
+    /// 压制全程生效，不随进出游玩切换。按局切换会让 <see cref="OsuSetting.GameplayLeaderboard"/> 这类
+    /// 被 <c>OnScreenDisplay</c> 追踪的项每张图弹两次提示，而游玩期间 <c>OverlayActivationMode</c> 本来就挡住了
+    /// 设置面板，按局切换换不到任何收益。
+    /// </para>
     /// <para>
     /// 刻意不做的事：不降低任何线程频率（update / draw / audio），也不把 <c>FrameSync</c> 改成 VSync。
     /// 提高帧数的目的是降低延迟，而降频与锁帧都与该目的相反；音频线程更是判定时间的锚点
@@ -35,28 +39,18 @@ namespace osu.Game.EzOsuGame.Performance
         /// </summary>
         public static bool Active => active;
 
-        /// <summary>
-        /// 压制是否会在接下来的一局游玩中生效。
-        /// </summary>
-        /// <remarks>
-        /// 「仅游玩中生效」模式下 <see cref="Active"/> 要等 <c>UserPlayingState</c> 转入游玩才置位，
-        /// 而那晚于 <c>Player</c> 建树。因此建树期决定要不要构造某个组件时必须直接看总开关。
-        /// </remarks>
-        public static bool ActiveForGameplay => active || GlobalConfigStore.EzConfig.Get<bool>(Ez2Setting.TurboMode);
-
         private readonly OsuConfigManager osuConfig;
         private readonly Ez2ConfigManager ezConfig;
 
         private readonly Bindable<bool> enabled;
-        private readonly Bindable<bool> gameplayOnly;
-        private readonly IBindable<LocalUserPlayingState> playingState;
 
         /// <summary>
-        /// 当前生效的压制是否包含「仅全局模式」那一组；用于在子开关变化时判断需不需要重建压制。
+        /// 生效期间持有已应用的覆盖项，让它们持有的 bindable 副本不被回收——
+        /// <see cref="Bindable{T}"/> 的绑定表是弱引用的。
         /// </summary>
-        private bool appliedGlobalOverrides;
+        private IReadOnlyList<SettingOverride>? appliedOverrides;
 
-        public EzTurboMode(OsuConfigManager osuConfig, Ez2ConfigManager ezConfig, IBindable<LocalUserPlayingState> playingState)
+        public EzTurboMode(OsuConfigManager osuConfig, Ez2ConfigManager ezConfig)
         {
             this.osuConfig = osuConfig;
             this.ezConfig = ezConfig;
@@ -65,37 +59,37 @@ namespace osu.Game.EzOsuGame.Performance
             restoreFromSnapshot(recovery: true);
 
             enabled = ezConfig.GetBindable<bool>(Ez2Setting.TurboMode);
-            gameplayOnly = ezConfig.GetBindable<bool>(Ez2Setting.TurboModeGameplayOnly);
-            this.playingState = playingState.GetBoundCopy();
-
-            enabled.BindValueChanged(_ => updateState());
-            gameplayOnly.BindValueChanged(_ => updateState());
-            this.playingState.BindValueChanged(_ => updateState(), true);
+            enabled.BindValueChanged(_ => updateState(), true);
         }
 
         private void updateState()
         {
-            bool globalMode = enabled.Value && !gameplayOnly.Value;
-            bool shouldBeActive = enabled.Value && (globalMode || playingState.Value != LocalUserPlayingState.NotPlaying);
-
-            if (shouldBeActive == active && globalMode == appliedGlobalOverrides)
+            if (enabled.Value == active)
                 return;
 
             if (active)
                 restore();
-
-            if (shouldBeActive)
-                apply(globalMode);
+            else
+                apply();
         }
 
-        private void apply(bool includeGlobalOverrides)
+        private void apply()
         {
-            var overrides = buildOverrides(includeGlobalOverrides);
-
             var snapshot = new Dictionary<string, string>();
+            var applicable = new List<SettingOverride>();
 
-            foreach (var setting in overrides)
-                snapshot[setting.Key] = setting.CaptureCurrent();
+            foreach (var setting in buildOverrides())
+            {
+                // 已被别处锁住（例如某个 BeginLease）的项写不进去，整项跳过而不是让它抛。
+                if (!setting.TryCaptureCurrent(out string captured))
+                {
+                    Logger.Log($"[Ez] 极速模式跳过 {setting.Key}：该设置当前被其它逻辑锁定。", level: LogLevel.Debug);
+                    continue;
+                }
+
+                snapshot[setting.Key] = captured;
+                applicable.Add(setting);
+            }
 
             // 原值必须先落盘再改写：否则进程在改写后崩溃就再也找不回用户设置。
             ezConfig.SetValue(Ez2Setting.TurboModeSnapshot, JsonConvert.SerializeObject(snapshot));
@@ -103,9 +97,9 @@ namespace osu.Game.EzOsuGame.Performance
 
             // 先置位再改写，让 DimLevel 等改写触发的 UpdateVisuals 能看到已生效的状态。
             active = true;
-            appliedGlobalOverrides = includeGlobalOverrides;
+            appliedOverrides = applicable;
 
-            foreach (var setting in overrides)
+            foreach (var setting in applicable)
                 setting.ApplyTurboValue();
         }
 
@@ -113,7 +107,7 @@ namespace osu.Game.EzOsuGame.Performance
         {
             // 先复位再写回，理由同 apply()。
             active = false;
-            appliedGlobalOverrides = false;
+            appliedOverrides = null;
 
             restoreFromSnapshot(recovery: false);
         }
@@ -144,7 +138,7 @@ namespace osu.Game.EzOsuGame.Performance
             {
                 var byKey = new Dictionary<string, SettingOverride>();
 
-                foreach (var setting in buildOverrides(includeGlobalOverrides: true))
+                foreach (var setting in buildOverrides())
                     byKey[setting.Key] = setting;
 
                 int restored = 0;
@@ -164,56 +158,42 @@ namespace osu.Game.EzOsuGame.Performance
         }
 
         /// <summary>
-        /// 压制清单。<paramref name="includeGlobalOverrides"/> 为 false 时只保留游玩中真正会生效的项，
-        /// 避免为了一局游戏去动选歌与主菜单的外观。
+        /// 压制清单。<c>lockWhileActive</c> 为 true 的项在生效期间会被 <see cref="Bindable{T}.Disabled"/> 置灰，
+        /// 使设置面板显示为不可改；只有确认除设置面板外没有运行时写入方的项才能置灰，
+        /// 否则那些写入会撞上 <see cref="Bindable{T}.Value"/> 的 disabled 检查而抛异常。
         /// </summary>
-        private IReadOnlyList<SettingOverride> buildOverrides(bool includeGlobalOverrides)
+        private IReadOnlyList<SettingOverride> buildOverrides() => new List<SettingOverride>
         {
-            var overrides = new List<SettingOverride>
-            {
-                // 直接跳过 GameplayDrawableStoryboard 与视频层的创建，不只是隐藏。
-                osu(OsuSetting.ShowStoryboard, false),
-                // 关掉背景的模糊 pass；配合 DimLevel = 1 让 UserDimContainer 整棵子树不参与绘制。
-                osu(OsuSetting.BlurLevel, 0.0),
-                osu(OsuSetting.DimLevel, 1.0),
-                osu(OsuSetting.LightenDuringBreaks, false),
-                osu(OsuSetting.HitLighting, false),
-                osu(OsuSetting.StarFountains, false),
-                osu(OsuSetting.GameplayLeaderboard, false),
-                osu(OsuSetting.KeyOverlay, false),
-                osu(OsuSetting.FloatingComments, false),
-                // 0 同时让 ParallaxContainer 不再产生位移。
-                osu(OsuSetting.MenuParallaxScale, 0f),
+            // 直接跳过 GameplayDrawableStoryboard 与视频层的创建，不只是隐藏。
+            osu(OsuSetting.ShowStoryboard, false),
+            // 关掉背景的模糊 pass；配合 DimLevel = 1 让 UserDimContainer 整棵子树不参与绘制。
+            osu(OsuSetting.BlurLevel, 0.0),
+            osu(OsuSetting.DimLevel, 1.0),
+            osu(OsuSetting.LightenDuringBreaks, false),
+            osu(OsuSetting.HitLighting, false),
+            osu(OsuSetting.StarFountains, false),
+            osu(OsuSetting.KeyOverlay, false),
+            osu(OsuSetting.FloatingComments, false),
+            osu(OsuSetting.SeasonalBackgroundMode, SeasonalBackgroundMode.Never),
+            osu(OsuSetting.SongSelectBackgroundBlur, false),
+            osu(OsuSetting.MenuBackgroundSource, BackgroundSource.Skin),
 
-                // 每帧一次全屏毛玻璃 pass。
-                ez(Ez2Setting.AcrylicUiEnabled, false),
-                ez(Ez2Setting.ColumnBlur, 0.0),
-                // 服务实例仍在，但会 no-op，不再做元数据查询与 timeline 构建。
-                ez(Ez2Setting.EzScoreRaceServiceEnabled, false),
-            };
+            // HUDOverlay 的 ToggleInGameLeaderboard 快捷键直接写这个 bindable，置灰会让游玩中按下时抛异常。
+            osu(OsuSetting.GameplayLeaderboard, false, lockWhileActive: false),
+            // 0 同时让 ParallaxContainer 不再产生位移。OsuGame 的一次性配置迁移会写它，同样不能置灰。
+            osu(OsuSetting.MenuParallaxScale, 0f, lockWhileActive: false),
 
-            if (includeGlobalOverrides)
-            {
-                overrides.AddRange(new[]
-                {
-                    osu(OsuSetting.SeasonalBackgroundMode, SeasonalBackgroundMode.Never),
-                    osu(OsuSetting.SongSelectBackgroundBlur, false),
-                    osu(OsuSetting.MenuBackgroundSource, BackgroundSource.Skin),
+            // 每帧一次全屏毛玻璃 pass。
+            ez(Ez2Setting.AcrylicUiEnabled, false),
+            // 服务实例仍在，但会 no-op，不再做元数据查询与 timeline 构建。
+            ez(Ez2Setting.EzScoreRaceServiceEnabled, false),
+        };
 
-                    // 选歌时的即时计算与 SQLite 读写；游玩中本来就不跑，只有全局模式才有意义。
-                    ez(Ez2Setting.EzAnalysisRecEnabled, false),
-                    ez(Ez2Setting.EzAnalysisSqliteEnabled, false),
-                });
-            }
+        private SettingOverride osu<TValue>(OsuSetting lookup, TValue turboValue, bool lockWhileActive = true) =>
+            new SettingOverride<OsuSetting, TValue>(osuConfig, lookup, turboValue, lockWhileActive);
 
-            return overrides;
-        }
-
-        private SettingOverride osu<TValue>(OsuSetting lookup, TValue turboValue) =>
-            new SettingOverride<OsuSetting, TValue>(osuConfig, lookup, turboValue);
-
-        private SettingOverride ez<TValue>(Ez2Setting lookup, TValue turboValue) =>
-            new SettingOverride<Ez2Setting, TValue>(ezConfig, lookup, turboValue);
+        private SettingOverride ez<TValue>(Ez2Setting lookup, TValue turboValue, bool lockWhileActive = true) =>
+            new SettingOverride<Ez2Setting, TValue>(ezConfig, lookup, turboValue, lockWhileActive);
 
         public void Dispose()
         {
@@ -225,7 +205,8 @@ namespace osu.Game.EzOsuGame.Performance
         {
             public abstract string Key { get; }
 
-            public abstract string CaptureCurrent();
+            /// <returns>是否取到原值；该设置已被别处锁定时为 false。</returns>
+            public abstract bool TryCaptureCurrent(out string value);
 
             public abstract void ApplyTurboValue();
 
@@ -236,32 +217,54 @@ namespace osu.Game.EzOsuGame.Performance
         private sealed class SettingOverride<TLookup, TValue> : SettingOverride
             where TLookup : struct, Enum
         {
-            private readonly ConfigManager<TLookup> config;
+            private readonly Bindable<TValue> bindable;
             private readonly TLookup lookup;
             private readonly TValue turboValue;
+            private readonly bool lockWhileActive;
 
-            public SettingOverride(ConfigManager<TLookup> config, TLookup lookup, TValue turboValue)
+            public SettingOverride(ConfigManager<TLookup> config, TLookup lookup, TValue turboValue, bool lockWhileActive)
             {
-                this.config = config;
+                bindable = config.GetBindable<TValue>(lookup);
                 this.lookup = lookup;
                 this.turboValue = turboValue;
+                this.lockWhileActive = lockWhileActive;
             }
 
             public override string Key => $"{typeof(TLookup).Name}.{lookup}";
 
-            public override string CaptureCurrent() => serialise(config.Get<TValue>(lookup));
+            public override bool TryCaptureCurrent(out string value)
+            {
+                if (bindable.Disabled)
+                {
+                    value = string.Empty;
+                    return false;
+                }
 
-            public override void ApplyTurboValue() => config.SetValue(lookup, turboValue);
+                value = serialise(bindable.Value);
+                return true;
+            }
+
+            public override void ApplyTurboValue()
+            {
+                // 顺序不能颠倒：置灰后 Bindable.Value 的 setter 会抛异常。
+                bindable.Value = turboValue;
+
+                if (lockWhileActive)
+                    bindable.Disabled = true;
+            }
 
             public override bool RestoreFrom(string serialised)
             {
+                // 同样不能颠倒：先解锁才写得回去。异常退出后重开时本来就没锁，这里是空操作。
+                bindable.Disabled = false;
+
                 if (!tryDeserialise(serialised, out TValue value))
                 {
                     Logger.Log($"[Ez] 极速模式无法还原 {Key}（快照值 \"{serialised}\"）。", level: LogLevel.Important);
                     return false;
                 }
 
-                config.SetValue(lookup, value);
+                bindable.Value = value;
                 return true;
             }
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -45,6 +45,7 @@ using osu.Game.EzOsuGame.Edit;
 using osu.Game.EzOsuGame.Analysis;
 using osu.Game.EzOsuGame.Background.Pixiv;
 using osu.Game.EzOsuGame.Overlays;
+using osu.Game.EzOsuGame.Performance;
 using osu.Game.EzOsuGame.Scoring;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
@@ -186,6 +187,8 @@ namespace osu.Game
         private readonly ScreenshotManager screenshotManager = new ScreenshotManager();
 
         private SentryLogger sentryLogger;
+
+        private EzTurboMode turboMode;
 
         public virtual StableStorage GetStorageForStableInstall() => null;
 
@@ -463,6 +466,8 @@ namespace osu.Game
                 SkinManager.PauseImports = p.NewValue != LocalUserPlayingState.NotPlaying;
                 ScoreManager.PauseImports = p.NewValue != LocalUserPlayingState.NotPlaying;
             }, true);
+
+            turboMode = new EzTurboMode(LocalConfig, Ez2ConfigManager, UserPlayingState);
 
             IsActive.BindValueChanged(active => updateActiveState(active.NewValue), true);
 
@@ -1041,6 +1046,9 @@ namespace osu.Game
             // Without this, tests may deadlock due to cancellation token not becoming cancelled before disposal.
             // To reproduce, run `TestSceneButtonSystemNavigation` ensuring `TestConstructor` runs before `TestFastShortcutKeys`.
             detachedBeatmapStore?.Dispose();
+
+            // 必须在配置管理器落盘前还原，否则压制值会被当成用户设置持久化。
+            turboMode?.Dispose();
 
             base.Dispose(isDisposing);
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -467,7 +467,7 @@ namespace osu.Game
                 ScoreManager.PauseImports = p.NewValue != LocalUserPlayingState.NotPlaying;
             }, true);
 
-            turboMode = new EzTurboMode(LocalConfig, Ez2ConfigManager, UserPlayingState);
+            turboMode = new EzTurboMode(LocalConfig, Ez2ConfigManager);
 
             IsActive.BindValueChanged(active => updateActiveState(active.NewValue), true);
 

--- a/osu.Game/Overlays/Settings/SettingsItemV2.cs
+++ b/osu.Game/Overlays/Settings/SettingsItemV2.cs
@@ -8,6 +8,8 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Localisation;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.EzOsuGame.Performance;
 using osu.Game.Graphics.UserInterfaceV2;
 
 namespace osu.Game.Overlays.Settings
@@ -17,6 +19,7 @@ namespace osu.Game.Overlays.Settings
         public readonly IFormControl Control;
 
         private readonly SettingsRevertToDefaultButton revertButton;
+        private readonly SettingsNote note;
 
         private readonly BindableBool controlDefault = new BindableBool(true);
         private readonly BindableBool controlEnabled = new BindableBool(true);
@@ -66,10 +69,9 @@ namespace osu.Game.Overlays.Settings
                             }
                         }
                     },
-                    new SettingsNote
+                    note = new SettingsNote
                     {
                         RelativeSizeAxes = Axes.X,
-                        Current = { BindTarget = Note },
                     },
                 },
             };
@@ -83,7 +85,12 @@ namespace osu.Game.Overlays.Settings
             controlEnabled.Value = !Control.IsDisabled;
 
             controlDefault.BindValueChanged(_ => updateDefaultState());
-            controlEnabled.BindValueChanged(_ => updateDefaultState(), true);
+            controlEnabled.BindValueChanged(_ =>
+            {
+                updateDefaultState();
+                updateNote();
+            }, true);
+            Note.BindValueChanged(_ => updateNote(), true);
             FinishTransforms(true);
         }
 
@@ -95,6 +102,16 @@ namespace osu.Game.Overlays.Settings
                 revertButton.Show();
             else
                 revertButton.Hide();
+        }
+
+        private void updateNote()
+        {
+            // [Ez] 极速模式会把它接管的设置项置灰。这里拿不到设置的 key，无法反查具体是哪一项被接管，
+            // 所以用「压制生效中且控件被禁用」近似；只在调用方没提供自己的 note 时才回落。
+            note.Current.Value = Note.Value
+                                 ?? (controlEnabled.Value || !EzTurboMode.Active
+                                     ? null
+                                     : new SettingsNote.Data(EzSettingsStrings.TURBO_MODE_MANAGED_NOTE, SettingsNote.Type.Informational));
         }
 
         protected override void Update()

--- a/osu.Game/Screens/Backgrounds/BackgroundScreenBeatmap.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenBeatmap.cs
@@ -10,6 +10,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.EzOsuGame.Performance;
 using osu.Game.Graphics.Backgrounds;
 using osu.Game.Graphics.Containers;
 using osu.Game.Screens.Play;
@@ -194,6 +195,19 @@ namespace osu.Game.Screens.Backgrounds
                         return 1;
 
                     return base.DimLevel;
+                }
+            }
+
+            protected override bool ShowDimContent
+            {
+                get
+                {
+                    // [Ez] 极速模式把 DimLevel 压到 1，此时背景已无可见内容。让整棵子树退出绘制，
+                    // 而不是照旧画成全黑——后者仍要跑一次全屏贴图与模糊目标。
+                    if (EzTurboMode.Active && !IgnoreUserSettings.Value && DimLevel >= 1)
+                        return false;
+
+                    return base.ShowDimContent;
                 }
             }
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -524,7 +524,7 @@ namespace osu.Game.Screens.Play
             var children = new List<Drawable> { DimmableStoryboard, letterboxOverlay };
 
             // [Ez] 喷泉没有对应的用户设置，只能在极速模式下直接不构造。
-            if (!EzTurboMode.ActiveForGameplay)
+            if (!EzTurboMode.Active)
                 children.Add(new KiaiGameplayFountains());
 
             var container = new Container

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -29,6 +29,7 @@ using osu.Game.Graphics.Containers;
 using osu.Game.IO.Archives;
 using osu.Game.EzOsuGame.Audio;
 using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Performance;
 using osu.Game.EzOsuGame.Scoring;
 using osu.Game.EzOsuGame.Screens.Play;
 using osu.Game.Online.API;
@@ -509,22 +510,27 @@ namespace osu.Game.Screens.Play
 
         private Drawable createUnderlayComponents(WorkingBeatmap working)
         {
+            DimmableStoryboard = new DimmableStoryboard(GameplayState.Storyboard, GameplayState.Mods)
+            {
+                RelativeSizeAxes = Axes.Both
+            };
+
+            letterboxOverlay = new LetterboxOverlay
+            {
+                BreakTracker = breakTracker,
+                Alpha = working.Beatmap.LetterboxInBreaks ? 1 : 0,
+            };
+
+            var children = new List<Drawable> { DimmableStoryboard, letterboxOverlay };
+
+            // [Ez] 喷泉没有对应的用户设置，只能在极速模式下直接不构造。
+            if (!EzTurboMode.ActiveForGameplay)
+                children.Add(new KiaiGameplayFountains());
+
             var container = new Container
             {
                 RelativeSizeAxes = Axes.Both,
-                Children = new Drawable[]
-                {
-                    DimmableStoryboard = new DimmableStoryboard(GameplayState.Storyboard, GameplayState.Mods)
-                    {
-                        RelativeSizeAxes = Axes.Both
-                    },
-                    letterboxOverlay = new LetterboxOverlay
-                    {
-                        BreakTracker = breakTracker,
-                        Alpha = working.Beatmap.LetterboxInBreaks ? 1 : 0,
-                    },
-                    new KiaiGameplayFountains(),
-                },
+                Children = children,
             };
 
             // Provide a stable background capture source for rulesets that require backdrop effects.


### PR DESCRIPTION
## 这是什么

一个开关，把游戏内除皮肤以外的每帧开销批量压掉以提高帧数。设置里在「Ez UI」一节，两项：

- **极速模式**：总开关
- **极速模式仅在游玩中生效**：默认开，只在游玩期间压制，退出立刻还原；关掉则全程压制，并额外处理只有在菜单/选歌才有意义的几项

## 前提：提高帧数是为了降低延迟

所以**刻意不做**任何以延迟换帧数的取舍：

- 不降低 update / draw / audio 任何线程频率
- 不把 `FrameSync` 改成 VSync、不锁帧

音频线程尤其不能动——`TrackBass.CurrentTime` 只在音频线程每帧刷新，而它是判定的时间锚点，键音派发也排队在该线程上。降它等于直接放大判定误差和键音抖动，那与本功能的目的相反。

## 压制清单

始终生效（游玩与全局两种模式都包含）：

| 项 | 压制值 | 省掉什么 |
| --- | --- | --- |
| `ShowStoryboard` | false | 直接跳过故事板与视频层的构造 |
| `DimLevel` | 1.0 | 配合下面的 gate 让背景整棵子树退出绘制 |
| `BlurLevel` | 0.0 | 背景模糊 pass |
| `LightenDuringBreaks` | false | 休息段的背景亮度动画 |
| `HitLighting` | false | 打击闪光 |
| `StarFountains` | false | 星星喷泉 |
| `GameplayLeaderboard` | false | 游戏内排行榜 |
| `KeyOverlay` | false | 按键显示 |
| `FloatingComments` | false | 漂浮评论 |
| `MenuParallaxScale` | 0 | 视差每帧移动背景带来的 draw info 失效 |
| `AcrylicUiEnabled` | false | 每帧一次全屏毛玻璃 pass |
| `ColumnBlur` | 0.0 | mania stage 的 `BackdropBlurDrawable` 全屏捕获 + 模糊 |
| `EzScoreRaceServiceEnabled` | false | 角逐服务空转，不再做元数据查询与 timeline 构建 |

仅全局模式额外包含 `SeasonalBackgroundMode`、`SongSelectBackgroundBlur`、`MenuBackgroundSource`，以及 Ez 分析的 `EzAnalysisRecEnabled` / `EzAnalysisSqliteEnabled`（选歌时的即时计算与 SQLite 读写，游玩中本来就不跑）。

**唯一会改变皮肤观感的是 `ColumnBlur`**，它属于舞台外观。之所以还是放进来，是因为它是 mania playfield 上最贵的单项效果（每帧全屏 backdrop 捕获再模糊）。这一点在开关的说明文本里写明了，不接受的话可以在开启极速模式后把它手动调回来（见下面的注意事项）。

## 快照与还原

改写前先把原值快照写入 `Ez2Setting.TurboModeSnapshot` 并**落盘**，再改写；顺序反了的话进程在改写后崩溃就再也找不回用户设置。关闭时按快照逐项写回并清空快照。

启动时若发现快照非空，即为上次异常退出，立即还原并记一条日志。还原是**按快照里的键**做的，不是按当前压制清单——这样压制清单在两次运行之间改动过也能正确恢复。

注意事项：开启期间上述设置项处于被改写状态，此时手动改这些项，改动会在还原时被快照覆盖。这个行为写在开关的说明文本里了。

## 上游改动

只有两处，都是无法在 Ez 侧闭环的：

1. `BackgroundScreenBeatmap.DimmableBackground` 加 `ShowDimContent` 判断。压到全暗的背景已经没有可见内容，让整棵子树退出绘制，而不是照旧画成全黑——后者仍要跑一次全屏贴图。
2. `Player` 在极速模式下不构造 `KiaiGameplayFountains`。它是 `BeatSyncedContainer`，每帧跑 `Update()`，两套粒子发射器常驻绘制树，而 `StarFountains` 默认是关的，也就是说对多数用户这整棵子树纯属空转。

计划里原本还有两处，实现时查清后放弃了：

- **`Player` 不构造 `ComboEffects`**：它只是连击断裂音效，事件驱动，零每帧开销。关掉只会静音，没有性能收益。
- **`OsuScreenStack.setParallax` 置 0**：`setParallax` 只在切屏时调用，而「仅游玩中」模式下 `Active` 要等 `UserPlayingState` 转入游玩才置位，晚于切屏，这个 gate 根本不会生效。视差的实际每帧成本已由 `MenuParallaxScale = 0` 覆盖，那条是响应式的。

同样的时序问题也影响 `Player` 的两处 gate（建树早于 `UserPlayingState` 变化），所以它们读的是 `EzTurboMode.ActiveForGameplay`（直接看总开关）而不是 `Active`。

## 验证

- `dotnet build osu.Game`
- 新增 `EzTurboModeTest` 7 项：全局压制与还原、跟随 `UserPlayingState`（含休息段不抖动）、快照在生效期间非空、陈旧快照在构造时被还原、损坏快照被丢弃且不抛、生效中切换子开关会撤销仅全局那一组、`Dispose` 时还原
- Ez 相关测试共 159 项全过

按 Realm 纪律没有启动客户端（本 PR 不涉及 schema，但也没有需要跑图才能验的东西）。

## 相关

[SK-la/osu-framework#13](https://github.com/SK-la/osu-framework/pull/13) 加了 `OSU_PERFORMANCE_MONITORING` 环境变量以关掉每帧性能统计。本 PR **不引用**它的任何 API（osu.Game 默认从 NuGet 取 framework，引用新 API 会直接编译不过），两者独立合并即可。
