### PR TITLE
主菜单 Logo 外圈音频可视化样式

### DIFF
--- a/osu.Game/EzOsuGame/Configuration/Ez2ConfigManager.cs
+++ b/osu.Game/EzOsuGame/Configuration/Ez2ConfigManager.cs
@@ -96,6 +96,7 @@ namespace osu.Game.EzOsuGame.Configuration
             SetDefault(Ez2Setting.EzAnalysisSqliteEnabled, true);
             SetDefault(Ez2Setting.HideMainMenuOnlineBanner, false);
             SetDefault(Ez2Setting.MenuLogoPath, @"Menu/logo");
+            SetDefault(Ez2Setting.MenuLogoVisualisationStyle, EzLogoVisualisationStyle.RadialBars);
             SetDefault(Ez2Setting.NotificationBehaviour, EzNotificationBehaviour.Normal);
             SetDefault(Ez2Setting.ScreenshotAction, EzScreenshotAction.SaveAndCopy);
             SetDefault(Ez2Setting.HitObjectLifetimeUsesOwnTime, !DebugUtils.IsNUnitRunning);
@@ -875,6 +876,11 @@ namespace osu.Game.EzOsuGame.Configuration
         /// 主菜单 logo 贴图路径，默认 Menu/logo，可切换到 Menu/logo2 等同级资源。
         /// </summary>
         MenuLogoPath,
+
+        /// <summary>
+        /// 主菜单/选歌 logo 外圈音频可视化样式。
+        /// </summary>
+        MenuLogoVisualisationStyle,
         NotificationBehaviour,
         ScreenshotAction,
         ManiaSkipEmptyEdgeColumns,

--- a/osu.Game/EzOsuGame/Configuration/EzEnumDisplay.cs
+++ b/osu.Game/EzOsuGame/Configuration/EzEnumDisplay.cs
@@ -69,4 +69,25 @@ namespace osu.Game.EzOsuGame.Configuration
 
         Catch,
     }
+
+    public enum EzLogoVisualisationStyle
+    {
+        [LocalisableDescription(typeof(EzEnumStrings), nameof(EzEnumStrings.LOGO_VIS_BARS))]
+        RadialBars,
+
+        [LocalisableDescription(typeof(EzEnumStrings), nameof(EzEnumStrings.LOGO_VIS_POLYLINE))]
+        CircularPolyline,
+
+        [LocalisableDescription(typeof(EzEnumStrings), nameof(EzEnumStrings.LOGO_VIS_WAVE))]
+        CircularWave,
+
+        [LocalisableDescription(typeof(EzEnumStrings), nameof(EzEnumStrings.LOGO_VIS_DOTS))]
+        CircularDots,
+
+        [LocalisableDescription(typeof(EzEnumStrings), nameof(EzEnumStrings.LOGO_VIS_NET))]
+        CircularNet,
+
+        [LocalisableDescription(typeof(EzEnumStrings), nameof(EzEnumStrings.LOGO_VIS_OFF))]
+        Off,
+    }
 }

--- a/osu.Game/EzOsuGame/Localization/EzEnumStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzEnumStrings.cs
@@ -48,5 +48,12 @@ namespace osu.Game.EzOsuGame.Localization
         public static readonly LocalisableString DATA_REBUILD_TARGET_REALM_SCORES = new EzLocalizationManager.EzLocalisableString("Realm 成绩全量重算", "Realm full score recalculation");
         public static readonly LocalisableString DATA_REBUILD_TARGET_SQLITE_MAIN = new EzLocalizationManager.EzLocalisableString("SQLite 主库 kps/KPC", "SQLite main kps/KPC");
         public static readonly LocalisableString DATA_REBUILD_TARGET_SQLITE_BRANCHES = new EzLocalizationManager.EzLocalisableString("SQLite 分支曲库 xxy/PP", "SQLite songs branches xxy/PP");
+
+        public static readonly LocalisableString LOGO_VIS_BARS = new EzLocalizationManager.EzLocalisableString("柱状", "Bars");
+        public static readonly LocalisableString LOGO_VIS_POLYLINE = new EzLocalizationManager.EzLocalisableString("折线", "Polyline");
+        public static readonly LocalisableString LOGO_VIS_WAVE = new EzLocalizationManager.EzLocalisableString("波形", "Waveform");
+        public static readonly LocalisableString LOGO_VIS_DOTS = new EzLocalizationManager.EzLocalisableString("圆点", "Dots");
+        public static readonly LocalisableString LOGO_VIS_NET = new EzLocalizationManager.EzLocalisableString("网状", "Net");
+        public static readonly LocalisableString LOGO_VIS_OFF = new EzLocalizationManager.EzLocalisableString("关闭", "Off");
     }
 }

--- a/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
@@ -50,6 +50,13 @@ namespace osu.Game.EzOsuGame.Localization
             "限制游戏逻辑更新（Update）线程的最高帧率。Draw 帧率仍由图形设置中的「帧率限制」控制。",
             "Limits the maximum update rate of the game logic thread. Draw frame rate is still controlled by the \"Frame limiter\" setting in Graphics.");
 
+        public static readonly EzLocalizationManager.EzLocalisableString LOGO_VISUALISATION =
+            new EzLocalizationManager.EzLocalisableString("Logo 可视化", "Logo Visualiser");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOGO_VISUALISATION_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "主菜单与选歌界面 logo 外圈的音频抖动样式。",
+            "Audio visualiser style around the logo on the main menu and song select.");
+
         public static readonly EzLocalizationManager.EzLocalisableString HIDE_MAIN_MENU_ONLINE_BANNER =
             new EzLocalizationManager.EzLocalisableString("屏蔽主界面底部新闻广告", "Hide main menu bottom news banner");
 

--- a/osu.Game/EzOsuGame/Screens/Menu/EzMenuLogoVisualisation.cs
+++ b/osu.Game/EzOsuGame/Screens/Menu/EzMenuLogoVisualisation.cs
@@ -28,19 +28,20 @@ namespace osu.Game.EzOsuGame.Screens.Menu
         private const int bars_per_visualiser = 200;
         private const float visualiser_rounds = 5;
         private const float amplitude_dead_zone = 1f / bar_length;
-        private const int band_count = 64;
+        private const int band_count = 200;
+        private const int wave_band_count = 64;
         private const int wave_catmull_detail = 3;
         private const int wave_rounds = 4;
         private const float wave_amplitude = bar_length * 0.72f;
 
         private Bindable<EzLogoVisualisationStyle> style = new Bindable<EzLogoVisualisationStyle>(EzLogoVisualisationStyle.RadialBars);
 
-        protected override int SpectrumIndexChange => style.Value == EzLogoVisualisationStyle.RadialBars ? 5 : 0;
+        protected override int SpectrumIndexChange => style.Value == EzLogoVisualisationStyle.Off ? 0 : 5;
 
-        private readonly float[] smoothedWaveformLeft = new float[band_count];
-        private readonly float[] smoothedWaveformRight = new float[band_count];
-        private readonly float[] waveScratchLeft = new float[band_count];
-        private readonly float[] waveScratchRight = new float[band_count];
+        private readonly float[] smoothedWaveformLeft = new float[wave_band_count];
+        private readonly float[] smoothedWaveformRight = new float[wave_band_count];
+        private readonly float[] waveScratchLeft = new float[wave_band_count];
+        private readonly float[] waveScratchRight = new float[wave_band_count];
 
         [BackgroundDependencyLoader(permitNulls: true)]
         private void load(Ez2ConfigManager? ezConfig)
@@ -75,9 +76,9 @@ namespace osu.Game.EzOsuGame.Screens.Menu
         private static void downsampleChannel(ReadOnlySpan<float> samples, int channel, float[] destination)
         {
             int frames = samples.Length / 2;
-            int perBand = Math.Max(1, frames / band_count);
+            int perBand = Math.Max(1, frames / wave_band_count);
 
-            for (int i = 0; i < band_count; i++)
+            for (int i = 0; i < wave_band_count; i++)
             {
                 float sum = 0;
                 int count = 0;
@@ -100,10 +101,10 @@ namespace osu.Game.EzOsuGame.Screens.Menu
 
         private static void smoothChannel(float[] scratch, float[] smoothed, float blend)
         {
-            for (int i = 0; i < band_count; i++)
+            for (int i = 0; i < wave_band_count; i++)
             {
-                float prev = scratch[(i - 1 + band_count) % band_count];
-                float next = scratch[(i + 1) % band_count];
+                float prev = scratch[(i - 1 + wave_band_count) % wave_band_count];
+                float next = scratch[(i + 1) % wave_band_count];
                 float target = prev * 0.25f + scratch[i] * 0.5f + next * 0.25f;
 
                 float current = smoothed[i];
@@ -126,13 +127,15 @@ namespace osu.Game.EzOsuGame.Screens.Menu
             private static readonly Color4 transparent_white = Color4.White.Opacity(0.2f);
             private static readonly Color4 dots_white = Color4.White.Opacity(0.38f);
 
+            private float spectrumSpin;
+
             private readonly float[] barAmplitudes = new float[256];
             private readonly float[] bands = new float[band_count];
-            private readonly float[] waveformLeft = new float[band_count];
-            private readonly float[] waveformRight = new float[band_count];
+            private readonly float[] waveformLeft = new float[wave_band_count];
+            private readonly float[] waveformRight = new float[wave_band_count];
             private readonly Vector2[] controlPoints = new Vector2[band_count];
             private readonly Vector2[] innerPoints = new Vector2[band_count];
-            private readonly Vector2[] contourPoints = new Vector2[band_count * wave_catmull_detail];
+            private readonly Vector2[] contourPoints = new Vector2[band_count];
 
             private IVertexBatch<TexturedVertex2D>? vertexBatch;
 
@@ -154,24 +157,13 @@ namespace osu.Game.EzOsuGame.Screens.Menu
                 fillBandsFromPeakHold();
                 Source.smoothedWaveformLeft.AsSpan().CopyTo(waveformLeft);
                 Source.smoothedWaveformRight.AsSpan().CopyTo(waveformRight);
+                spectrumSpin = Source.SpectrumIndexOffset / (float)bars_per_visualiser * MathF.Tau;
             }
 
             private void fillBandsFromPeakHold()
             {
-                const int src_per_band = 3;
-
                 for (int i = 0; i < band_count; i++)
-                {
-                    int src = i * src_per_band;
-                    float mag = barAmplitudes[src];
-
-                    if (src + 1 < barAmplitudes.Length)
-                        mag = Math.Max(mag, barAmplitudes[src + 1]);
-                    if (src + 2 < barAmplitudes.Length)
-                        mag = Math.Max(mag, barAmplitudes[src + 2]);
-
-                    bands[i] = mag;
-                }
+                    bands[i] = barAmplitudes[i];
             }
 
             protected override void Draw(IRenderer renderer)
@@ -271,17 +263,17 @@ namespace osu.Game.EzOsuGame.Screens.Menu
 
                 for (int j = 0; j < wave_rounds; j++)
                 {
-                    float offset = j * MathF.Tau / wave_rounds;
+                    float offset = j * MathF.Tau / wave_rounds + spectrumSpin;
                     float[] channel = j % 2 == 0 ? waveformLeft : waveformRight;
 
-                    for (int i = 0; i < band_count; i++)
+                    for (int i = 0; i < wave_band_count; i++)
                     {
-                        float angle = i / (float)band_count * MathF.Tau + offset;
+                        float angle = i / (float)wave_band_count * MathF.Tau + offset;
                         float r = radius + channel[i] * wave_amplitude;
                         controlPoints[i] = centre + new Vector2(MathF.Cos(angle) * r, MathF.Sin(angle) * r);
                     }
 
-                    int count = fillClosedCatmull(controlPoints, band_count, contourPoints, wave_catmull_detail);
+                    int count = fillClosedCatmull(controlPoints, wave_band_count, contourPoints, wave_catmull_detail);
                     drawClosedLine(renderer, colourInfo, inflation, contourPoints, count, thickness);
                 }
             }

--- a/osu.Game/EzOsuGame/Screens/Menu/EzMenuLogoVisualisation.cs
+++ b/osu.Game/EzOsuGame/Screens/Menu/EzMenuLogoVisualisation.cs
@@ -31,6 +31,7 @@ namespace osu.Game.EzOsuGame.Screens.Menu
         private const int band_count = 64;
         private const int wave_catmull_detail = 3;
         private const int wave_rounds = 4;
+        private const float wave_amplitude = bar_length * 0.72f;
 
         private Bindable<EzLogoVisualisationStyle> style = new Bindable<EzLogoVisualisationStyle>(EzLogoVisualisationStyle.RadialBars);
 
@@ -123,6 +124,7 @@ namespace osu.Game.EzOsuGame.Screens.Menu
             private EzLogoVisualisationStyle style;
 
             private static readonly Color4 transparent_white = Color4.White.Opacity(0.2f);
+            private static readonly Color4 dots_white = Color4.White.Opacity(0.38f);
 
             private readonly float[] barAmplitudes = new float[256];
             private readonly float[] bands = new float[band_count];
@@ -186,7 +188,7 @@ namespace osu.Game.EzOsuGame.Screens.Menu
                 Vector2 inflation = DrawInfo.MatrixInverse.ExtractScale().Xy;
 
                 ColourInfo colourInfo = DrawColourInfo.Colour;
-                colourInfo.ApplyChild(transparent_white);
+                colourInfo.ApplyChild(style == EzLogoVisualisationStyle.CircularDots ? dots_white : transparent_white);
 
                 switch (style)
                 {
@@ -275,7 +277,7 @@ namespace osu.Game.EzOsuGame.Screens.Menu
                     for (int i = 0; i < band_count; i++)
                     {
                         float angle = i / (float)band_count * MathF.Tau + offset;
-                        float r = radius + channel[i] * bar_length;
+                        float r = radius + channel[i] * wave_amplitude;
                         controlPoints[i] = centre + new Vector2(MathF.Cos(angle) * r, MathF.Sin(angle) * r);
                     }
 

--- a/osu.Game/EzOsuGame/Screens/Menu/EzMenuLogoVisualisation.cs
+++ b/osu.Game/EzOsuGame/Screens/Menu/EzMenuLogoVisualisation.cs
@@ -3,7 +3,6 @@
 
 using System;
 using osu.Framework.Allocation;
-using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -31,16 +30,85 @@ namespace osu.Game.EzOsuGame.Screens.Menu
         private const float amplitude_dead_zone = 1f / bar_length;
         private const int band_count = 64;
         private const int wave_catmull_detail = 3;
+        private const int wave_rounds = 4;
 
         private Bindable<EzLogoVisualisationStyle> style = new Bindable<EzLogoVisualisationStyle>(EzLogoVisualisationStyle.RadialBars);
 
         protected override int SpectrumIndexChange => style.Value == EzLogoVisualisationStyle.RadialBars ? 5 : 0;
+
+        private readonly float[] smoothedWaveformLeft = new float[band_count];
+        private readonly float[] smoothedWaveformRight = new float[band_count];
+        private readonly float[] waveScratchLeft = new float[band_count];
+        private readonly float[] waveScratchRight = new float[band_count];
 
         [BackgroundDependencyLoader(permitNulls: true)]
         private void load(Ez2ConfigManager? ezConfig)
         {
             if (ezConfig != null)
                 style = ezConfig.GetBindable<EzLogoVisualisationStyle>(Ez2Setting.MenuLogoVisualisationStyle);
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (style.Value == EzLogoVisualisationStyle.CircularWave)
+                updateSmoothedWaveform();
+        }
+
+        private void updateSmoothedWaveform()
+        {
+            var samples = BeatSyncProvider.CurrentAmplitudes.WaveformSamples.Span;
+
+            if (samples.Length < 2)
+                return;
+
+            downsampleChannel(samples, 0, waveScratchLeft);
+            downsampleChannel(samples, 1, waveScratchRight);
+
+            float blend = 1 - MathF.Exp(-(float)Time.Elapsed * 0.006f);
+            smoothChannel(waveScratchLeft, smoothedWaveformLeft, blend);
+            smoothChannel(waveScratchRight, smoothedWaveformRight, blend);
+        }
+
+        private static void downsampleChannel(ReadOnlySpan<float> samples, int channel, float[] destination)
+        {
+            int frames = samples.Length / 2;
+            int perBand = Math.Max(1, frames / band_count);
+
+            for (int i = 0; i < band_count; i++)
+            {
+                float sum = 0;
+                int count = 0;
+                int startFrame = i * perBand;
+
+                for (int k = 0; k < perBand; k++)
+                {
+                    int src = (startFrame + k) * 2 + channel;
+
+                    if (src >= samples.Length)
+                        break;
+
+                    sum += samples[src];
+                    count++;
+                }
+
+                destination[i] = count > 0 ? sum / count : 0;
+            }
+        }
+
+        private static void smoothChannel(float[] scratch, float[] smoothed, float blend)
+        {
+            for (int i = 0; i < band_count; i++)
+            {
+                float prev = scratch[(i - 1 + band_count) % band_count];
+                float next = scratch[(i + 1) % band_count];
+                float target = prev * 0.25f + scratch[i] * 0.5f + next * 0.25f;
+
+                float current = smoothed[i];
+                float factor = Math.Abs(target) > Math.Abs(current) ? Math.Min(1, blend * 2.5f) : blend;
+                smoothed[i] = current + (target - current) * factor;
+            }
         }
 
         protected override DrawNode CreateDrawNode() => new EzVisualisationDrawNode(this);
@@ -56,14 +124,13 @@ namespace osu.Game.EzOsuGame.Screens.Menu
 
             private static readonly Color4 transparent_white = Color4.White.Opacity(0.2f);
 
-            // Bars stack 5 additive rounds at 0.2; a single stroke needs near-opaque vertices to match.
-            private static readonly Color4 contour_white = Color4.White.Opacity(0.85f);
-
             private readonly float[] barAmplitudes = new float[256];
             private readonly float[] bands = new float[band_count];
-            private readonly float[] waveform = new float[ChannelAmplitudes.WAVEFORM_SIZE];
-            private readonly Vector2[] controlPoints = new Vector2[ChannelAmplitudes.WAVEFORM_SIZE];
-            private readonly Vector2[] contourPoints = new Vector2[ChannelAmplitudes.WAVEFORM_SIZE * wave_catmull_detail];
+            private readonly float[] waveformLeft = new float[band_count];
+            private readonly float[] waveformRight = new float[band_count];
+            private readonly Vector2[] controlPoints = new Vector2[band_count];
+            private readonly Vector2[] innerPoints = new Vector2[band_count];
+            private readonly Vector2[] contourPoints = new Vector2[band_count * wave_catmull_detail];
 
             private IVertexBatch<TexturedVertex2D>? vertexBatch;
 
@@ -83,7 +150,8 @@ namespace osu.Game.EzOsuGame.Screens.Menu
 
                 Source.FrequencyAmplitudes.AsSpan().CopyTo(barAmplitudes);
                 fillBandsFromPeakHold();
-                Source.BeatSyncProvider.CurrentAmplitudes.WaveformSamples.Span.CopyTo(waveform);
+                Source.smoothedWaveformLeft.AsSpan().CopyTo(waveformLeft);
+                Source.smoothedWaveformRight.AsSpan().CopyTo(waveformRight);
             }
 
             private void fillBandsFromPeakHold()
@@ -118,7 +186,7 @@ namespace osu.Game.EzOsuGame.Screens.Menu
                 Vector2 inflation = DrawInfo.MatrixInverse.ExtractScale().Xy;
 
                 ColourInfo colourInfo = DrawColourInfo.Colour;
-                colourInfo.ApplyChild(style == EzLogoVisualisationStyle.RadialBars ? transparent_white : contour_white);
+                colourInfo.ApplyChild(transparent_white);
 
                 switch (style)
                 {
@@ -184,41 +252,55 @@ namespace osu.Game.EzOsuGame.Screens.Menu
 
             private void drawPolyline(IRenderer renderer, ColourInfo colourInfo, Vector2 inflation)
             {
-                int count = fillSpectrumPoints(controlPoints, band_count);
-                drawClosedLine(renderer, colourInfo, inflation, controlPoints, count, Math.Max(size * 0.012f, 3.5f));
+                float thickness = Math.Max(size * 0.012f, 3.5f);
+
+                for (int j = 0; j < visualiser_rounds; j++)
+                {
+                    fillSpectrumPoints(controlPoints, band_count, j * MathF.Tau / visualiser_rounds);
+                    drawClosedLine(renderer, colourInfo, inflation, controlPoints, band_count, thickness);
+                }
             }
 
             private void drawWaveform(IRenderer renderer, ColourInfo colourInfo, Vector2 inflation)
             {
                 float radius = size / 2;
                 var centre = new Vector2(radius);
-                const float scale = bar_length;
-                int sampleCount = waveform.Length;
+                float thickness = Math.Max(size * 0.007f, 2.2f);
 
-                for (int i = 0; i < sampleCount; i++)
+                for (int j = 0; j < wave_rounds; j++)
                 {
-                    float angle = i / (float)sampleCount * MathF.Tau;
-                    float r = radius + waveform[i] * scale;
-                    controlPoints[i] = centre + new Vector2(MathF.Cos(angle) * r, MathF.Sin(angle) * r);
-                }
+                    float offset = j * MathF.Tau / wave_rounds;
+                    float[] channel = j % 2 == 0 ? waveformLeft : waveformRight;
 
-                int count = fillClosedCatmull(controlPoints, sampleCount, contourPoints, wave_catmull_detail);
-                drawClosedLine(renderer, colourInfo, inflation, contourPoints, count, Math.Max(size * 0.007f, 2.2f));
+                    for (int i = 0; i < band_count; i++)
+                    {
+                        float angle = i / (float)band_count * MathF.Tau + offset;
+                        float r = radius + channel[i] * bar_length;
+                        controlPoints[i] = centre + new Vector2(MathF.Cos(angle) * r, MathF.Sin(angle) * r);
+                    }
+
+                    int count = fillClosedCatmull(controlPoints, band_count, contourPoints, wave_catmull_detail);
+                    drawClosedLine(renderer, colourInfo, inflation, contourPoints, count, thickness);
+                }
             }
 
             private void drawDots(IRenderer renderer, ColourInfo colourInfo, Vector2 inflation)
             {
                 float radius = size / 2;
                 var centre = new Vector2(radius);
-                const float scale = bar_length;
 
-                for (int i = 0; i < band_count; i++)
+                for (int j = 0; j < visualiser_rounds; j++)
                 {
-                    float angle = i / (float)band_count * MathF.Tau;
-                    float r = radius + scale * bands[i];
-                    Vector2 pos = centre + new Vector2(MathF.Cos(angle) * r, MathF.Sin(angle) * r);
-                    float dot = Math.Max(size * 0.018f, 4.5f) * (0.55f + 0.7f * bands[i]);
-                    drawDot(renderer, colourInfo, inflation, pos, dot);
+                    float offset = j * MathF.Tau / visualiser_rounds;
+
+                    for (int i = 0; i < band_count; i++)
+                    {
+                        float angle = i / (float)band_count * MathF.Tau + offset;
+                        float r = radius + bar_length * bands[i];
+                        Vector2 pos = centre + new Vector2(MathF.Cos(angle) * r, MathF.Sin(angle) * r);
+                        float dot = Math.Max(size * 0.018f, 4.5f) * (0.55f + 0.7f * bands[i]);
+                        drawDot(renderer, colourInfo, inflation, pos, dot);
+                    }
                 }
             }
 
@@ -226,37 +308,38 @@ namespace osu.Game.EzOsuGame.Screens.Menu
             {
                 float radius = size / 2;
                 var centre = new Vector2(radius);
-                const float scale = bar_length;
                 float thickness = Math.Max(size * 0.006f, 2f);
 
-                for (int i = 0; i < band_count; i++)
+                for (int j = 0; j < visualiser_rounds; j++)
                 {
-                    float angle = i / (float)band_count * MathF.Tau;
-                    var dir = new Vector2(MathF.Cos(angle), MathF.Sin(angle));
-                    controlPoints[i] = centre + dir * (radius + scale * bands[i]);
-                    contourPoints[i] = centre + dir * radius;
+                    float offset = j * MathF.Tau / visualiser_rounds;
+
+                    for (int i = 0; i < band_count; i++)
+                    {
+                        float angle = i / (float)band_count * MathF.Tau + offset;
+                        var dir = new Vector2(MathF.Cos(angle), MathF.Sin(angle));
+                        controlPoints[i] = centre + dir * (radius + bar_length * bands[i]);
+                        innerPoints[i] = centre + dir * radius;
+                    }
+
+                    drawClosedLine(renderer, colourInfo, inflation, controlPoints, band_count, thickness);
+
+                    for (int i = 0; i < band_count; i += 2)
+                        drawSegment(renderer, colourInfo, inflation, controlPoints[i], innerPoints[i], thickness);
                 }
-
-                drawClosedLine(renderer, colourInfo, inflation, controlPoints, band_count, thickness);
-
-                for (int i = 0; i < band_count; i += 2)
-                    drawSegment(renderer, colourInfo, inflation, controlPoints[i], contourPoints[i], thickness);
             }
 
-            private int fillSpectrumPoints(Vector2[] destination, int count)
+            private void fillSpectrumPoints(Vector2[] destination, int count, float angleOffset)
             {
                 float radius = size / 2;
                 var centre = new Vector2(radius);
-                const float scale = bar_length;
 
                 for (int i = 0; i < count; i++)
                 {
-                    float angle = i / (float)count * MathF.Tau;
-                    float r = radius + scale * bands[i];
+                    float angle = i / (float)count * MathF.Tau + angleOffset;
+                    float r = radius + bar_length * bands[i];
                     destination[i] = centre + new Vector2(MathF.Cos(angle) * r, MathF.Sin(angle) * r);
                 }
-
-                return count;
             }
 
             private static int fillClosedCatmull(Vector2[] source, int sourceCount, Vector2[] destination, int detail)

--- a/osu.Game/EzOsuGame/Screens/Menu/EzMenuLogoVisualisation.cs
+++ b/osu.Game/EzOsuGame/Screens/Menu/EzMenuLogoVisualisation.cs
@@ -1,0 +1,353 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Audio.Track;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Rendering;
+using osu.Framework.Graphics.Rendering.Vertices;
+using osu.Framework.Graphics.Shaders;
+using osu.Framework.Graphics.Textures;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.Screens.Menu;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.EzOsuGame.Screens.Menu
+{
+    /// <summary>
+    /// Menu logo visualiser with selectable geometry around the cookie.
+    /// </summary>
+    public partial class EzMenuLogoVisualisation : MenuLogoVisualisation
+    {
+        private const float bar_length = 600;
+        private const int bars_per_visualiser = 200;
+        private const float visualiser_rounds = 5;
+        private const float amplitude_dead_zone = 1f / bar_length;
+        private const int band_count = 64;
+        private const int wave_catmull_detail = 3;
+
+        private Bindable<EzLogoVisualisationStyle> style = new Bindable<EzLogoVisualisationStyle>(EzLogoVisualisationStyle.RadialBars);
+
+        protected override int SpectrumIndexChange => style.Value == EzLogoVisualisationStyle.RadialBars ? 5 : 0;
+
+        [BackgroundDependencyLoader(permitNulls: true)]
+        private void load(Ez2ConfigManager? ezConfig)
+        {
+            if (ezConfig != null)
+                style = ezConfig.GetBindable<EzLogoVisualisationStyle>(Ez2Setting.MenuLogoVisualisationStyle);
+        }
+
+        protected override DrawNode CreateDrawNode() => new EzVisualisationDrawNode(this);
+
+        private class EzVisualisationDrawNode : DrawNode
+        {
+            protected new EzMenuLogoVisualisation Source => (EzMenuLogoVisualisation)base.Source;
+
+            private IShader shader = null!;
+            private Texture texture = null!;
+            private float size;
+            private EzLogoVisualisationStyle style;
+
+            private static readonly Color4 transparent_white = Color4.White.Opacity(0.2f);
+
+            // Bars stack 5 additive rounds at 0.2; a single stroke needs near-opaque vertices to match.
+            private static readonly Color4 contour_white = Color4.White.Opacity(0.85f);
+
+            private readonly float[] barAmplitudes = new float[256];
+            private readonly float[] bands = new float[band_count];
+            private readonly float[] waveform = new float[ChannelAmplitudes.WAVEFORM_SIZE];
+            private readonly Vector2[] controlPoints = new Vector2[ChannelAmplitudes.WAVEFORM_SIZE];
+            private readonly Vector2[] contourPoints = new Vector2[ChannelAmplitudes.WAVEFORM_SIZE * wave_catmull_detail];
+
+            private IVertexBatch<TexturedVertex2D>? vertexBatch;
+
+            public EzVisualisationDrawNode(EzMenuLogoVisualisation source)
+                : base(source)
+            {
+            }
+
+            public override void ApplyState()
+            {
+                base.ApplyState();
+
+                shader = Source.Shader;
+                texture = Source.Texture;
+                size = Source.DrawSize.X;
+                style = Source.style.Value;
+
+                Source.FrequencyAmplitudes.AsSpan().CopyTo(barAmplitudes);
+                fillBandsFromPeakHold();
+                Source.BeatSyncProvider.CurrentAmplitudes.WaveformSamples.Span.CopyTo(waveform);
+            }
+
+            private void fillBandsFromPeakHold()
+            {
+                const int src_per_band = 3;
+
+                for (int i = 0; i < band_count; i++)
+                {
+                    int src = i * src_per_band;
+                    float mag = barAmplitudes[src];
+
+                    if (src + 1 < barAmplitudes.Length)
+                        mag = Math.Max(mag, barAmplitudes[src + 1]);
+                    if (src + 2 < barAmplitudes.Length)
+                        mag = Math.Max(mag, barAmplitudes[src + 2]);
+
+                    bands[i] = mag;
+                }
+            }
+
+            protected override void Draw(IRenderer renderer)
+            {
+                base.Draw(renderer);
+
+                if (style == EzLogoVisualisationStyle.Off || size <= 0)
+                    return;
+
+                vertexBatch ??= renderer.CreateQuadBatch<TexturedVertex2D>(200, 10);
+
+                shader.Bind();
+
+                Vector2 inflation = DrawInfo.MatrixInverse.ExtractScale().Xy;
+
+                ColourInfo colourInfo = DrawColourInfo.Colour;
+                colourInfo.ApplyChild(style == EzLogoVisualisationStyle.RadialBars ? transparent_white : contour_white);
+
+                switch (style)
+                {
+                    case EzLogoVisualisationStyle.CircularPolyline:
+                        drawPolyline(renderer, colourInfo, inflation);
+                        break;
+
+                    case EzLogoVisualisationStyle.CircularWave:
+                        drawWaveform(renderer, colourInfo, inflation);
+                        break;
+
+                    case EzLogoVisualisationStyle.CircularDots:
+                        drawDots(renderer, colourInfo, inflation);
+                        break;
+
+                    case EzLogoVisualisationStyle.CircularNet:
+                        drawNet(renderer, colourInfo, inflation);
+                        break;
+
+                    default:
+                        drawRadialBars(renderer, colourInfo, inflation);
+                        break;
+                }
+
+                shader.Unbind();
+            }
+
+            private void drawRadialBars(IRenderer renderer, ColourInfo colourInfo, Vector2 inflation)
+            {
+                for (int j = 0; j < visualiser_rounds; j++)
+                {
+                    for (int i = 0; i < bars_per_visualiser; i++)
+                    {
+                        if (barAmplitudes[i] < amplitude_dead_zone)
+                            continue;
+
+                        float rotation = float.DegreesToRadians(i / (float)bars_per_visualiser * 360 + j * 360 / visualiser_rounds);
+                        float rotationCos = MathF.Cos(rotation);
+                        float rotationSin = MathF.Sin(rotation);
+                        var barPosition = new Vector2(rotationCos / 2 + 0.5f, rotationSin / 2 + 0.5f) * size;
+
+                        var barSize = new Vector2(size * MathF.Sqrt(2 * (1 - MathF.Cos(float.DegreesToRadians(360f / bars_per_visualiser)))) / 2f, bar_length * barAmplitudes[i]);
+                        var bottomOffset = new Vector2(-rotationSin * barSize.X / 2, rotationCos * barSize.X / 2);
+                        var amplitudeOffset = new Vector2(rotationCos * barSize.Y, rotationSin * barSize.Y);
+
+                        var rectangle = new Quad(
+                            Vector2Extensions.Transform(barPosition - bottomOffset, DrawInfo.Matrix),
+                            Vector2Extensions.Transform(barPosition - bottomOffset + amplitudeOffset, DrawInfo.Matrix),
+                            Vector2Extensions.Transform(barPosition + bottomOffset, DrawInfo.Matrix),
+                            Vector2Extensions.Transform(barPosition + bottomOffset + amplitudeOffset, DrawInfo.Matrix)
+                        );
+
+                        renderer.DrawQuad(
+                            texture,
+                            rectangle,
+                            colourInfo,
+                            null,
+                            vertexBatch!.AddAction,
+                            Vector2.Divide(inflation, barSize.Yx));
+                    }
+                }
+            }
+
+            private void drawPolyline(IRenderer renderer, ColourInfo colourInfo, Vector2 inflation)
+            {
+                int count = fillSpectrumPoints(controlPoints, band_count);
+                drawClosedLine(renderer, colourInfo, inflation, controlPoints, count, Math.Max(size * 0.012f, 3.5f));
+            }
+
+            private void drawWaveform(IRenderer renderer, ColourInfo colourInfo, Vector2 inflation)
+            {
+                float radius = size / 2;
+                var centre = new Vector2(radius);
+                const float scale = bar_length;
+                int sampleCount = waveform.Length;
+
+                for (int i = 0; i < sampleCount; i++)
+                {
+                    float angle = i / (float)sampleCount * MathF.Tau;
+                    float r = radius + waveform[i] * scale;
+                    controlPoints[i] = centre + new Vector2(MathF.Cos(angle) * r, MathF.Sin(angle) * r);
+                }
+
+                int count = fillClosedCatmull(controlPoints, sampleCount, contourPoints, wave_catmull_detail);
+                drawClosedLine(renderer, colourInfo, inflation, contourPoints, count, Math.Max(size * 0.007f, 2.2f));
+            }
+
+            private void drawDots(IRenderer renderer, ColourInfo colourInfo, Vector2 inflation)
+            {
+                float radius = size / 2;
+                var centre = new Vector2(radius);
+                const float scale = bar_length;
+
+                for (int i = 0; i < band_count; i++)
+                {
+                    float angle = i / (float)band_count * MathF.Tau;
+                    float r = radius + scale * bands[i];
+                    Vector2 pos = centre + new Vector2(MathF.Cos(angle) * r, MathF.Sin(angle) * r);
+                    float dot = Math.Max(size * 0.018f, 4.5f) * (0.55f + 0.7f * bands[i]);
+                    drawDot(renderer, colourInfo, inflation, pos, dot);
+                }
+            }
+
+            private void drawNet(IRenderer renderer, ColourInfo colourInfo, Vector2 inflation)
+            {
+                float radius = size / 2;
+                var centre = new Vector2(radius);
+                const float scale = bar_length;
+                float thickness = Math.Max(size * 0.006f, 2f);
+
+                for (int i = 0; i < band_count; i++)
+                {
+                    float angle = i / (float)band_count * MathF.Tau;
+                    var dir = new Vector2(MathF.Cos(angle), MathF.Sin(angle));
+                    controlPoints[i] = centre + dir * (radius + scale * bands[i]);
+                    contourPoints[i] = centre + dir * radius;
+                }
+
+                drawClosedLine(renderer, colourInfo, inflation, controlPoints, band_count, thickness);
+
+                for (int i = 0; i < band_count; i += 2)
+                    drawSegment(renderer, colourInfo, inflation, controlPoints[i], contourPoints[i], thickness);
+            }
+
+            private int fillSpectrumPoints(Vector2[] destination, int count)
+            {
+                float radius = size / 2;
+                var centre = new Vector2(radius);
+                const float scale = bar_length;
+
+                for (int i = 0; i < count; i++)
+                {
+                    float angle = i / (float)count * MathF.Tau;
+                    float r = radius + scale * bands[i];
+                    destination[i] = centre + new Vector2(MathF.Cos(angle) * r, MathF.Sin(angle) * r);
+                }
+
+                return count;
+            }
+
+            private static int fillClosedCatmull(Vector2[] source, int sourceCount, Vector2[] destination, int detail)
+            {
+                int count = 0;
+
+                for (int i = 0; i < sourceCount; i++)
+                {
+                    Vector2 p0 = source[(i - 1 + sourceCount) % sourceCount];
+                    Vector2 p1 = source[i];
+                    Vector2 p2 = source[(i + 1) % sourceCount];
+                    Vector2 p3 = source[(i + 2) % sourceCount];
+
+                    for (int s = 0; s < detail; s++)
+                        destination[count++] = catmull(p0, p1, p2, p3, s / (float)detail);
+                }
+
+                return count;
+            }
+
+            private static Vector2 catmull(Vector2 p0, Vector2 p1, Vector2 p2, Vector2 p3, float t)
+            {
+                float t2 = t * t;
+                float t3 = t2 * t;
+
+                return 0.5f * (
+                    2f * p1
+                    + (-p0 + p2) * t
+                    + (2f * p0 - 5f * p1 + 4f * p2 - p3) * t2
+                    + (-p0 + 3f * p1 - 3f * p2 + p3) * t3);
+            }
+
+            private void drawClosedLine(IRenderer renderer, ColourInfo colourInfo, Vector2 inflation, Vector2[] points, int pointCount, float thickness)
+            {
+                for (int i = 0; i < pointCount; i++)
+                    drawSegment(renderer, colourInfo, inflation, points[i], points[(i + 1) % pointCount], thickness);
+            }
+
+            private void drawSegment(IRenderer renderer, ColourInfo colourInfo, Vector2 inflation, Vector2 start, Vector2 end, float thickness)
+            {
+                Vector2 delta = end - start;
+                float length = delta.Length;
+
+                if (length < 0.001f)
+                    return;
+
+                float halfThickness = thickness / 2;
+                var normal = new Vector2(-delta.Y / length, delta.X / length) * halfThickness;
+
+                var rectangle = new Quad(
+                    Vector2Extensions.Transform(start - normal, DrawInfo.Matrix),
+                    Vector2Extensions.Transform(end - normal, DrawInfo.Matrix),
+                    Vector2Extensions.Transform(start + normal, DrawInfo.Matrix),
+                    Vector2Extensions.Transform(end + normal, DrawInfo.Matrix)
+                );
+
+                renderer.DrawQuad(
+                    texture,
+                    rectangle,
+                    colourInfo,
+                    null,
+                    vertexBatch!.AddAction,
+                    Vector2.Divide(inflation, new Vector2(thickness, length)));
+            }
+
+            private void drawDot(IRenderer renderer, ColourInfo colourInfo, Vector2 inflation, Vector2 centre, float diameter)
+            {
+                float half = diameter / 2;
+                var offset = new Vector2(half);
+
+                var rectangle = new Quad(
+                    Vector2Extensions.Transform(centre + new Vector2(-half, -half), DrawInfo.Matrix),
+                    Vector2Extensions.Transform(centre + new Vector2(half, -half), DrawInfo.Matrix),
+                    Vector2Extensions.Transform(centre + new Vector2(-half, half), DrawInfo.Matrix),
+                    Vector2Extensions.Transform(centre + new Vector2(half, half), DrawInfo.Matrix)
+                );
+
+                renderer.DrawQuad(
+                    texture,
+                    rectangle,
+                    colourInfo,
+                    null,
+                    vertexBatch!.AddAction,
+                    Vector2.Divide(inflation, offset));
+            }
+
+            protected override void Dispose(bool isDisposing)
+            {
+                base.Dispose(isDisposing);
+                vertexBatch?.Dispose();
+            }
+        }
+    }
+}

--- a/osu.Game/Overlays/Settings/Sections/UserInterface/MainMenuSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterface/MainMenuSettings.cs
@@ -9,6 +9,7 @@ using osu.Framework.Localisation;
 using osu.Game.Configuration;
 using osu.Game.EzOsuGame.Background.Pixiv;
 using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Localization;
 using osu.Game.EzOsuGame.Overlays;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Localisation;
@@ -73,6 +74,12 @@ namespace osu.Game.Overlays.Settings.Sections.UserInterface
                     Caption = "Menu Logo",
                     Current = menuLogoPath,
                     Items = menu_logo_items,
+                }),
+                new SettingsItemV2(new FormEnumDropdown<EzLogoVisualisationStyle>
+                {
+                    Caption = EzSettingsStrings.LOGO_VISUALISATION,
+                    HintText = EzSettingsStrings.LOGO_VISUALISATION_TOOLTIP,
+                    Current = ezConfig.GetBindable<EzLogoVisualisationStyle>(Ez2Setting.MenuLogoVisualisationStyle),
                 }),
                 new EzPixivBackgroundSettings(ezConfig, pixivBackgroundCoordinator, notifications, backgroundSource),
                 new SettingsItemV2(new FormEnumDropdown<SeasonalBackgroundMode>

--- a/osu.Game/Screens/Menu/LogoVisualisation.cs
+++ b/osu.Game/Screens/Menu/LogoVisualisation.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Screens.Menu
         /// </summary>
         private const float amplitude_dead_zone = 1f / bar_length;
 
-        private int indexOffset;
+        protected int SpectrumIndexOffset { get; private set; }
 
         /// <summary>
         /// The relative movement of bars based on input amplification. Defaults to 1.
@@ -110,13 +110,13 @@ namespace osu.Game.Screens.Menu
 
             for (int i = 0; i < bars_per_visualiser; i++)
             {
-                float targetAmplitude = (temporalAmplitudes[(i + indexOffset) % bars_per_visualiser]) * kiaiMultiplier;
+                float targetAmplitude = (temporalAmplitudes[(i + SpectrumIndexOffset) % bars_per_visualiser]) * kiaiMultiplier;
 
                 if (targetAmplitude > FrequencyAmplitudes[i])
                     FrequencyAmplitudes[i] = targetAmplitude;
             }
 
-            indexOffset = (indexOffset + SpectrumIndexChange) % bars_per_visualiser;
+            SpectrumIndexOffset = (SpectrumIndexOffset + SpectrumIndexChange) % bars_per_visualiser;
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/Menu/LogoVisualisation.cs
+++ b/osu.Game/Screens/Menu/LogoVisualisation.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Screens.Menu
         /// <summary>
         /// The number of bars to jump each update iteration.
         /// </summary>
-        private const int index_change = 5;
+        protected virtual int SpectrumIndexChange => 5;
 
         /// <summary>
         /// The maximum length of each bar in the visualiser. Will be reduced when kiai is not activated.
@@ -67,10 +67,10 @@ namespace osu.Game.Screens.Menu
         /// </summary>
         public float Magnitude { get; set; } = 1;
 
-        private readonly float[] frequencyAmplitudes = new float[256];
+        protected readonly float[] FrequencyAmplitudes = new float[256];
 
-        private IShader shader = null!;
-        private Texture texture = null!;
+        protected IShader Shader = null!;
+        protected Texture Texture = null!;
 
         public LogoVisualisation()
         {
@@ -87,36 +87,36 @@ namespace osu.Game.Screens.Menu
         [BackgroundDependencyLoader]
         private void load(IRenderer renderer, ShaderManager shaders)
         {
-            texture = renderer.WhitePixel;
-            shader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE);
+            Texture = renderer.WhitePixel;
+            Shader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE);
         }
 
         private readonly float[] temporalAmplitudes = new float[ChannelAmplitudes.AMPLITUDES_SIZE];
 
         [Resolved]
-        private IBeatSyncProvider beatSyncProvider { get; set; } = null!;
+        protected IBeatSyncProvider BeatSyncProvider { get; private set; } = null!;
 
         private void updateAmplitudes()
         {
             for (int i = 0; i < temporalAmplitudes.Length; i++)
                 temporalAmplitudes[i] = 0;
 
-            addAmplitudesFromSource(beatSyncProvider);
+            addAmplitudesFromSource(BeatSyncProvider);
 
             foreach (var source in amplitudeSources)
                 addAmplitudesFromSource(source);
 
-            float kiaiMultiplier = beatSyncProvider.CheckIsKiaiTime() ? 1 : 0.5f;
+            float kiaiMultiplier = BeatSyncProvider.CheckIsKiaiTime() ? 1 : 0.5f;
 
             for (int i = 0; i < bars_per_visualiser; i++)
             {
                 float targetAmplitude = (temporalAmplitudes[(i + indexOffset) % bars_per_visualiser]) * kiaiMultiplier;
 
-                if (targetAmplitude > frequencyAmplitudes[i])
-                    frequencyAmplitudes[i] = targetAmplitude;
+                if (targetAmplitude > FrequencyAmplitudes[i])
+                    FrequencyAmplitudes[i] = targetAmplitude;
             }
 
-            indexOffset = (indexOffset + index_change) % bars_per_visualiser;
+            indexOffset = (indexOffset + SpectrumIndexChange) % bars_per_visualiser;
         }
 
         protected override void LoadComplete()
@@ -136,9 +136,9 @@ namespace osu.Game.Screens.Menu
             for (int i = 0; i < bars_per_visualiser; i++)
             {
                 //3% of extra bar length to make it a little faster when bar is almost at it's minimum
-                frequencyAmplitudes[i] -= decayFactor * (frequencyAmplitudes[i] + 0.03f);
-                if (frequencyAmplitudes[i] < 0)
-                    frequencyAmplitudes[i] = 0;
+                FrequencyAmplitudes[i] -= decayFactor * (FrequencyAmplitudes[i] + 0.03f);
+                if (FrequencyAmplitudes[i] < 0)
+                    FrequencyAmplitudes[i] = 0;
             }
 
             Invalidate(Invalidation.DrawNode);
@@ -184,11 +184,11 @@ namespace osu.Game.Screens.Menu
             {
                 base.ApplyState();
 
-                shader = Source.shader;
-                texture = Source.texture;
+                shader = Source.Shader;
+                texture = Source.Texture;
                 size = Source.DrawSize.X;
 
-                Source.frequencyAmplitudes.AsSpan().CopyTo(audioData);
+                Source.FrequencyAmplitudes.AsSpan().CopyTo(audioData);
             }
 
             protected override void Draw(IRenderer renderer)

--- a/osu.Game/Screens/Menu/OsuLogo.cs
+++ b/osu.Game/Screens/Menu/OsuLogo.cs
@@ -23,6 +23,7 @@ using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics.Backgrounds;
 using osu.Game.Graphics.Containers;
 using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Screens.Menu;
 using osu.Game.Overlays;
 using osuTK;
 using osuTK.Graphics;
@@ -59,7 +60,7 @@ namespace osu.Game.Screens.Menu
         [Resolved(canBeNull: true)]
         private Ez2ConfigManager ezConfig { get; set; }
 
-        protected virtual MenuLogoVisualisation CreateMenuLogoVisualisation() => new MenuLogoVisualisation();
+        protected virtual MenuLogoVisualisation CreateMenuLogoVisualisation() => new EzMenuLogoVisualisation();
 
         protected virtual double BeatSampleVariance => 0.1;
 

--- a/osu.Game/Seasonal/SeasonalMenuLogoVisualisation.cs
+++ b/osu.Game/Seasonal/SeasonalMenuLogoVisualisation.cs
@@ -1,11 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Screens.Menu;
+using osu.Game.EzOsuGame.Screens.Menu;
 
 namespace osu.Game.Seasonal
 {
-    internal partial class SeasonalMenuLogoVisualisation : MenuLogoVisualisation
+    internal partial class SeasonalMenuLogoVisualisation : EzMenuLogoVisualisation
     {
         protected override void UpdateColour() => Colour = SeasonalUIConfig.AMBIENT_COLOUR_1;
     }


### PR DESCRIPTION
## Summary
- 设置 → 用户界面 → 主菜单增加「Logo 可视化」下拉栏，可在径向柱状（默认）、环形折线、环形波形、环形圆点、环形网状和关闭之间切换，即时生效。
- 折线/圆点/网状沿用柱状图的 FFT peak-hold、200 点密度、5 圈叠加和绕圈旋转；波形用时域 PCM，左声道两圈 + 右声道两圈叠加。
- 圣诞皮肤继续走 Seasonal 配色。欢迎动画里那份独立可视化未改。

## Test plan
- [x] 主菜单/选歌看脸外圈：默认仍是径向柱状。
- [x] 下拉栏切换样式即时生效，无需重启。
- [x] 折线、圆点、网状有绕圈旋转和多层叠加，鼓点起伏接近柱状图。
- [x] 波形跟左右声道，形状不会每一帧整圈乱跳。
- [x] 关闭后外圈消失；supporter 颜色仍走皮肤 MenuGlow。