### PR TITLE
Add Ez client layout editor independent of skins

### DIFF
--- a/osu.Game.Tests/NonVisual/EzLayoutStoreTest.cs
+++ b/osu.Game.Tests/NonVisual/EzLayoutStoreTest.cs
@@ -1,0 +1,111 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.IO;
+using NUnit.Framework;
+using osu.Framework.Platform;
+using osu.Game.EzOsuGame.Layout;
+using osu.Game.Rulesets;
+using osu.Game.Skinning;
+using osu.Game.Skinning.Components;
+
+namespace osu.Game.Tests.NonVisual
+{
+    [TestFixture]
+    public class EzLayoutStoreTest
+    {
+        [Test]
+        public void TestSaveAndLoadRoundTrip()
+        {
+            string path = Path.Combine(Path.GetTempPath(), "ez-layout-test-" + Guid.NewGuid().ToString("N"));
+            var storage = new NativeStorage(path);
+
+            try
+            {
+                var store = new EzLayoutStore(storage);
+
+                var layout = new SkinLayoutInfo();
+                layout.Update(null, new[]
+                {
+                    new SerialisedDrawableInfo(new BoxElement())
+                });
+
+                store.Save(GlobalSkinnableContainers.SongSelect, layout);
+
+                var loaded = store.Load(GlobalSkinnableContainers.SongSelect);
+                Assert.That(loaded.TryGetDrawableInfo(null, out var infos), Is.True);
+                Assert.That(infos!.Length, Is.EqualTo(1));
+                Assert.That(infos[0].Type, Is.EqualTo(typeof(BoxElement)));
+
+                store.Reset(GlobalSkinnableContainers.SongSelect);
+                var empty = store.Load(GlobalSkinnableContainers.SongSelect);
+                Assert.That(empty.TryGetDrawableInfo(null, out _), Is.False);
+            }
+            finally
+            {
+                try
+                {
+                    if (Directory.Exists(path))
+                        Directory.Delete(path, true);
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        [Test]
+        public void TestSavePreservesOtherRulesetLayer()
+        {
+            string path = Path.Combine(Path.GetTempPath(), "ez-layout-test-" + Guid.NewGuid().ToString("N"));
+            var storage = new NativeStorage(path);
+            var mania = new RulesetInfo("mania", "osu!mania", string.Empty, 3);
+
+            try
+            {
+                var store = new EzLayoutStore(storage);
+
+                var globalLayout = new SkinLayoutInfo();
+                globalLayout.Update(null, new[] { new SerialisedDrawableInfo(new BoxElement()) });
+                store.Save(GlobalSkinnableContainers.MainHUDComponents, globalLayout);
+
+                var merged = store.Load(GlobalSkinnableContainers.MainHUDComponents);
+                merged.Update(mania, new[] { new SerialisedDrawableInfo(new BigBlackBox()) });
+                store.Save(GlobalSkinnableContainers.MainHUDComponents, merged);
+
+                var loaded = store.Load(GlobalSkinnableContainers.MainHUDComponents);
+                Assert.That(loaded.TryGetDrawableInfo(null, out var global), Is.True);
+                Assert.That(global![0].Type, Is.EqualTo(typeof(BoxElement)));
+                Assert.That(loaded.TryGetDrawableInfo(mania, out var ruleset), Is.True);
+                Assert.That(ruleset![0].Type, Is.EqualTo(typeof(BigBlackBox)));
+
+                store.Reset(new GlobalSkinnableContainerLookup(GlobalSkinnableContainers.MainHUDComponents, mania));
+                var afterReset = store.Load(GlobalSkinnableContainers.MainHUDComponents);
+                Assert.That(afterReset.TryGetDrawableInfo(mania, out _), Is.False);
+                Assert.That(afterReset.TryGetDrawableInfo(null, out var stillGlobal), Is.True);
+                Assert.That(stillGlobal![0].Type, Is.EqualTo(typeof(BoxElement)));
+            }
+            finally
+            {
+                try
+                {
+                    if (Directory.Exists(path))
+                        Directory.Delete(path, true);
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        [Test]
+        public void TestToolboxBlacklistExcludesSpecifiedTypesOnly()
+        {
+            var filter = EzLayoutToolboxBlacklist.INSTANCE;
+
+            Assert.That(filter.IsExcluded(typeof(BigBlackBox)), Is.True);
+            Assert.That(filter.IsExcluded(typeof(BoxElement)), Is.False);
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/EzModifyPath.cs
+++ b/osu.Game/EzOsuGame/EzModifyPath.cs
@@ -17,6 +17,7 @@ namespace osu.Game.EzOsuGame
         public const string VIDEO_PATH = @"EzResources/Video";
         public const string BG_PATH = @"EzResources/BG";
         public const string BG_PIXIV_PATH = @"EzResources/BG_PIXIV";
+        public const string CONFIG_LAYOUT_PATH = @"EzResources/Config/layout";
 
         /// <summary>
         /// Pixiv OAuth refresh token (same directory as client.realm / framework.ini).

--- a/osu.Game/EzOsuGame/Layout/EzLayoutContainer.cs
+++ b/osu.Game/EzOsuGame/Layout/EzLayoutContainer.cs
@@ -1,0 +1,59 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Skinning;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.Layout
+{
+    /// <summary>
+    /// A skinnable-style container that reloads from <see cref="EzLayoutStore"/> instead of the current skin.
+    /// Lives on <see cref="EzLayoutLayer"/> so the official skin editor cannot see it.
+    /// </summary>
+    public partial class EzLayoutContainer : SkinnableContainer
+    {
+        private readonly EzLayoutStore store;
+        private CompositeDrawable? dependencyDonor;
+
+        public EzLayoutContainer(EzLayoutStore store, GlobalSkinnableContainerLookup lookup)
+            : base(lookup)
+        {
+            this.store = store;
+            RelativeSizeAxes = Axes.Both;
+        }
+
+        /// <summary>
+        /// Must be set before this drawable is loaded if child components need another screen's DI
+        /// (for example <c>ScoreProcessor</c> from <c>Player</c>).
+        /// </summary>
+        public void SetDependencyDonor(CompositeDrawable? donor)
+        {
+            dependencyDonor = donor;
+        }
+
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+        {
+            var baseDependencies = base.CreateChildDependencies(parent);
+
+            if (dependencyDonor?.Dependencies == null)
+                return baseDependencies;
+
+            return new DependencyContainer(dependencyDonor.Dependencies);
+        }
+
+        protected override void SkinChanged(ISkinSource skin)
+        {
+            // Never pull layout from the active skin.
+            LoadFromStore();
+        }
+
+        public void LoadFromStore() => Reload(store.CreateComponentsContainer(Lookup));
+
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) =>
+            Alpha > 0 && InternalChildren.Any(c => c.IsPresent && c.ReceivePositionalInputAt(screenSpacePos));
+    }
+}

--- a/osu.Game/EzOsuGame/Layout/EzLayoutEditor.cs
+++ b/osu.Game/EzOsuGame/Layout/EzLayoutEditor.cs
@@ -1,0 +1,93 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.Graphics;
+using osu.Game.Overlays;
+using osu.Game.Overlays.SkinEditor;
+using osu.Game.Skinning;
+using SkinEditorControl = osu.Game.Overlays.SkinEditor.SkinEditor;
+
+namespace osu.Game.EzOsuGame.Layout
+{
+    /// <summary>
+    /// Skin editor UI pointed at <see cref="EzLayoutLayer"/>, persisting to <see cref="EzLayoutStore"/>.
+    /// </summary>
+    public partial class EzLayoutEditor : SkinEditorControl
+    {
+        [Resolved]
+        private EzLayoutLayer layoutLayer { get; set; } = null!;
+
+        [Resolved]
+        private EzLayoutEditorOverlay editorOverlay { get; set; } = null!;
+
+        [Resolved]
+        private OsuColour colours { get; set; } = null!;
+
+        [Resolved]
+        private OnScreenDisplay? onScreenDisplay { get; set; }
+
+        [Cached(typeof(ISkinComponentToolboxFilter))]
+        private readonly ISkinComponentToolboxFilter toolboxFilter = EzLayoutToolboxBlacklist.INSTANCE;
+
+        protected override IEnumerable<SkinnableContainer> AvailableTargets =>
+            layoutLayer.LayoutContainers.Where(c => c.Alpha > 0);
+
+        protected override void RequestClose() => editorOverlay.Hide();
+
+        protected override void OnSkinChanged()
+        {
+            HeaderText.Clear();
+            HeaderText.AddText(EzEditorStrings.LAYOUT_EDITOR_TITLE, cp => cp.Font = OsuFont.Default.With(size: 16));
+            HeaderText.NewLine();
+            HeaderText.AddText(EzEditorStrings.LAYOUT_EDITOR_SUBTITLE, cp =>
+            {
+                cp.Font = OsuFont.Default.With(size: 12);
+                cp.Colour = colours.Yellow;
+            });
+
+            Schedule(() =>
+            {
+                HasBegunMutating = true;
+                SelectedTarget.TriggerChange();
+            });
+        }
+
+        protected override void SaveLayout(Skin skin, bool userTriggered = true)
+        {
+            if (!HasBegunMutating)
+                return;
+
+            var targets = AvailableTargets.ToArray();
+
+            if (targets.Length == 0 || !targets.All(c => c.ComponentsLoaded))
+                return;
+
+            foreach (var t in targets)
+                layoutLayer.Store.Save(t);
+
+            if (userTriggered)
+            {
+                onScreenDisplay?.Display(new SkinEditorToast(
+                    EzEditorStrings.LAYOUT_SAVED,
+                    EzModifyPath.CONFIG_LAYOUT_PATH));
+            }
+        }
+
+        protected override void RevertToDefault()
+        {
+            foreach (var t in AvailableTargets.ToArray())
+            {
+                layoutLayer.Store.Reset(t.Lookup);
+
+                if (t is EzLayoutContainer ez)
+                    ez.LoadFromStore();
+                else
+                    t.Reload();
+            }
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Layout/EzLayoutEditorOverlay.cs
+++ b/osu.Game/EzOsuGame/Layout/EzLayoutEditorOverlay.cs
@@ -1,0 +1,51 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Overlays.SkinEditor;
+using osu.Game.Screens;
+using SkinEditorControl = osu.Game.Overlays.SkinEditor.SkinEditor;
+
+namespace osu.Game.EzOsuGame.Layout
+{
+    /// <summary>
+    /// Overlay host for <see cref="EzLayoutEditor"/>. No hotkey; opened from settings.
+    /// </summary>
+    [Cached(typeof(SkinEditorOverlay))]
+    public partial class EzLayoutEditorOverlay : SkinEditorOverlay
+    {
+        private readonly EzLayoutLayer layoutLayer;
+
+        protected override bool PresentsGameplayFromMainMenu => false;
+
+        public EzLayoutEditorOverlay(ScalingContainer scalingContainer, EzLayoutLayer layoutLayer)
+            : base(scalingContainer)
+        {
+            this.layoutLayer = layoutLayer;
+        }
+
+        protected override SkinEditorControl CreateEditor() => new EzLayoutEditor();
+
+        protected override Drawable GetEditorTarget(OsuScreen screen) => layoutLayer;
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            layoutLayer.LayoutTargetsChanged += onLayoutTargetsChanged;
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            layoutLayer.LayoutTargetsChanged -= onLayoutTargetsChanged;
+            base.Dispose(isDisposing);
+        }
+
+        private void onLayoutTargetsChanged()
+        {
+            if (LastTargetScreen != null)
+                SetTarget(LastTargetScreen);
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Layout/EzLayoutLayer.cs
+++ b/osu.Game/EzOsuGame/Layout/EzLayoutLayer.cs
@@ -1,0 +1,168 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Platform;
+using osu.Framework.Screens;
+using osu.Game.Screens.Play;
+using osu.Game.Screens.Select;
+using osu.Game.Skinning;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.Layout
+{
+    /// <summary>
+    /// Game-level host for Ez layout containers. Shown on song select and player; not mixed into skins.
+    /// </summary>
+    public partial class EzLayoutLayer : CompositeDrawable
+    {
+        public EzLayoutStore Store { get; private set; } = null!;
+
+        public EzLayoutContainer SongSelectContainer { get; private set; } = null!;
+
+        /// <summary>
+        /// Fired after song-select / gameplay containers are shown, hidden, or recreated.
+        /// </summary>
+        public event Action? LayoutTargetsChanged;
+
+        private EzLayoutContainer? gameplayContainer;
+        private EzLayoutContainer? rulesetGameplayContainer;
+        private Player? pendingPlayer;
+
+        [Resolved]
+        private OsuGame game { get; set; } = null!;
+
+        public EzLayoutLayer()
+        {
+            RelativeSizeAxes = Axes.Both;
+            Depth = -0.5f;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(Storage storage)
+        {
+            Store = new EzLayoutStore(storage);
+
+            InternalChild = SongSelectContainer = new EzLayoutContainer(
+                Store,
+                new GlobalSkinnableContainerLookup(GlobalSkinnableContainers.SongSelect));
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            game.ScreenStack.ScreenPushed += onScreenChanged;
+            game.ScreenStack.ScreenExited += onScreenChanged;
+            applyScreen(game.ScreenStack.CurrentScreen);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            unbindPendingPlayer();
+
+            if (game.ScreenStack != null)
+            {
+                game.ScreenStack.ScreenPushed -= onScreenChanged;
+                game.ScreenStack.ScreenExited -= onScreenChanged;
+            }
+
+            base.Dispose(isDisposing);
+        }
+
+        public IEnumerable<EzLayoutContainer> LayoutContainers => InternalChildren.OfType<EzLayoutContainer>();
+
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) =>
+            InternalChildren.Any(c => c.IsPresent && c.ReceivePositionalInputAt(screenSpacePos));
+
+        private void onScreenChanged(IScreen last, IScreen next) => Schedule(() => applyScreen(next));
+
+        private void applyScreen(IScreen? screen)
+        {
+            unbindPendingPlayer();
+
+            bool onSongSelect = screen is SongSelect;
+            bool onPlayer = screen is Player;
+
+            SongSelectContainer.Alpha = onSongSelect ? 1 : 0;
+
+            if (onPlayer && screen is Player player)
+            {
+                if (!player.IsLoaded)
+                {
+                    pendingPlayer = player;
+                    pendingPlayer.OnLoadComplete += onPendingPlayerLoaded;
+                    notifyTargetsChanged();
+                    return;
+                }
+
+                recreateGameplayContainers(player);
+            }
+            else if (gameplayContainer != null || rulesetGameplayContainer != null)
+            {
+                expireGameplayContainers();
+                notifyTargetsChanged();
+            }
+            else
+            {
+                notifyTargetsChanged();
+            }
+        }
+
+        private void onPendingPlayerLoaded(Drawable loaded)
+        {
+            unbindPendingPlayer();
+
+            Schedule(() =>
+            {
+                if (game.ScreenStack.CurrentScreen == loaded && loaded is Player player)
+                    recreateGameplayContainers(player);
+            });
+        }
+
+        private void unbindPendingPlayer()
+        {
+            if (pendingPlayer == null)
+                return;
+
+            pendingPlayer.OnLoadComplete -= onPendingPlayerLoaded;
+            pendingPlayer = null;
+        }
+
+        private void recreateGameplayContainers(Player player)
+        {
+            expireGameplayContainers();
+
+            gameplayContainer = addGameplayContainer(player, new GlobalSkinnableContainerLookup(GlobalSkinnableContainers.MainHUDComponents));
+
+            var ruleset = player.Ruleset.Value;
+            if (ruleset != null)
+                rulesetGameplayContainer = addGameplayContainer(player, new GlobalSkinnableContainerLookup(GlobalSkinnableContainers.MainHUDComponents, ruleset));
+
+            notifyTargetsChanged();
+        }
+
+        private EzLayoutContainer addGameplayContainer(Player player, GlobalSkinnableContainerLookup lookup)
+        {
+            var container = new EzLayoutContainer(Store, lookup);
+            container.SetDependencyDonor(player.Dependencies.Get(typeof(HUDOverlay)) as CompositeDrawable ?? player);
+            AddInternal(container);
+            return container;
+        }
+
+        private void expireGameplayContainers()
+        {
+            gameplayContainer?.Expire();
+            gameplayContainer = null;
+            rulesetGameplayContainer?.Expire();
+            rulesetGameplayContainer = null;
+        }
+
+        private void notifyTargetsChanged() => LayoutTargetsChanged?.Invoke();
+    }
+}

--- a/osu.Game/EzOsuGame/Layout/EzLayoutStore.cs
+++ b/osu.Game/EzOsuGame/Layout/EzLayoutStore.cs
@@ -1,0 +1,129 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.IO.Serialization;
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using osu.Game.Skinning;
+
+namespace osu.Game.EzOsuGame.Layout
+{
+    /// <summary>
+    /// Loads and saves Ez client layout JSON under <see cref="EzModifyPath.CONFIG_LAYOUT_PATH"/>.
+    /// Independent of skin files and Realm skin storage.
+    /// </summary>
+    public class EzLayoutStore
+    {
+        private static readonly JsonSerializerSettings json_settings = new JsonSerializerSettings
+        {
+            Formatting = Formatting.Indented,
+            ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+            Converters = new List<JsonConverter> { new Vector2Converter() },
+        };
+
+        private readonly Storage storage;
+
+        public EzLayoutStore(Storage gameStorage)
+        {
+            storage = gameStorage.GetStorageForDirectory(EzModifyPath.CONFIG_LAYOUT_PATH);
+        }
+
+        public SkinLayoutInfo Load(GlobalSkinnableContainers target)
+        {
+            string filename = getFilename(target);
+
+            if (!storage.Exists(filename))
+                return new SkinLayoutInfo();
+
+            try
+            {
+                using (var stream = storage.GetStream(filename))
+                {
+                    if (stream == null)
+                        return new SkinLayoutInfo();
+
+                    using (var reader = new StreamReader(stream, Encoding.UTF8))
+                    {
+                        string json = reader.ReadToEnd();
+                        return JsonConvert.DeserializeObject<SkinLayoutInfo>(json, json_settings) ?? new SkinLayoutInfo();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, $"Failed to load Ez layout {filename}");
+                return new SkinLayoutInfo();
+            }
+        }
+
+        public void Save(SkinnableContainer container)
+        {
+            var layout = Load(container.Lookup.Lookup);
+            layout.Update(container.Lookup.Ruleset, ((ISerialisableDrawableContainer)container).CreateSerialisedInfo().ToArray());
+            Save(container.Lookup.Lookup, layout);
+        }
+
+        public void Save(GlobalSkinnableContainers target, SkinLayoutInfo layout)
+        {
+            string filename = getFilename(target);
+            string json = JsonConvert.SerializeObject(layout, json_settings);
+
+            using (var stream = storage.CreateFileSafely(filename))
+            using (var writer = new StreamWriter(stream, Encoding.UTF8))
+                writer.Write(json);
+        }
+
+        public void Reset(GlobalSkinnableContainers target)
+        {
+            string filename = getFilename(target);
+
+            if (storage.Exists(filename))
+                storage.Delete(filename);
+        }
+
+        public void Reset(GlobalSkinnableContainerLookup lookup)
+        {
+            var layout = Load(lookup.Lookup);
+            layout.Reset(lookup.Ruleset);
+
+            if (layout.DrawableInfo.Count == 0)
+                Reset(lookup.Lookup);
+            else
+                Save(lookup.Lookup, layout);
+        }
+
+        public Container CreateComponentsContainer(GlobalSkinnableContainerLookup lookup)
+        {
+            var layout = Load(lookup.Lookup);
+
+            if (!layout.TryGetDrawableInfo(lookup.Ruleset, out var drawableInfos) || drawableInfos.Length == 0)
+            {
+                return new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                };
+            }
+
+            return new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                ChildrenEnumerable = drawableInfos.Select(i => i.CreateInstance())
+            };
+        }
+
+        private static string getFilename(GlobalSkinnableContainers target) => target switch
+        {
+            GlobalSkinnableContainers.SongSelect => @"SongSelect.json",
+            GlobalSkinnableContainers.MainHUDComponents => @"Gameplay.json",
+            _ => $"{target}.json",
+        };
+    }
+}

--- a/osu.Game/EzOsuGame/Layout/EzLayoutToolboxBlacklist.cs
+++ b/osu.Game/EzOsuGame/Layout/EzLayoutToolboxBlacklist.cs
@@ -1,0 +1,31 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Game.Overlays.SkinEditor;
+using osu.Game.Skinning.Components;
+
+namespace osu.Game.EzOsuGame.Layout
+{
+    /// <summary>
+    /// Types hidden from the Ez layout editor toolbox.
+    /// Official HUD components are intentionally not listed so they can be placed in the client layout.
+    /// </summary>
+    public sealed class EzLayoutToolboxBlacklist : ISkinComponentToolboxFilter
+    {
+        public static readonly EzLayoutToolboxBlacklist INSTANCE = new EzLayoutToolboxBlacklist();
+
+        private readonly HashSet<Type> excluded = new HashSet<Type>
+        {
+            // BigBlackBox is a joke/debug skin component; keep it out of the client layout toolbox.
+            typeof(BigBlackBox),
+        };
+
+        private EzLayoutToolboxBlacklist()
+        {
+        }
+
+        public bool IsExcluded(Type type) => excluded.Contains(type);
+    }
+}

--- a/osu.Game/EzOsuGame/Localization/EzEditorStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzEditorStrings.cs
@@ -23,6 +23,26 @@ namespace osu.Game.EzOsuGame.Localization
             + "\n2. Full Ez skin settings with skin.ini export"
             + "\n3. In-game image export (including gradient animations)");
 
+        public static readonly LocalisableString SETTINGS_LAYOUT_EDITOR_BUTTON = new EzLocalizationManager.EzLocalisableString(
+            "Ez 布局编辑器",
+            "Ez layout editor");
+
+        public static readonly LocalisableString SETTINGS_LAYOUT_EDITOR_BUTTON_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "编辑与皮肤无关的客户端布局（存于 EzResources/Config/layout）",
+            "Edit the client layout stored in EzResources/Config/layout, independent of skins");
+
+        public static readonly LocalisableString LAYOUT_EDITOR_TITLE = new EzLocalizationManager.EzLocalisableString(
+            "Ez 布局编辑器",
+            "Ez layout editor");
+
+        public static readonly LocalisableString LAYOUT_EDITOR_SUBTITLE = new EzLocalizationManager.EzLocalisableString(
+            "客户端布局（不写入皮肤）",
+            "Client layout (not saved to skin)");
+
+        public static readonly LocalisableString LAYOUT_SAVED = new EzLocalizationManager.EzLocalisableString(
+            "布局已保存",
+            "Layout saved");
+
         public static readonly LocalisableString SETTINGS_AUTO_APPLY_SKIN_JSON = new EzLocalizationManager.EzLocalisableString(
             "自动切换皮肤配置",
             "Auto-apply skin configuration");

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -44,6 +44,7 @@ using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.Edit;
 using osu.Game.EzOsuGame.Analysis;
 using osu.Game.EzOsuGame.Background.Pixiv;
+using osu.Game.EzOsuGame.Layout;
 using osu.Game.EzOsuGame.Overlays;
 using osu.Game.EzOsuGame.Performance;
 using osu.Game.EzOsuGame.Scoring;
@@ -155,6 +156,10 @@ namespace osu.Game
 
         private SkinEditorOverlay skinEditor;
 
+        private EzLayoutLayer ezLayoutLayer;
+
+        private EzLayoutEditorOverlay ezLayoutEditor;
+
         private Container overlayContent;
 
         private Container rightFloatingOverlayContent;
@@ -248,6 +253,7 @@ namespace osu.Game
         private ScreenStackFooter screenStackFooter;
 
         private AcrylicCaptureScope acrylicCaptureScope;
+        private Container screenCaptureContent;
 
         private readonly string[] args;
 
@@ -1145,7 +1151,11 @@ namespace osu.Game
                             Children = new Drawable[]
                             {
                                 backReceptor = new ScreenFooter.BackReceptor(),
-                                acrylicCaptureScope = new AcrylicCaptureScope(ScreenStack = new OsuScreenStack { RelativeSizeAxes = Axes.Both }),
+                                acrylicCaptureScope = new AcrylicCaptureScope(screenCaptureContent = new Container
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Child = ScreenStack = new OsuScreenStack { RelativeSizeAxes = Axes.Both },
+                                }),
                                 logoContainer = new Container { RelativeSizeAxes = Axes.Both },
                                 // TODO: what is this? why is this?
                                 // TODO: this is being screen scaled even though it's probably AN OVERLAY.
@@ -1264,7 +1274,21 @@ namespace osu.Game
             loadComponentSingleFile(userProfile = new UserProfileOverlay(), overlayContent.Add, true);
             loadComponentSingleFile(beatmapSetOverlay = new BeatmapSetOverlay(), overlayContent.Add, true);
             loadComponentSingleFile(wikiOverlay = new WikiOverlay(), overlayContent.Add, true);
+            loadComponentSingleFile(ezLayoutLayer = new EzLayoutLayer(), screenCaptureContent.Add, true);
             loadComponentSingleFile(skinEditor = new SkinEditorOverlay(ScreenContainer), overlayContent.Add, true);
+            loadComponentSingleFile(ezLayoutEditor = new EzLayoutEditorOverlay(ScreenContainer, ezLayoutLayer), topMostOverlayContent.Add, true);
+
+            skinEditor.State.ValueChanged += state =>
+            {
+                if (state.NewValue == Visibility.Visible)
+                    ezLayoutEditor.Hide();
+            };
+
+            ezLayoutEditor.State.ValueChanged += state =>
+            {
+                if (state.NewValue == Visibility.Visible)
+                    skinEditor.Hide();
+            };
 
             loadComponentSingleFile(loginOverlay = new LoginOverlay
             {
@@ -1889,6 +1913,7 @@ namespace osu.Game
                     Toolbar.Show();
 
                 skinEditor.SetTarget(newOsuScreen);
+                ezLayoutEditor.SetTarget(newOsuScreen);
             }
         }
 

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -20,6 +20,7 @@ using osu.Framework.Localisation;
 using osu.Framework.Logging;
 using osu.Game.Database;
 using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Layout;
 using osu.Game.EzOsuGame.Localization;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
@@ -61,7 +62,7 @@ namespace osu.Game.Overlays.Settings.Sections
         private IDisposable realmSubscription;
 
         [BackgroundDependencyLoader(permitNulls: true)]
-        private void load([CanBeNull] SkinEditorOverlay skinEditor)
+        private void load([CanBeNull] SkinEditorOverlay skinEditor, [CanBeNull] EzLayoutEditorOverlay ezLayoutEditor)
         {
             Children = new Drawable[]
             {
@@ -90,6 +91,12 @@ namespace osu.Game.Overlays.Settings.Sections
                 {
                     Text = SkinSettingsStrings.SkinLayoutEditor,
                     Action = () => skinEditor?.ToggleVisibility(),
+                },
+                new SettingsButtonV2
+                {
+                    Text = EzEditorStrings.SETTINGS_LAYOUT_EDITOR_BUTTON,
+                    TooltipText = EzEditorStrings.SETTINGS_LAYOUT_EDITOR_BUTTON_TOOLTIP,
+                    Action = () => ezLayoutEditor?.ToggleVisibility(),
                 },
                 new SettingsButtonV2
                 {

--- a/osu.Game/Overlays/SkinEditor/SkinComponentToolbox.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinComponentToolbox.cs
@@ -20,6 +20,15 @@ using osuTK;
 
 namespace osu.Game.Overlays.SkinEditor
 {
+    /// <summary>
+    /// Optional filter applied when listing components in <see cref="SkinComponentToolbox"/>.
+    /// Official skin editor does not cache this, so it has no effect there.
+    /// </summary>
+    public interface ISkinComponentToolboxFilter
+    {
+        bool IsExcluded(Type type);
+    }
+
     public partial class SkinComponentToolbox : EditorSidebarSection
     {
         public Action<Type>? RequestPlacement;
@@ -29,6 +38,9 @@ namespace osu.Game.Overlays.SkinEditor
         private readonly RulesetInfo? ruleset;
 
         private FillFlowContainer fill = null!;
+
+        [Resolved(canBeNull: true)]
+        private ISkinComponentToolboxFilter? typeFilter { get; set; }
 
         /// <summary>
         /// Create a new component toolbox for the specified taget.
@@ -67,6 +79,9 @@ namespace osu.Game.Overlays.SkinEditor
 
         private void attemptAddComponent(Type type)
         {
+            if (typeFilter?.IsExcluded(type) == true)
+                return;
+
             try
             {
                 Drawable instance = (Drawable)Activator.CreateInstance(type)!;

--- a/osu.Game/Overlays/SkinEditor/SkinEditor.EzMenu.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.EzMenu.cs
@@ -59,6 +59,6 @@ namespace osu.Game.Overlays.SkinEditor
             };
         }
 
-        internal GlobalSkinnableContainerLookup? CurrentTarget => selectedTarget.Value;
+        internal GlobalSkinnableContainerLookup? CurrentTarget => SelectedTarget.Value;
     }
 }

--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -54,9 +54,9 @@ namespace osu.Game.Overlays.SkinEditor
 
         protected override bool StartHidden => true;
 
-        private Drawable? targetScreen;
+        protected Drawable? TargetScreen;
 
-        private OsuTextFlowContainer headerText = null!;
+        protected OsuTextFlowContainer HeaderText = null!;
 
         private Bindable<Skin> currentSkin = null!;
         private Bindable<string> clipboardContent = null!;
@@ -79,9 +79,9 @@ namespace osu.Game.Overlays.SkinEditor
         [Cached]
         private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Blue);
 
-        private readonly Bindable<GlobalSkinnableContainerLookup?> selectedTarget = new Bindable<GlobalSkinnableContainerLookup?>();
+        protected readonly Bindable<GlobalSkinnableContainerLookup?> SelectedTarget = new Bindable<GlobalSkinnableContainerLookup?>();
 
-        private bool hasBegunMutating;
+        protected bool HasBegunMutating;
 
         private Container? content;
 
@@ -174,9 +174,9 @@ namespace osu.Game.Overlays.SkinEditor
                                                         editExternallyMenuItem = new EditorMenuItem(EditorStrings.EditExternally, MenuItemType.Standard, () => _ = editExternally()) { Action = { Disabled = !RuntimeInfo.IsDesktop } },
                                                         openScriptFolderMenuItem = new EditorMenuItem("Open script folder", MenuItemType.Standard, () => _ = openScriptedSkinFolder()) { Action = { Disabled = !RuntimeInfo.IsDesktop } },
                                                         new OsuMenuItemSpacer(),
-                                                        new EditorMenuItem(CommonStrings.RevertToDefault, MenuItemType.Destructive, () => dialogOverlay?.Push(new RevertConfirmDialog(revert))),
+                                                        new EditorMenuItem(CommonStrings.RevertToDefault, MenuItemType.Destructive, () => dialogOverlay?.Push(new RevertConfirmDialog(RevertToDefault))),
                                                         new OsuMenuItemSpacer(),
-                                                        new EditorMenuItem(CommonStrings.Exit, MenuItemType.Standard, () => skinEditorOverlay?.Hide()),
+                                                        new EditorMenuItem(CommonStrings.Exit, MenuItemType.Standard, RequestClose),
                                                     },
                                                 },
                                                 new MenuItem(CommonStrings.MenuBarEdit)
@@ -195,7 +195,7 @@ namespace osu.Game.Overlays.SkinEditor
                                                 createEzSettingsMenu(),
                                             }
                                         },
-                                        headerText = new OsuTextFlowContainer
+                                        HeaderText = new OsuTextFlowContainer
                                         {
                                             TextAnchor = Anchor.TopRight,
                                             Padding = new MarginPadding(5),
@@ -279,16 +279,16 @@ namespace osu.Game.Overlays.SkinEditor
             // probably something which will be factored out in a future database refactor so not too concerning for now.
             currentSkin.BindValueChanged(val =>
             {
-                if (val.OldValue != null && hasBegunMutating)
-                    save(val.OldValue);
+                if (val.OldValue != null && HasBegunMutating)
+                    SaveLayout(val.OldValue);
 
-                hasBegunMutating = false;
-                Scheduler.AddOnce(skinChanged);
+                HasBegunMutating = false;
+                Scheduler.AddOnce(OnSkinChanged);
             }, true);
 
             SelectedComponents.BindCollectionChanged((_, _) => Scheduler.AddOnce(populateSettings), true);
 
-            selectedTarget.BindValueChanged(targetChanged, true);
+            SelectedTarget.BindValueChanged(targetChanged, true);
         }
 
         private async Task editExternally()
@@ -320,9 +320,6 @@ namespace osu.Game.Overlays.SkinEditor
 
         private void updateExternalEditMenuState()
         {
-            if (editExternallyMenuItem == null || openScriptFolderMenuItem == null)
-                return;
-
             bool isScripted = ScriptedSkinSupport.IsScriptedSkin(currentSkin.Value.SkinInfo);
             bool canRealmEdit = ScriptedSkinSupport.CanUseRealmExternalEdit(currentSkin.Value.SkinInfo);
 
@@ -388,9 +385,11 @@ namespace osu.Game.Overlays.SkinEditor
         {
         }
 
+        protected virtual void RequestClose() => skinEditorOverlay?.Hide();
+
         public void UpdateTargetScreen(Drawable targetScreen)
         {
-            this.targetScreen = targetScreen;
+            TargetScreen = targetScreen;
 
             changeHandler?.Dispose();
 
@@ -403,10 +402,10 @@ namespace osu.Game.Overlays.SkinEditor
 
             void loadBlueprintContainer()
             {
-                selectedTarget.Default = getFirstTarget()?.Lookup;
+                SelectedTarget.Default = GetFirstTarget()?.Lookup;
 
-                if (!availableTargets.Any(t => t.Lookup.Equals(selectedTarget.Value)))
-                    selectedTarget.SetDefault();
+                if (!AvailableTargets.Any(t => t.Lookup.Equals(SelectedTarget.Value)))
+                    SelectedTarget.SetDefault();
             }
         }
 
@@ -420,7 +419,7 @@ namespace osu.Game.Overlays.SkinEditor
 
             Debug.Assert(content != null);
 
-            var skinComponentsContainer = getTarget(target.NewValue);
+            var skinComponentsContainer = GetTarget(target.NewValue);
 
             if (target.NewValue == null || skinComponentsContainer == null)
             {
@@ -443,8 +442,8 @@ namespace osu.Game.Overlays.SkinEditor
                     {
                         new SettingsDropdown<GlobalSkinnableContainerLookup?>
                         {
-                            Items = availableTargets.Select(t => t.Lookup).Distinct(),
-                            Current = selectedTarget,
+                            Items = AvailableTargets.Select(t => t.Lookup).Distinct(),
+                            Current = SelectedTarget,
                         }
                     }
                 }
@@ -491,23 +490,23 @@ namespace osu.Game.Overlays.SkinEditor
             }
         }
 
-        private void skinChanged()
+        protected virtual void OnSkinChanged()
         {
             if (skins.EnsureMutableSkin())
                 // Another skin changed event will arrive which will complete the process.
                 return;
 
-            headerText.Clear();
+            HeaderText.Clear();
 
-            headerText.AddText(SkinEditorStrings.SkinEditor, cp => cp.Font = OsuFont.Default.With(size: 16));
-            headerText.NewLine();
-            headerText.AddText(SkinEditorStrings.CurrentlyEditing, cp =>
+            HeaderText.AddText(SkinEditorStrings.SkinEditor, cp => cp.Font = OsuFont.Default.With(size: 16));
+            HeaderText.NewLine();
+            HeaderText.AddText(SkinEditorStrings.CurrentlyEditing, cp =>
             {
                 cp.Font = OsuFont.Default.With(size: 12);
                 cp.Colour = colours.Yellow;
             });
 
-            headerText.AddText($" {currentSkin.Value.SkinInfo}", cp =>
+            HeaderText.AddText($" {currentSkin.Value.SkinInfo}", cp =>
             {
                 cp.Font = OsuFont.Default.With(size: 12, weight: FontWeight.Bold);
                 cp.Colour = colours.Yellow;
@@ -524,15 +523,15 @@ namespace osu.Game.Overlays.SkinEditor
             // See https://github.com/ppy/osu/blob/8e6a4559e3ae8c9892866cf9cf8d4e8d1b72afd0/osu.Game/Skinning/SkinReloadableDrawable.cs#L76.
             Schedule(() =>
             {
-                var targetContainer = getTarget(selectedTarget.Value);
+                var targetContainer = GetTarget(SelectedTarget.Value);
 
                 if (targetContainer != null)
                     changeHandler = new SkinEditorChangeHandler(targetContainer);
 
-                hasBegunMutating = true;
+                HasBegunMutating = true;
 
                 // Reload sidebar components.
-                selectedTarget.TriggerChange();
+                SelectedTarget.TriggerChange();
             });
         }
 
@@ -544,7 +543,7 @@ namespace osu.Game.Overlays.SkinEditor
         /// <returns>Whether placement succeeded. Could fail if no target is available, or if the current target has missing dependency requirements for the component.</returns>
         private bool placeComponent(ISerialisableDrawable component, bool applyDefaults = true)
         {
-            var targetContainer = getTarget(selectedTarget.Value);
+            var targetContainer = GetTarget(SelectedTarget.Value);
 
             if (targetContainer == null)
                 return false;
@@ -586,25 +585,26 @@ namespace osu.Game.Overlays.SkinEditor
             });
         }
 
-        private IEnumerable<SkinnableContainer> availableTargets => targetScreen.ChildrenOfType<SkinnableContainer>();
+        protected virtual IEnumerable<SkinnableContainer> AvailableTargets =>
+            TargetScreen?.ChildrenOfType<SkinnableContainer>() ?? Enumerable.Empty<SkinnableContainer>();
 
-        private SkinnableContainer? getFirstTarget() => availableTargets.FirstOrDefault();
+        protected SkinnableContainer? GetFirstTarget() => AvailableTargets.FirstOrDefault();
 
-        private SkinnableContainer? getTarget(GlobalSkinnableContainerLookup? target)
+        protected virtual SkinnableContainer? GetTarget(GlobalSkinnableContainerLookup? target)
         {
-            return availableTargets.FirstOrDefault(c => c.Lookup.Equals(target));
+            return AvailableTargets.FirstOrDefault(c => c.Lookup.Equals(target));
         }
 
-        private void revert()
+        protected virtual void RevertToDefault()
         {
-            SkinnableContainer[] targetContainers = availableTargets.ToArray();
+            SkinnableContainer[] targetContainers = AvailableTargets.ToArray();
 
             foreach (var t in targetContainers)
             {
                 currentSkin.Value.ResetDrawableTarget(t);
 
                 // add back default components
-                getTarget(t.Lookup)?.Reload();
+                GetTarget(t.Lookup)?.Reload();
             }
         }
 
@@ -659,17 +659,17 @@ namespace osu.Game.Overlays.SkinEditor
 
         void IEditorChangeHandler.RestoreState(int direction) => changeHandler?.RestoreState(direction);
 
-        public void Save(bool userTriggered = true) => save(currentSkin.Value, userTriggered);
+        public void Save(bool userTriggered = true) => SaveLayout(currentSkin.Value, userTriggered);
 
-        private void save(Skin skin, bool userTriggered = true)
+        protected virtual void SaveLayout(Skin skin, bool userTriggered = true)
         {
-            if (!hasBegunMutating)
+            if (!HasBegunMutating)
                 return;
 
-            if (targetScreen?.IsLoaded != true)
+            if (TargetScreen?.IsLoaded != true)
                 return;
 
-            SkinnableContainer[] targetContainers = availableTargets.ToArray();
+            SkinnableContainer[] targetContainers = AvailableTargets.ToArray();
 
             if (!targetContainers.All(c => c.ComponentsLoaded))
                 return;
@@ -707,14 +707,14 @@ namespace osu.Game.Overlays.SkinEditor
             changeHandler?.BeginChange();
 
             foreach (var item in items)
-                availableTargets.FirstOrDefault(t => t.Components.Contains(item))?.Remove(item, true);
+                AvailableTargets.FirstOrDefault(t => t.Components.Contains(item))?.Remove(item, true);
 
             changeHandler?.EndChange();
         }
 
         public void BringSelectionToFront()
         {
-            if (getTarget(selectedTarget.Value) is not SkinnableContainer target)
+            if (GetTarget(SelectedTarget.Value) is not SkinnableContainer target)
                 return;
 
             changeHandler?.BeginChange();
@@ -738,7 +738,7 @@ namespace osu.Game.Overlays.SkinEditor
 
         public void SendSelectionToBack()
         {
-            if (getTarget(selectedTarget.Value) is not SkinnableContainer target)
+            if (GetTarget(SelectedTarget.Value) is not SkinnableContainer target)
                 return;
 
             changeHandler?.BeginChange();
@@ -775,7 +775,7 @@ namespace osu.Game.Overlays.SkinEditor
                 // This is the best we can do for now.
                 realm.Run(r => r.Refresh());
 
-                var skinnableTarget = getFirstTarget();
+                var skinnableTarget = GetFirstTarget();
 
                 // Import still should happen for now, even if not placeable (as it allows a user to import skin resources that would apply to legacy gameplay skins).
                 if (skinnableTarget == null)
@@ -809,7 +809,7 @@ namespace osu.Game.Overlays.SkinEditor
             game?.UnregisterImportHandler(this);
         }
 
-        private partial class SkinEditorToast : Toast
+        protected partial class SkinEditorToast : Toast
         {
             public SkinEditorToast(LocalisableString value, string skinDisplayName)
                 : base(SkinSettingsStrings.SkinLayoutEditor, value)

--- a/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Overlays.SkinEditor
 
         protected override bool BlockNonPositionalInput => true;
 
-        private SkinEditor? skinEditor;
+        protected SkinEditor? Editor;
 
         [Resolved]
         private IPerformFromScreenRunner? performer { get; set; }
@@ -74,7 +74,7 @@ namespace osu.Game.Overlays.SkinEditor
         [Resolved]
         private IBindable<WorkingBeatmap> beatmap { get; set; } = null!;
 
-        private OsuScreen? lastTargetScreen;
+        protected OsuScreen? LastTargetScreen;
         private InvokeOnDisposal? nestedInputManagerDisable;
         private IDisposable? externalEditOverlayRegistration;
 
@@ -107,7 +107,7 @@ namespace osu.Game.Overlays.SkinEditor
             switch (e.Action)
             {
                 case GlobalAction.Back:
-                    if (skinEditor?.State.Value != Visibility.Visible)
+                    if (Editor?.State.Value != Visibility.Visible)
                         break;
 
                     Hide();
@@ -117,47 +117,56 @@ namespace osu.Game.Overlays.SkinEditor
             return false;
         }
 
+        protected virtual bool PresentsGameplayFromMainMenu => true;
+
+        protected virtual SkinEditor CreateEditor() => new SkinEditor();
+
         protected override void PopIn()
         {
+            OnEditorOpening();
             overrideSkinEditorRelevantSettings();
 
-            if (skinEditor != null)
+            if (Editor != null)
             {
                 disableNestedInputManagers();
-                skinEditor.Show();
+                Editor.Show();
 
-                if (lastTargetScreen is MainMenu)
+                if (PresentsGameplayFromMainMenu && LastTargetScreen is MainMenu)
                     PresentGameplay();
 
                 return;
             }
 
-            var editor = new SkinEditor();
+            var editor = CreateEditor();
 
             editor.State.BindValueChanged(_ => updateComponentVisibility());
 
-            skinEditor = editor;
+            Editor = editor;
 
             LoadComponentAsync(editor, _ =>
             {
-                if (editor != skinEditor)
+                if (editor != Editor)
                     return;
 
                 AddInternal(editor);
 
-                if (lastTargetScreen is MainMenu)
+                if (PresentsGameplayFromMainMenu && LastTargetScreen is MainMenu)
                     PresentGameplay();
 
-                Debug.Assert(lastTargetScreen != null);
+                Debug.Assert(LastTargetScreen != null);
 
-                SetTarget(lastTargetScreen);
+                SetTarget(LastTargetScreen);
             });
+        }
+
+        protected virtual void OnEditorOpening()
+        {
         }
 
         protected override void PopOut()
         {
-            skinEditor?.Save(false);
-            skinEditor?.Hide();
+            Editor?.Save(false);
+            Editor?.Hide();
             nestedInputManagerDisable?.Dispose();
             nestedInputManagerDisable = null;
 
@@ -240,7 +249,7 @@ namespace osu.Game.Overlays.SkinEditor
 
         private void updateScreenSizing()
         {
-            if (skinEditor?.State.Value != Visibility.Visible) return;
+            if (Editor?.State.Value != Visibility.Visible) return;
 
             const float padding = 10;
 
@@ -279,9 +288,9 @@ namespace osu.Game.Overlays.SkinEditor
 
         private void updateComponentVisibility()
         {
-            Debug.Assert(skinEditor != null);
+            Debug.Assert(Editor != null);
 
-            if (skinEditor.State.Value == Visibility.Visible)
+            if (Editor.State.Value == Visibility.Visible)
             {
                 Scheduler.AddOnce(updateScreenSizing);
 
@@ -293,7 +302,7 @@ namespace osu.Game.Overlays.SkinEditor
             {
                 scalingContainer.SetCustomRect(null);
 
-                if (lastTargetScreen?.HideOverlaysOnEnter != true)
+                if (LastTargetScreen?.HideOverlaysOnEnter != true)
                     game.Toolbar.Show();
             }
         }
@@ -305,7 +314,7 @@ namespace osu.Game.Overlays.SkinEditor
         /// <summary>
         /// Set a new target screen which will be used to find skinnable components.
         /// </summary>
-        public void SetTarget(OsuScreen screen)
+        public virtual void SetTarget(OsuScreen screen)
         {
             if (screen is EzSkinEditorScreen)
                 return;
@@ -313,9 +322,9 @@ namespace osu.Game.Overlays.SkinEditor
             nestedInputManagerDisable?.Dispose();
             nestedInputManagerDisable = null;
 
-            lastTargetScreen = screen;
+            LastTargetScreen = screen;
 
-            if (skinEditor == null) return;
+            if (Editor == null) return;
 
             // ensure the toolbar is re-hidden even if a new screen decides to try and show it.
             updateComponentVisibility();
@@ -324,40 +333,42 @@ namespace osu.Game.Overlays.SkinEditor
             Scheduler.AddOnce(setTarget, screen);
         }
 
+        protected virtual Drawable GetEditorTarget(OsuScreen screen) => screen;
+
         private void setTarget(OsuScreen? target)
         {
             if (target == null)
                 return;
 
-            Debug.Assert(skinEditor != null);
+            Debug.Assert(Editor != null);
 
-            if (!target.IsLoaded || !skinEditor.IsLoaded)
+            if (!target.IsLoaded || !Editor.IsLoaded)
             {
                 Scheduler.AddOnce(setTarget, target);
                 return;
             }
 
-            if (skinEditor.State.Value == Visibility.Visible)
+            if (Editor.State.Value == Visibility.Visible)
             {
                 if (externalEditOverlay.State.Value != Visibility.Visible)
-                    skinEditor.Save(false);
-                skinEditor.UpdateTargetScreen(target);
+                    Editor.Save(false);
+                Editor.UpdateTargetScreen(GetEditorTarget(target));
                 disableNestedInputManagers();
             }
             else
             {
-                skinEditor.Hide();
-                skinEditor.Expire();
-                skinEditor = null;
+                Editor.Hide();
+                Editor.Expire();
+                Editor = null;
             }
         }
 
         private void disableNestedInputManagers()
         {
-            if (lastTargetScreen == null)
+            if (LastTargetScreen == null)
                 return;
 
-            var nestedInputManagers = lastTargetScreen.ChildrenOfType<PassThroughInputManager>().Where(manager => manager.UseParentInput).ToArray();
+            var nestedInputManagers = LastTargetScreen.ChildrenOfType<PassThroughInputManager>().Where(manager => manager.UseParentInput).ToArray();
             foreach (var inputManager in nestedInputManagers)
                 inputManager.UseParentInput = false;
             nestedInputManagerDisable = new InvokeOnDisposal(() =>
@@ -401,7 +412,7 @@ namespace osu.Game.Overlays.SkinEditor
 
         public new void ToggleVisibility()
         {
-            if (skinEditor?.ExternalEditInProgress == true)
+            if (Editor?.ExternalEditInProgress == true)
                 return;
 
             base.ToggleVisibility();


### PR DESCRIPTION
## Summary
- Add an Ez layout editor under Settings → Skin layout editor (no hotkey). Layout is stored in `EzResources/Config/layout` (`SongSelect.json` / `Gameplay.json`), not in skin JSON or Realm.
- Gameplay exposes both global HUD and the current-ruleset HUD layer. Toolbox uses a blacklist so official HUD components can be placed; changing skins does not reset this layout.
- Ez HUD lives in the acrylic capture tree so EzBox blur works, and gameplay components resolve `HUDOverlay` dependencies like the official HUD.

## Test plan
- [x] Open Settings → Ez layout editor from song select; place HUD (e.g. combo, EzBox); quit and relaunch — layout remains, independent of current skin.
- [ ] In gameplay, switch the working layer between HUD and HUD (current mode only); save one layer without wiping the other.
- [x] EzBox blur works in this editor (same as official skin editor).
- [ ] Official skin editor save does not pick up Ez layout components; opening either editor hides the other.
- [x] First Settings open after launch completes (no FormSliderBar crash if turbo mode has dim locked).


Made with [Cursor](https://cursor.com)