### PR TITLE
系统 UI/Emoji 字体设置与 Twemoji 资源接入

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -9,4 +9,28 @@
     <AssemblyVersion>$(ReleaseVersion)</AssemblyVersion>
     <InformationalVersion>$(ReleaseVersion)-ez2lazer</InformationalVersion>
   </PropertyGroup>
+
+  <!--
+    Local Framework ProjectReference does not flow packed RID natives into the app output
+    (CopyToOutputDirectory on Framework natives breaks iOS mtouch). Copy plutosvgft next to
+    FreeTypeSharp's freetype.dll so OT-SVG hooks can load.
+  -->
+  <Target Name="CopyEzPlutoSvgFtNatives"
+          AfterTargets="Build"
+          Condition="'$(UseEz2LazerLocalFrameworkProject)' == 'true'
+                     and ('$(OutputType)' == 'Exe' or '$(OutputType)' == 'WinExe')
+                     and !$([System.String]::Copy('$(TargetFramework)').Contains('ios'))
+                     and !$([System.String]::Copy('$(TargetFramework)').Contains('android'))
+                     and '$(Ez2LazerFrameworkProjectPath)' != ''">
+    <PropertyGroup>
+      <_EzFwDir>$([System.IO.Path]::GetDirectoryName('$(Ez2LazerFrameworkProjectPath)'))</_EzFwDir>
+    </PropertyGroup>
+    <ItemGroup>
+      <_EzPlutoSvgFtNative Include="$(_EzFwDir)\runtimes\**\native\*" Condition="Exists('$(_EzFwDir)\runtimes')" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_EzPlutoSvgFtNative)"
+          DestinationFiles="@(_EzPlutoSvgFtNative->'$(OutputPath)runtimes\%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true"
+          Condition="'@(_EzPlutoSvgFtNative)' != ''" />
+  </Target>
 </Project>

--- a/Ez2Lazer.Dependencies.props
+++ b/Ez2Lazer.Dependencies.props
@@ -1,8 +1,8 @@
 ﻿<!-- Ez2Lazer：Framework / Resources 依赖。版本仅在此文件维护。 -->
 <Project>
   <PropertyGroup Label="Ez2Lazer">
-    <Ez2LazerFrameworkVersion>2026.809.0-ez2lazer</Ez2LazerFrameworkVersion>
-    <Ez2LazerGameResourcesVersion>2026.812.0-ez2lazer</Ez2LazerGameResourcesVersion>
+    <Ez2LazerFrameworkVersion>2026.814.0-ez2lazer</Ez2LazerFrameworkVersion>
+    <Ez2LazerGameResourcesVersion>2026.814.0-ez2lazer</Ez2LazerGameResourcesVersion>
     <Ez2LazerFrameworkProjectPath>$(MSBuildThisFileDirectory)..\osu-framework\osu.Framework\osu.Framework.csproj</Ez2LazerFrameworkProjectPath>
     <Ez2LazerResourcesProjectPath>$(MSBuildThisFileDirectory)..\osu-resources\osu.Game.Resources\osu.Game.Resources.csproj</Ez2LazerResourcesProjectPath>
 

--- a/osu.Game.Tests/Visual/Fonts/TestSceneEmojiRendering.cs
+++ b/osu.Game.Tests/Visual/Fonts/TestSceneEmojiRendering.cs
@@ -61,11 +61,27 @@ namespace osu.Game.Tests.Visual.Fonts
                     {
                         new OsuSpriteText
                         {
-                            Text = "Static emoji glyphs:",
+                            Text = "Static emoji glyphs (BMFont Noto-Emoji):",
                             Font = OsuFont.GetFont(size: 20, weight: FontWeight.Bold),
                         },
                     }.Concat(staticEmojiTexts).Concat(new Drawable[]
                     {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            Height = 2,
+                            Colour = Color4.DimGray,
+                        },
+                        new OsuSpriteText
+                        {
+                            Text = "OT-SVG NotoColorEmoji-Regular (when plutosvgft hooks available):",
+                            Font = OsuFont.GetFont(size: 20, weight: FontWeight.Bold),
+                        },
+                        new OsuSpriteText
+                        {
+                            Text = emojis,
+                            Font = new FontUsage("NotoColorEmoji-Regular", 48),
+                        },
                         new Box
                         {
                             RelativeSizeAxes = Axes.X,

--- a/osu.Game/EzOsuGame/Configuration/Ez2ConfigManager.cs
+++ b/osu.Game/EzOsuGame/Configuration/Ez2ConfigManager.cs
@@ -114,6 +114,12 @@ namespace osu.Game.EzOsuGame.Configuration
             SetDefault(Ez2Setting.StoryboardAutoVideoSize, false);
             SetDefault(Ez2Setting.AcrylicUiEnabled, false);
             SetDefault(Ez2Setting.AcrylicUiBlurStrength, 16.0, 0.0, 40.0, 1.0);
+            SetDefault(Ez2Setting.UiFontDefault, string.Empty);
+            SetDefault(Ez2Setting.UiFontDefaultLocalized, string.Empty);
+            SetDefault(Ez2Setting.UiFontTitleAlternate, string.Empty);
+            SetDefault(Ez2Setting.UiFontTitleAlternateLocalized, string.Empty);
+            SetDefault(Ez2Setting.UiFontNumeric, string.Empty);
+            SetDefault(Ez2Setting.UiFontEmoji, string.Empty);
             SetDefault(Ez2Setting.KeySoundPreviewMode, KeySoundPreviewMode.Off);
             SetDefault(Ez2Setting.BeatmapPreviewMode, EzBeatmapPreviewMode.Static);
             SetDefault(Ez2Setting.BeatmapPreviewModeMania, EzBeatmapPreviewMode.StaticFullMap);
@@ -915,6 +921,24 @@ namespace osu.Game.EzOsuGame.Configuration
         StoryboardAutoVideoSize,
         AcrylicUiEnabled,
         AcrylicUiBlurStrength,
+
+        /// <summary>English / Latin system font for default UI (empty = built-in Torus BMFont).</summary>
+        UiFontDefault,
+
+        /// <summary>Localized (CJK etc.) system font for default UI empty-name fallback (empty = Noto BMFont).</summary>
+        UiFontDefaultLocalized,
+
+        /// <summary>English system font for title/alternate (empty = built-in TorusAlternate).</summary>
+        UiFontTitleAlternate,
+
+        /// <summary>Localized system font for title/alternate empty-name fallback.</summary>
+        UiFontTitleAlternateLocalized,
+
+        /// <summary>System font family for numeric display (empty = built-in Venera).</summary>
+        UiFontNumeric,
+
+        /// <summary>System colour emoji font (empty = auto-detect platform emoji face).</summary>
+        UiFontEmoji,
 
         // 界面功能
         KeySoundPreviewMode,

--- a/osu.Game/EzOsuGame/Fonts/EzSystemFontCatalog.cs
+++ b/osu.Game/EzOsuGame/Fonts/EzSystemFontCatalog.cs
@@ -1,0 +1,350 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using osu.Framework;
+using osu.Framework.Logging;
+using osu.Framework.Text;
+using osu.Game.EzOsuGame.Configuration;
+
+namespace osu.Game.EzOsuGame.Fonts
+{
+    /// <summary>
+    /// Enumerates installed outline fonts from common system font directories,
+    /// and resolves the platform colour emoji font for global fallback.
+    /// </summary>
+    public static class EzSystemFontCatalog
+    {
+        public const string NONE_OPTION = "";
+
+        private static readonly object cache_lock = new object();
+        private static IReadOnlyList<EzSystemFontEntry>? cached;
+        public static IReadOnlyList<EzSystemFontEntry>? CachedEmoji;
+
+        /// <summary>Sample emoji codepoints used to verify a face is emoji-capable.</summary>
+        private static readonly int[] emoji_probe_codepoints =
+        {
+            0x1F600, // 😀
+            0x1F602, // 😂
+            0x1F44D, // 👍
+            0x1F389, // 🎉
+            0x1F525, // 🔥
+        };
+
+        public static IReadOnlyList<EzSystemFontEntry> GetEntries(bool forceRefresh = false)
+        {
+            lock (cache_lock)
+            {
+                if (cached != null && !forceRefresh)
+                    return cached;
+
+                if (forceRefresh)
+                    CachedEmoji = null;
+
+                var byFamily = new Dictionary<string, EzSystemFontEntry>(StringComparer.OrdinalIgnoreCase);
+
+                foreach (string directory in enumerateFontDirectories())
+                {
+                    if (!Directory.Exists(directory))
+                        continue;
+
+                    IEnumerable<string> files;
+
+                    try
+                    {
+                        // Windows Fonts is mostly flat; Linux/macOS trees nest under family dirs.
+                        var depth = RuntimeInfo.OS == RuntimeInfo.Platform.Windows
+                            ? SearchOption.TopDirectoryOnly
+                            : SearchOption.AllDirectories;
+
+                        files = Directory.EnumerateFiles(directory, "*.*", depth)
+                                         .Where(f =>
+                                         {
+                                             string ext = Path.GetExtension(f);
+                                             return ext.Equals(".ttf", StringComparison.OrdinalIgnoreCase)
+                                                    || ext.Equals(".otf", StringComparison.OrdinalIgnoreCase)
+                                                    || ext.Equals(".ttc", StringComparison.OrdinalIgnoreCase);
+                                         });
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Log($"EzSystemFontCatalog: cannot list {directory}: {ex.Message}", Ez2ConfigManager.LOGGER_NAME);
+                        continue;
+                    }
+
+                    foreach (string file in files)
+                    {
+                        try
+                        {
+                            // Face 0 only for v1 (collections may expose more later).
+                            string? family = OutlineFont.TryGetFamilyName(file, 0);
+
+                            if (string.IsNullOrWhiteSpace(family) || isPlaceholderFamilyName(family))
+                                family = Path.GetFileNameWithoutExtension(file);
+
+                            bool prefer = isPreferredStyleFile(file);
+
+                            if (!byFamily.TryGetValue(family, out var existing) || (prefer && !isPreferredStyleFile(existing.Path)))
+                                byFamily[family] = new EzSystemFontEntry(family, family, file, 0);
+                        }
+                        catch
+                        {
+                            // Skip unreadable / broken fonts.
+                        }
+                    }
+                }
+
+                cached = byFamily.Values
+                                 .OrderBy(e => e.DisplayName, StringComparer.CurrentCultureIgnoreCase)
+                                 .ToList();
+
+                return cached;
+            }
+        }
+
+        public static EzSystemFontEntry? FindByFamily(string? family)
+        {
+            if (string.IsNullOrWhiteSpace(family))
+                return null;
+
+            foreach (var entry in GetEntries())
+            {
+                if (string.Equals(entry.Family, family, StringComparison.OrdinalIgnoreCase))
+                    return entry;
+            }
+
+            return null;
+        }
+
+        private static bool isPlaceholderFamilyName(string name)
+        {
+            foreach (char c in name)
+            {
+                if (c != '?')
+                    return false;
+            }
+
+            return name.Length > 0;
+        }
+
+        /// <summary>
+        /// Resolves the platform colour emoji font (TTF/OTF/TTC) for global glyph fallback.
+        /// Does not require a full catalog scan when well-known paths exist.
+        /// </summary>
+        public static EzSystemFontEntry? FindSystemEmojiFont()
+        {
+            foreach (var candidate in enumerateSystemEmojiCandidates())
+            {
+                if (!File.Exists(candidate.Path))
+                    continue;
+
+                try
+                {
+                    string? family = OutlineFont.TryGetFamilyName(candidate.Path, candidate.FaceIndex);
+
+                    if (string.IsNullOrWhiteSpace(family))
+                        family = Path.GetFileNameWithoutExtension(candidate.Path);
+
+                    return new EzSystemFontEntry(family, family, candidate.Path, candidate.FaceIndex);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Log($"EzSystemFontCatalog: emoji candidate unreadable {candidate.Path}: {ex.Message}", Ez2ConfigManager.LOGGER_NAME);
+                }
+            }
+
+            foreach (string family in knownSystemEmojiFamilyNames())
+            {
+                var entry = FindByFamily(family);
+
+                if (entry != null)
+                    return entry;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Installed fonts that look like emoji faces and actually contain common emoji codepoints.
+        /// </summary>
+        public static IReadOnlyList<EzSystemFontEntry> GetEmojiEntries(bool forceRefresh = false)
+        {
+            lock (cache_lock)
+            {
+                if (CachedEmoji != null && !forceRefresh)
+                    return CachedEmoji;
+
+                var byFamily = new Dictionary<string, EzSystemFontEntry>(StringComparer.OrdinalIgnoreCase);
+
+                foreach (var candidate in enumerateSystemEmojiCandidates())
+                    tryAddEmojiEntry(byFamily, candidate.Path, candidate.FaceIndex);
+
+                foreach (var entry in GetEntries())
+                {
+                    if (!looksLikeEmojiFont(entry.Family, entry.Path))
+                        continue;
+
+                    if (!isEmojiCapable(entry.Path, entry.FaceIndex))
+                        continue;
+
+                    byFamily.TryAdd(entry.Family, entry);
+                }
+
+                foreach (string family in knownSystemEmojiFamilyNames())
+                {
+                    if (byFamily.ContainsKey(family))
+                        continue;
+
+                    var entry = FindByFamily(family);
+                    if (entry == null || !isEmojiCapable(entry.Value.Path, entry.Value.FaceIndex))
+                        continue;
+
+                    byFamily[entry.Value.Family] = entry.Value;
+                }
+
+                CachedEmoji = byFamily.Values
+                                      .OrderBy(e => e.DisplayName, StringComparer.CurrentCultureIgnoreCase)
+                                      .ToList();
+
+                return CachedEmoji;
+            }
+        }
+
+        private static void tryAddEmojiEntry(Dictionary<string, EzSystemFontEntry> byFamily, string path, int faceIndex)
+        {
+            if (!File.Exists(path) || !isEmojiCapable(path, faceIndex))
+                return;
+
+            try
+            {
+                string? family = OutlineFont.TryGetFamilyName(path, faceIndex);
+
+                if (string.IsNullOrWhiteSpace(family) || isPlaceholderFamilyName(family))
+                    family = Path.GetFileNameWithoutExtension(path);
+
+                byFamily.TryAdd(family, new EzSystemFontEntry(family, family, path, faceIndex));
+            }
+            catch
+            {
+                // Skip unreadable candidates.
+            }
+        }
+
+        private static bool looksLikeEmojiFont(string family, string path)
+        {
+            string haystack = family + " " + Path.GetFileNameWithoutExtension(path);
+
+            return haystack.Contains("emoji", StringComparison.OrdinalIgnoreCase)
+                   || haystack.Contains("seguiemj", StringComparison.OrdinalIgnoreCase)
+                   || haystack.Contains("seguisym", StringComparison.OrdinalIgnoreCase)
+                   || haystack.Contains("twemoji", StringComparison.OrdinalIgnoreCase)
+                   || haystack.Contains("joypixels", StringComparison.OrdinalIgnoreCase)
+                   || haystack.Contains("openmoji", StringComparison.OrdinalIgnoreCase)
+                   || haystack.Contains("blobmoji", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool isEmojiCapable(string path, int faceIndex)
+            => OutlineFont.TryHasAnyCodepoint(path, faceIndex, emoji_probe_codepoints);
+
+        private static IEnumerable<(string Path, int FaceIndex)> enumerateSystemEmojiCandidates()
+        {
+            string fonts = Environment.GetFolderPath(Environment.SpecialFolder.Fonts);
+
+            if (RuntimeInfo.OS == RuntimeInfo.Platform.Windows)
+            {
+                if (!string.IsNullOrEmpty(fonts))
+                {
+                    // Colour CBDT emoji first; Symbol is a mono/symbol fallback.
+                    yield return (Path.Combine(fonts, "seguiemj.ttf"), 0);
+                    yield return (Path.Combine(fonts, "seguisym.ttf"), 0);
+                }
+            }
+
+            if (RuntimeInfo.IsApple)
+            {
+                yield return ("/System/Library/Fonts/Apple Color Emoji.ttc", 0);
+                yield return ("/Library/Fonts/Apple Color Emoji.ttc", 0);
+                yield return ("/System/Library/Fonts/Supplemental/Apple Color Emoji.ttc", 0);
+            }
+
+            if (RuntimeInfo.OS == RuntimeInfo.Platform.Linux)
+            {
+                yield return ("/usr/share/fonts/truetype/noto/NotoColorEmoji.ttf", 0);
+                yield return ("/usr/share/fonts/noto/NotoColorEmoji.ttf", 0);
+                yield return ("/usr/share/fonts/google-noto-emoji/NotoColorEmoji.ttf", 0);
+                yield return ("/usr/share/fonts/truetype/noto-color-emoji/NotoColorEmoji.ttf", 0);
+                yield return ("/usr/local/share/fonts/NotoColorEmoji.ttf", 0);
+
+                string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+                if (!string.IsNullOrEmpty(home))
+                {
+                    yield return (Path.Combine(home, ".local", "share", "fonts", "NotoColorEmoji.ttf"), 0);
+                    yield return (Path.Combine(home, ".fonts", "NotoColorEmoji.ttf"), 0);
+                }
+            }
+        }
+
+        private static IEnumerable<string> knownSystemEmojiFamilyNames()
+        {
+            yield return "Segoe UI Emoji";
+            yield return "Segoe UI Symbol";
+            yield return "Apple Color Emoji";
+            yield return "Noto Color Emoji";
+            yield return "NotoColorEmoji";
+        }
+
+        private static IEnumerable<string> enumerateFontDirectories()
+        {
+            string fonts = Environment.GetFolderPath(Environment.SpecialFolder.Fonts);
+
+            if (!string.IsNullOrEmpty(fonts))
+                yield return fonts;
+
+            // Per-user Windows fonts
+            string local = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+
+            if (!string.IsNullOrEmpty(local))
+                yield return Path.Combine(local, "Microsoft", "Windows", "Fonts");
+
+            if (RuntimeInfo.IsApple)
+            {
+                yield return "/System/Library/Fonts";
+                yield return "/Library/Fonts";
+
+                string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+                if (!string.IsNullOrEmpty(home))
+                    yield return Path.Combine(home, "Library", "Fonts");
+            }
+
+            if (RuntimeInfo.OS == RuntimeInfo.Platform.Linux)
+            {
+                yield return "/usr/share/fonts";
+                yield return "/usr/local/share/fonts";
+
+                string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+                if (!string.IsNullOrEmpty(home))
+                {
+                    yield return Path.Combine(home, ".fonts");
+                    yield return Path.Combine(home, ".local", "share", "fonts");
+                }
+            }
+        }
+
+        private static bool isPreferredStyleFile(string path)
+        {
+            string name = Path.GetFileNameWithoutExtension(path);
+
+            return name.Contains("Regular", StringComparison.OrdinalIgnoreCase)
+                   || name.Contains("正常", StringComparison.OrdinalIgnoreCase)
+                   || name.EndsWith("Reg", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    public readonly record struct EzSystemFontEntry(string Family, string DisplayName, string Path, int FaceIndex);
+}

--- a/osu.Game/EzOsuGame/Fonts/EzUiFontBootstrap.cs
+++ b/osu.Game/EzOsuGame/Fonts/EzUiFontBootstrap.cs
@@ -1,0 +1,147 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Logging;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.Graphics;
+
+namespace osu.Game.EzOsuGame.Fonts
+{
+    /// <summary>
+    /// Registers system outline fonts: localized CJK fallbacks, platform emoji, and English UI typeface remaps.
+    /// Settings slots are entry points for choosing families — not the boundary of “system fonts”.
+    /// </summary>
+    public static class EzUiFontBootstrap
+    {
+        private static bool systemEmojiRegistered;
+        private static bool localizedFallbacksRegistered;
+
+        /// <summary>
+        /// Registers localized (CJK etc.) outline fonts into the empty-name fallback chain.
+        /// Must run before Noto CJK BMFont so missing glyphs prefer the user's system localized face.
+        /// </summary>
+        public static void RegisterLocalizedFallbacks(OsuGameBase game, Ez2ConfigManager ezConfig)
+        {
+            ArgumentNullException.ThrowIfNull(game);
+            ArgumentNullException.ThrowIfNull(ezConfig);
+
+            if (localizedFallbacksRegistered)
+                return;
+
+            localizedFallbacksRegistered = true;
+
+            tryRegisterFallback(game, EzUiFontIds.UI_DEFAULT_LOCALIZED, ezConfig.Get<string>(Ez2Setting.UiFontDefaultLocalized));
+            tryRegisterFallback(game, EzUiFontIds.TITLE_ALTERNATE_LOCALIZED, ezConfig.Get<string>(Ez2Setting.UiFontTitleAlternateLocalized));
+        }
+
+        /// <summary>
+        /// Registers the platform / configured colour emoji font into the global FontStore fallback chain.
+        /// Must run before resource BMFont emoji. Empty config = auto-detect; otherwise use the chosen family.
+        /// </summary>
+        public static void RegisterSystemEmojiFallback(OsuGameBase game, Ez2ConfigManager ezConfig)
+        {
+            ArgumentNullException.ThrowIfNull(game);
+            ArgumentNullException.ThrowIfNull(ezConfig);
+
+            if (systemEmojiRegistered)
+                return;
+
+            systemEmojiRegistered = true;
+
+            string configured = ezConfig.Get<string>(Ez2Setting.UiFontEmoji);
+            EzSystemFontEntry? entry = null;
+
+            if (!string.IsNullOrWhiteSpace(configured))
+            {
+                entry = EzSystemFontCatalog.FindByFamily(configured);
+
+                if (entry == null)
+                    Logger.Log($"Ez system emoji: configured family '{configured}' not found; falling back to platform auto-detect.", Ez2ConfigManager.LOGGER_NAME);
+            }
+
+            entry ??= EzSystemFontCatalog.FindSystemEmojiFont();
+
+            if (entry == null)
+            {
+                Logger.Log("Ez system emoji: no platform emoji font found; BMFont / resource emoji remain fallbacks.", Ez2ConfigManager.LOGGER_NAME);
+                return;
+            }
+
+            try
+            {
+                game.AddOutlineFontFromFile(entry.Value.Path, EzUiFontIds.EMOJI, entry.Value.FaceIndex);
+                Logger.Log($"Ez system emoji: {entry.Value.Family} -> {EzUiFontIds.EMOJI} ({entry.Value.Path})", Ez2ConfigManager.LOGGER_NAME);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"Ez system emoji: failed to load '{entry.Value.Path}': {ex.Message}", Ez2ConfigManager.LOGGER_NAME, LogLevel.Important);
+            }
+        }
+
+        /// <summary>
+        /// Remaps English UI / title / numeric typefaces to system outline families at cold start.
+        /// Localized faces are registered separately via <see cref="RegisterLocalizedFallbacks"/>.
+        /// </summary>
+        public static void Apply(OsuGameBase game, Ez2ConfigManager ezConfig)
+        {
+            ArgumentNullException.ThrowIfNull(game);
+            ArgumentNullException.ThrowIfNull(ezConfig);
+
+            OsuFont.ClearFamilyOverrides();
+
+            tryApplySlot(game, Typeface.Torus, EzUiFontIds.UI_DEFAULT, ezConfig.Get<string>(Ez2Setting.UiFontDefault));
+            tryApplySlot(game, Typeface.TorusAlternate, EzUiFontIds.TITLE_ALTERNATE, ezConfig.Get<string>(Ez2Setting.UiFontTitleAlternate));
+            tryApplySlot(game, Typeface.Venera, EzUiFontIds.NUMERIC, ezConfig.Get<string>(Ez2Setting.UiFontNumeric));
+        }
+
+        private static void tryRegisterFallback(OsuGameBase game, string lookupId, string systemFamily)
+        {
+            if (string.IsNullOrWhiteSpace(systemFamily))
+                return;
+
+            var entry = EzSystemFontCatalog.FindByFamily(systemFamily);
+
+            if (entry == null)
+            {
+                Logger.Log($"Ez localized font: system family '{systemFamily}' not found for {lookupId}.", Ez2ConfigManager.LOGGER_NAME);
+                return;
+            }
+
+            try
+            {
+                game.AddOutlineFontFromFile(entry.Value.Path, lookupId, entry.Value.FaceIndex);
+                Logger.Log($"Ez localized font: {entry.Value.Family} -> {lookupId}", Ez2ConfigManager.LOGGER_NAME);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"Ez localized font: failed to load '{entry.Value.Path}': {ex.Message}", Ez2ConfigManager.LOGGER_NAME, LogLevel.Important);
+            }
+        }
+
+        private static void tryApplySlot(OsuGameBase game, Typeface typeface, string lookupId, string systemFamily)
+        {
+            if (string.IsNullOrWhiteSpace(systemFamily))
+                return;
+
+            var entry = EzSystemFontCatalog.FindByFamily(systemFamily);
+
+            if (entry == null)
+            {
+                Logger.Log($"Ez UI font: system family '{systemFamily}' not found; keeping built-in for {typeface}.", Ez2ConfigManager.LOGGER_NAME);
+                return;
+            }
+
+            try
+            {
+                game.AddOutlineFontFromFile(entry.Value.Path, lookupId, entry.Value.FaceIndex);
+                OsuFont.SetFamilyOverride(typeface, lookupId);
+                Logger.Log($"Ez UI font: {typeface} -> {entry.Value.Family} ({lookupId})", Ez2ConfigManager.LOGGER_NAME);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"Ez UI font: failed to load '{entry.Value.Path}': {ex.Message}", Ez2ConfigManager.LOGGER_NAME, LogLevel.Important);
+            }
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Fonts/EzUiFontIds.cs
+++ b/osu.Game/EzOsuGame/Fonts/EzUiFontIds.cs
@@ -1,0 +1,23 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.EzOsuGame.Fonts
+{
+    /// <summary>
+    /// Stable <see cref="osu.Framework.Graphics.Sprites.FontUsage"/> family ids for system outline fonts.
+    /// English remaps are primary FontUsage; localized ids are empty-name fallbacks ahead of Noto CJK.
+    /// </summary>
+    public static class EzUiFontIds
+    {
+        public const string UI_DEFAULT = "EzSys-UiDefault";
+        public const string UI_DEFAULT_LOCALIZED = "EzSys-UiDefault-Loc";
+        public const string TITLE_ALTERNATE = "EzSys-TitleAlternate";
+        public const string TITLE_ALTERNATE_LOCALIZED = "EzSys-TitleAlternate-Loc";
+        public const string NUMERIC = "EzSys-Numeric";
+
+        /// <summary>
+        /// Platform colour emoji outline font, registered ahead of resource BMFont emoji for empty-name fallback.
+        /// </summary>
+        public const string EMOJI = "EzSys-Emoji";
+    }
+}

--- a/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
@@ -94,6 +94,67 @@ namespace osu.Game.EzOsuGame.Localization
             "选歌界面毛玻璃面板的模糊强度。总开关关闭时不生效。",
             "Blur strength for song select acrylic panels. Has no effect when acrylic UI is disabled.");
 
+        public static readonly EzLocalizationManager.EzLocalisableString UI_FONT_MODIFY =
+            new EzLocalizationManager.EzLocalisableString("修改字体", "Modify fonts");
+
+        public static readonly EzLocalizationManager.EzLocalisableString UI_FONT_MODIFY_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "选择系统字体：英文主字体 + 本地化缺字回退 + 系统 emoji（空=平台自动）。英语界面时英/本地化合一。更改下次启动生效。",
+            "Pick system fonts: English primary + localized fallback + system emoji (empty = platform auto). English UI merges EN/localized. Applies on next launch.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString UI_FONT_DIALOG_HEADER =
+            new EzLocalizationManager.EzLocalisableString("字体设置", "Font settings");
+
+        public static readonly EzLocalizationManager.EzLocalisableString UI_FONT_NEXT_LAUNCH =
+            new EzLocalizationManager.EzLocalisableString("下次启动时生效", "Takes effect on next launch");
+
+        public static readonly EzLocalizationManager.EzLocalisableString UI_FONT_SLOT_DEFAULT =
+            new EzLocalizationManager.EzLocalisableString("UI 默认", "UI default");
+
+        public static readonly EzLocalizationManager.EzLocalisableString UI_FONT_SLOT_DEFAULT_EN =
+            new EzLocalizationManager.EzLocalisableString("UI 英文", "UI English");
+
+        public static readonly EzLocalizationManager.EzLocalisableString UI_FONT_SLOT_DEFAULT_LOC =
+            new EzLocalizationManager.EzLocalisableString("UI 本地化", "UI localized");
+
+        public static readonly EzLocalizationManager.EzLocalisableString UI_FONT_SLOT_TITLE =
+            new EzLocalizationManager.EzLocalisableString("标题花体", "Title / alternate");
+
+        public static readonly EzLocalizationManager.EzLocalisableString UI_FONT_SLOT_TITLE_EN =
+            new EzLocalizationManager.EzLocalisableString("标题英文", "Title English");
+
+        public static readonly EzLocalizationManager.EzLocalisableString UI_FONT_SLOT_TITLE_LOC =
+            new EzLocalizationManager.EzLocalisableString("标题本地化", "Title localized");
+
+        public static readonly EzLocalizationManager.EzLocalisableString UI_FONT_SLOT_NUMERIC =
+            new EzLocalizationManager.EzLocalisableString("数字", "Numeric");
+
+        public static readonly EzLocalizationManager.EzLocalisableString UI_FONT_SLOT_EMOJI =
+            new EzLocalizationManager.EzLocalisableString("系统 Emoji", "System emoji");
+
+        public static readonly EzLocalizationManager.EzLocalisableString UI_FONT_NONE =
+            new EzLocalizationManager.EzLocalisableString("（未覆盖，使用内置）", "(No override — use built-in)");
+
+        public static readonly EzLocalizationManager.EzLocalisableString UI_FONT_EMOJI_AUTO =
+            new EzLocalizationManager.EzLocalisableString("（自动：平台默认彩色 emoji）", "(Auto — platform colour emoji)");
+
+        public static readonly EzLocalizationManager.EzLocalisableString UI_FONT_SEARCH =
+            new EzLocalizationManager.EzLocalisableString("搜索字体…", "Search fonts…");
+
+        public static readonly EzLocalizationManager.EzLocalisableString UI_FONT_PREVIEW_DEFAULT =
+            new EzLocalizationManager.EzLocalisableString("选歌与设置 Aa 测试", "Song select & settings Aa");
+
+        public static readonly EzLocalizationManager.EzLocalisableString UI_FONT_PREVIEW_TITLE =
+            new EzLocalizationManager.EzLocalisableString("Heading 标题", "Heading Title");
+
+        public static readonly EzLocalizationManager.EzLocalisableString UI_FONT_PREVIEW_NUMERIC =
+            new EzLocalizationManager.EzLocalisableString("0123456789", "0123456789");
+
+        public static readonly EzLocalizationManager.EzLocalisableString UI_FONT_PREVIEW_EMOJI =
+            new EzLocalizationManager.EzLocalisableString("😀🎉✨👍🔥", "😀🎉✨👍🔥");
+
+        public static readonly EzLocalizationManager.EzLocalisableString UI_FONT_CLOSE =
+            new EzLocalizationManager.EzLocalisableString("关闭", "Close");
+
         public static readonly EzLocalizationManager.EzLocalisableString NOTIFICATION_BEHAVIOUR =
             new EzLocalizationManager.EzLocalisableString("通知行为", "Notification behaviour");
 

--- a/osu.Game/EzOsuGame/Overlays/EzFontSettingsOverlay.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzFontSettingsOverlay.cs
@@ -1,0 +1,1183 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Rendering;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.Input.Events;
+using osu.Framework.IO.Stores;
+using osu.Framework.Localisation;
+using osu.Framework.Threading;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Fonts;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Localisation;
+using osu.Game.Overlays;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.EzOsuGame.Overlays
+{
+    /// <summary>
+    /// Dialog for picking system fonts. Writes config only; applies on next launch.
+    /// Visual style matches <see cref="osu.Game.Collections.ManageCollectionsDialog"/>.
+    /// </summary>
+    public partial class EzFontSettingsOverlay : OsuFocusedOverlayContainer
+    {
+        private const double enter_duration = 500;
+        private const double exit_duration = 200;
+        private const float list_height = 220;
+        private const double hover_font_dwell_ms = 200;
+
+        protected override string PopInSampleName => @"UI/overlay-big-pop-in";
+        protected override string PopOutSampleName => @"UI/overlay-big-pop-out";
+
+        private FillFlowContainer rows = null!;
+        private OsuSpriteText statusText = null!;
+        private IDisposable? duckOperation;
+        private IReadOnlyList<EzSystemFontEntry> catalogEntries = Array.Empty<EzSystemFontEntry>();
+        private IReadOnlyList<EzSystemFontEntry> emojiCatalogEntries = Array.Empty<EzSystemFontEntry>();
+        private readonly Dictionary<string, string> lookupIdByPath = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        private readonly HashSet<string> registeredLookupIds = new HashSet<string>(StringComparer.Ordinal);
+        private readonly HashSet<string> failedFontPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, Task<bool>> pendingFontRegistrations = new Dictionary<string, Task<bool>>(StringComparer.OrdinalIgnoreCase);
+        private readonly List<OutlineGlyphStore> dialogGlyphStores = new List<OutlineGlyphStore>();
+        private readonly object fontRegisterLock = new object();
+        private FontFamilyPicker? expandedPicker;
+        private FontStore? dialogFonts;
+        private bool dialogFontsActive;
+        private int sharedLookupSerial;
+
+        [Resolved]
+        private Ez2ConfigManager ezConfig { get; set; } = null!;
+
+        [Resolved]
+        private MusicController? musicController { get; set; }
+
+        [Resolved(CanBeNull = true)]
+        private SettingsOverlay? settings { get; set; }
+
+        [Resolved]
+        private OsuGameBase game { get; set; } = null!;
+
+        [Resolved]
+        private FontStore fonts { get; set; } = null!;
+
+        [Resolved]
+        private IRenderer renderer { get; set; } = null!;
+
+        public EzFontSettingsOverlay()
+        {
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+
+            RelativeSizeAxes = Axes.Both;
+            Size = new Vector2(0.58f, 0.78f);
+
+            Masking = true;
+            CornerRadius = 10;
+        }
+
+        /// <summary>
+        /// Open from settings: hide the settings sidebar first so the modal matches collection / BMS managers.
+        /// </summary>
+        public void ShowFromSettings()
+        {
+            settings?.Hide();
+            Show();
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            Children = new Drawable[]
+            {
+                new Box
+                {
+                    Colour = colours.GreySeaFoamDark,
+                    RelativeSizeAxes = Axes.Both,
+                },
+                new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = new GridContainer
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        RowDimensions = new[]
+                        {
+                            new Dimension(GridSizeMode.AutoSize),
+                            new Dimension(),
+                        },
+                        Content = new[]
+                        {
+                            new Drawable[]
+                            {
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    Children = new Drawable[]
+                                    {
+                                        new FillFlowContainer
+                                        {
+                                            RelativeSizeAxes = Axes.X,
+                                            AutoSizeAxes = Axes.Y,
+                                            Direction = FillDirection.Vertical,
+                                            Padding = new MarginPadding { Vertical = 10, Horizontal = 20 },
+                                            Children = new Drawable[]
+                                            {
+                                                new OsuSpriteText
+                                                {
+                                                    Anchor = Anchor.TopCentre,
+                                                    Origin = Anchor.TopCentre,
+                                                    Text = EzSettingsStrings.UI_FONT_DIALOG_HEADER,
+                                                    Font = OsuFont.GetFont(size: 30),
+                                                },
+                                                new OsuSpriteText
+                                                {
+                                                    Anchor = Anchor.TopCentre,
+                                                    Origin = Anchor.TopCentre,
+                                                    Text = EzSettingsStrings.UI_FONT_NEXT_LAUNCH,
+                                                    Font = OsuFont.GetFont(size: 14),
+                                                    Colour = colours.Yellow,
+                                                    Margin = new MarginPadding { Top = 4 },
+                                                },
+                                                statusText = new OsuSpriteText
+                                                {
+                                                    Anchor = Anchor.TopCentre,
+                                                    Origin = Anchor.TopCentre,
+                                                    Font = OsuFont.GetFont(size: 12),
+                                                    Colour = colours.GreySeaFoamLighter,
+                                                    Margin = new MarginPadding { Top = 2 },
+                                                },
+                                            }
+                                        },
+                                        new IconButton
+                                        {
+                                            Anchor = Anchor.CentreRight,
+                                            Origin = Anchor.CentreRight,
+                                            Icon = FontAwesome.Solid.Times,
+                                            Colour = colours.GreySeaFoamDarker,
+                                            Scale = new Vector2(0.8f),
+                                            X = -10,
+                                            Action = Hide,
+                                        }
+                                    }
+                                }
+                            },
+                            new Drawable[]
+                            {
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Masking = true,
+                                    Children = new Drawable[]
+                                    {
+                                        new Box
+                                        {
+                                            RelativeSizeAxes = Axes.Both,
+                                            Colour = colours.GreySeaFoamDarker,
+                                        },
+                                        new OsuScrollContainer
+                                        {
+                                            RelativeSizeAxes = Axes.Both,
+                                            ClampExtension = 0,
+                                            Padding = new MarginPadding(16),
+                                            Child = rows = new FillFlowContainer
+                                            {
+                                                RelativeSizeAxes = Axes.X,
+                                                AutoSizeAxes = Axes.Y,
+                                                Direction = FillDirection.Vertical,
+                                                Spacing = new Vector2(0, 12),
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                        }
+                    }
+                }
+            };
+
+            rebuildSlots();
+        }
+
+        private void rebuildSlots()
+        {
+            rows.Clear();
+
+            bool englishUi = game.CurrentLanguage.Value == Language.en;
+
+            var uiEn = ezConfig.GetBindable<string>(Ez2Setting.UiFontDefault);
+            var uiLoc = ezConfig.GetBindable<string>(Ez2Setting.UiFontDefaultLocalized);
+            var titleEn = ezConfig.GetBindable<string>(Ez2Setting.UiFontTitleAlternate);
+            var titleLoc = ezConfig.GetBindable<string>(Ez2Setting.UiFontTitleAlternateLocalized);
+            var numeric = ezConfig.GetBindable<string>(Ez2Setting.UiFontNumeric);
+
+            if (englishUi)
+            {
+                rows.Add(new FontSlotRow(
+                    this,
+                    "EzPreview-Ui",
+                    EzSettingsStrings.UI_FONT_SLOT_DEFAULT,
+                    EzSettingsStrings.UI_FONT_PREVIEW_DEFAULT,
+                    uiEn,
+                    syncLocalized: uiLoc));
+                rows.Add(new FontSlotRow(
+                    this,
+                    "EzPreview-Title",
+                    EzSettingsStrings.UI_FONT_SLOT_TITLE,
+                    EzSettingsStrings.UI_FONT_PREVIEW_TITLE,
+                    titleEn,
+                    syncLocalized: titleLoc));
+            }
+            else
+            {
+                rows.Add(new FontSlotRow(
+                    this,
+                    "EzPreview-UiEn",
+                    EzSettingsStrings.UI_FONT_SLOT_DEFAULT_EN,
+                    EzSettingsStrings.UI_FONT_PREVIEW_DEFAULT,
+                    uiEn));
+                rows.Add(new FontSlotRow(
+                    this,
+                    "EzPreview-UiLoc",
+                    EzSettingsStrings.UI_FONT_SLOT_DEFAULT_LOC,
+                    EzSettingsStrings.UI_FONT_PREVIEW_DEFAULT,
+                    uiLoc));
+                rows.Add(new FontSlotRow(
+                    this,
+                    "EzPreview-TitleEn",
+                    EzSettingsStrings.UI_FONT_SLOT_TITLE_EN,
+                    EzSettingsStrings.UI_FONT_PREVIEW_TITLE,
+                    titleEn));
+                rows.Add(new FontSlotRow(
+                    this,
+                    "EzPreview-TitleLoc",
+                    EzSettingsStrings.UI_FONT_SLOT_TITLE_LOC,
+                    EzSettingsStrings.UI_FONT_PREVIEW_TITLE,
+                    titleLoc));
+            }
+
+            rows.Add(new FontSlotRow(
+                this,
+                "EzPreview-Numeric",
+                EzSettingsStrings.UI_FONT_SLOT_NUMERIC,
+                EzSettingsStrings.UI_FONT_PREVIEW_NUMERIC,
+                numeric));
+            rows.Add(new FontSlotRow(
+                this,
+                "EzPreview-Emoji",
+                EzSettingsStrings.UI_FONT_SLOT_EMOJI,
+                EzSettingsStrings.UI_FONT_PREVIEW_EMOJI,
+                ezConfig.GetBindable<string>(Ez2Setting.UiFontEmoji),
+                noneLabel: EzSettingsStrings.UI_FONT_EMOJI_AUTO,
+                emojiCatalog: true));
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+            duckOperation?.Dispose();
+            dialogFontsActive = false;
+            releaseDialogFonts();
+        }
+
+        protected override void PopIn()
+        {
+            dialogFontsActive = true;
+            ensureDialogFontStore();
+
+            duckOperation = musicController?.Duck(new DuckParameters
+            {
+                DuckVolumeTo = 1,
+                DuckDuration = 100,
+                RestoreDuration = 100,
+            });
+
+            this.FadeIn(enter_duration, Easing.OutQuint);
+            this.ScaleTo(0.9f).Then().ScaleTo(1f, enter_duration, Easing.OutQuint);
+
+            if (catalogEntries.Count > 0)
+            {
+                applyCatalogsToRows();
+                restoreDialogFontPreviews();
+                statusText.Text = $"{catalogEntries.Count} / emoji {emojiCatalogEntries.Count}";
+            }
+            else
+            {
+                Schedule(loadFontListAsync);
+            }
+        }
+
+        protected override void PopOut()
+        {
+            base.PopOut();
+
+            duckOperation?.Dispose();
+            collapseExpandedPicker();
+            dialogFontsActive = false;
+            releaseDialogFonts();
+
+            this.FadeOut(exit_duration, Easing.OutQuint);
+            this.ScaleTo(0.9f, exit_duration);
+
+            GetContainingFocusManager()?.TriggerFocusContention(this);
+        }
+
+        /// <summary>
+        /// Preview faces live in a nested FontStore with its own 4096 atlas so rapid browsing
+        /// does not overflow the global UI FontStore. Released on dialog close.
+        /// </summary>
+        private void ensureDialogFontStore()
+        {
+            if (dialogFonts != null || !dialogFontsActive)
+                return;
+
+            dialogFonts = new FontStore(renderer, null, 100, TextureFilteringMode.Linear);
+            fonts.AddStore(dialogFonts);
+        }
+
+        private void releaseDialogFonts()
+        {
+            resetDialogFontUsages();
+
+            lock (fontRegisterLock)
+            {
+                foreach (var store in dialogGlyphStores)
+                {
+                    dialogFonts?.RemoveTextureStore(store);
+                    store.Dispose();
+                }
+
+                dialogGlyphStores.Clear();
+                registeredLookupIds.Clear();
+                lookupIdByPath.Clear();
+                pendingFontRegistrations.Clear();
+            }
+
+            if (dialogFonts != null)
+            {
+                fonts.RemoveStore(dialogFonts);
+                fonts.EvictGlyphCache(name => name.StartsWith("EzDlg-", StringComparison.Ordinal));
+                dialogFonts.ClearCache(disposeAtlas: true);
+                dialogFonts.Dispose();
+                dialogFonts = null;
+            }
+        }
+
+        private void resetDialogFontUsages()
+        {
+            if (rows == null)
+                return;
+
+            foreach (var child in rows)
+            {
+                if (child is FontSlotRow row)
+                    row.ResetDialogFonts();
+            }
+        }
+
+        private void restoreDialogFontPreviews()
+        {
+            if (rows == null)
+                return;
+
+            foreach (var child in rows)
+            {
+                if (child is FontSlotRow row)
+                    row.RestoreDialogFonts();
+            }
+        }
+
+        private void applyCatalogsToRows()
+        {
+            foreach (var child in rows)
+            {
+                if (child is FontSlotRow row)
+                    row.SetCatalog(row.UseEmojiCatalog ? emojiCatalogEntries : catalogEntries);
+            }
+        }
+
+        private void loadFontListAsync()
+        {
+            statusText.Text = "…";
+
+            Task.Run(() =>
+                {
+                    var all = EzSystemFontCatalog.GetEntries();
+                    var emoji = EzSystemFontCatalog.GetEmojiEntries();
+                    return (all, emoji);
+                })
+                .ContinueWith(t => Schedule(() =>
+                {
+                    if (t.IsFaulted)
+                    {
+                        statusText.Text = t.Exception?.GetBaseException().Message ?? "error";
+                        return;
+                    }
+
+                    var result = t.GetResultSafely();
+                    catalogEntries = result.all;
+                    emojiCatalogEntries = result.emoji;
+                    applyCatalogsToRows();
+                    statusText.Text = $"{catalogEntries.Count} / emoji {emojiCatalogEntries.Count}";
+                }));
+        }
+
+        private void notifyPickerExpanded(FontFamilyPicker picker)
+        {
+            if (expandedPicker != null && expandedPicker != picker)
+                expandedPicker.SetExpanded(false);
+
+            expandedPicker = picker.Expanded ? picker : null;
+        }
+
+        private void collapseExpandedPicker()
+        {
+            expandedPicker?.SetExpanded(false);
+            expandedPicker = null;
+        }
+
+        /// <summary>
+        /// Dialog-scoped FontStore id for a font file — shared across all slots/list rows so each face loads once.
+        /// </summary>
+        private string getSharedLookupId(string path)
+        {
+            lock (fontRegisterLock)
+                return getSharedLookupIdUnlocked(path);
+        }
+
+        private string getSharedLookupIdUnlocked(string path)
+        {
+            if (lookupIdByPath.TryGetValue(path, out string? existing))
+                return existing;
+
+            string id = $"EzDlg-{Interlocked.Increment(ref sharedLookupSerial)}";
+            lookupIdByPath[path] = id;
+            return id;
+        }
+
+        private bool tryGetRegisteredLookupId(string family, out string lookupId)
+        {
+            lookupId = string.Empty;
+            var entry = EzSystemFontCatalog.FindByFamily(family);
+            if (entry == null)
+                return false;
+
+            lock (fontRegisterLock)
+            {
+                if (!lookupIdByPath.TryGetValue(entry.Value.Path, out string? id))
+                    return false;
+
+                if (!registeredLookupIds.Contains(id))
+                    return false;
+
+                lookupId = id;
+                return true;
+            }
+        }
+
+        private Task<bool> ensureFontRegisteredAsync(string path, int faceIndex)
+        {
+            lock (fontRegisterLock)
+            {
+                if (failedFontPaths.Contains(path))
+                    return Task.FromResult(false);
+
+                string lookupId = getSharedLookupIdUnlocked(path);
+
+                if (registeredLookupIds.Contains(lookupId))
+                    return Task.FromResult(true);
+
+                if (pendingFontRegistrations.TryGetValue(path, out var pending))
+                    return pending;
+
+                var task = registerFontCoreAsync(path, lookupId, faceIndex);
+                pendingFontRegistrations[path] = task;
+                return task;
+            }
+        }
+
+        private async Task<bool> registerFontCoreAsync(string path, string lookupId, int faceIndex)
+        {
+            OutlineGlyphStore? store = null;
+
+            try
+            {
+                store = new OutlineGlyphStore(path, lookupId, faceIndex);
+                await store.LoadFontAsync().ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                store?.Dispose();
+
+                lock (fontRegisterLock)
+                {
+                    failedFontPaths.Add(path);
+                    pendingFontRegistrations.Remove(path);
+                }
+
+                return false;
+            }
+
+            var tcs = new TaskCompletionSource<bool>();
+
+            Schedule(() =>
+            {
+                try
+                {
+                    lock (fontRegisterLock)
+                    {
+                        if (!dialogFontsActive)
+                        {
+                            store.Dispose();
+                            pendingFontRegistrations.Remove(path);
+                            tcs.TrySetResult(false);
+                            return;
+                        }
+
+                        ensureDialogFontStore();
+
+                        if (dialogFonts == null)
+                        {
+                            store.Dispose();
+                            pendingFontRegistrations.Remove(path);
+                            tcs.TrySetResult(false);
+                            return;
+                        }
+
+                        if (registeredLookupIds.Add(lookupId))
+                        {
+                            dialogFonts.AddTextureSource(store);
+                            dialogGlyphStores.Add(store);
+                        }
+                        else
+                            store.Dispose();
+
+                        pendingFontRegistrations.Remove(path);
+                    }
+
+                    tcs.TrySetResult(true);
+                }
+                catch (Exception ex)
+                {
+                    store.Dispose();
+
+                    lock (fontRegisterLock)
+                    {
+                        failedFontPaths.Add(path);
+                        pendingFontRegistrations.Remove(path);
+                    }
+
+                    tcs.TrySetException(ex);
+                }
+            });
+
+            try
+            {
+                return await tcs.Task.ConfigureAwait(false);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static void fireAndForget(Task task)
+        {
+            task.ContinueWith(t =>
+            {
+                // Observe failures from UI fire-and-forget loads (bad system fonts, etc.).
+                _ = t.Exception;
+            }, TaskContinuationOptions.OnlyOnFaulted);
+        }
+
+        private partial class FontSlotRow : Container
+        {
+            private readonly EzFontSettingsOverlay owner;
+            private readonly string previewIdPrefix;
+            private readonly Bindable<string> current;
+            private readonly Bindable<string>? syncLocalized;
+            private readonly OsuSpriteText previewText;
+            private readonly FontFamilyPicker picker;
+            private int previewRequestId;
+
+            public bool UseEmojiCatalog { get; }
+
+            public FontSlotRow(
+                EzFontSettingsOverlay owner,
+                string previewIdPrefix,
+                LocalisableString caption,
+                LocalisableString preview,
+                Bindable<string> current,
+                Bindable<string>? syncLocalized = null,
+                LocalisableString? noneLabel = null,
+                bool emojiCatalog = false)
+            {
+                this.owner = owner;
+                this.previewIdPrefix = previewIdPrefix;
+                this.current = current;
+                this.syncLocalized = syncLocalized;
+                UseEmojiCatalog = emojiCatalog;
+
+                RelativeSizeAxes = Axes.X;
+                AutoSizeAxes = Axes.Y;
+
+                picker = new FontFamilyPicker(owner, previewIdPrefix, current, noneLabel ?? EzSettingsStrings.UI_FONT_NONE)
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Width = 1,
+                };
+
+                previewText = new OsuSpriteText
+                {
+                    Text = preview,
+                    Font = OsuFont.GetFont(size: 18),
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    Margin = new MarginPadding { Left = 8 },
+                };
+
+                Child = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Vertical,
+                    Spacing = new Vector2(0, 6),
+                    Children = new Drawable[]
+                    {
+                        new OsuSpriteText
+                        {
+                            Text = caption,
+                            Font = OsuFont.GetFont(size: 14, weight: FontWeight.SemiBold),
+                        },
+                        new GridContainer
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            ColumnDimensions = new[]
+                            {
+                                new Dimension(GridSizeMode.Relative, 0.62f),
+                                new Dimension(),
+                            },
+                            RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) },
+                            Content = new[]
+                            {
+                                new Drawable[]
+                                {
+                                    picker,
+                                    previewText,
+                                }
+                            }
+                        }
+                    }
+                };
+
+                current.BindValueChanged(v =>
+                {
+                    if (syncLocalized != null)
+                        syncLocalized.Value = v.NewValue;
+
+                    updatePreview(v.NewValue);
+                }, true);
+            }
+
+            public void SetCatalog(IReadOnlyList<EzSystemFontEntry> entries) => picker.SetCatalog(entries);
+
+            public void ResetDialogFonts()
+            {
+                Interlocked.Increment(ref previewRequestId);
+                previewText.Font = OsuFont.GetFont(size: 18);
+                picker.ResetDialogFonts();
+            }
+
+            public void RestoreDialogFonts()
+            {
+                updatePreview(current.Value);
+                picker.RestoreDialogFonts();
+            }
+
+            private void updatePreview(string family)
+            {
+                int requestId = Interlocked.Increment(ref previewRequestId);
+
+                if (string.IsNullOrEmpty(family))
+                {
+                    previewText.Font = OsuFont.GetFont(size: 18);
+                    return;
+                }
+
+                if (owner.tryGetRegisteredLookupId(family, out string lookupId))
+                {
+                    previewText.Font = new FontUsage(lookupId, 18);
+                    return;
+                }
+
+                var entry = EzSystemFontCatalog.FindByFamily(family);
+
+                if (entry == null)
+                {
+                    previewText.Font = OsuFont.GetFont(size: 18);
+                    return;
+                }
+
+                previewText.Font = OsuFont.GetFont(size: 18);
+                fireAndForget(applyPreviewAsync(requestId, entry.Value.Path, entry.Value.FaceIndex));
+            }
+
+            private async Task applyPreviewAsync(int requestId, string path, int faceIndex)
+            {
+                bool ok = await owner.ensureFontRegisteredAsync(path, faceIndex).ConfigureAwait(false);
+
+                Schedule(() =>
+                {
+                    if (requestId != previewRequestId)
+                        return;
+
+                    previewText.Font = ok
+                        ? new FontUsage(owner.getSharedLookupId(path), 18)
+                        : OsuFont.GetFont(size: 18);
+                });
+            }
+        }
+
+        private partial class FontFamilyPicker : Container
+        {
+            private readonly EzFontSettingsOverlay owner;
+            private readonly string previewIdPrefix;
+            private readonly Bindable<string> current;
+            private readonly TruncatingSpriteText headerLabel;
+            private readonly Container listPanel;
+            private readonly FillFlowContainer listFlow;
+            private readonly OsuScrollContainer listScroll;
+            private readonly SearchTextBox searchBox;
+            private readonly string noneLabel;
+            private IReadOnlyList<EzSystemFontEntry> catalog = Array.Empty<EzSystemFontEntry>();
+            private readonly List<FontListItem> items = new List<FontListItem>();
+            private FontListItem? selectedItem;
+
+            public bool Expanded { get; private set; }
+
+            public FontFamilyPicker(EzFontSettingsOverlay owner, string previewIdPrefix, Bindable<string> current, LocalisableString noneLabelSource)
+            {
+                this.owner = owner;
+                this.previewIdPrefix = previewIdPrefix;
+                this.current = current;
+                noneLabel = noneLabelSource.ToString();
+
+                AutoSizeAxes = Axes.Y;
+                Masking = true;
+                CornerRadius = 5;
+
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = Color4.Black.Opacity(0.25f),
+                    },
+                    new FillFlowContainer
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Direction = FillDirection.Vertical,
+                        Children = new Drawable[]
+                        {
+                            new HeaderButton
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                Height = 36,
+                                Action = toggleExpanded,
+                                Child = headerLabel = new TruncatingSpriteText
+                                {
+                                    Anchor = Anchor.CentreLeft,
+                                    Origin = Anchor.CentreLeft,
+                                    RelativeSizeAxes = Axes.X,
+                                    Margin = new MarginPadding { Horizontal = 10 },
+                                    Font = OsuFont.GetFont(size: 16),
+                                }
+                            },
+                            listPanel = new Container
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                Height = 0,
+                                Masking = true,
+                                Children = new Drawable[]
+                                {
+                                    new Box
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        Colour = Color4.Black.Opacity(0.35f),
+                                    },
+                                    new FillFlowContainer
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        Direction = FillDirection.Vertical,
+                                        Padding = new MarginPadding(6),
+                                        Spacing = new Vector2(0, 4),
+                                        Children = new Drawable[]
+                                        {
+                                            searchBox = new SearchTextBox
+                                            {
+                                                RelativeSizeAxes = Axes.X,
+                                                Height = 30,
+                                            },
+                                            listScroll = new OsuScrollContainer
+                                            {
+                                                RelativeSizeAxes = Axes.X,
+                                                Height = list_height - 46,
+                                                Child = listFlow = new FillFlowContainer
+                                                {
+                                                    RelativeSizeAxes = Axes.X,
+                                                    AutoSizeAxes = Axes.Y,
+                                                    Direction = FillDirection.Vertical,
+                                                    Spacing = new Vector2(0, 2),
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+
+                searchBox.Current.BindValueChanged(_ => applyFilter(), true);
+                current.BindValueChanged(_ => refreshHeader(), true);
+            }
+
+            public void SetCatalog(IReadOnlyList<EzSystemFontEntry> entries)
+            {
+                if (!ReferenceEquals(catalog, entries) || items.Count == 0)
+                {
+                    catalog = entries;
+                    rebuildList();
+                }
+                else
+                {
+                    markSelected();
+                }
+
+                refreshHeader();
+
+                if (Expanded)
+                    Schedule(scrollToSelected);
+            }
+
+            public void SetExpanded(bool expanded)
+            {
+                if (Expanded == expanded)
+                    return;
+
+                Expanded = expanded;
+                listPanel.Height = expanded ? list_height : 0;
+
+                if (expanded)
+                {
+                    owner.notifyPickerExpanded(this);
+                    Schedule(() =>
+                    {
+                        GetContainingFocusManager()?.ChangeFocus(searchBox);
+                        scrollToSelected();
+                    });
+                }
+                else if (owner.expandedPicker == this)
+                {
+                    owner.expandedPicker = null;
+                }
+            }
+
+            public void ResetDialogFonts()
+            {
+                foreach (var item in items)
+                    item.ResetOwnFont();
+
+                headerLabel.Font = OsuFont.GetFont(size: 16);
+            }
+
+            public void RestoreDialogFonts()
+            {
+                refreshHeader();
+                markSelected();
+            }
+
+            private void toggleExpanded() => SetExpanded(!Expanded);
+
+            private void refreshHeader()
+            {
+                string family = current.Value;
+
+                if (string.IsNullOrEmpty(family))
+                {
+                    headerLabel.Text = noneLabel;
+                    headerLabel.Font = OsuFont.GetFont(size: 16);
+                    return;
+                }
+
+                string display = family;
+
+                foreach (var entry in catalog)
+                {
+                    if (string.Equals(entry.Family, family, StringComparison.OrdinalIgnoreCase))
+                    {
+                        display = entry.DisplayName;
+                        break;
+                    }
+                }
+
+                headerLabel.Text = display;
+
+                if (owner.tryGetRegisteredLookupId(family, out string lookupId))
+                {
+                    headerLabel.Font = new FontUsage(lookupId, 16);
+                    return;
+                }
+
+                headerLabel.Font = OsuFont.GetFont(size: 16);
+
+                var resolved = EzSystemFontCatalog.FindByFamily(family);
+                if (resolved == null)
+                    return;
+
+                fireAndForget(loadHeaderFontAsync(resolved.Value.Path, resolved.Value.FaceIndex, family));
+            }
+
+            private async Task loadHeaderFontAsync(string path, int faceIndex, string family)
+            {
+                bool ok = await owner.ensureFontRegisteredAsync(path, faceIndex).ConfigureAwait(false);
+
+                Schedule(() =>
+                {
+                    if (!ok || !string.Equals(current.Value, family, StringComparison.OrdinalIgnoreCase))
+                        return;
+
+                    headerLabel.Font = new FontUsage(owner.getSharedLookupId(path), 16);
+                });
+            }
+
+            private void rebuildList()
+            {
+                listFlow.Clear();
+                items.Clear();
+                selectedItem = null;
+
+                var noneItem = new FontListItem(owner, string.Empty, noneLabel, () => selectFamily(string.Empty));
+                items.Add(noneItem);
+                listFlow.Add(noneItem);
+
+                foreach (var entry in catalog)
+                {
+                    var item = new FontListItem(owner, entry.Family, entry.DisplayName, () => selectFamily(entry.Family));
+                    items.Add(item);
+                    listFlow.Add(item);
+                }
+
+                applyFilter();
+                markSelected();
+            }
+
+            private void applyFilter()
+            {
+                string filter = searchBox.Current.Value?.Trim() ?? string.Empty;
+
+                foreach (var item in items)
+                {
+                    bool match = string.IsNullOrEmpty(filter)
+                                 || item.Family.Contains(filter, StringComparison.CurrentCultureIgnoreCase)
+                                 || item.DisplayName.Contains(filter, StringComparison.CurrentCultureIgnoreCase)
+                                 || (string.IsNullOrEmpty(item.Family) && noneLabel.Contains(filter, StringComparison.CurrentCultureIgnoreCase));
+
+                    item.Alpha = match ? 1 : 0;
+                    item.Height = match ? 28 : 0;
+                }
+            }
+
+            private void selectFamily(string family)
+            {
+                current.Value = family;
+                markSelected();
+                SetExpanded(false);
+            }
+
+            private void markSelected()
+            {
+                selectedItem = null;
+
+                foreach (var item in items)
+                {
+                    bool selected = string.Equals(item.Family, current.Value, StringComparison.OrdinalIgnoreCase);
+                    item.SetSelected(selected);
+
+                    if (selected)
+                        selectedItem = item;
+                }
+            }
+
+            private void scrollToSelected()
+            {
+                markSelected();
+
+                if (selectedItem == null || selectedItem.Alpha < 1)
+                    return;
+
+                listScroll.ScrollIntoView(selectedItem, false);
+            }
+
+            private partial class HeaderButton : OsuClickableContainer
+            {
+                public HeaderButton()
+                {
+                    RelativeSizeAxes = Axes.X;
+                }
+            }
+        }
+
+        private partial class FontListItem : OsuClickableContainer
+        {
+            private readonly EzFontSettingsOverlay owner;
+            private readonly TruncatingSpriteText label;
+            private readonly Box background;
+            private bool selected;
+            private bool fontApplied;
+            private int loadRequestId;
+            private ScheduledDelegate? hoverFontLoad;
+
+            public string Family { get; }
+            public string DisplayName { get; }
+
+            public FontListItem(EzFontSettingsOverlay owner, string family, string displayName, Action action)
+            {
+                this.owner = owner;
+                Family = family;
+                DisplayName = displayName;
+                Action = action;
+                TooltipText = displayName;
+
+                RelativeSizeAxes = Axes.X;
+                Height = 28;
+
+                Children = new Drawable[]
+                {
+                    background = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = Color4.White,
+                        Alpha = 0,
+                    },
+                    label = new TruncatingSpriteText
+                    {
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        RelativeSizeAxes = Axes.X,
+                        Margin = new MarginPadding { Horizontal = 8 },
+                        Text = displayName,
+                        Font = OsuFont.GetFont(size: 15),
+                    }
+                };
+
+                if (!string.IsNullOrEmpty(family) && owner.tryGetRegisteredLookupId(family, out string lookupId))
+                {
+                    label.Font = new FontUsage(lookupId, 15);
+                    fontApplied = true;
+                }
+            }
+
+            public void ResetOwnFont()
+            {
+                hoverFontLoad?.Cancel();
+                hoverFontLoad = null;
+                Interlocked.Increment(ref loadRequestId);
+                fontApplied = false;
+                label.Font = OsuFont.GetFont(size: 15);
+            }
+
+            public void SetSelected(bool value)
+            {
+                selected = value;
+                background.Alpha = selected ? 0.18f : 0;
+
+                if (selected && !string.IsNullOrEmpty(Family))
+                {
+                    hoverFontLoad?.Cancel();
+                    hoverFontLoad = null;
+                    ensureOwnFont();
+                }
+            }
+
+            protected override bool OnHover(HoverEvent e)
+            {
+                if (!selected)
+                    background.Alpha = 0.08f;
+
+                if (!string.IsNullOrEmpty(Family) && !fontApplied)
+                {
+                    hoverFontLoad?.Cancel();
+                    hoverFontLoad = Scheduler.AddDelayed(ensureOwnFont, hover_font_dwell_ms);
+                }
+
+                return base.OnHover(e);
+            }
+
+            protected override void OnHoverLost(HoverLostEvent e)
+            {
+                hoverFontLoad?.Cancel();
+                hoverFontLoad = null;
+                background.Alpha = selected ? 0.18f : 0;
+                base.OnHoverLost(e);
+            }
+
+            private void ensureOwnFont()
+            {
+                if (fontApplied)
+                    return;
+
+                if (owner.tryGetRegisteredLookupId(Family, out string lookupId))
+                {
+                    label.Font = new FontUsage(lookupId, 15);
+                    fontApplied = true;
+                    return;
+                }
+
+                fireAndForget(loadOwnFontAsync());
+            }
+
+            private async Task loadOwnFontAsync()
+            {
+                int requestId = Interlocked.Increment(ref loadRequestId);
+                var entry = EzSystemFontCatalog.FindByFamily(Family);
+
+                if (entry == null)
+                    return;
+
+                bool ok = await owner.ensureFontRegisteredAsync(entry.Value.Path, entry.Value.FaceIndex).ConfigureAwait(false);
+
+                Schedule(() =>
+                {
+                    if (requestId != loadRequestId || !ok)
+                        return;
+
+                    label.Font = new FontUsage(owner.getSharedLookupId(entry.Value.Path), 15);
+                    fontApplied = true;
+                });
+            }
+        }
+
+        // Legacy per-slot lookup ids removed — fonts are cached per file path for the dialog lifetime.
+    }
+}

--- a/osu.Game/EzOsuGame/Overlays/EzUISettings.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzUISettings.cs
@@ -15,6 +15,9 @@ namespace osu.Game.EzOsuGame.Overlays
     {
         protected override LocalisableString Header => EzSettingsStrings.EZ_UI_SETTINGS_HEADER;
 
+        [Resolved(CanBeNull = true)]
+        private EzFontSettingsOverlay? fontOverlay { get; set; }
+
         [BackgroundDependencyLoader]
         private void load(Ez2ConfigManager ezConfig)
         {
@@ -55,6 +58,13 @@ namespace osu.Game.EzOsuGame.Overlays
                 })
                 {
                     Keywords = new[] { "acrylic", "glass", "blur", "song select", "ui", "毛玻璃" }
+                },
+                new SettingsButtonV2
+                {
+                    Text = EzSettingsStrings.UI_FONT_MODIFY,
+                    TooltipText = EzSettingsStrings.UI_FONT_MODIFY_TOOLTIP,
+                    Action = () => fontOverlay?.ShowFromSettings(),
+                    Keywords = new[] { "font", "typeface", "ui", "system", "字体" }
                 },
                 new SettingsItemV2(new FormSliderBar<double>
                 {

--- a/osu.Game/Graphics/OsuFont.cs
+++ b/osu.Game/Graphics/OsuFont.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System.Collections.Generic;
 using System.ComponentModel;
 using osu.Framework.Graphics.Sprites;
 
@@ -15,6 +16,8 @@ namespace osu.Game.Graphics
         /// </summary>
         public const float DEFAULT_FONT_SIZE = 16;
 
+        private static readonly Dictionary<Typeface, string> family_overrides = new Dictionary<Typeface, string>();
+
         /// <summary>
         /// Template font styles which should be preferred whenever possible for UI elements.
         /// </summary>
@@ -26,32 +29,32 @@ namespace osu.Game.Graphics
             public static FontUsage Title => GetFont(Typeface.TorusAlternate, size: 32, weight: FontWeight.Regular);
 
             /// <summary>
-            /// Torus with 28px size and semi-bold weight.
+            /// Default UI typeface with 28px size and regular weight.
             /// </summary>
             public static FontUsage Subtitle => GetFont(size: 28, weight: FontWeight.Regular);
 
             /// <summary>
-            /// Torus with 22px size and bold weight.
+            /// Default UI typeface with 22px size and bold weight.
             /// </summary>
             public static FontUsage Heading1 => GetFont(size: 22, weight: FontWeight.Bold);
 
             /// <summary>
-            /// Torus with 18px size and semi-bold weight.
+            /// Default UI typeface with 18px size and semi-bold weight.
             /// </summary>
             public static FontUsage Heading2 => GetFont(size: 18, weight: FontWeight.SemiBold);
 
             /// <summary>
-            /// Torus with 16px size and regular weight.
+            /// Default UI typeface with 16px size and regular weight.
             /// </summary>
             public static FontUsage Body => GetFont(size: DEFAULT_FONT_SIZE, weight: FontWeight.Regular);
 
             /// <summary>
-            /// Torus with 14px size and regular weight.
+            /// Default UI typeface with 14px size and regular weight.
             /// </summary>
             public static FontUsage Caption1 => GetFont(size: 14, weight: FontWeight.Regular);
 
             /// <summary>
-            /// Torus with 12px size and regular weight.
+            /// Default UI typeface with 12px size and regular weight.
             /// </summary>
             public static FontUsage Caption2 => GetFont(size: 12, weight: FontWeight.Regular);
         }
@@ -79,18 +82,32 @@ namespace osu.Game.Graphics
         public static FontUsage Inter => GetFont(Typeface.Inter, weight: FontWeight.Regular);
 
         /// <summary>
+        /// Remap a built-in <see cref="Typeface"/> to an alternate <see cref="FontUsage"/> family id
+        /// (e.g. a registered system outline font). Pass null/empty to clear.
+        /// </summary>
+        public static void SetFamilyOverride(Typeface typeface, string familyName)
+        {
+            if (string.IsNullOrWhiteSpace(familyName))
+                family_overrides.Remove(typeface);
+            else
+                family_overrides[typeface] = familyName;
+        }
+
+        public static void ClearFamilyOverrides() => family_overrides.Clear();
+
+        public static bool HasFamilyOverride(Typeface typeface) => family_overrides.ContainsKey(typeface);
+
+        /// <summary>
         /// Retrieves a <see cref="FontUsage"/>.
         /// </summary>
-        /// <param name="typeface">The font typeface.</param>
-        /// <param name="size">The size of the text in local space. For a value of 16, a single line will have a height of 16px.</param>
-        /// <param name="weight">The font weight.</param>
-        /// <param name="italics">Whether the font is italic.</param>
-        /// <param name="fixedWidth">Whether all characters should be spaced the same distance apart.</param>
-        /// <returns>The <see cref="FontUsage"/>.</returns>
         public static FontUsage GetFont(Typeface typeface = Typeface.Torus, float size = DEFAULT_FONT_SIZE, FontWeight weight = FontWeight.Medium, bool italics = false, bool fixedWidth = false)
         {
             string familyString = GetFamilyString(typeface);
-            return new FontUsage(familyString, size, GetWeightString(familyString, weight), getItalics(italics), fixedWidth);
+
+            // System outline fonts are registered under a single stable family id without BMFont weight suffixes.
+            string weightString = HasFamilyOverride(typeface) ? null : GetWeightString(familyString, weight);
+
+            return new FontUsage(familyString, size, weightString, getItalics(italics), fixedWidth);
         }
 
         private static bool getItalics(in bool italicsRequested)
@@ -103,10 +120,11 @@ namespace osu.Game.Graphics
         /// <summary>
         /// Retrieves the string representation of a <see cref="Typeface"/>.
         /// </summary>
-        /// <param name="typeface">The <see cref="Typeface"/>.</param>
-        /// <returns>The string representation.</returns>
         public static string GetFamilyString(Typeface typeface)
         {
+            if (family_overrides.TryGetValue(typeface, out string overrideFamily))
+                return overrideFamily;
+
             switch (typeface)
             {
                 case Typeface.Venera:
@@ -128,13 +146,10 @@ namespace osu.Game.Graphics
         /// <summary>
         /// Retrieves the string representation of a <see cref="FontWeight"/>.
         /// </summary>
-        /// <param name="family">The font family.</param>
-        /// <param name="weight">The font weight.</param>
-        /// <returns>The string representation of <paramref name="weight"/> in the specified <paramref name="family"/>.</returns>
         public static string GetWeightString(string family, FontWeight weight)
         {
-            if ((family == GetFamilyString(Typeface.Torus) || family == GetFamilyString(Typeface.TorusAlternate)) && weight == FontWeight.Medium)
-                // torus doesn't have a medium; fallback to regular.
+            // Built-in Torus family (not remapped system fonts).
+            if ((family == @"Torus" || family == @"Torus-Alternate") && weight == FontWeight.Medium)
                 weight = FontWeight.Regular;
 
             return weight.ToString();
@@ -143,20 +158,15 @@ namespace osu.Game.Graphics
 
     public static class OsuFontExtensions
     {
-        /// <summary>
-        /// Creates a new <see cref="FontUsage"/> by applying adjustments to this <see cref="FontUsage"/>.
-        /// </summary>
-        /// <param name="usage">The base <see cref="FontUsage"/>.</param>
-        /// <param name="typeface">The font typeface. If null, the value is copied from this <see cref="FontUsage"/>.</param>
-        /// <param name="size">The text size. If null, the value is copied from this <see cref="FontUsage"/>.</param>
-        /// <param name="weight">The font weight. If null, the value is copied from this <see cref="FontUsage"/>.</param>
-        /// <param name="italics">Whether the font is italic. If null, the value is copied from this <see cref="FontUsage"/>.</param>
-        /// <param name="fixedWidth">Whether all characters should be spaced apart the same distance. If null, the value is copied from this <see cref="FontUsage"/>.</param>
-        /// <returns>The resulting <see cref="FontUsage"/>.</returns>
         public static FontUsage With(this FontUsage usage, Typeface? typeface = null, float? size = null, FontWeight? weight = null, bool? italics = null, bool? fixedWidth = null)
         {
             string familyString = typeface != null ? OsuFont.GetFamilyString(typeface.Value) : usage.Family;
-            string weightString = weight != null ? OsuFont.GetWeightString(familyString, weight.Value) : usage.Weight;
+            string weightString = weight != null
+                ? (typeface != null && OsuFont.HasFamilyOverride(typeface.Value) ? null : OsuFont.GetWeightString(familyString, weight.Value))
+                : usage.Weight;
+
+            if (typeface != null && OsuFont.HasFamilyOverride(typeface.Value))
+                weightString = null;
 
             return usage.With(familyString, size, weightString, italics, fixedWidth);
         }
@@ -174,34 +184,11 @@ namespace osu.Game.Graphics
 
     public enum FontWeight
     {
-        /// <summary>
-        /// Equivalent to weight 300.
-        /// </summary>
         Light = 300,
-
-        /// <summary>
-        /// Equivalent to weight 400.
-        /// </summary>
         Regular = 400,
-
-        /// <summary>
-        /// Equivalent to weight 500.
-        /// </summary>
         Medium = 500,
-
-        /// <summary>
-        /// Equivalent to weight 600.
-        /// </summary>
         SemiBold = 600,
-
-        /// <summary>
-        /// Equivalent to weight 700.
-        /// </summary>
         Bold = 700,
-
-        /// <summary>
-        /// Equivalent to weight 900.
-        /// </summary>
         Black = 900
     }
 }

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1251,6 +1251,7 @@ namespace osu.Game
             loadComponentSingleFile(FirstRunOverlay = new FirstRunSetupOverlay(), footerBasedOverlayContent.Add, true);
             loadComponentSingleFile(new ManageCollectionsDialog(), overlayContent.Add, true);
             loadComponentSingleFile(new EzManageSongsBranchesDialog(), overlayContent.Add, true);
+            loadComponentSingleFile(new EzFontSettingsOverlay(), topMostOverlayContent.Add, true);
             loadComponentSingleFile(beatmapListing = new BeatmapListingOverlay(), overlayContent.Add, true);
             loadComponentSingleFile(dashboard = new DashboardOverlay(), overlayContent.Add, true);
             loadComponentSingleFile(news = new NewsOverlay(), overlayContent.Add, true);

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -360,6 +360,7 @@ namespace osu.Game
             dependencies.CacheAs<IGameplaySettings>(LocalConfig);
 
             InitialiseFonts();
+            EzOsuGame.Fonts.EzUiFontBootstrap.Apply(this, Ez2ConfigManager);
 
             addFilesWarning();
 
@@ -577,6 +578,9 @@ namespace osu.Game
             AddFont(Resources, @"Fonts/Inter/Inter-Bold");
             AddFont(Resources, @"Fonts/Inter/Inter-BoldItalic");
 
+            // Localized system outline faces must precede Noto CJK so empty-name scans prefer them.
+            EzOsuGame.Fonts.EzUiFontBootstrap.RegisterLocalizedFallbacks(this, Ez2ConfigManager);
+
             AddFont(Resources, @"Fonts/Noto/Noto-Basic");
             AddFont(Resources, @"Fonts/Noto/Noto-Bopomofo");
             AddFont(Resources, @"Fonts/Noto/Noto-CJK-Basic");
@@ -584,14 +588,60 @@ namespace osu.Game
             AddFont(Resources, @"Fonts/Noto/Noto-Hangul");
             AddFont(Resources, @"Fonts/Noto/Noto-Thai");
 
-            // 加载内置emoji字体
+            // Emoji glyph fallback order (empty FontName scan): system colour emoji → packaged
+            // Twemoji / NotoColorEmoji → BMFont Noto-Emoji → mono outline.
+            EzOsuGame.Fonts.EzUiFontBootstrap.RegisterSystemEmojiFallback(this, Ez2ConfigManager);
+
+            const string twemoji = @"Fonts/Twemoji/Twemoji.Mozilla";
+
+            if (resourcesContainFont(twemoji))
+            {
+                try
+                {
+                    AddOutlineFont(Resources, twemoji);
+                }
+                catch
+                {
+                    // Optional packaged colour emoji (CC BY 4.0 Twemoji / Mozilla COLR).
+                }
+            }
+
+            const string color_emoji = @"Fonts/Emoji/NotoColorEmoji-Regular";
+
+            if (resourcesContainFont(color_emoji))
+            {
+                try
+                {
+                    AddOutlineFont(Resources, color_emoji);
+                }
+                catch
+                {
+                    // Optional extra outline fallback after system / Twemoji.
+                }
+            }
+
             try
             {
                 Fonts.AddTextureSource(new GlyphStore(Resources, @"Fonts/Emoji/Noto-Emoji", Host.CreateTextureLoaderStore(Resources)));
             }
             catch
             {
-                // It's fine if a candidate is not provided in resources.
+                // Silent BMFont hole-fill when system / outline colour sources miss a codepoint.
+            }
+
+            // Outline (monochrome) Noto Emoji covers codepoints missing from colour sources.
+            const string mono_emoji = @"Fonts/Noto_Emoji/static/NotoEmoji-Regular";
+
+            if (resourcesContainFont(mono_emoji))
+            {
+                try
+                {
+                    AddOutlineFont(Resources, mono_emoji);
+                }
+                catch
+                {
+                    // Optional wider emoji coverage; safe to skip.
+                }
             }
 
             AddFont(Resources, @"Fonts/Venera/Venera-Light");
@@ -599,6 +649,20 @@ namespace osu.Game
             AddFont(Resources, @"Fonts/Venera/Venera-Black");
 
             Fonts.AddStore(new OsuIcon.OsuIconStore(Textures));
+        }
+
+        private bool resourcesContainFont(string assetName)
+        {
+            // OutlineFont ResourceStore probes these extensions.
+            foreach (string ext in new[] { ".ttf", ".otf", ".ttc", ".woff", string.Empty })
+            {
+                using var stream = Resources.GetStream(assetName + ext);
+
+                if (stream != null)
+                    return true;
+            }
+
+            return false;
         }
 
         protected override void LoadComplete()


### PR DESCRIPTION
## Summary
- 依赖升至 `2026.814.0-ez2lazer`（Framework Outline 字体 + Resources 打包 Twemoji / 彩色 emoji TTF）。
- 冷启动支持系统 UI/标题/数字字体 remap，以及平台彩色 emoji → Twemoji → NotoColorEmoji → BMFont 回退链。
- 新增可搜索的字体设置对话框：英/本地化槽位、系统 emoji 选择、对话框独立图集与悬停防抖，避免快速滚动撑爆全局 FontStore。

## Test plan
- [x] 设置 → UI 字体：打开对话框，各槽位可选系统字体；重启后冷启动生效
- [ ] 列表快速滚动：不刷全局 `TextureAtlas [FontStore] size exceeded`；停悬约 200ms 后自字体显示名
- [ ] 无系统 emoji 时，打包 Twemoji / NotoColorEmoji 仍能显示彩色 emoji；有系统 emoji 时优先系统
- [ ] 关闭对话框再打开：预览与选中项正常，无残留图集压力
- [x] `dotnet build` osu.Game（NuGet 或本地 Framework/Resources 均可）