### PR TITLE
本地个人档案 + 线上 BP/MostPlayed 拉取与增量重算

### DIFF
--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileAggregator.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileAggregator.cs
@@ -1,0 +1,244 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+using osu.Game.EzOsuGame.Analysis;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
+using Realms;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    public class EzLocalProfileAggregator
+    {
+        private readonly RealmAccess realm;
+        private readonly EzAnalysisPersistentStore analysisStore;
+
+        public EzLocalProfileAggregator(RealmAccess realm, EzAnalysisPersistentStore analysisStore)
+        {
+            this.realm = realm;
+            this.analysisStore = analysisStore;
+        }
+
+        public IReadOnlyList<EzLocalProfileUsernameCount> ScanUsernameCounts()
+        {
+            return realm.Run(r =>
+            {
+                var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+
+                foreach (var score in queryValidScores(r))
+                {
+                    string username = normaliseUsername(score.RealmUser.Username);
+                    counts.TryGetValue(username, out int existing);
+                    counts[username] = existing + 1;
+                }
+
+                return counts
+                       .Select(kv => new EzLocalProfileUsernameCount(kv.Key, kv.Value))
+                       .OrderByDescending(c => c.ScoreCount)
+                       .ThenBy(c => c.Username, StringComparer.Ordinal)
+                       .ToList();
+            });
+        }
+
+        public EzLocalProfileAggregationResult Aggregate(IReadOnlyCollection<string> includedUsernames)
+        {
+            var includeSet = new HashSet<string>(includedUsernames.Select(normaliseUsername), StringComparer.Ordinal);
+            var result = new EzLocalProfileAggregationResult
+            {
+                IncludedUsernames = includeSet.OrderBy(n => n, StringComparer.Ordinal).ToList(),
+                ComputedAt = DateTimeOffset.UtcNow,
+            };
+
+            if (includeSet.Count == 0)
+                return result;
+
+            realm.Run(r =>
+            {
+                foreach (var score in queryValidScores(r))
+                {
+                    string username = normaliseUsername(score.RealmUser.Username);
+                    if (!includeSet.Contains(username))
+                        continue;
+
+                    int rulesetId = score.Ruleset.OnlineID;
+                    var beatmap = score.BeatmapInfo;
+                    if (beatmap == null)
+                        continue;
+
+                    long keys = countKeys(score);
+                    bool hasKps = analysisStore.TryGet(beatmap, out var analysis);
+                    double avgKps = hasKps ? analysis.AverageKps : 0;
+                    double maxKps = hasKps ? analysis.MaxKps : 0;
+
+                    var rulesetStats = getOrCreate(result.RulesetStats, rulesetId, () => new EzLocalProfileAggregationResult.MutableRulesetStats());
+                    rulesetStats.TotalKeys += keys;
+                    rulesetStats.ScoreCount++;
+
+                    if (hasKps)
+                    {
+                        rulesetStats.KpsSum += avgKps;
+                        rulesetStats.KpsSampleCount++;
+                        if (maxKps > rulesetStats.MaxKps)
+                            rulesetStats.MaxKps = maxKps;
+                    }
+
+                    incrementGrade(result, rulesetId, score.Rank);
+                    incrementStar(result, rulesetId, beatmap.StarRating);
+
+                    if (rulesetId == EzLocalProfileConstants.MANIA_RULESET_ID)
+                        accumulateMania(result, beatmap, analysis, hasKps, keys, avgKps, maxKps);
+
+                    if (rulesetId == EzLocalProfileConstants.OSU_RULESET_ID)
+                        accumulateStdAttr(result, beatmap, score.Rank);
+                }
+            });
+
+            return result;
+        }
+
+        private static void accumulateMania(
+            EzLocalProfileAggregationResult result,
+            BeatmapInfo beatmap,
+            EzAnalysisResult analysis,
+            bool hasKps,
+            long keys,
+            double avgKps,
+            double maxKps)
+        {
+            int keyCount = (int)Math.Round(beatmap.Difficulty.CircleSize);
+            if (keyCount <= 0)
+                return;
+
+            var keyStats = getOrCreate(result.ManiaKeyStats, keyCount, () => new EzLocalProfileAggregationResult.MutableManiaKeyStats());
+            keyStats.TotalKeys += keys;
+            keyStats.ScoreCount++;
+
+            if (hasKps)
+            {
+                keyStats.KpsSum += avgKps;
+                keyStats.KpsSampleCount++;
+                if (maxKps > keyStats.MaxKps)
+                    keyStats.MaxKps = maxKps;
+            }
+
+            if (!hasKps || analysis.ManiaSummary == null)
+                return;
+
+            var columnCounts = analysis.ManiaSummary.Value.ColumnCounts;
+            long totalNotes = 0;
+            foreach (var count in columnCounts.Values)
+                totalNotes += count;
+
+            if (totalNotes <= 0)
+                return;
+
+            foreach (var (column, count) in columnCounts)
+            {
+                var columnStats = getOrCreate(result.ManiaColumnStats, (keyCount, column), () => new EzLocalProfileAggregationResult.MutableManiaColumnStats());
+                columnStats.TotalKeys += count;
+                columnStats.ScoreCount++;
+
+                // Density-proportional column KPS from chart-wide analysis (no per-column series in SQLite yet).
+                double share = (double)count / totalNotes;
+                double columnAvg = avgKps * share;
+                double columnMax = maxKps * share;
+                columnStats.KpsSum += columnAvg;
+                columnStats.KpsSampleCount++;
+                if (columnMax > columnStats.MaxKps)
+                    columnStats.MaxKps = columnMax;
+            }
+        }
+
+        private static void accumulateStdAttr(EzLocalProfileAggregationResult result, BeatmapInfo beatmap, ScoreRank rank)
+        {
+            bool highGrade = isHighGrade(rank);
+            addStd(result, EzLocalProfileStdAttr.ApproachRate, roundAttr(beatmap.Difficulty.ApproachRate), highGrade);
+            addStd(result, EzLocalProfileStdAttr.CircleSize, roundAttr(beatmap.Difficulty.CircleSize), highGrade);
+        }
+
+        private static void addStd(EzLocalProfileAggregationResult result, EzLocalProfileStdAttr attr, double value, bool highGrade)
+        {
+            var stats = getOrCreate(result.StdAttrAffinities, (attr, value), () => new EzLocalProfileAggregationResult.MutableStdAttr());
+            stats.PlayCount++;
+            if (highGrade)
+                stats.HighGradeCount++;
+        }
+
+        private static void incrementGrade(EzLocalProfileAggregationResult result, int rulesetId, ScoreRank rank)
+        {
+            var key = (rulesetId, rank);
+            result.GradeCounts.TryGetValue(key, out int existing);
+            result.GradeCounts[key] = existing + 1;
+        }
+
+        private static void incrementStar(EzLocalProfileAggregationResult result, int rulesetId, double starRating)
+        {
+            if (starRating < 0)
+                return;
+
+            int bucket = (int)Math.Floor(starRating);
+            var key = (rulesetId, bucket);
+            result.StarPlayCounts.TryGetValue(key, out int existing);
+            result.StarPlayCounts[key] = existing + 1;
+        }
+
+        private static IQueryable<ScoreInfo> queryValidScores(Realm realm)
+        {
+            return realm.All<ScoreInfo>()
+                        .Filter($"{nameof(ScoreInfo.DeletePending)} == false"
+                                + $" && {nameof(ScoreInfo.BeatmapInfo)}.{nameof(BeatmapInfo.Hash)} == {nameof(ScoreInfo.BeatmapHash)}");
+        }
+
+        private static string normaliseUsername(string? username)
+        {
+            if (string.IsNullOrWhiteSpace(username))
+                return EzLocalProfileConstants.UNKNOWN_USERNAME;
+
+            return username.Trim();
+        }
+
+        private static long countKeys(ScoreInfo score)
+        {
+            long fromMaximum = sumCountable(score.MaximumStatistics);
+            if (fromMaximum > 0)
+                return fromMaximum;
+
+            return sumCountable(score.Statistics);
+        }
+
+        private static long sumCountable(IReadOnlyDictionary<HitResult, int> statistics)
+        {
+            long total = 0;
+
+            foreach (var (result, count) in statistics)
+            {
+                if (result.IsScorable() && !result.IsBonus())
+                    total += count;
+            }
+
+            return total;
+        }
+
+        private static double roundAttr(float value) => Math.Round(value, 1, MidpointRounding.AwayFromZero);
+
+        private static bool isHighGrade(ScoreRank rank) =>
+            rank is ScoreRank.S or ScoreRank.SH or ScoreRank.X or ScoreRank.XH;
+
+        private static TValue getOrCreate<TKey, TValue>(Dictionary<TKey, TValue> dict, TKey key, Func<TValue> factory)
+            where TKey : notnull
+            where TValue : class
+        {
+            if (dict.TryGetValue(key, out var existing))
+                return existing;
+
+            var created = factory();
+            dict[key] = created;
+            return created;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileAggregator.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileAggregator.cs
@@ -45,7 +45,9 @@ namespace osu.Game.EzOsuGame.LocalProfile
             });
         }
 
-        public EzLocalProfileAggregationResult Aggregate(IReadOnlyCollection<string> includedUsernames)
+        public EzLocalProfileAggregationResult Aggregate(
+            IReadOnlyCollection<string> includedUsernames,
+            IReadOnlyList<EzLocalProfileOnlineScoreContribution>? onlineContributions = null)
         {
             var includeSet = new HashSet<string>(includedUsernames.Select(normaliseUsername), StringComparer.Ordinal);
             var result = new EzLocalProfileAggregationResult
@@ -54,11 +56,16 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 ComputedAt = DateTimeOffset.UtcNow,
             };
 
-            if (includeSet.Count == 0)
-                return result;
+            var localOnlineIds = new HashSet<long>();
 
             realm.Run(r =>
             {
+                foreach (var score in r.All<ScoreInfo>().Where(s => !s.DeletePending && s.OnlineID > 0))
+                    localOnlineIds.Add(score.OnlineID);
+
+                if (includeSet.Count == 0)
+                    return;
+
                 foreach (var score in queryValidScores(r))
                 {
                     string username = normaliseUsername(score.RealmUser.Username);
@@ -98,7 +105,48 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 }
             });
 
+            if (onlineContributions != null)
+                mergeOnlineContributions(result, onlineContributions, localOnlineIds);
+
             return result;
+        }
+
+        private static void mergeOnlineContributions(
+            EzLocalProfileAggregationResult result,
+            IReadOnlyList<EzLocalProfileOnlineScoreContribution> contributions,
+            HashSet<long> localOnlineIds)
+        {
+            foreach (var c in contributions)
+            {
+                if (c.OnlineId > 0 && localOnlineIds.Contains(c.OnlineId))
+                    continue;
+
+                int rulesetId = c.RulesetId;
+                var rulesetStats = getOrCreate(result.RulesetStats, rulesetId, () => new EzLocalProfileAggregationResult.MutableRulesetStats());
+                rulesetStats.TotalKeys += Math.Max(0, c.KeyCount);
+                rulesetStats.ScoreCount++;
+
+                incrementGrade(result, rulesetId, c.Rank);
+                incrementStar(result, rulesetId, c.StarRating);
+
+                if (rulesetId == EzLocalProfileConstants.MANIA_RULESET_ID)
+                {
+                    int keyMode = (int)Math.Round(c.CircleSize);
+                    if (keyMode > 0)
+                    {
+                        var keyStats = getOrCreate(result.ManiaKeyStats, keyMode, () => new EzLocalProfileAggregationResult.MutableManiaKeyStats());
+                        keyStats.TotalKeys += Math.Max(0, c.KeyCount);
+                        keyStats.ScoreCount++;
+                    }
+                }
+
+                if (rulesetId == EzLocalProfileConstants.OSU_RULESET_ID)
+                {
+                    bool highGrade = isHighGrade(c.Rank);
+                    addStd(result, EzLocalProfileStdAttr.ApproachRate, roundAttr(c.ApproachRate), highGrade);
+                    addStd(result, EzLocalProfileStdAttr.CircleSize, roundAttr(c.CircleSize), highGrade);
+                }
+            }
         }
 
         private static void accumulateMania(

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileAggregator.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileAggregator.cs
@@ -4,9 +4,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.EzOsuGame.Analysis;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using Realms;
@@ -17,11 +21,13 @@ namespace osu.Game.EzOsuGame.LocalProfile
     {
         private readonly RealmAccess realm;
         private readonly EzAnalysisPersistentStore analysisStore;
+        private readonly BeatmapManager beatmapManager;
 
-        public EzLocalProfileAggregator(RealmAccess realm, EzAnalysisPersistentStore analysisStore)
+        public EzLocalProfileAggregator(RealmAccess realm, EzAnalysisPersistentStore analysisStore, BeatmapManager beatmapManager)
         {
             this.realm = realm;
             this.analysisStore = analysisStore;
+            this.beatmapManager = beatmapManager;
         }
 
         public IReadOnlyList<EzLocalProfileUsernameCount> ScanUsernameCounts()
@@ -45,70 +51,240 @@ namespace osu.Game.EzOsuGame.LocalProfile
             });
         }
 
-        public EzLocalProfileAggregationResult Aggregate(
-            IReadOnlyCollection<string> includedUsernames,
-            IReadOnlyList<EzLocalProfileOnlineScoreContribution>? onlineContributions = null)
+        /// <summary>
+        /// Aggregate only the given usernames, returning one result slice per username (all scores counted).
+        /// Does not merge online contributions — that happens when rebuilding display totals.
+        /// </summary>
+        public Dictionary<string, EzLocalProfileAggregationResult> AggregateByUsername(
+            IReadOnlyCollection<string> usernames,
+            IProgress<EzLocalProfileComputeProgress>? progress = null,
+            CancellationToken cancellationToken = default)
         {
-            var includeSet = new HashSet<string>(includedUsernames.Select(normaliseUsername), StringComparer.Ordinal);
-            var result = new EzLocalProfileAggregationResult
-            {
-                IncludedUsernames = includeSet.OrderBy(n => n, StringComparer.Ordinal).ToList(),
-                ComputedAt = DateTimeOffset.UtcNow,
-            };
-
-            var localOnlineIds = new HashSet<long>();
+            var includeSet = new HashSet<string>(usernames.Select(normaliseUsername), StringComparer.Ordinal);
+            var byUser = new Dictionary<string, EzLocalProfileAggregationResult>(StringComparer.Ordinal);
+            var detachedScores = new List<(string Username, ScoreInfo Score)>();
 
             realm.Run(r =>
             {
-                foreach (var score in r.All<ScoreInfo>().Where(s => !s.DeletePending && s.OnlineID > 0))
-                    localOnlineIds.Add(score.OnlineID);
-
                 if (includeSet.Count == 0)
                     return;
 
                 foreach (var score in queryValidScores(r))
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
+
                     string username = normaliseUsername(score.RealmUser.Username);
                     if (!includeSet.Contains(username))
                         continue;
 
-                    int rulesetId = score.Ruleset.OnlineID;
-                    var beatmap = score.BeatmapInfo;
-                    if (beatmap == null)
+                    if (score.BeatmapInfo == null)
                         continue;
 
-                    long keys = countKeys(score);
-                    bool hasKps = analysisStore.TryGet(beatmap, out var analysis);
-                    double avgKps = hasKps ? analysis.AverageKps : 0;
-                    double maxKps = hasKps ? analysis.MaxKps : 0;
-
-                    var rulesetStats = getOrCreate(result.RulesetStats, rulesetId, () => new EzLocalProfileAggregationResult.MutableRulesetStats());
-                    rulesetStats.TotalKeys += keys;
-                    rulesetStats.ScoreCount++;
-
-                    if (hasKps)
-                    {
-                        rulesetStats.KpsSum += avgKps;
-                        rulesetStats.KpsSampleCount++;
-                        if (maxKps > rulesetStats.MaxKps)
-                            rulesetStats.MaxKps = maxKps;
-                    }
-
-                    incrementGrade(result, rulesetId, score.Rank);
-                    incrementStar(result, rulesetId, beatmap.StarRating);
-
-                    if (rulesetId == EzLocalProfileConstants.MANIA_RULESET_ID)
-                        accumulateMania(result, beatmap, analysis, hasKps, keys, avgKps, maxKps);
-
-                    if (rulesetId == EzLocalProfileConstants.OSU_RULESET_ID)
-                        accumulateStdAttr(result, beatmap, score.Rank);
+                    detachedScores.Add((username, score.DeepClone()));
                 }
             });
 
-            if (onlineContributions != null)
-                mergeOnlineContributions(result, onlineContributions, localOnlineIds);
+            foreach (string username in includeSet)
+            {
+                byUser[username] = new EzLocalProfileAggregationResult
+                {
+                    IncludedUsernames = new[] { username },
+                    ComputedAt = DateTimeOffset.UtcNow,
+                };
+            }
 
-            return result;
+            int total = Math.Max(1, detachedScores.Count);
+            int processed = 0;
+
+            void report() =>
+                progress?.Report(new EzLocalProfileComputeProgress(processed, total, Saving: false));
+
+            report();
+
+            var scoreList = detachedScores.Select(s => s.Score).ToList();
+            double[] resolvedPp = resolveAllPp(scoreList, progress, total, cancellationToken);
+            processed = scoreList.Count;
+            report();
+
+            for (int i = 0; i < detachedScores.Count; i++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var (username, score) = detachedScores[i];
+                var result = byUser[username];
+                int rulesetId = score.Ruleset.OnlineID;
+                var beatmap = score.BeatmapInfo!;
+
+                long keys = countKeys(score);
+                bool hasKps = analysisStore.TryGet(beatmap, out var analysis);
+                double avgKps = hasKps ? analysis.AverageKps : 0;
+                double maxKps = hasKps ? analysis.MaxKps : 0;
+                double pp = resolvedPp[i];
+                long durationMs = beatmap.Length > 0 ? (long)beatmap.Length : 0;
+
+                var rulesetStats = getOrCreate(result.RulesetStats, rulesetId, () => new EzLocalProfileAggregationResult.MutableRulesetStats());
+                rulesetStats.TotalKeys += keys;
+                rulesetStats.ScoreCount++;
+                rulesetStats.TotalPp += pp;
+                rulesetStats.TotalDurationMs += durationMs;
+
+                if (hasKps)
+                {
+                    rulesetStats.KpsSum += avgKps;
+                    rulesetStats.KpsSampleCount++;
+                    if (maxKps > rulesetStats.MaxKps)
+                        rulesetStats.MaxKps = maxKps;
+                }
+
+                incrementGrade(result, rulesetId, score.Rank);
+                incrementStar(result, rulesetId, beatmap.StarRating);
+
+                if (rulesetId == EzLocalProfileConstants.MANIA_RULESET_ID)
+                    accumulateMania(result, beatmap, analysis, hasKps, keys, avgKps, maxKps, pp, durationMs);
+
+                if (rulesetId == EzLocalProfileConstants.OSU_RULESET_ID)
+                    accumulateStdAttr(result, beatmap, score.Rank);
+            }
+
+            return byUser;
+        }
+
+        public HashSet<long> CollectLocalOnlineScoreIds()
+        {
+            return realm.Run(r =>
+            {
+                var ids = new HashSet<long>();
+
+                foreach (var score in r.All<ScoreInfo>().Where(s => !s.DeletePending && s.OnlineID > 0))
+                    ids.Add(score.OnlineID);
+
+                return ids;
+            });
+        }
+
+        public static void MergeOnlineContributions(
+            EzLocalProfileAggregationResult result,
+            IReadOnlyList<EzLocalProfileOnlineScoreContribution> contributions,
+            HashSet<long> localOnlineIds)
+        {
+            mergeOnlineContributions(result, contributions, localOnlineIds);
+        }
+
+        private double[] resolveAllPp(
+            IReadOnlyList<ScoreInfo> scores,
+            IProgress<EzLocalProfileComputeProgress>? progress,
+            int progressTotal,
+            CancellationToken cancellationToken)
+        {
+            double[] values = new double[scores.Count];
+            if (scores.Count == 0)
+                return values;
+
+            var attributeCache = new Dictionary<string, DifficultyAttributes?>(StringComparer.Ordinal);
+            int failures = 0;
+            int loggedFailures = 0;
+            const int max_logged_failures = 8;
+
+            // Sequential on purpose: WorkingBeatmapCache locks around Realm reads; Parallel.For
+            // deadlocks easily once scores without stored PP start loading beatmaps.
+            int reportEvery = Math.Max(10, progressTotal / 100);
+
+            for (int i = 0; i < scores.Count; i++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                values[i] = resolvePp(scores[i], attributeCache, ref failures, ref loggedFailures, max_logged_failures);
+
+                int current = i + 1;
+                if (current == scores.Count || current % reportEvery == 0)
+                    progress?.Report(new EzLocalProfileComputeProgress(current, progressTotal, Saving: false));
+            }
+
+            if (failures > 0)
+            {
+                Logger.Log(
+                    $"[EzLocalProfile] PP calc finished with {failures} failure(s) out of {scores.Count} score(s).",
+                    Ez2ConfigManager.LOGGER_NAME);
+            }
+
+            return values;
+        }
+
+        /// <summary>
+        /// Prefer a positive stored PP; otherwise calculate from detached score + cached difficulty attributes.
+        /// </summary>
+        private double resolvePp(
+            ScoreInfo score,
+            Dictionary<string, DifficultyAttributes?> attributeCache,
+            ref int failures,
+            ref int loggedFailures,
+            int maxLoggedFailures)
+        {
+            if (score.PP is > 0)
+                return score.PP.Value;
+
+            // Failed plays contribute no PP for profile totals.
+            if (score.Rank == ScoreRank.F)
+                return 0;
+
+            if (score.BeatmapInfo == null)
+                return 0;
+
+            try
+            {
+                var ruleset = score.Ruleset.CreateInstance();
+                var calculator = ruleset.CreatePerformanceCalculator();
+                if (calculator == null)
+                    return 0;
+
+                string cacheKey = buildAttributeCacheKey(score);
+                if (!attributeCache.TryGetValue(cacheKey, out var attributes))
+                {
+                    attributes = tryCalculateAttributes(score, ruleset);
+                    attributeCache[cacheKey] = attributes;
+                }
+
+                if (attributes == null)
+                    return 0;
+
+                return Math.Max(0, calculator.Calculate(score, attributes).Total);
+            }
+            catch (Exception ex)
+            {
+                failures++;
+
+                if (++loggedFailures <= maxLoggedFailures)
+                {
+                    Logger.Log(
+                        $"[EzLocalProfile] PP calc failed for score {score.ID}: {ex.Message}",
+                        Ez2ConfigManager.LOGGER_NAME);
+                }
+
+                return 0;
+            }
+        }
+
+        private DifficultyAttributes? tryCalculateAttributes(ScoreInfo score, Rulesets.Ruleset ruleset)
+        {
+            try
+            {
+                var working = beatmapManager.GetWorkingBeatmap(score.BeatmapInfo);
+                return ruleset.CreateDifficultyCalculator(working).Calculate(score.Mods);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log(
+                    $"[EzLocalProfile] Difficulty attrs failed ({score.BeatmapInfo?.ID}): {ex.Message}",
+                    Ez2ConfigManager.LOGGER_NAME,
+                    LogLevel.Verbose);
+                return null;
+            }
+        }
+
+        private static string buildAttributeCacheKey(ScoreInfo score)
+        {
+            // ModsJson is stable and cheaper than formatting Mod[].
+            return $"{score.BeatmapInfo?.ID:N}|{score.Ruleset.ShortName}|{score.ModsJson}";
         }
 
         private static void mergeOnlineContributions(
@@ -125,6 +301,8 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 var rulesetStats = getOrCreate(result.RulesetStats, rulesetId, () => new EzLocalProfileAggregationResult.MutableRulesetStats());
                 rulesetStats.TotalKeys += Math.Max(0, c.KeyCount);
                 rulesetStats.ScoreCount++;
+                rulesetStats.TotalPp += Math.Max(0, c.Pp);
+                rulesetStats.TotalDurationMs += Math.Max(0, c.DurationMs);
 
                 incrementGrade(result, rulesetId, c.Rank);
                 incrementStar(result, rulesetId, c.StarRating);
@@ -132,11 +310,14 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 if (rulesetId == EzLocalProfileConstants.MANIA_RULESET_ID)
                 {
                     int keyMode = (int)Math.Round(c.CircleSize);
+
                     if (keyMode > 0)
                     {
                         var keyStats = getOrCreate(result.ManiaKeyStats, keyMode, () => new EzLocalProfileAggregationResult.MutableManiaKeyStats());
                         keyStats.TotalKeys += Math.Max(0, c.KeyCount);
                         keyStats.ScoreCount++;
+                        keyStats.TotalPp += Math.Max(0, c.Pp);
+                        keyStats.TotalDurationMs += Math.Max(0, c.DurationMs);
                     }
                 }
 
@@ -156,7 +337,9 @@ namespace osu.Game.EzOsuGame.LocalProfile
             bool hasKps,
             long keys,
             double avgKps,
-            double maxKps)
+            double maxKps,
+            double pp,
+            long durationMs)
         {
             int keyCount = (int)Math.Round(beatmap.Difficulty.CircleSize);
             if (keyCount <= 0)
@@ -165,6 +348,8 @@ namespace osu.Game.EzOsuGame.LocalProfile
             var keyStats = getOrCreate(result.ManiaKeyStats, keyCount, () => new EzLocalProfileAggregationResult.MutableManiaKeyStats());
             keyStats.TotalKeys += keys;
             keyStats.ScoreCount++;
+            keyStats.TotalPp += pp;
+            keyStats.TotalDurationMs += durationMs;
 
             if (hasKps)
             {
@@ -179,7 +364,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
             var columnCounts = analysis.ManiaSummary.Value.ColumnCounts;
             long totalNotes = 0;
-            foreach (var count in columnCounts.Values)
+            foreach (int count in columnCounts.Values)
                 totalNotes += count;
 
             if (totalNotes <= 0)

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileColumnTable.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileColumnTable.cs
@@ -1,0 +1,142 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    /// <summary>
+    /// Transposed column table: metrics as rows, columns as headers.
+    /// </summary>
+    public partial class EzLocalProfileColumnTable : FillFlowContainer
+    {
+        public EzLocalProfileColumnTable(IReadOnlyList<EzLocalProfileManiaColumnStats> columns)
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            Direction = FillDirection.Vertical;
+            Spacing = new Vector2(0, 2);
+
+            var ordered = columns.OrderBy(c => c.ColumnIndex).ToList();
+
+            if (ordered.Count == 0)
+            {
+                Add(new OsuSpriteText
+                {
+                    Text = EzSettingsStrings.LOCAL_PROFILE_NO_RULESET_DATA,
+                    Font = OsuFont.GetFont(size: 13),
+                });
+                return;
+            }
+
+            var headers = new LocalisableString[ordered.Count + 1];
+            headers[0] = EzSettingsStrings.LOCAL_PROFILE_COL_HEADER;
+
+            for (int i = 0; i < ordered.Count; i++)
+                headers[i + 1] = $"#{ordered[i].ColumnIndex + 1}";
+
+            Add(new MetricRow(headers, header: true, alternate: false));
+
+            Add(new MetricRow(buildMetricRow(EzSettingsStrings.LOCAL_PROFILE_TOTAL_KEYS, ordered.Select(c => (LocalisableString)c.TotalKeys.ToString("N0"))), header: false, alternate: false));
+            Add(new MetricRow(buildMetricRow(EzSettingsStrings.LOCAL_PROFILE_AVG_KPS, ordered.Select(c => (LocalisableString)formatKps(c.AvgKps))), header: false, alternate: true));
+            Add(new MetricRow(buildMetricRow(EzSettingsStrings.LOCAL_PROFILE_MAX_KPS, ordered.Select(c => (LocalisableString)formatKps(c.MaxKps))), header: false, alternate: false));
+            Add(new MetricRow(buildMetricRow(EzSettingsStrings.LOCAL_PROFILE_SCORE_COUNT, ordered.Select(c => (LocalisableString)c.ScoreCount.ToString("N0"))), header: false, alternate: true));
+        }
+
+        private static LocalisableString[] buildMetricRow(LocalisableString label, IEnumerable<LocalisableString> values)
+        {
+            var list = values.ToList();
+            var row = new LocalisableString[list.Count + 1];
+            row[0] = label;
+
+            for (int i = 0; i < list.Count; i++)
+                row[i + 1] = list[i];
+
+            return row;
+        }
+
+        private static string formatKps(double value) => value.ToString("0.00", CultureInfo.InvariantCulture);
+
+        private partial class MetricRow : Container
+        {
+            private readonly LocalisableString[] cells;
+            private readonly bool header;
+            private readonly bool alternate;
+
+            public MetricRow(LocalisableString[] cells, bool header, bool alternate)
+            {
+                this.cells = cells;
+                this.header = header;
+                this.alternate = alternate;
+
+                RelativeSizeAxes = Axes.X;
+                Height = 30;
+                Masking = true;
+                CornerRadius = header ? 6 : 4;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colours)
+            {
+                int count = cells.Length;
+                float labelWidth = 0.18f;
+                float valueWidth = count <= 1 ? 0.82f : 0.82f / (count - 1);
+
+                var dimensions = new Dimension[count];
+                dimensions[0] = new Dimension(GridSizeMode.Relative, labelWidth);
+
+                for (int i = 1; i < count; i++)
+                    dimensions[i] = new Dimension(GridSizeMode.Relative, valueWidth);
+
+                var weight = header ? FontWeight.Bold : FontWeight.Regular;
+                var colour = header ? colours.Content2 : colours.Content1;
+                var labelColour = header ? colours.Content2 : colours.Content2;
+
+                var content = new Drawable[count];
+                content[0] = cell(cells[0], labelColour, FontWeight.Bold);
+
+                for (int i = 1; i < count; i++)
+                    content[i] = cell(cells[i], colour, weight);
+
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = colours.Background5,
+                        Alpha = header ? 1 : alternate ? 0.55f : 0,
+                    },
+                    new GridContainer
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Padding = new MarginPadding { Horizontal = 10 },
+                        ColumnDimensions = dimensions,
+                        Content = new[] { content }
+                    }
+                };
+            }
+
+            private static Drawable cell(LocalisableString text, Colour4 colour, FontWeight weight) => new TruncatingSpriteText
+            {
+                Anchor = Anchor.CentreLeft,
+                Origin = Anchor.CentreLeft,
+                Text = text,
+                Colour = colour,
+                Font = OsuFont.GetFont(size: 12, weight: weight),
+                RelativeSizeAxes = Axes.X,
+            };
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileEmptyState.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileEmptyState.cs
@@ -1,0 +1,50 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    public partial class EzLocalProfileEmptyState : FillFlowContainer
+    {
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colours)
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            Direction = FillDirection.Vertical;
+            Spacing = new Vector2(0, 12);
+            Padding = new MarginPadding { Vertical = 48 };
+            Anchor = Anchor.TopCentre;
+            Origin = Anchor.TopCentre;
+
+            Children = new Drawable[]
+            {
+                new SpriteIcon
+                {
+                    Icon = FontAwesome.Solid.ChartLine,
+                    Size = new Vector2(40),
+                    Anchor = Anchor.TopCentre,
+                    Origin = Anchor.TopCentre,
+                    Colour = colours.Content2,
+                },
+                new OsuSpriteText
+                {
+                    Text = EzSettingsStrings.LOCAL_PROFILE_EMPTY_HINT,
+                    Font = OsuFont.GetFont(size: 14),
+                    Colour = colours.Content2,
+                    Anchor = Anchor.TopCentre,
+                    Origin = Anchor.TopCentre,
+                }
+            };
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileExpandableRow.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileExpandableRow.cs
@@ -1,0 +1,241 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    public partial class EzLocalProfileExpandableRow : CompositeDrawable
+    {
+        private readonly string header;
+        private readonly IReadOnlyList<EzLocalProfileManiaColumnStats> columns;
+        private Container detailFlow = null!;
+        private SpriteIcon chevron = null!;
+        private bool expanded;
+
+        public EzLocalProfileExpandableRow(EzLocalProfileManiaKeyStats keyStats, IReadOnlyList<EzLocalProfileManiaColumnStats> columns)
+        {
+            this.columns = columns;
+            header =
+                $"{keyStats.KeyCount}K  ·  {keyStats.TotalKeys:N0} keys  ·  avg {keyStats.AvgKps.ToString("0.00", CultureInfo.InvariantCulture)}  ·  max {keyStats.MaxKps.ToString("0.00", CultureInfo.InvariantCulture)}  ·  {keyStats.ScoreCount} plays";
+
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colours)
+        {
+            InternalChild = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(0, 6),
+                Children = new Drawable[]
+                {
+                    new HeaderButton(toggle)
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Height = 36,
+                        Child = new Container
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Padding = new MarginPadding { Horizontal = 12 },
+                            Children = new Drawable[]
+                            {
+                                chevron = new SpriteIcon
+                                {
+                                    Icon = FontAwesome.Solid.ChevronRight,
+                                    Size = new Vector2(12),
+                                    Anchor = Anchor.CentreLeft,
+                                    Origin = Anchor.CentreLeft,
+                                    Colour = colours.Content2,
+                                },
+                                new OsuSpriteText
+                                {
+                                    Text = header,
+                                    Font = OsuFont.GetFont(size: 13),
+                                    Colour = colours.Content1,
+                                    Anchor = Anchor.CentreLeft,
+                                    Origin = Anchor.CentreLeft,
+                                    Margin = new MarginPadding { Left = 22 },
+                                }
+                            }
+                        }
+                    },
+                    detailFlow = new Container
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Alpha = 0,
+                        Padding = new MarginPadding { Left = 4, Right = 4, Bottom = 4 },
+                        Child = new EzLocalProfileColumnTable(columns)
+                    }
+                }
+            };
+        }
+
+        private void toggle()
+        {
+            expanded = !expanded;
+            detailFlow.FadeTo(expanded ? 1 : 0, 150, Easing.OutQuint);
+            chevron.RotateTo(expanded ? 90 : 0, 150, Easing.OutQuint);
+        }
+
+        private partial class HeaderButton : OsuClickableContainer
+        {
+            private Box background = null!;
+            private Colour4 idleColour;
+            private Colour4 hoverColour;
+
+            public HeaderButton(System.Action action)
+            {
+                Action = action;
+                Masking = true;
+                CornerRadius = 8;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colours)
+            {
+                idleColour = colours.Background5;
+                hoverColour = colours.Background6;
+
+                AddInternal(background = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = idleColour,
+                    Depth = float.MaxValue,
+                });
+            }
+
+            protected override bool OnHover(osu.Framework.Input.Events.HoverEvent e)
+            {
+                background.FadeColour(hoverColour, 200, Easing.OutQuint);
+                return base.OnHover(e);
+            }
+
+            protected override void OnHoverLost(osu.Framework.Input.Events.HoverLostEvent e)
+            {
+                background.FadeColour(idleColour, 200, Easing.OutQuint);
+                base.OnHoverLost(e);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Mania key-mode overview: rounded play bars + avg-KPS line graph.
+    /// </summary>
+    public partial class EzLocalProfileManiaOverview : FillFlowContainer
+    {
+        public EzLocalProfileManiaOverview(IReadOnlyList<EzLocalProfileManiaKeyStats> keyStats)
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            Direction = FillDirection.Vertical;
+            Spacing = new Vector2(0, 12);
+
+            var ordered = keyStats.OrderBy(k => k.KeyCount).ToList();
+            if (ordered.Count == 0)
+                return;
+
+            int maxPlays = ordered.Max(k => k.ScoreCount);
+
+            Add(new OsuSpriteText
+            {
+                Text = EzSettingsStrings.LOCAL_PROFILE_MANIA_PLAYS_BY_KEY,
+                Font = OsuFont.GetFont(size: 13, weight: FontWeight.Bold),
+            });
+
+            var barFlow = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(0, 6),
+            };
+
+            foreach (var key in ordered)
+            {
+                float ratio = maxPlays <= 0 ? 0 : (float)key.ScoreCount / maxPlays;
+                barFlow.Add(new KeyPlayBarRow($"{key.KeyCount}K", key.ScoreCount, ratio));
+            }
+
+            Add(barFlow);
+
+            Add(new OsuSpriteText
+            {
+                Text = EzSettingsStrings.LOCAL_PROFILE_MANIA_AVG_KPS_LINE,
+                Font = OsuFont.GetFont(size: 13, weight: FontWeight.Bold),
+                Margin = new MarginPadding { Top = 4 },
+            });
+
+            Add(new EzLocalProfileLabeledLineChart(
+                ordered.Select(k => (float)k.AvgKps).ToArray(),
+                ordered.Select(k => $"{k.KeyCount}K").ToArray())
+            {
+                RelativeSizeAxes = Axes.X,
+            });
+        }
+
+        private partial class KeyPlayBarRow : Container
+        {
+            private readonly string label;
+            private readonly int plays;
+            private readonly float ratio;
+
+            public KeyPlayBarRow(string label, int plays, float ratio)
+            {
+                this.label = label;
+                this.plays = plays;
+                this.ratio = ratio;
+                RelativeSizeAxes = Axes.X;
+                Height = 20;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colours)
+            {
+                Children = new Drawable[]
+                {
+                    new OsuSpriteText
+                    {
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Text = label,
+                        Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
+                        Width = 36,
+                    },
+                    new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Padding = new MarginPadding { Left = 40, Right = 48 },
+                        Child = new EzLocalProfileRoundedBar(ratio),
+                    },
+                    new OsuSpriteText
+                    {
+                        Anchor = Anchor.CentreRight,
+                        Origin = Anchor.CentreRight,
+                        Text = plays.ToString("N0"),
+                        Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
+                        Colour = colours.Content2,
+                    }
+                };
+            }
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileExpandableRow.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileExpandableRow.cs
@@ -30,7 +30,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
         {
             this.columns = columns;
             header =
-                $"{keyStats.KeyCount}K  ·  {keyStats.TotalKeys:N0} keys  ·  avg {keyStats.AvgKps.ToString("0.00", CultureInfo.InvariantCulture)}  ·  max {keyStats.MaxKps.ToString("0.00", CultureInfo.InvariantCulture)}  ·  {keyStats.ScoreCount} plays";
+                $"{keyStats.KeyCount}K  ·  {keyStats.TotalKeys:N0} keys  ·  avg {keyStats.AvgKps.ToString("0.00", CultureInfo.InvariantCulture)}  ·  max {keyStats.MaxKps.ToString("0.00", CultureInfo.InvariantCulture)}  ·  {keyStats.ScoreCount} plays  ·  {EzLocalProfileFormat.FormatPp(keyStats.TotalPp)}pp  ·  {EzLocalProfileFormat.FormatDuration(keyStats.TotalDurationMs)}";
 
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileFormat.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileFormat.cs
@@ -1,0 +1,30 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Globalization;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    public static class EzLocalProfileFormat
+    {
+        public static string FormatPp(double pp) =>
+            pp.ToString(pp >= 100 ? "N0" : "0.##", CultureInfo.CurrentCulture);
+
+        public static string FormatDuration(long durationMs)
+        {
+            if (durationMs <= 0)
+                return "0s";
+
+            var span = TimeSpan.FromMilliseconds(durationMs);
+
+            if (span.TotalHours >= 1)
+                return $"{(int)span.TotalHours}h {span.Minutes}m";
+
+            if (span.TotalMinutes >= 1)
+                return $"{(int)span.TotalMinutes}m {span.Seconds}s";
+
+            return $"{Math.Max(1, span.Seconds)}s";
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileGradeRow.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileGradeRow.cs
@@ -1,0 +1,73 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Extensions.LocalisationExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Online.Leaderboards;
+using osu.Game.Scoring;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    public partial class EzLocalProfileGradeRow : FillFlowContainer
+    {
+        public EzLocalProfileGradeRow(IEnumerable<EzLocalProfileGradeCount> grades)
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            Direction = FillDirection.Horizontal;
+            Spacing = new Vector2(12, 0);
+
+            var list = grades.OrderByDescending(g => g.Rank).ToList();
+
+            if (list.Count == 0)
+            {
+                Add(new OsuSpriteText
+                {
+                    Text = EzSettingsStrings.LOCAL_PROFILE_NO_RULESET_DATA,
+                    Font = OsuFont.GetFont(size: 14),
+                });
+                return;
+            }
+
+            foreach (var grade in list)
+                Add(new GradeCell(grade.Rank, grade.Count));
+        }
+
+        private partial class GradeCell : CompositeDrawable
+        {
+            public GradeCell(ScoreRank rank, int count)
+            {
+                AutoSizeAxes = Axes.Both;
+                InternalChild = new FillFlowContainer
+                {
+                    AutoSizeAxes = Axes.Y,
+                    Width = 48,
+                    Direction = FillDirection.Vertical,
+                    Spacing = new Vector2(0, 4),
+                    Children = new Drawable[]
+                    {
+                        new DrawableRank(rank)
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            Height = 22,
+                        },
+                        new OsuSpriteText
+                        {
+                            Text = count.ToLocalisableString("#,##0"),
+                            Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
+                            Anchor = Anchor.TopCentre,
+                            Origin = Anchor.TopCentre,
+                        }
+                    }
+                };
+            }
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileHeader.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileHeader.cs
@@ -1,0 +1,229 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Effects;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Online.API;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Profile.Header.Components;
+using osu.Game.Users.Drawables;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    public partial class EzLocalProfileHeader : OverlayHeader
+    {
+        private const float avatar_size = 70;
+
+        public Action? OpenAccount { get; set; }
+
+        private UpdateableAvatar avatar = null!;
+        private OsuSpriteText usernameText = null!;
+        private OsuTextFlowContainer metaText = null!;
+        private Box contentBackground = null!;
+        private Box coverBackground = null!;
+
+        protected override OverlayTitle CreateTitle() => new HeaderTitle();
+
+        protected override Drawable CreateBackground() => coverBackground = new Box
+        {
+            RelativeSizeAxes = Axes.X,
+            Height = 60,
+        };
+
+        protected override Drawable CreateContent()
+        {
+            return new Container
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Children = new Drawable[]
+                {
+                    contentBackground = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    },
+                    new Container
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Padding = new MarginPadding
+                        {
+                            Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING,
+                            Vertical = 12
+                        },
+                        Children = new Drawable[]
+                        {
+                            new FillFlowContainer
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y,
+                                Direction = FillDirection.Horizontal,
+                                Spacing = new Vector2(16, 0),
+                                Padding = new MarginPadding { Right = 140 },
+                                Children = new Drawable[]
+                                {
+                                    new Container
+                                    {
+                                        Size = new Vector2(avatar_size),
+                                        Anchor = Anchor.CentreLeft,
+                                        Origin = Anchor.CentreLeft,
+                                        Masking = true,
+                                        CornerRadius = 8,
+                                        EdgeEffect = new EdgeEffectParameters
+                                        {
+                                            Type = EdgeEffectType.Shadow,
+                                            Radius = 6,
+                                            Colour = Colour4.Black.Opacity(0.35f),
+                                        },
+                                        Child = avatar = new UpdateableAvatar(isInteractive: false)
+                                        {
+                                            RelativeSizeAxes = Axes.Both,
+                                        }
+                                    },
+                                    new FillFlowContainer
+                                    {
+                                        RelativeSizeAxes = Axes.X,
+                                        AutoSizeAxes = Axes.Y,
+                                        Anchor = Anchor.CentreLeft,
+                                        Origin = Anchor.CentreLeft,
+                                        Direction = FillDirection.Vertical,
+                                        Spacing = new Vector2(0, 6),
+                                        Children = new Drawable[]
+                                        {
+                                            new FillFlowContainer
+                                            {
+                                                AutoSizeAxes = Axes.Both,
+                                                Direction = FillDirection.Horizontal,
+                                                Spacing = new Vector2(10, 0),
+                                                Children = new Drawable[]
+                                                {
+                                                    usernameText = new OsuSpriteText
+                                                    {
+                                                        Anchor = Anchor.CentreLeft,
+                                                        Origin = Anchor.CentreLeft,
+                                                        Font = OsuFont.GetFont(size: 24, weight: FontWeight.Bold),
+                                                    },
+                                                    new LocalBadge
+                                                    {
+                                                        Anchor = Anchor.CentreLeft,
+                                                        Origin = Anchor.CentreLeft,
+                                                    }
+                                                }
+                                            },
+                                            metaText = new OsuTextFlowContainer(t => t.Font = OsuFont.GetFont(size: 12))
+                                            {
+                                                RelativeSizeAxes = Axes.X,
+                                                AutoSizeAxes = Axes.Y,
+                                            }
+                                        }
+                                    },
+                                }
+                            },
+                            new AccountHeaderButton
+                            {
+                                Anchor = Anchor.CentreRight,
+                                Origin = Anchor.CentreRight,
+                                Action = () => OpenAccount?.Invoke(),
+                            }
+                        }
+                    }
+                }
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colours, IAPIProvider api)
+        {
+            coverBackground.Colour = colours.Background3;
+            contentBackground.Colour = colours.Background4;
+            metaText.Colour = colours.Content2;
+
+            var localUser = api.LocalUser.GetBoundCopy();
+            localUser.BindValueChanged(u =>
+            {
+                avatar.User = u.NewValue;
+                UpdateUsername(u.NewValue.Username);
+            }, true);
+        }
+
+        public void UpdateUsername(string username)
+        {
+            usernameText.Text = string.IsNullOrEmpty(username)
+                ? EzSettingsStrings.LOCAL_PROFILE_TITLE
+                : username;
+        }
+
+        public void UpdateMeta(EzLocalProfileSnapshot snapshot)
+        {
+            if (!snapshot.HasData || snapshot.LastComputedAt == null)
+            {
+                metaText.Text = EzSettingsStrings.LOCAL_PROFILE_SHARED_HINT.ToString();
+                return;
+            }
+
+            string names = snapshot.IncludedUsernames.Count == 0
+                ? "-"
+                : string.Join(", ", snapshot.IncludedUsernames);
+            metaText.Text = $"{EzSettingsStrings.LOCAL_PROFILE_SHARED_HINT} · {snapshot.LastComputedAt.Value.LocalDateTime:g} · {names}";
+        }
+
+        private partial class HeaderTitle : OverlayTitle
+        {
+            public HeaderTitle()
+            {
+                Title = EzSettingsStrings.LOCAL_PROFILE_TITLE;
+                Description = EzSettingsStrings.LOCAL_PROFILE_DESCRIPTION;
+                Icon = FontAwesome.Solid.User;
+            }
+        }
+
+        private partial class LocalBadge : CircularContainer
+        {
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colours)
+            {
+                AutoSizeAxes = Axes.Both;
+                Masking = true;
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = colours.Background6,
+                    },
+                    new OsuSpriteText
+                    {
+                        Text = EzSettingsStrings.LOCAL_PROFILE_BADGE,
+                        Font = OsuFont.GetFont(size: 11, weight: FontWeight.Bold),
+                        Colour = colours.Foreground1,
+                        Margin = new MarginPadding { Horizontal = 8, Vertical = 3 },
+                    }
+                };
+            }
+        }
+
+        private partial class AccountHeaderButton : ProfileHeaderButton
+        {
+            public AccountHeaderButton()
+            {
+                Child = new OsuSpriteText
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Text = EzSettingsStrings.LOCAL_PROFILE_ACCOUNT_BUTTON,
+                    Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
+                };
+            }
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileImportDialog.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileImportDialog.cs
@@ -18,6 +18,10 @@ namespace osu.Game.EzOsuGame.LocalProfile
 {
     public partial class EzLocalProfileImportDialog : PopupDialog
     {
+        private const float content_width = 420;
+        private const float row_height = 36;
+        private const float list_max_height = 200;
+
         private readonly Dictionary<string, BindableBool> selections = new Dictionary<string, BindableBool>(StringComparer.Ordinal);
 
         public EzLocalProfileImportDialog(
@@ -53,11 +57,18 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 });
             }
 
+            float listHeight = Math.Clamp(
+                usernameCounts.Count * row_height + Math.Max(0, usernameCounts.Count - 1) * 4,
+                row_height,
+                list_max_height);
+
             MainContent.Child = new Container
             {
-                RelativeSizeAxes = Axes.X,
-                Height = 280,
-                Margin = new MarginPadding { Top = 16 },
+                Margin = new MarginPadding { Top = 12 },
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Width = content_width,
+                Height = listHeight,
                 Child = new OsuScrollContainer
                 {
                     RelativeSizeAxes = Axes.Both,

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileImportDialog.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileImportDialog.cs
@@ -1,0 +1,86 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays.Dialog;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    public partial class EzLocalProfileImportDialog : PopupDialog
+    {
+        private readonly Dictionary<string, BindableBool> selections = new Dictionary<string, BindableBool>(StringComparer.Ordinal);
+
+        public EzLocalProfileImportDialog(
+            IReadOnlyList<EzLocalProfileUsernameCount> usernameCounts,
+            IReadOnlyCollection<string> previouslyIncluded,
+            Action<IReadOnlyList<string>> onConfirm)
+        {
+            HeaderText = EzSettingsStrings.LOCAL_PROFILE_IMPORT_HEADER;
+            BodyText = EzSettingsStrings.LOCAL_PROFILE_IMPORT_BODY;
+            Icon = FontAwesome.Solid.User;
+
+            var previous = new HashSet<string>(previouslyIncluded, StringComparer.Ordinal);
+            bool usePrevious = previous.Count > 0 && usernameCounts.Any(c => previous.Contains(c.Username));
+
+            var flow = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(4),
+            };
+
+            foreach (var entry in usernameCounts)
+            {
+                bool selected = !usePrevious || previous.Contains(entry.Username);
+                var bindable = new BindableBool(selected);
+                selections[entry.Username] = bindable;
+
+                flow.Add(new OsuCheckbox
+                {
+                    LabelText = $"{entry.Username}  ({entry.ScoreCount})",
+                    Current = { BindTarget = bindable },
+                });
+            }
+
+            MainContent.Child = new Container
+            {
+                RelativeSizeAxes = Axes.X,
+                Height = 280,
+                Margin = new MarginPadding { Top = 16 },
+                Child = new OsuScrollContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = flow,
+                }
+            };
+
+            Buttons = new PopupDialogButton[]
+            {
+                new PopupDialogOkButton
+                {
+                    Text = EzSettingsStrings.LOCAL_PROFILE_IMPORT_CONFIRM,
+                    Action = () =>
+                    {
+                        var chosen = selections.Where(kv => kv.Value.Value).Select(kv => kv.Key).ToList();
+                        onConfirm(chosen);
+                    }
+                },
+                new PopupDialogCancelButton
+                {
+                    Text = EzSettingsStrings.LOCAL_PROFILE_IMPORT_CANCEL,
+                }
+            };
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileImportDialog.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileImportDialog.cs
@@ -20,14 +20,15 @@ namespace osu.Game.EzOsuGame.LocalProfile
     {
         private const float content_width = 420;
         private const float row_height = 36;
-        private const float list_max_height = 200;
+        private const float list_max_height = 180;
 
         private readonly Dictionary<string, BindableBool> selections = new Dictionary<string, BindableBool>(StringComparer.Ordinal);
+        private readonly BindableBool replaceMode = new BindableBool();
 
         public EzLocalProfileImportDialog(
             IReadOnlyList<EzLocalProfileUsernameCount> usernameCounts,
             IReadOnlyCollection<string> previouslyIncluded,
-            Action<IReadOnlyList<string>> onConfirm)
+            Action<IReadOnlyList<string>, bool> onConfirm)
         {
             HeaderText = EzSettingsStrings.LOCAL_PROFILE_IMPORT_HEADER;
             BodyText = EzSettingsStrings.LOCAL_PROFILE_IMPORT_BODY;
@@ -62,17 +63,32 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 row_height,
                 list_max_height);
 
-            MainContent.Child = new Container
+            MainContent.Child = new FillFlowContainer
             {
                 Margin = new MarginPadding { Top = 12 },
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 Width = content_width,
-                Height = listHeight,
-                Child = new OsuScrollContainer
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(8),
+                Children = new Drawable[]
                 {
-                    RelativeSizeAxes = Axes.Both,
-                    Child = flow,
+                    new Container
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Height = listHeight,
+                        Child = new OsuScrollContainer
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Child = flow,
+                        }
+                    },
+                    new OsuCheckbox
+                    {
+                        LabelText = EzSettingsStrings.LOCAL_PROFILE_IMPORT_REPLACE,
+                        Current = { BindTarget = replaceMode },
+                    },
                 }
             };
 
@@ -84,7 +100,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
                     Action = () =>
                     {
                         var chosen = selections.Where(kv => kv.Value.Value).Select(kv => kv.Key).ToList();
-                        onConfirm(chosen);
+                        onConfirm(chosen, replaceMode.Value);
                     }
                 },
                 new PopupDialogCancelButton

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileLabeledLineChart.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileLabeledLineChart.cs
@@ -1,0 +1,128 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Globalization;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    /// <summary>
+    /// Line chart with per-point X labels and value labels.
+    /// </summary>
+    public partial class EzLocalProfileLabeledLineChart : Container
+    {
+        private readonly float[] values;
+        private readonly string[] labels;
+
+        public EzLocalProfileLabeledLineChart(float[] values, string[] labels)
+        {
+            this.values = values;
+            this.labels = labels;
+
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            Masking = true;
+            CornerRadius = 8;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colours)
+        {
+            int count = values.Length;
+            if (count == 0)
+            {
+                Height = 40;
+                Child = new Box { RelativeSizeAxes = Axes.Both, Colour = colours.Background5 };
+                return;
+            }
+
+            var valueLabels = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                Height = 16,
+                Direction = FillDirection.Horizontal,
+                Padding = new MarginPadding { Horizontal = 8, Top = 6 },
+            };
+
+            var xLabels = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                Height = 18,
+                Direction = FillDirection.Horizontal,
+                Padding = new MarginPadding { Horizontal = 8, Bottom = 6 },
+            };
+
+            float cellWidth = 1f / count;
+
+            for (int i = 0; i < count; i++)
+            {
+                string valueText = values[i] % 1f == 0
+                    ? ((int)values[i]).ToString("N0", CultureInfo.InvariantCulture)
+                    : values[i].ToString("0.00", CultureInfo.InvariantCulture);
+
+                valueLabels.Add(new TruncatingSpriteText
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Width = cellWidth,
+                    Text = valueText,
+                    Font = OsuFont.GetFont(size: 11, weight: FontWeight.Bold),
+                    Colour = colours.Highlight1,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                });
+
+                xLabels.Add(new TruncatingSpriteText
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Width = cellWidth,
+                    Text = i < labels.Length ? labels[i] : string.Empty,
+                    Font = OsuFont.GetFont(size: 11, weight: FontWeight.Bold),
+                    Colour = colours.Content2,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                });
+            }
+
+            InternalChildren = new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = colours.Background5,
+                },
+                new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Vertical,
+                    Children = new Drawable[]
+                    {
+                        valueLabels,
+                        new Container
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            Height = 56,
+                            Padding = new MarginPadding { Horizontal = 8 },
+                            Child = new LineGraph
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Padding = new MarginPadding { Vertical = 4 },
+                                MinValue = 0,
+                                LineColour = colours.Highlight1,
+                                Values = values,
+                            }
+                        },
+                        xLabels,
+                    }
+                }
+            };
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileMetricRow.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileMetricRow.cs
@@ -41,41 +41,69 @@ namespace osu.Game.EzOsuGame.LocalProfile
             Add(createChip(EzSettingsStrings.LOCAL_PROFILE_SCORE_COUNT, stats.ScoreCount.ToString("N0")));
         }
 
-        private static Drawable createChip(LocalisableString title, string value)
+        private static Drawable createChip(LocalisableString title, string value) => EzLocalProfileMetricChip.Create(title, value);
+
+        private static string formatKps(double value) => value.ToString("0.00", CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// PP + play-duration chips shown for every ruleset.
+    /// </summary>
+    public partial class EzLocalProfilePerformanceRow : FillFlowContainer
+    {
+        public EzLocalProfilePerformanceRow(EzLocalProfileRulesetStats stats)
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            Direction = FillDirection.Full;
+            Spacing = new Vector2(10);
+
+            if (stats.ScoreCount == 0 && stats.TotalPp <= 0 && stats.TotalDurationMs <= 0)
+            {
+                Add(new OsuSpriteText
+                {
+                    Text = EzSettingsStrings.LOCAL_PROFILE_NO_RULESET_DATA,
+                    Font = OsuFont.GetFont(size: 14),
+                });
+                return;
+            }
+
+            Add(EzLocalProfileMetricChip.Create(EzSettingsStrings.LOCAL_PROFILE_TOTAL_PP, EzLocalProfileFormat.FormatPp(stats.TotalPp)));
+            Add(EzLocalProfileMetricChip.Create(EzSettingsStrings.LOCAL_PROFILE_TOTAL_DURATION, EzLocalProfileFormat.FormatDuration(stats.TotalDurationMs)));
+        }
+    }
+
+    internal partial class EzLocalProfileMetricChip : Container
+    {
+        public static Drawable Create(LocalisableString title, string value)
         {
             var display = new ProfileValueDisplay { Title = title };
             display.Content.Text = value;
-
-            return new MetricChip(display);
+            return new EzLocalProfileMetricChip(display);
         }
 
-        private static string formatKps(double value) => value.ToString("0.00", CultureInfo.InvariantCulture);
-
-        private partial class MetricChip : Container
+        private EzLocalProfileMetricChip(Drawable content)
         {
-            public MetricChip(Drawable content)
+            AutoSizeAxes = Axes.Both;
+            Masking = true;
+            CornerRadius = 8;
+            Child = new Container
             {
-                AutoSizeAxes = Axes.Both;
-                Masking = true;
-                CornerRadius = 8;
-                Child = new Container
-                {
-                    AutoSizeAxes = Axes.Both,
-                    Padding = new MarginPadding { Horizontal = 14, Vertical = 10 },
-                    Child = content,
-                };
-            }
+                AutoSizeAxes = Axes.Both,
+                Padding = new MarginPadding { Horizontal = 14, Vertical = 10 },
+                Child = content,
+            };
+        }
 
-            [BackgroundDependencyLoader]
-            private void load(OverlayColourProvider colours)
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colours)
+        {
+            AddInternal(new Box
             {
-                AddInternal(new Box
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Colour = colours.Background5,
-                    Depth = float.MaxValue,
-                });
-            }
+                RelativeSizeAxes = Axes.Both,
+                Colour = colours.Background5,
+                Depth = float.MaxValue,
+            });
         }
     }
 }

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileMetricRow.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileMetricRow.cs
@@ -1,0 +1,81 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Globalization;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Profile.Header.Components;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    public partial class EzLocalProfileMetricRow : FillFlowContainer
+    {
+        public EzLocalProfileMetricRow(EzLocalProfileRulesetStats stats)
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            Direction = FillDirection.Full;
+            Spacing = new Vector2(10);
+
+            if (stats.ScoreCount == 0 && stats.TotalKeys == 0)
+            {
+                Add(new OsuSpriteText
+                {
+                    Text = EzSettingsStrings.LOCAL_PROFILE_NO_RULESET_DATA,
+                    Font = OsuFont.GetFont(size: 14),
+                });
+                return;
+            }
+
+            Add(createChip(EzSettingsStrings.LOCAL_PROFILE_TOTAL_KEYS, stats.TotalKeys.ToString("N0")));
+            Add(createChip(EzSettingsStrings.LOCAL_PROFILE_AVG_KPS, formatKps(stats.AvgKps)));
+            Add(createChip(EzSettingsStrings.LOCAL_PROFILE_MAX_KPS, formatKps(stats.MaxKps)));
+            Add(createChip(EzSettingsStrings.LOCAL_PROFILE_SCORE_COUNT, stats.ScoreCount.ToString("N0")));
+        }
+
+        private static Drawable createChip(LocalisableString title, string value)
+        {
+            var display = new ProfileValueDisplay { Title = title };
+            display.Content.Text = value;
+
+            return new MetricChip(display);
+        }
+
+        private static string formatKps(double value) => value.ToString("0.00", CultureInfo.InvariantCulture);
+
+        private partial class MetricChip : Container
+        {
+            public MetricChip(Drawable content)
+            {
+                AutoSizeAxes = Axes.Both;
+                Masking = true;
+                CornerRadius = 8;
+                Child = new Container
+                {
+                    AutoSizeAxes = Axes.Both,
+                    Padding = new MarginPadding { Horizontal = 14, Vertical = 10 },
+                    Child = content,
+                };
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colours)
+            {
+                AddInternal(new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = colours.Background5,
+                    Depth = float.MaxValue,
+                });
+            }
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileModels.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileModels.cs
@@ -16,6 +16,11 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
     public readonly record struct EzLocalProfileUsernameCount(string Username, int ScoreCount);
 
+    /// <summary>
+    /// Progress payload for local profile compute (scores processed / total, then save).
+    /// </summary>
+    public readonly record struct EzLocalProfileComputeProgress(int Processed, int Total, bool Saving);
+
     public sealed class EzLocalProfileSnapshot
     {
         public bool HasData { get; init; }
@@ -35,7 +40,9 @@ namespace osu.Game.EzOsuGame.LocalProfile
         double AvgKps,
         double MaxKps,
         int ScoreCount,
-        int KpsSampleCount);
+        int KpsSampleCount,
+        double TotalPp,
+        long TotalDurationMs);
 
     public readonly record struct EzLocalProfileManiaKeyStats(
         int KeyCount,
@@ -43,7 +50,9 @@ namespace osu.Game.EzOsuGame.LocalProfile
         double AvgKps,
         double MaxKps,
         int ScoreCount,
-        int KpsSampleCount);
+        int KpsSampleCount,
+        double TotalPp,
+        long TotalDurationMs);
 
     public readonly record struct EzLocalProfileManiaColumnStats(
         int KeyCount,
@@ -80,15 +89,17 @@ namespace osu.Game.EzOsuGame.LocalProfile
         double StarRating,
         float CircleSize,
         float ApproachRate,
-        long KeyCount);
+        long KeyCount,
+        double Pp,
+        long DurationMs);
 
     /// <summary>
     /// In-memory aggregation buffer written atomically to SQLite.
     /// </summary>
     public sealed class EzLocalProfileAggregationResult
     {
-        public IReadOnlyList<string> IncludedUsernames { get; init; } = Array.Empty<string>();
-        public DateTimeOffset ComputedAt { get; init; } = DateTimeOffset.UtcNow;
+        public IReadOnlyList<string> IncludedUsernames { get; set; } = Array.Empty<string>();
+        public DateTimeOffset ComputedAt { get; set; } = DateTimeOffset.UtcNow;
         public Dictionary<int, MutableRulesetStats> RulesetStats { get; } = new Dictionary<int, MutableRulesetStats>();
         public Dictionary<int, MutableManiaKeyStats> ManiaKeyStats { get; } = new Dictionary<int, MutableManiaKeyStats>();
         public Dictionary<(int KeyCount, int Column), MutableManiaColumnStats> ManiaColumnStats { get; } = new Dictionary<(int KeyCount, int Column), MutableManiaColumnStats>();
@@ -103,6 +114,8 @@ namespace osu.Game.EzOsuGame.LocalProfile
             public int KpsSampleCount;
             public double MaxKps;
             public int ScoreCount;
+            public double TotalPp;
+            public long TotalDurationMs;
         }
 
         public sealed class MutableManiaKeyStats
@@ -112,6 +125,8 @@ namespace osu.Game.EzOsuGame.LocalProfile
             public int KpsSampleCount;
             public double MaxKps;
             public int ScoreCount;
+            public double TotalPp;
+            public long TotalDurationMs;
         }
 
         public sealed class MutableManiaColumnStats

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileModels.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileModels.cs
@@ -1,0 +1,120 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Game.Scoring;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    public static class EzLocalProfileConstants
+    {
+        public const string UNKNOWN_USERNAME = "(unknown)";
+        public const int OSU_RULESET_ID = 0;
+        public const int MANIA_RULESET_ID = 3;
+    }
+
+    public readonly record struct EzLocalProfileUsernameCount(string Username, int ScoreCount);
+
+    public sealed class EzLocalProfileSnapshot
+    {
+        public bool HasData { get; init; }
+        public DateTimeOffset? LastComputedAt { get; init; }
+        public IReadOnlyList<string> IncludedUsernames { get; init; } = Array.Empty<string>();
+        public IReadOnlyList<EzLocalProfileRulesetStats> RulesetStats { get; init; } = Array.Empty<EzLocalProfileRulesetStats>();
+        public IReadOnlyList<EzLocalProfileManiaKeyStats> ManiaKeyStats { get; init; } = Array.Empty<EzLocalProfileManiaKeyStats>();
+        public IReadOnlyList<EzLocalProfileManiaColumnStats> ManiaColumnStats { get; init; } = Array.Empty<EzLocalProfileManiaColumnStats>();
+        public IReadOnlyList<EzLocalProfileGradeCount> GradeCounts { get; init; } = Array.Empty<EzLocalProfileGradeCount>();
+        public IReadOnlyList<EzLocalProfileStarPlayCount> StarPlayCounts { get; init; } = Array.Empty<EzLocalProfileStarPlayCount>();
+        public IReadOnlyList<EzLocalProfileStdAttrAffinity> StdAttrAffinities { get; init; } = Array.Empty<EzLocalProfileStdAttrAffinity>();
+    }
+
+    public readonly record struct EzLocalProfileRulesetStats(
+        int RulesetId,
+        long TotalKeys,
+        double AvgKps,
+        double MaxKps,
+        int ScoreCount,
+        int KpsSampleCount);
+
+    public readonly record struct EzLocalProfileManiaKeyStats(
+        int KeyCount,
+        long TotalKeys,
+        double AvgKps,
+        double MaxKps,
+        int ScoreCount,
+        int KpsSampleCount);
+
+    public readonly record struct EzLocalProfileManiaColumnStats(
+        int KeyCount,
+        int ColumnIndex,
+        long TotalKeys,
+        double AvgKps,
+        double MaxKps,
+        int ScoreCount,
+        int KpsSampleCount);
+
+    public readonly record struct EzLocalProfileGradeCount(int RulesetId, ScoreRank Rank, int Count);
+
+    public readonly record struct EzLocalProfileStarPlayCount(int RulesetId, int StarBucket, int Count);
+
+    public enum EzLocalProfileStdAttr
+    {
+        ApproachRate = 0,
+        CircleSize = 1,
+    }
+
+    public readonly record struct EzLocalProfileStdAttrAffinity(
+        EzLocalProfileStdAttr Attr,
+        double Value,
+        int PlayCount,
+        int HighGradeCount);
+
+    /// <summary>
+    /// In-memory aggregation buffer written atomically to SQLite.
+    /// </summary>
+    public sealed class EzLocalProfileAggregationResult
+    {
+        public IReadOnlyList<string> IncludedUsernames { get; init; } = Array.Empty<string>();
+        public DateTimeOffset ComputedAt { get; init; } = DateTimeOffset.UtcNow;
+        public Dictionary<int, MutableRulesetStats> RulesetStats { get; } = new Dictionary<int, MutableRulesetStats>();
+        public Dictionary<int, MutableManiaKeyStats> ManiaKeyStats { get; } = new Dictionary<int, MutableManiaKeyStats>();
+        public Dictionary<(int KeyCount, int Column), MutableManiaColumnStats> ManiaColumnStats { get; } = new Dictionary<(int KeyCount, int Column), MutableManiaColumnStats>();
+        public Dictionary<(int RulesetId, ScoreRank Rank), int> GradeCounts { get; } = new Dictionary<(int RulesetId, ScoreRank Rank), int>();
+        public Dictionary<(int RulesetId, int StarBucket), int> StarPlayCounts { get; } = new Dictionary<(int RulesetId, int StarBucket), int>();
+        public Dictionary<(EzLocalProfileStdAttr Attr, double Value), MutableStdAttr> StdAttrAffinities { get; } = new Dictionary<(EzLocalProfileStdAttr Attr, double Value), MutableStdAttr>();
+
+        public sealed class MutableRulesetStats
+        {
+            public long TotalKeys;
+            public double KpsSum;
+            public int KpsSampleCount;
+            public double MaxKps;
+            public int ScoreCount;
+        }
+
+        public sealed class MutableManiaKeyStats
+        {
+            public long TotalKeys;
+            public double KpsSum;
+            public int KpsSampleCount;
+            public double MaxKps;
+            public int ScoreCount;
+        }
+
+        public sealed class MutableManiaColumnStats
+        {
+            public long TotalKeys;
+            public double KpsSum;
+            public int KpsSampleCount;
+            public double MaxKps;
+            public int ScoreCount;
+        }
+
+        public sealed class MutableStdAttr
+        {
+            public int PlayCount;
+            public int HighGradeCount;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileModels.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileModels.cs
@@ -71,6 +71,18 @@ namespace osu.Game.EzOsuGame.LocalProfile
         int HighGradeCount);
 
     /// <summary>
+    /// Online API score metadata persisted for profile stats when local .osr import is unavailable.
+    /// </summary>
+    public readonly record struct EzLocalProfileOnlineScoreContribution(
+        long OnlineId,
+        int RulesetId,
+        ScoreRank Rank,
+        double StarRating,
+        float CircleSize,
+        float ApproachRate,
+        long KeyCount);
+
+    /// <summary>
     /// In-memory aggregation buffer written atomically to SQLite.
     /// </summary>
     public sealed class EzLocalProfileAggregationResult

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOnlinePullDialog.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOnlinePullDialog.cs
@@ -21,6 +21,8 @@ namespace osu.Game.EzOsuGame.LocalProfile
 {
     public partial class EzLocalProfileOnlinePullDialog : PopupDialog
     {
+        private const float content_width = 420;
+
         private readonly Bindable<EzLocalProfileOnlinePullKind> kind = new Bindable<EzLocalProfileOnlinePullKind>(EzLocalProfileOnlinePullKind.Best);
         private readonly Bindable<EzLocalProfileOnlinePullRulesetChoice> rulesetChoice = new Bindable<EzLocalProfileOnlinePullRulesetChoice>(EzLocalProfileOnlinePullRulesetChoice.Osu);
         private readonly BindableBool includeStatsWithoutImport = new BindableBool(true);
@@ -40,13 +42,13 @@ namespace osu.Game.EzOsuGame.LocalProfile
             offsetStoredHint = new OsuSpriteText
             {
                 RelativeSizeAxes = Axes.X,
-                Font = OsuFont.GetFont(size: 14),
+                Font = OsuFont.GetFont(size: 13),
             };
 
             offsetInput = new OsuNumberBox
             {
                 RelativeSizeAxes = Axes.X,
-                Height = 40,
+                Height = 36,
                 PlaceholderText = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_OFFSET_INPUT,
             };
 
@@ -75,18 +77,21 @@ namespace osu.Game.EzOsuGame.LocalProfile
                     new OsuSpriteText
                     {
                         Text = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_OFFSET_INPUT,
-                        Font = OsuFont.GetFont(size: 14, weight: FontWeight.Bold),
+                        Font = OsuFont.GetFont(size: 13, weight: FontWeight.Bold),
                     },
                     offsetInput,
                 }
             };
 
-            var flow = new FillFlowContainer
+            MainContent.Child = new FillFlowContainer
             {
-                RelativeSizeAxes = Axes.X,
+                Margin = new MarginPadding { Top = 12 },
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Width = content_width,
                 AutoSizeAxes = Axes.Y,
                 Direction = FillDirection.Vertical,
-                Spacing = new Vector2(8),
+                Spacing = new Vector2(6),
                 Children = new Drawable[]
                 {
                     createLabeledDropdown(EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_RULESET.ToString(), rulesetChoice),
@@ -103,14 +108,6 @@ namespace osu.Game.EzOsuGame.LocalProfile
                         Current = { BindTarget = downloadMissingBeatmaps },
                     },
                 }
-            };
-
-            MainContent.Child = new Container
-            {
-                RelativeSizeAxes = Axes.X,
-                Height = 360,
-                Margin = new MarginPadding { Top = 16 },
-                Child = flow,
             };
 
             Buttons = new PopupDialogButton[]
@@ -166,7 +163,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
                     new OsuSpriteText
                     {
                         Text = caption,
-                        Font = OsuFont.GetFont(size: 14, weight: FontWeight.Bold),
+                        Font = OsuFont.GetFont(size: 13, weight: FontWeight.Bold),
                     },
                     new OsuEnumDropdown<T>
                     {

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOnlinePullDialog.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOnlinePullDialog.cs
@@ -1,0 +1,131 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Overlays.Dialog;
+using osu.Game.Rulesets;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    public partial class EzLocalProfileOnlinePullDialog : PopupDialog
+    {
+        private readonly Bindable<EzLocalProfileOnlinePullKind> kind = new Bindable<EzLocalProfileOnlinePullKind>(EzLocalProfileOnlinePullKind.Best);
+        private readonly Bindable<EzLocalProfileOnlinePullRulesetChoice> rulesetChoice = new Bindable<EzLocalProfileOnlinePullRulesetChoice>(EzLocalProfileOnlinePullRulesetChoice.Mania);
+        private readonly BindableBool resetOffset = new BindableBool();
+        private readonly OsuSpriteText offsetHint;
+
+        public EzLocalProfileOnlinePullDialog(
+            RulesetStore rulesetStore,
+            Func<int, int> getMostPlayedOffset,
+            Action<EzLocalProfileOnlinePullRequest> onConfirm)
+        {
+            HeaderText = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_HEADER;
+            BodyText = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_BODY;
+            Icon = FontAwesome.Solid.CloudDownloadAlt;
+
+            offsetHint = new OsuSpriteText
+            {
+                RelativeSizeAxes = Axes.X,
+                Font = OsuFont.GetFont(size: 14),
+            };
+
+            void refreshOffsetHint()
+            {
+                int offset = getMostPlayedOffset((int)rulesetChoice.Value);
+                offsetHint.Text = string.Format(
+                    EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_OFFSET_HINT.ToString(),
+                    rulesetChoice.Value,
+                    offset,
+                    EzLocalProfileOnlinePullService.DEFAULT_MOST_PLAYED_BATCH);
+            }
+
+            rulesetChoice.BindValueChanged(_ => refreshOffsetHint(), true);
+            kind.BindValueChanged(_ =>
+            {
+                offsetHint.Alpha = kind.Value == EzLocalProfileOnlinePullKind.MostPlayed ? 1 : 0.4f;
+            }, true);
+
+            var flow = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(8),
+                Children = new Drawable[]
+                {
+                    new FormEnumDropdown<EzLocalProfileOnlinePullRulesetChoice>
+                    {
+                        Caption = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_RULESET,
+                        Current = { BindTarget = rulesetChoice },
+                    },
+                    new FormEnumDropdown<EzLocalProfileOnlinePullKind>
+                    {
+                        Caption = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_KIND,
+                        Current = { BindTarget = kind },
+                    },
+                    offsetHint,
+                    new OsuCheckbox
+                    {
+                        LabelText = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_RESET_OFFSET,
+                        Current = { BindTarget = resetOffset },
+                    },
+                }
+            };
+
+            MainContent.Child = new Container
+            {
+                RelativeSizeAxes = Axes.X,
+                Height = 260,
+                Margin = new MarginPadding { Top = 16 },
+                Child = flow,
+            };
+
+            Buttons = new PopupDialogButton[]
+            {
+                new PopupDialogOkButton
+                {
+                    Text = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_CONFIRM,
+                    Action = () =>
+                    {
+                        var ruleset = rulesetStore.GetRuleset((int)rulesetChoice.Value)
+                                      ?? rulesetStore.AvailableRulesets.FirstOrDefault(r => r.OnlineID == (int)rulesetChoice.Value);
+
+                        if (ruleset == null)
+                            return;
+
+                        onConfirm(new EzLocalProfileOnlinePullRequest
+                        {
+                            Kind = kind.Value,
+                            Ruleset = ruleset,
+                            ResetMostPlayedOffset = resetOffset.Value,
+                            MostPlayedBatchSize = EzLocalProfileOnlinePullService.DEFAULT_MOST_PLAYED_BATCH,
+                        });
+                    }
+                },
+                new PopupDialogCancelButton
+                {
+                    Text = EzSettingsStrings.LOCAL_PROFILE_IMPORT_CANCEL,
+                }
+            };
+        }
+    }
+
+    public enum EzLocalProfileOnlinePullRulesetChoice
+    {
+        Osu = 0,
+        Taiko = 1,
+        Catch = 2,
+        Mania = 3,
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOnlinePullDialog.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOnlinePullDialog.cs
@@ -24,12 +24,13 @@ namespace osu.Game.EzOsuGame.LocalProfile
         private readonly Bindable<EzLocalProfileOnlinePullKind> kind = new Bindable<EzLocalProfileOnlinePullKind>(EzLocalProfileOnlinePullKind.Best);
         private readonly Bindable<EzLocalProfileOnlinePullRulesetChoice> rulesetChoice = new Bindable<EzLocalProfileOnlinePullRulesetChoice>(EzLocalProfileOnlinePullRulesetChoice.Osu);
         private readonly BindableBool includeStatsWithoutImport = new BindableBool(true);
+        private readonly BindableBool downloadMissingBeatmaps = new BindableBool();
         private readonly OsuSpriteText offsetStoredHint;
         private readonly OsuNumberBox offsetInput;
 
         public EzLocalProfileOnlinePullDialog(
             RulesetStore rulesetStore,
-            Func<int, int> getMostPlayedOffset,
+            Func<EzLocalProfileOnlinePullKind, int, int> getPullOffset,
             Action<EzLocalProfileOnlinePullRequest> onConfirm)
         {
             HeaderText = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_HEADER;
@@ -51,17 +52,18 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
             void syncOffsetFromStore()
             {
-                int stored = getMostPlayedOffset((int)rulesetChoice.Value);
+                int stored = getPullOffset(kind.Value, (int)rulesetChoice.Value);
                 offsetStoredHint.Text = string.Format(
                     EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_OFFSET_HINT.ToString(),
                     stored,
-                    EzLocalProfileOnlinePullService.DEFAULT_MOST_PLAYED_BATCH);
+                    EzLocalProfileOnlinePullService.BATCH_SIZE);
                 offsetInput.Text = stored.ToString(CultureInfo.InvariantCulture);
             }
 
             rulesetChoice.BindValueChanged(_ => syncOffsetFromStore(), true);
+            kind.BindValueChanged(_ => syncOffsetFromStore(), true);
 
-            var mostPlayedOffsetSection1 = new FillFlowContainer
+            var offsetSection = new FillFlowContainer
             {
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,
@@ -79,26 +81,26 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 }
             };
 
-            kind.BindValueChanged(k =>
-            {
-                mostPlayedOffsetSection1.Alpha = k.NewValue == EzLocalProfileOnlinePullKind.MostPlayed ? 1 : 0.35f;
-            }, true);
-
             var flow = new FillFlowContainer
             {
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,
                 Direction = FillDirection.Vertical,
                 Spacing = new Vector2(8),
-                Children = new[]
+                Children = new Drawable[]
                 {
                     createLabeledDropdown(EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_RULESET.ToString(), rulesetChoice),
                     createLabeledDropdown(EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_KIND.ToString(), kind),
-                    mostPlayedOffsetSection1,
+                    offsetSection,
                     new OsuCheckbox
                     {
                         LabelText = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_INCLUDE_STATS,
                         Current = { BindTarget = includeStatsWithoutImport },
+                    },
+                    new OsuCheckbox
+                    {
+                        LabelText = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_DOWNLOAD_MAPS,
+                        Current = { BindTarget = downloadMissingBeatmaps },
                     },
                 }
             };
@@ -106,7 +108,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
             MainContent.Child = new Container
             {
                 RelativeSizeAxes = Axes.X,
-                Height = 320,
+                Height = 360,
                 Margin = new MarginPadding { Top = 16 },
                 Child = flow,
             };
@@ -124,7 +126,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
                         if (ruleset == null)
                             return;
 
-                        int startOffset = getMostPlayedOffset((int)rulesetChoice.Value);
+                        int startOffset = getPullOffset(kind.Value, (int)rulesetChoice.Value);
 
                         if (int.TryParse(offsetInput.Text, NumberStyles.Integer, CultureInfo.InvariantCulture, out int typed)
                             && typed >= 0)
@@ -136,9 +138,10 @@ namespace osu.Game.EzOsuGame.LocalProfile
                         {
                             Kind = kind.Value,
                             Ruleset = ruleset,
-                            MostPlayedStartOffset = startOffset,
+                            StartOffset = startOffset,
                             IncludeInStatsWithoutImport = includeStatsWithoutImport.Value,
-                            MostPlayedBatchSize = EzLocalProfileOnlinePullService.DEFAULT_MOST_PLAYED_BATCH,
+                            DownloadMissingBeatmaps = downloadMissingBeatmaps.Value,
+                            BatchSize = EzLocalProfileOnlinePullService.BATCH_SIZE,
                         });
                     }
                 },
@@ -177,16 +180,16 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
     public enum EzLocalProfileOnlinePullRulesetChoice
     {
-        [Description("osu!")]
+        [DescriptionAttribute("osu!")]
         Osu = 0,
 
-        [Description("osu!taiko")]
+        [DescriptionAttribute("osu!taiko")]
         Taiko = 1,
 
-        [Description("osu!catch")]
+        [DescriptionAttribute("osu!catch")]
         Catch = 2,
 
-        [Description("osu!mania")]
+        [DescriptionAttribute("osu!mania")]
         Mania = 3,
     }
 }

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOnlinePullDialog.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOnlinePullDialog.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Globalization;
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -11,19 +12,20 @@ using osu.Game.EzOsuGame.Localization;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
-using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Overlays.Dialog;
 using osu.Game.Rulesets;
 using osuTK;
+using DescriptionAttribute = System.ComponentModel.DescriptionAttribute;
 
 namespace osu.Game.EzOsuGame.LocalProfile
 {
     public partial class EzLocalProfileOnlinePullDialog : PopupDialog
     {
         private readonly Bindable<EzLocalProfileOnlinePullKind> kind = new Bindable<EzLocalProfileOnlinePullKind>(EzLocalProfileOnlinePullKind.Best);
-        private readonly Bindable<EzLocalProfileOnlinePullRulesetChoice> rulesetChoice = new Bindable<EzLocalProfileOnlinePullRulesetChoice>(EzLocalProfileOnlinePullRulesetChoice.Mania);
-        private readonly BindableBool resetOffset = new BindableBool();
-        private readonly OsuSpriteText offsetHint;
+        private readonly Bindable<EzLocalProfileOnlinePullRulesetChoice> rulesetChoice = new Bindable<EzLocalProfileOnlinePullRulesetChoice>(EzLocalProfileOnlinePullRulesetChoice.Osu);
+        private readonly BindableBool includeStatsWithoutImport = new BindableBool(true);
+        private readonly OsuSpriteText offsetStoredHint;
+        private readonly OsuNumberBox offsetInput;
 
         public EzLocalProfileOnlinePullDialog(
             RulesetStore rulesetStore,
@@ -34,26 +36,52 @@ namespace osu.Game.EzOsuGame.LocalProfile
             BodyText = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_BODY;
             Icon = FontAwesome.Solid.CloudDownloadAlt;
 
-            offsetHint = new OsuSpriteText
+            offsetStoredHint = new OsuSpriteText
             {
                 RelativeSizeAxes = Axes.X,
                 Font = OsuFont.GetFont(size: 14),
             };
 
-            void refreshOffsetHint()
+            offsetInput = new OsuNumberBox
             {
-                int offset = getMostPlayedOffset((int)rulesetChoice.Value);
-                offsetHint.Text = string.Format(
+                RelativeSizeAxes = Axes.X,
+                Height = 40,
+                PlaceholderText = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_OFFSET_INPUT,
+            };
+
+            void syncOffsetFromStore()
+            {
+                int stored = getMostPlayedOffset((int)rulesetChoice.Value);
+                offsetStoredHint.Text = string.Format(
                     EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_OFFSET_HINT.ToString(),
-                    rulesetChoice.Value,
-                    offset,
+                    stored,
                     EzLocalProfileOnlinePullService.DEFAULT_MOST_PLAYED_BATCH);
+                offsetInput.Text = stored.ToString(CultureInfo.InvariantCulture);
             }
 
-            rulesetChoice.BindValueChanged(_ => refreshOffsetHint(), true);
-            kind.BindValueChanged(_ =>
+            rulesetChoice.BindValueChanged(_ => syncOffsetFromStore(), true);
+
+            var mostPlayedOffsetSection1 = new FillFlowContainer
             {
-                offsetHint.Alpha = kind.Value == EzLocalProfileOnlinePullKind.MostPlayed ? 1 : 0.4f;
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(4),
+                Children = new Drawable[]
+                {
+                    offsetStoredHint,
+                    new OsuSpriteText
+                    {
+                        Text = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_OFFSET_INPUT,
+                        Font = OsuFont.GetFont(size: 14, weight: FontWeight.Bold),
+                    },
+                    offsetInput,
+                }
+            };
+
+            kind.BindValueChanged(k =>
+            {
+                mostPlayedOffsetSection1.Alpha = k.NewValue == EzLocalProfileOnlinePullKind.MostPlayed ? 1 : 0.35f;
             }, true);
 
             var flow = new FillFlowContainer
@@ -62,23 +90,15 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 AutoSizeAxes = Axes.Y,
                 Direction = FillDirection.Vertical,
                 Spacing = new Vector2(8),
-                Children = new Drawable[]
+                Children = new[]
                 {
-                    new FormEnumDropdown<EzLocalProfileOnlinePullRulesetChoice>
-                    {
-                        Caption = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_RULESET,
-                        Current = { BindTarget = rulesetChoice },
-                    },
-                    new FormEnumDropdown<EzLocalProfileOnlinePullKind>
-                    {
-                        Caption = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_KIND,
-                        Current = { BindTarget = kind },
-                    },
-                    offsetHint,
+                    createLabeledDropdown(EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_RULESET.ToString(), rulesetChoice),
+                    createLabeledDropdown(EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_KIND.ToString(), kind),
+                    mostPlayedOffsetSection1,
                     new OsuCheckbox
                     {
-                        LabelText = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_RESET_OFFSET,
-                        Current = { BindTarget = resetOffset },
+                        LabelText = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_INCLUDE_STATS,
+                        Current = { BindTarget = includeStatsWithoutImport },
                     },
                 }
             };
@@ -86,7 +106,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
             MainContent.Child = new Container
             {
                 RelativeSizeAxes = Axes.X,
-                Height = 260,
+                Height = 320,
                 Margin = new MarginPadding { Top = 16 },
                 Child = flow,
             };
@@ -104,11 +124,20 @@ namespace osu.Game.EzOsuGame.LocalProfile
                         if (ruleset == null)
                             return;
 
+                        int startOffset = getMostPlayedOffset((int)rulesetChoice.Value);
+
+                        if (int.TryParse(offsetInput.Text, NumberStyles.Integer, CultureInfo.InvariantCulture, out int typed)
+                            && typed >= 0)
+                        {
+                            startOffset = typed;
+                        }
+
                         onConfirm(new EzLocalProfileOnlinePullRequest
                         {
                             Kind = kind.Value,
                             Ruleset = ruleset,
-                            ResetMostPlayedOffset = resetOffset.Value,
+                            MostPlayedStartOffset = startOffset,
+                            IncludeInStatsWithoutImport = includeStatsWithoutImport.Value,
                             MostPlayedBatchSize = EzLocalProfileOnlinePullService.DEFAULT_MOST_PLAYED_BATCH,
                         });
                     }
@@ -119,13 +148,45 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 }
             };
         }
+
+        private static Drawable createLabeledDropdown<T>(string caption, Bindable<T> current)
+            where T : struct, Enum
+        {
+            return new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(2),
+                Children = new Drawable[]
+                {
+                    new OsuSpriteText
+                    {
+                        Text = caption,
+                        Font = OsuFont.GetFont(size: 14, weight: FontWeight.Bold),
+                    },
+                    new OsuEnumDropdown<T>
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Current = { BindTarget = current },
+                    },
+                }
+            };
+        }
     }
 
     public enum EzLocalProfileOnlinePullRulesetChoice
     {
+        [Description("osu!")]
         Osu = 0,
+
+        [Description("osu!taiko")]
         Taiko = 1,
+
+        [Description("osu!catch")]
         Catch = 2,
+
+        [Description("osu!mania")]
         Mania = 3,
     }
 }

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOnlinePullKind.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOnlinePullKind.cs
@@ -7,10 +7,10 @@ namespace osu.Game.EzOsuGame.LocalProfile
 {
     public enum EzLocalProfileOnlinePullKind
     {
-        [Description("BP100")]
+        [Description("BP（每批50）")]
         Best,
 
-        [Description("Most played")]
+        [Description("玩过的图（每批50）")]
         MostPlayed,
     }
 }

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOnlinePullKind.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOnlinePullKind.cs
@@ -1,0 +1,11 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    public enum EzLocalProfileOnlinePullKind
+    {
+        Best,
+        MostPlayed,
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOnlinePullKind.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOnlinePullKind.cs
@@ -1,11 +1,16 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.ComponentModel;
+
 namespace osu.Game.EzOsuGame.LocalProfile
 {
     public enum EzLocalProfileOnlinePullKind
     {
+        [Description("BP100")]
         Best,
+
+        [Description("Most played")]
         MostPlayed,
     }
 }

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOnlinePullModels.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOnlinePullModels.cs
@@ -1,0 +1,33 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    public readonly struct EzLocalProfileOnlinePullRequest
+    {
+        public EzLocalProfileOnlinePullKind Kind { get; init; }
+
+        public RulesetInfo Ruleset { get; init; }
+
+        /// <summary>
+        /// When true and <see cref="Kind"/> is <see cref="EzLocalProfileOnlinePullKind.MostPlayed"/>, offset is reset to 0 before pulling.
+        /// </summary>
+        public bool ResetMostPlayedOffset { get; init; }
+
+        public int MostPlayedBatchSize { get; init; }
+    }
+
+    public sealed class EzLocalProfileOnlinePullResult
+    {
+        public int Candidates { get; set; }
+        public int Imported { get; set; }
+        public int AlreadyOwned { get; set; }
+        public int NoReplay { get; set; }
+        public int MissingBeatmap { get; set; }
+        public int Failed { get; set; }
+        public int MostPlayedOffsetAfter { get; set; }
+        public string? ErrorMessage { get; set; }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOnlinePullModels.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOnlinePullModels.cs
@@ -12,17 +12,21 @@ namespace osu.Game.EzOsuGame.LocalProfile
         public RulesetInfo Ruleset { get; init; }
 
         /// <summary>
-        /// Starting pagination offset for <see cref="EzLocalProfileOnlinePullKind.MostPlayed"/> (0 = from the beginning).
-        /// After a successful batch the store advances to this value + batch size.
+        /// Starting pagination offset (0 = from the beginning). Applies to both BP and most-played batches of <see cref="EzLocalProfileOnlinePullService.BATCH_SIZE"/>.
         /// </summary>
-        public int MostPlayedStartOffset { get; init; }
+        public int StartOffset { get; init; }
 
         /// <summary>
         /// When true, write API score metadata into the local profile contribution table even if .osr cannot be imported.
         /// </summary>
         public bool IncludeInStatsWithoutImport { get; init; }
 
-        public int MostPlayedBatchSize { get; init; }
+        /// <summary>
+        /// When true, download missing beatmapsets (throttled) and add each map into the BP / most-played collection.
+        /// </summary>
+        public bool DownloadMissingBeatmaps { get; init; }
+
+        public int BatchSize { get; init; }
     }
 
     public sealed class EzLocalProfileOnlinePullResult
@@ -34,7 +38,10 @@ namespace osu.Game.EzOsuGame.LocalProfile
         public int MissingBeatmap { get; set; }
         public int Failed { get; set; }
         public int StatsRecorded { get; set; }
-        public int MostPlayedOffsetAfter { get; set; }
+        public int MapsDownloaded { get; set; }
+        public int MapsAlreadyLocal { get; set; }
+        public int CollectionAdds { get; set; }
+        public int OffsetAfter { get; set; }
         public string? ErrorMessage { get; set; }
     }
 }

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOnlinePullModels.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOnlinePullModels.cs
@@ -12,9 +12,15 @@ namespace osu.Game.EzOsuGame.LocalProfile
         public RulesetInfo Ruleset { get; init; }
 
         /// <summary>
-        /// When true and <see cref="Kind"/> is <see cref="EzLocalProfileOnlinePullKind.MostPlayed"/>, offset is reset to 0 before pulling.
+        /// Starting pagination offset for <see cref="EzLocalProfileOnlinePullKind.MostPlayed"/> (0 = from the beginning).
+        /// After a successful batch the store advances to this value + batch size.
         /// </summary>
-        public bool ResetMostPlayedOffset { get; init; }
+        public int MostPlayedStartOffset { get; init; }
+
+        /// <summary>
+        /// When true, write API score metadata into the local profile contribution table even if .osr cannot be imported.
+        /// </summary>
+        public bool IncludeInStatsWithoutImport { get; init; }
 
         public int MostPlayedBatchSize { get; init; }
     }
@@ -27,6 +33,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
         public int NoReplay { get; set; }
         public int MissingBeatmap { get; set; }
         public int Failed { get; set; }
+        public int StatsRecorded { get; set; }
         public int MostPlayedOffsetAfter { get; set; }
         public string? ErrorMessage { get; set; }
     }

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOnlinePullService.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOnlinePullService.cs
@@ -10,6 +10,8 @@ using System.Threading.Tasks;
 using osu.Framework.Bindables;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
+using osu.Game.Beatmaps;
+using osu.Game.Collections;
 using osu.Game.Database;
 using osu.Game.EzOsuGame.Configuration;
 using osu.Game.Online.API;
@@ -27,12 +29,20 @@ namespace osu.Game.EzOsuGame.LocalProfile
     /// </summary>
     public class EzLocalProfileOnlinePullService : IDisposable
     {
-        public const int BEST_LIMIT = 100;
-        public const int DEFAULT_MOST_PLAYED_BATCH = 50;
+        public const int BATCH_SIZE = 50;
+        public const int BEST_TOTAL = 100;
+        public const string COLLECTION_BP = "BP";
+        public const string COLLECTION_MOST_PLAYED = "玩过的图";
+
+        /// <summary>Legacy alias used by dialog copy.</summary>
+        public const int DEFAULT_MOST_PLAYED_BATCH = BATCH_SIZE;
+
         private static readonly TimeSpan request_delay = TimeSpan.FromSeconds(1);
 
         private readonly IAPIProvider api;
         private readonly ScoreManager scoreManager;
+        private readonly BeatmapManager beatmapManager;
+        private readonly RealmAccess realm;
         private readonly EzLocalProfileStore store;
         private readonly object pullLock = new object();
         private CancellationTokenSource? pullCts;
@@ -40,14 +50,22 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
         public BindableBool IsPulling { get; } = new BindableBool();
 
-        public EzLocalProfileOnlinePullService(IAPIProvider api, ScoreManager scoreManager, Storage storage)
+        public EzLocalProfileOnlinePullService(
+            IAPIProvider api,
+            ScoreManager scoreManager,
+            BeatmapManager beatmapManager,
+            RealmAccess realm,
+            Storage storage)
         {
             this.api = api;
             this.scoreManager = scoreManager;
+            this.beatmapManager = beatmapManager;
+            this.realm = realm;
             store = new EzLocalProfileStore(storage);
         }
 
-        public int PeekMostPlayedOffset(int rulesetId) => store.GetMostPlayedOffset(rulesetId);
+        public int PeekPullOffset(EzLocalProfileOnlinePullKind kind, int rulesetId) =>
+            store.GetPullOffset(kind, rulesetId);
 
         public Task<EzLocalProfileOnlinePullResult> PullAsync(EzLocalProfileOnlinePullRequest request, CancellationToken cancellationToken = default)
         {
@@ -104,37 +122,34 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
             var ruleset = request.Ruleset ?? throw new ArgumentNullException(nameof(request.Ruleset));
             int rulesetId = ruleset.OnlineID;
-            int batchSize = request.MostPlayedBatchSize > 0 ? request.MostPlayedBatchSize : DEFAULT_MOST_PLAYED_BATCH;
+            int batchSize = request.BatchSize > 0 ? request.BatchSize : BATCH_SIZE;
+            int offset = Math.Max(0, request.StartOffset);
 
-            List<SoloScoreInfo> candidates;
-
-            switch (request.Kind)
+            List<SoloScoreInfo> candidates = request.Kind switch
             {
-                case EzLocalProfileOnlinePullKind.Best:
-                    candidates = await fetchBestAsync(userId, ruleset, token).ConfigureAwait(false);
-                    result.MostPlayedOffsetAfter = store.GetMostPlayedOffset(rulesetId);
-                    break;
+                EzLocalProfileOnlinePullKind.Best => await fetchBestBatchAsync(userId, ruleset, offset, batchSize, token).ConfigureAwait(false),
+                EzLocalProfileOnlinePullKind.MostPlayed => await fetchMostPlayedScoresAsync(userId, ruleset, offset, batchSize, token).ConfigureAwait(false),
+                _ => throw new InvalidOperationException("unknown_kind"),
+            };
 
-                case EzLocalProfileOnlinePullKind.MostPlayed:
-                {
-                    int offset = Math.Max(0, request.MostPlayedStartOffset);
-                    candidates = await fetchMostPlayedScoresAsync(userId, ruleset, offset, batchSize, token).ConfigureAwait(false);
-                    int nextOffset = offset + batchSize;
-                    store.SetMostPlayedOffset(rulesetId, nextOffset);
-                    result.MostPlayedOffsetAfter = nextOffset;
-                    break;
-                }
-
-                default:
-                    result.ErrorMessage = "unknown_kind";
-                    return result;
-            }
-
+            int nextOffset = offset + batchSize;
+            store.SetPullOffset(request.Kind, rulesetId, nextOffset);
+            result.OffsetAfter = nextOffset;
             result.Candidates = candidates.Count;
+
+            string? collectionName = request.DownloadMissingBeatmaps
+                ? (request.Kind == EzLocalProfileOnlinePullKind.Best ? COLLECTION_BP : COLLECTION_MOST_PLAYED)
+                : null;
+
+            var downloadedSetIds = new HashSet<int>();
 
             foreach (var solo in candidates)
             {
                 token.ThrowIfCancellationRequested();
+
+                if (request.DownloadMissingBeatmaps)
+                    await ensureBeatmapAndCollectionAsync(solo, collectionName!, downloadedSetIds, result, token).ConfigureAwait(false);
+
                 await processCandidateAsync(solo, request.IncludeInStatsWithoutImport, result, token).ConfigureAwait(false);
                 await Task.Delay(request_delay, token).ConfigureAwait(false);
             }
@@ -142,11 +157,17 @@ namespace osu.Game.EzOsuGame.LocalProfile
             return result;
         }
 
-        private async Task<List<SoloScoreInfo>> fetchBestAsync(int userId, RulesetInfo ruleset, CancellationToken token)
+        private async Task<List<SoloScoreInfo>> fetchBestBatchAsync(
+            int userId,
+            RulesetInfo ruleset,
+            int offset,
+            int batchSize,
+            CancellationToken token)
         {
             token.ThrowIfCancellationRequested();
 
-            var req = new GetUserScoresRequest(userId, ScoreType.Best, new PaginationParameters(BEST_LIMIT), ruleset);
+            // BP is capped around 100 online; still honour requested offset/limit for two×50 batches.
+            var req = new GetUserScoresRequest(userId, ScoreType.Best, new PaginationParameters(offset, batchSize), ruleset);
             await api.PerformAsync(req).ConfigureAwait(false);
 
             if (req.CompletionState != APIRequestCompletionState.Completed || req.Response == null)
@@ -183,7 +204,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 }
                 catch
                 {
-                    // Beatmap metadata may be incomplete; still try the score request with mode filter.
+                    // incomplete metadata — still try with mode filter
                 }
 
                 await Task.Delay(request_delay, token).ConfigureAwait(false);
@@ -201,6 +222,131 @@ namespace osu.Game.EzOsuGame.LocalProfile
             }
 
             return scores;
+        }
+
+        private async Task ensureBeatmapAndCollectionAsync(
+            SoloScoreInfo solo,
+            string collectionName,
+            HashSet<int> downloadedSetIds,
+            EzLocalProfileOnlinePullResult result,
+            CancellationToken token)
+        {
+            int beatmapOnlineId = solo.BeatmapID > 0 ? solo.BeatmapID : solo.Beatmap?.OnlineID ?? 0;
+            int setOnlineId = solo.Beatmap?.OnlineBeatmapSetID
+                              ?? solo.Beatmap?.BeatmapSet?.OnlineID
+                              ?? 0;
+
+            if (beatmapOnlineId <= 0 && setOnlineId <= 0)
+                return;
+
+            var local = beatmapOnlineId > 0
+                ? beatmapManager.QueryBeatmap(b => b.OnlineID == beatmapOnlineId)
+                : null;
+
+            if (local == null && setOnlineId > 0)
+            {
+                if (downloadedSetIds.Add(setOnlineId))
+                {
+                    try
+                    {
+                        bool ok = await downloadBeatmapSetAsync(setOnlineId, token).ConfigureAwait(false);
+                        if (ok)
+                            result.MapsDownloaded++;
+                        else
+                            result.Failed++;
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Log($"[EzLocalProfile] Beatmapset {setOnlineId} download failed: {ex.Message}", Ez2ConfigManager.LOGGER_NAME);
+                        result.Failed++;
+                    }
+
+                    await Task.Delay(request_delay, token).ConfigureAwait(false);
+                }
+
+                local = beatmapOnlineId > 0
+                    ? beatmapManager.QueryBeatmap(b => b.OnlineID == beatmapOnlineId)
+                    : null;
+            }
+            else if (local != null)
+            {
+                int localSetId = local.BeatmapSet?.OnlineID ?? setOnlineId;
+                if (localSetId > 0 && downloadedSetIds.Add(localSetId))
+                    result.MapsAlreadyLocal++;
+                else if (localSetId <= 0)
+                    result.MapsAlreadyLocal++;
+            }
+
+            string? hash = local?.MD5Hash;
+            if (string.IsNullOrEmpty(hash))
+                hash = solo.Beatmap?.Checksum;
+
+            if (!string.IsNullOrEmpty(hash) && tryAddHashToCollection(collectionName, hash))
+                result.CollectionAdds++;
+        }
+
+        private async Task<bool> downloadBeatmapSetAsync(int setOnlineId, CancellationToken token)
+        {
+            token.ThrowIfCancellationRequested();
+
+            var set = new APIBeatmapSet { OnlineID = setOnlineId };
+            var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var download = new DownloadBeatmapSetRequest(set, noVideo: true);
+
+            download.Success += path => tcs.TrySetResult(path);
+            download.Failure += ex => tcs.TrySetException(ex);
+
+            await api.PerformAsync(download).ConfigureAwait(false);
+
+            if (download.CompletionState == APIRequestCompletionState.Failed && !tcs.Task.IsCompleted)
+                tcs.TrySetException(new InvalidOperationException("Beatmap download failed."));
+
+            string path;
+
+            using (token.Register(() => tcs.TrySetCanceled(token)))
+                path = await tcs.Task.ConfigureAwait(false);
+
+            try
+            {
+                var notification = new ProgressNotification
+                {
+                    State = ProgressNotificationState.Active,
+                    Text = $"Importing beatmapset {setOnlineId}…",
+                };
+
+                var imported = (await beatmapManager.Import(notification, new[] { new ImportTask(path) }, new ImportParameters { Batch = true }).ConfigureAwait(false)).ToList();
+                return imported.Count > 0;
+            }
+            finally
+            {
+                try
+                {
+                    File.Delete(path);
+                }
+                catch
+                {
+                    // ignored
+                }
+            }
+        }
+
+        private bool tryAddHashToCollection(string collectionName, string md5Hash)
+        {
+            return realm.Write(r =>
+            {
+                var collection = r.All<BeatmapCollection>().FirstOrDefault(c => c.Name == collectionName) ?? r.Add(new BeatmapCollection(collectionName));
+
+                if (collection.BeatmapMD5Hashes.Contains(md5Hash))
+                    return false;
+
+                collection.BeatmapMD5Hashes.Add(md5Hash);
+                collection.LastModified = DateTimeOffset.UtcNow;
+                return true;
+            });
         }
 
         private async Task processCandidateAsync(

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOnlinePullService.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOnlinePullService.cs
@@ -17,6 +17,7 @@ using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 
 namespace osu.Game.EzOsuGame.LocalProfile
@@ -116,10 +117,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
                 case EzLocalProfileOnlinePullKind.MostPlayed:
                 {
-                    int offset = request.ResetMostPlayedOffset ? 0 : store.GetMostPlayedOffset(rulesetId);
-                    if (request.ResetMostPlayedOffset)
-                        store.SetMostPlayedOffset(rulesetId, 0);
-
+                    int offset = Math.Max(0, request.MostPlayedStartOffset);
                     candidates = await fetchMostPlayedScoresAsync(userId, ruleset, offset, batchSize, token).ConfigureAwait(false);
                     int nextOffset = offset + batchSize;
                     store.SetMostPlayedOffset(rulesetId, nextOffset);
@@ -137,7 +135,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
             foreach (var solo in candidates)
             {
                 token.ThrowIfCancellationRequested();
-                await processCandidateAsync(solo, result, token).ConfigureAwait(false);
+                await processCandidateAsync(solo, request.IncludeInStatsWithoutImport, result, token).ConfigureAwait(false);
                 await Task.Delay(request_delay, token).ConfigureAwait(false);
             }
 
@@ -207,6 +205,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
         private async Task processCandidateAsync(
             SoloScoreInfo solo,
+            bool includeInStatsWithoutImport,
             EzLocalProfileOnlinePullResult result,
             CancellationToken token)
         {
@@ -216,6 +215,12 @@ namespace osu.Game.EzOsuGame.LocalProfile
             {
                 result.Failed++;
                 return;
+            }
+
+            if (includeInStatsWithoutImport)
+            {
+                store.UpsertOnlineScoreContribution(CreateContribution(solo));
+                result.StatsRecorded++;
             }
 
             if (scoreManager.Query(s => s.OnlineID == onlineId) != null)
@@ -280,6 +285,36 @@ namespace osu.Game.EzOsuGame.LocalProfile
                     }
                 }
             }
+        }
+
+        public static EzLocalProfileOnlineScoreContribution CreateContribution(SoloScoreInfo solo)
+        {
+            var beatmap = solo.Beatmap;
+            long keys = countKeysFromStatistics(solo.MaximumStatistics);
+            if (keys <= 0)
+                keys = countKeysFromStatistics(solo.Statistics);
+
+            return new EzLocalProfileOnlineScoreContribution(
+                solo.OnlineID,
+                solo.RulesetID,
+                solo.Rank,
+                beatmap?.StarRating ?? 0,
+                beatmap?.CircleSize ?? 0,
+                beatmap?.ApproachRate ?? 0,
+                keys);
+        }
+
+        private static long countKeysFromStatistics(IReadOnlyDictionary<HitResult, int> statistics)
+        {
+            long total = 0;
+
+            foreach (var (hitResult, count) in statistics)
+            {
+                if (hitResult.IsScorable() && !hitResult.IsBonus())
+                    total += count;
+            }
+
+            return total;
         }
 
         private async Task<string?> downloadReplayAsync(IScoreInfo scoreInfo, CancellationToken token)

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOnlinePullService.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOnlinePullService.cs
@@ -1,0 +1,315 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using osu.Framework.Bindables;
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using osu.Game.Database;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Overlays.Notifications;
+using osu.Game.Rulesets;
+using osu.Game.Scoring;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    /// <summary>
+    /// Experimental pull of own online scores (BP / most-played) into local score storage via official API.
+    /// </summary>
+    public class EzLocalProfileOnlinePullService : IDisposable
+    {
+        public const int BEST_LIMIT = 100;
+        public const int DEFAULT_MOST_PLAYED_BATCH = 50;
+        private static readonly TimeSpan request_delay = TimeSpan.FromSeconds(1);
+
+        private readonly IAPIProvider api;
+        private readonly ScoreManager scoreManager;
+        private readonly EzLocalProfileStore store;
+        private readonly object pullLock = new object();
+        private CancellationTokenSource? pullCts;
+        private bool isDisposed;
+
+        public BindableBool IsPulling { get; } = new BindableBool();
+
+        public EzLocalProfileOnlinePullService(IAPIProvider api, ScoreManager scoreManager, Storage storage)
+        {
+            this.api = api;
+            this.scoreManager = scoreManager;
+            store = new EzLocalProfileStore(storage);
+        }
+
+        public int PeekMostPlayedOffset(int rulesetId) => store.GetMostPlayedOffset(rulesetId);
+
+        public Task<EzLocalProfileOnlinePullResult> PullAsync(EzLocalProfileOnlinePullRequest request, CancellationToken cancellationToken = default)
+        {
+            lock (pullLock)
+            {
+                if (IsPulling.Value)
+                    return Task.FromResult(new EzLocalProfileOnlinePullResult { ErrorMessage = "already_pulling" });
+
+                pullCts?.Cancel();
+                pullCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                var token = pullCts.Token;
+                IsPulling.Value = true;
+
+                return Task.Run(async () =>
+                {
+                    try
+                    {
+                        return await pullCoreAsync(request, token).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        return new EzLocalProfileOnlinePullResult { ErrorMessage = "cancelled" };
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error(ex, "[EzLocalProfile] Online score pull failed.", Ez2ConfigManager.LOGGER_NAME);
+                        return new EzLocalProfileOnlinePullResult { ErrorMessage = ex.Message };
+                    }
+                    finally
+                    {
+                        IsPulling.Value = false;
+                    }
+                }, token);
+            }
+        }
+
+        private async Task<EzLocalProfileOnlinePullResult> pullCoreAsync(EzLocalProfileOnlinePullRequest request, CancellationToken token)
+        {
+            var result = new EzLocalProfileOnlinePullResult();
+
+            if (!api.IsLoggedIn || api.IsLocalOnly)
+            {
+                result.ErrorMessage = "need_online";
+                return result;
+            }
+
+            int userId = api.LocalUser.Value.Id;
+
+            if (userId <= 1)
+            {
+                result.ErrorMessage = "need_online";
+                return result;
+            }
+
+            var ruleset = request.Ruleset ?? throw new ArgumentNullException(nameof(request.Ruleset));
+            int rulesetId = ruleset.OnlineID;
+            int batchSize = request.MostPlayedBatchSize > 0 ? request.MostPlayedBatchSize : DEFAULT_MOST_PLAYED_BATCH;
+
+            List<SoloScoreInfo> candidates;
+
+            switch (request.Kind)
+            {
+                case EzLocalProfileOnlinePullKind.Best:
+                    candidates = await fetchBestAsync(userId, ruleset, token).ConfigureAwait(false);
+                    result.MostPlayedOffsetAfter = store.GetMostPlayedOffset(rulesetId);
+                    break;
+
+                case EzLocalProfileOnlinePullKind.MostPlayed:
+                {
+                    int offset = request.ResetMostPlayedOffset ? 0 : store.GetMostPlayedOffset(rulesetId);
+                    if (request.ResetMostPlayedOffset)
+                        store.SetMostPlayedOffset(rulesetId, 0);
+
+                    candidates = await fetchMostPlayedScoresAsync(userId, ruleset, offset, batchSize, token).ConfigureAwait(false);
+                    int nextOffset = offset + batchSize;
+                    store.SetMostPlayedOffset(rulesetId, nextOffset);
+                    result.MostPlayedOffsetAfter = nextOffset;
+                    break;
+                }
+
+                default:
+                    result.ErrorMessage = "unknown_kind";
+                    return result;
+            }
+
+            result.Candidates = candidates.Count;
+
+            foreach (var solo in candidates)
+            {
+                token.ThrowIfCancellationRequested();
+                await processCandidateAsync(solo, result, token).ConfigureAwait(false);
+                await Task.Delay(request_delay, token).ConfigureAwait(false);
+            }
+
+            return result;
+        }
+
+        private async Task<List<SoloScoreInfo>> fetchBestAsync(int userId, RulesetInfo ruleset, CancellationToken token)
+        {
+            token.ThrowIfCancellationRequested();
+
+            var req = new GetUserScoresRequest(userId, ScoreType.Best, new PaginationParameters(BEST_LIMIT), ruleset);
+            await api.PerformAsync(req).ConfigureAwait(false);
+
+            if (req.CompletionState != APIRequestCompletionState.Completed || req.Response == null)
+                throw new InvalidOperationException("Failed to fetch best scores.");
+
+            return req.Response;
+        }
+
+        private async Task<List<SoloScoreInfo>> fetchMostPlayedScoresAsync(
+            int userId,
+            RulesetInfo ruleset,
+            int offset,
+            int batchSize,
+            CancellationToken token)
+        {
+            token.ThrowIfCancellationRequested();
+
+            var mpReq = new GetUserMostPlayedBeatmapsRequest(userId, new PaginationParameters(offset, batchSize));
+            await api.PerformAsync(mpReq).ConfigureAwait(false);
+
+            if (mpReq.CompletionState != APIRequestCompletionState.Completed || mpReq.Response == null)
+                throw new InvalidOperationException("Failed to fetch most-played beatmaps.");
+
+            var scores = new List<SoloScoreInfo>();
+
+            foreach (var entry in mpReq.Response)
+            {
+                token.ThrowIfCancellationRequested();
+
+                try
+                {
+                    if (entry.BeatmapInfo.Ruleset.OnlineID != ruleset.OnlineID)
+                        continue;
+                }
+                catch
+                {
+                    // Beatmap metadata may be incomplete; still try the score request with mode filter.
+                }
+
+                await Task.Delay(request_delay, token).ConfigureAwait(false);
+
+                var scoreReq = new GetUserBeatmapScoreRequest(entry.BeatmapID, userId, ruleset);
+                await api.PerformAsync(scoreReq).ConfigureAwait(false);
+
+                if (scoreReq.CompletionState != APIRequestCompletionState.Completed || scoreReq.Response?.Score == null)
+                    continue;
+
+                if (scoreReq.Response.Score.RulesetID != ruleset.OnlineID)
+                    continue;
+
+                scores.Add(scoreReq.Response.Score);
+            }
+
+            return scores;
+        }
+
+        private async Task processCandidateAsync(
+            SoloScoreInfo solo,
+            EzLocalProfileOnlinePullResult result,
+            CancellationToken token)
+        {
+            long onlineId = solo.OnlineID;
+
+            if (onlineId <= 0)
+            {
+                result.Failed++;
+                return;
+            }
+
+            if (scoreManager.Query(s => s.OnlineID == onlineId) != null)
+            {
+                result.AlreadyOwned++;
+                return;
+            }
+
+            if (!solo.HasReplay)
+            {
+                result.NoReplay++;
+                return;
+            }
+
+            string? path = null;
+
+            try
+            {
+                path = await downloadReplayAsync(solo, token).ConfigureAwait(false);
+
+                if (string.IsNullOrEmpty(path) || !File.Exists(path))
+                {
+                    result.Failed++;
+                    return;
+                }
+
+                var notification = new ProgressNotification
+                {
+                    State = ProgressNotificationState.Active,
+                    Text = $"Importing online score {onlineId}…",
+                };
+
+                var imported = (await scoreManager.Import(notification, new[] { new ImportTask(path) }, new ImportParameters { Batch = true }).ConfigureAwait(false)).ToList();
+
+                if (imported.Count > 0)
+                    result.Imported++;
+                else if (scoreManager.Query(s => s.OnlineID == onlineId) != null)
+                    result.AlreadyOwned++;
+                else
+                    result.MissingBeatmap++;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"[EzLocalProfile] Import failed for score {onlineId}: {ex.Message}", Ez2ConfigManager.LOGGER_NAME);
+                result.Failed++;
+            }
+            finally
+            {
+                if (!string.IsNullOrEmpty(path))
+                {
+                    try
+                    {
+                        File.Delete(path);
+                    }
+                    catch
+                    {
+                        // ignored
+                    }
+                }
+            }
+        }
+
+        private async Task<string?> downloadReplayAsync(IScoreInfo scoreInfo, CancellationToken token)
+        {
+            token.ThrowIfCancellationRequested();
+
+            var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var download = new DownloadReplayRequest(scoreInfo);
+
+            download.Success += path => tcs.TrySetResult(path);
+            download.Failure += ex => tcs.TrySetException(ex);
+
+            await api.PerformAsync(download).ConfigureAwait(false);
+
+            if (download.CompletionState == APIRequestCompletionState.Failed && !tcs.Task.IsCompleted)
+                tcs.TrySetException(new InvalidOperationException("Replay download failed."));
+
+            using (token.Register(() => tcs.TrySetCanceled(token)))
+                return await tcs.Task.ConfigureAwait(false);
+        }
+
+        public void Dispose()
+        {
+            if (isDisposed)
+                return;
+
+            isDisposed = true;
+            pullCts?.Cancel();
+            pullCts?.Dispose();
+            store.Dispose();
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOnlinePullService.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOnlinePullService.cs
@@ -440,6 +440,8 @@ namespace osu.Game.EzOsuGame.LocalProfile
             if (keys <= 0)
                 keys = countKeysFromStatistics(solo.Statistics);
 
+            long durationMs = beatmap != null && beatmap.Length > 0 ? (long)beatmap.Length : 0;
+
             return new EzLocalProfileOnlineScoreContribution(
                 solo.OnlineID,
                 solo.RulesetID,
@@ -447,7 +449,9 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 beatmap?.StarRating ?? 0,
                 beatmap?.CircleSize ?? 0,
                 beatmap?.ApproachRate ?? 0,
-                keys);
+                keys,
+                solo.PP ?? 0,
+                durationMs);
         }
 
         private static long countKeysFromStatistics(IReadOnlyDictionary<HitResult, int> statistics)

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOverlay.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOverlay.cs
@@ -159,6 +159,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
             int rulesetId = ruleset.Value?.OnlineID ?? 0;
             var rulesetStats = snapshot.RulesetStats.FirstOrDefault(s => s.RulesetId == rulesetId);
 
+            contentFlow.Add(new EzLocalProfileSection(EzSettingsStrings.LOCAL_PROFILE_SECTION_PERFORMANCE, new EzLocalProfilePerformanceRow(rulesetStats)));
             contentFlow.Add(new EzLocalProfileSection(EzSettingsStrings.LOCAL_PROFILE_SECTION_KEYS, new EzLocalProfileMetricRow(rulesetStats)));
 
             if (rulesetId == EzLocalProfileConstants.MANIA_RULESET_ID)

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOverlay.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOverlay.cs
@@ -1,0 +1,215 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
+using osu.Game.Rulesets;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    public partial class EzLocalProfileOverlay : FullscreenOverlay<EzLocalProfileHeader>
+    {
+        private readonly Bindable<RulesetInfo> ruleset = new Bindable<RulesetInfo>();
+        private FillFlowContainer contentFlow = null!;
+        private Container emptyStateContainer = null!;
+        private OverlayRulesetSelector rulesetSelector = null!;
+
+        [Resolved]
+        private EzLocalProfileService profileService { get; set; } = null!;
+
+        [Resolved]
+        private LoginOverlay? loginOverlay { get; set; }
+
+        [Resolved]
+        private RulesetStore rulesets { get; set; } = null!;
+
+        public EzLocalProfileOverlay()
+            : base(OverlayColourScheme.Pink)
+        {
+        }
+
+        protected override EzLocalProfileHeader CreateHeader() => new EzLocalProfileHeader
+        {
+            OpenAccount = () =>
+            {
+                Hide();
+                loginOverlay?.Show();
+            }
+        };
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Child = new OsuScrollContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                Child = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Vertical,
+                    Children = new Drawable[]
+                    {
+                        new Container
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Children = new Drawable[]
+                            {
+                                new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Colour = ColourProvider.Background5,
+                                },
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    Padding = new MarginPadding
+                                    {
+                                        Horizontal = HORIZONTAL_PADDING,
+                                        Vertical = 10
+                                    },
+                                    Child = rulesetSelector = new OverlayRulesetSelector
+                                    {
+                                        Current = { BindTarget = ruleset }
+                                    }
+                                }
+                            }
+                        },
+                        new Container
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Padding = new MarginPadding
+                            {
+                                Horizontal = HORIZONTAL_PADDING,
+                                Vertical = 20
+                            },
+                            Children = new Drawable[]
+                            {
+                                emptyStateContainer = new Container
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    Alpha = 0,
+                                    Child = new EzLocalProfileEmptyState()
+                                },
+                                contentFlow = new FillFlowContainer
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    Direction = FillDirection.Vertical,
+                                    Spacing = new Vector2(0, 16),
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            ruleset.Value = rulesets.GetRuleset(0) ?? rulesets.AvailableRulesets.First();
+            ruleset.BindValueChanged(_ => Schedule(refreshContent), true);
+
+            profileService.Snapshot.BindValueChanged(s => Schedule(() =>
+            {
+                Header.UpdateMeta(s.NewValue);
+                refreshContent();
+            }), true);
+
+            API.LocalUser.BindValueChanged(u => Schedule(() => Header.UpdateUsername(u.NewValue.Username)), true);
+        }
+
+        protected override void PopIn()
+        {
+            base.PopIn();
+            profileService.ReloadFromDisk();
+            refreshContent();
+        }
+
+        private void refreshContent()
+        {
+            contentFlow.Clear();
+
+            var snapshot = profileService.Snapshot.Value;
+
+            if (!snapshot.HasData)
+            {
+                emptyStateContainer.Show();
+                return;
+            }
+
+            emptyStateContainer.Hide();
+
+            int rulesetId = ruleset.Value?.OnlineID ?? 0;
+            var rulesetStats = snapshot.RulesetStats.FirstOrDefault(s => s.RulesetId == rulesetId);
+
+            contentFlow.Add(new EzLocalProfileSection(EzSettingsStrings.LOCAL_PROFILE_SECTION_KEYS, new EzLocalProfileMetricRow(rulesetStats)));
+
+            if (rulesetId == EzLocalProfileConstants.MANIA_RULESET_ID)
+                contentFlow.Add(new EzLocalProfileSection(EzSettingsStrings.LOCAL_PROFILE_SECTION_MANIA, createManiaContent(snapshot)));
+
+            if (rulesetId == EzLocalProfileConstants.OSU_RULESET_ID)
+                contentFlow.Add(new EzLocalProfileSection(EzSettingsStrings.LOCAL_PROFILE_SECTION_STD, new EzLocalProfileStdAffinityBlock(snapshot)));
+
+            contentFlow.Add(new EzLocalProfileSection(
+                EzSettingsStrings.LOCAL_PROFILE_SECTION_GRADES,
+                new EzLocalProfileGradeRow(snapshot.GradeCounts.Where(g => g.RulesetId == rulesetId))));
+
+            contentFlow.Add(new EzLocalProfileSection(
+                EzSettingsStrings.LOCAL_PROFILE_SECTION_STARS,
+                new EzLocalProfileStarBars(snapshot.StarPlayCounts.Where(s => s.RulesetId == rulesetId))));
+        }
+
+        private static Drawable createManiaContent(EzLocalProfileSnapshot snapshot)
+        {
+            var flow = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(0, 12),
+            };
+
+            var keyStats = snapshot.ManiaKeyStats.OrderBy(k => k.KeyCount).ToList();
+
+            if (keyStats.Count == 0)
+            {
+                flow.Add(new OsuSpriteText
+                {
+                    Text = EzSettingsStrings.LOCAL_PROFILE_NO_RULESET_DATA,
+                    Font = OsuFont.GetFont(size: 14),
+                });
+                return flow;
+            }
+
+            flow.Add(new EzLocalProfileManiaOverview(keyStats));
+
+            foreach (var key in keyStats)
+            {
+                var columns = snapshot.ManiaColumnStats
+                                      .Where(c => c.KeyCount == key.KeyCount)
+                                      .OrderBy(c => c.ColumnIndex)
+                                      .ToList();
+                flow.Add(new EzLocalProfileExpandableRow(key, columns));
+            }
+
+            return flow;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfilePartitionPayload.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfilePartitionPayload.cs
@@ -1,0 +1,221 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Game.Scoring;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    /// <summary>
+    /// Per-username persisted aggregation slice. Recomputing a name replaces only this slice.
+    /// </summary>
+    public sealed class EzLocalProfilePartitionPayload
+    {
+        public List<PartitionRulesetStats> RulesetStats { get; set; } = new List<PartitionRulesetStats>();
+        public List<PartitionManiaKeyStats> ManiaKeyStats { get; set; } = new List<PartitionManiaKeyStats>();
+        public List<PartitionManiaColumnStats> ManiaColumnStats { get; set; } = new List<PartitionManiaColumnStats>();
+        public List<PartitionGradeCount> GradeCounts { get; set; } = new List<PartitionGradeCount>();
+        public List<PartitionStarPlayCount> StarPlayCounts { get; set; } = new List<PartitionStarPlayCount>();
+        public List<PartitionStdAttrAffinity> StdAttrAffinities { get; set; } = new List<PartitionStdAttrAffinity>();
+
+        public static EzLocalProfilePartitionPayload FromAggregation(EzLocalProfileAggregationResult result)
+        {
+            var payload = new EzLocalProfilePartitionPayload();
+
+            foreach (var (rulesetId, stats) in result.RulesetStats)
+            {
+                payload.RulesetStats.Add(new PartitionRulesetStats
+                {
+                    RulesetId = rulesetId,
+                    TotalKeys = stats.TotalKeys,
+                    KpsSum = stats.KpsSum,
+                    KpsSampleCount = stats.KpsSampleCount,
+                    MaxKps = stats.MaxKps,
+                    ScoreCount = stats.ScoreCount,
+                    TotalPp = stats.TotalPp,
+                    TotalDurationMs = stats.TotalDurationMs,
+                });
+            }
+
+            foreach (var (keyCount, stats) in result.ManiaKeyStats)
+            {
+                payload.ManiaKeyStats.Add(new PartitionManiaKeyStats
+                {
+                    KeyCount = keyCount,
+                    TotalKeys = stats.TotalKeys,
+                    KpsSum = stats.KpsSum,
+                    KpsSampleCount = stats.KpsSampleCount,
+                    MaxKps = stats.MaxKps,
+                    ScoreCount = stats.ScoreCount,
+                    TotalPp = stats.TotalPp,
+                    TotalDurationMs = stats.TotalDurationMs,
+                });
+            }
+
+            foreach (var ((keyCount, column), stats) in result.ManiaColumnStats)
+            {
+                payload.ManiaColumnStats.Add(new PartitionManiaColumnStats
+                {
+                    KeyCount = keyCount,
+                    ColumnIndex = column,
+                    TotalKeys = stats.TotalKeys,
+                    KpsSum = stats.KpsSum,
+                    KpsSampleCount = stats.KpsSampleCount,
+                    MaxKps = stats.MaxKps,
+                    ScoreCount = stats.ScoreCount,
+                });
+            }
+
+            foreach (var ((rulesetId, rank), count) in result.GradeCounts)
+                payload.GradeCounts.Add(new PartitionGradeCount { RulesetId = rulesetId, Rank = (int)rank, Count = count });
+
+            foreach (var ((rulesetId, starBucket), count) in result.StarPlayCounts)
+                payload.StarPlayCounts.Add(new PartitionStarPlayCount { RulesetId = rulesetId, StarBucket = starBucket, Count = count });
+
+            foreach (var ((attr, value), stats) in result.StdAttrAffinities)
+            {
+                payload.StdAttrAffinities.Add(new PartitionStdAttrAffinity
+                {
+                    Attr = (int)attr,
+                    Value = value,
+                    PlayCount = stats.PlayCount,
+                    HighGradeCount = stats.HighGradeCount,
+                });
+            }
+
+            return payload;
+        }
+
+        public void MergeInto(EzLocalProfileAggregationResult target)
+        {
+            foreach (var row in RulesetStats)
+            {
+                var stats = getOrCreate(target.RulesetStats, row.RulesetId, () => new EzLocalProfileAggregationResult.MutableRulesetStats());
+                stats.TotalKeys += row.TotalKeys;
+                stats.KpsSum += row.KpsSum;
+                stats.KpsSampleCount += row.KpsSampleCount;
+                stats.ScoreCount += row.ScoreCount;
+                stats.TotalPp += row.TotalPp;
+                stats.TotalDurationMs += row.TotalDurationMs;
+                if (row.MaxKps > stats.MaxKps)
+                    stats.MaxKps = row.MaxKps;
+            }
+
+            foreach (var row in ManiaKeyStats)
+            {
+                var stats = getOrCreate(target.ManiaKeyStats, row.KeyCount, () => new EzLocalProfileAggregationResult.MutableManiaKeyStats());
+                stats.TotalKeys += row.TotalKeys;
+                stats.KpsSum += row.KpsSum;
+                stats.KpsSampleCount += row.KpsSampleCount;
+                stats.ScoreCount += row.ScoreCount;
+                stats.TotalPp += row.TotalPp;
+                stats.TotalDurationMs += row.TotalDurationMs;
+                if (row.MaxKps > stats.MaxKps)
+                    stats.MaxKps = row.MaxKps;
+            }
+
+            foreach (var row in ManiaColumnStats)
+            {
+                var stats = getOrCreate(target.ManiaColumnStats, (row.KeyCount, row.ColumnIndex), () => new EzLocalProfileAggregationResult.MutableManiaColumnStats());
+                stats.TotalKeys += row.TotalKeys;
+                stats.KpsSum += row.KpsSum;
+                stats.KpsSampleCount += row.KpsSampleCount;
+                stats.ScoreCount += row.ScoreCount;
+                if (row.MaxKps > stats.MaxKps)
+                    stats.MaxKps = row.MaxKps;
+            }
+
+            foreach (var row in GradeCounts)
+            {
+                var key = (row.RulesetId, (ScoreRank)row.Rank);
+                target.GradeCounts.TryGetValue(key, out int existing);
+                target.GradeCounts[key] = existing + row.Count;
+            }
+
+            foreach (var row in StarPlayCounts)
+            {
+                var key = (row.RulesetId, row.StarBucket);
+                target.StarPlayCounts.TryGetValue(key, out int existing);
+                target.StarPlayCounts[key] = existing + row.Count;
+            }
+
+            foreach (var row in StdAttrAffinities)
+            {
+                var key = ((EzLocalProfileStdAttr)row.Attr, row.Value);
+                var stats = getOrCreate(target.StdAttrAffinities, key, () => new EzLocalProfileAggregationResult.MutableStdAttr());
+                stats.PlayCount += row.PlayCount;
+                stats.HighGradeCount += row.HighGradeCount;
+            }
+        }
+
+        private static TValue getOrCreate<TKey, TValue>(Dictionary<TKey, TValue> dict, TKey key, Func<TValue> factory)
+            where TKey : notnull
+            where TValue : class
+        {
+            if (dict.TryGetValue(key, out var existing))
+                return existing;
+
+            var created = factory();
+            dict[key] = created;
+            return created;
+        }
+    }
+
+    public sealed class PartitionRulesetStats
+    {
+        public int RulesetId { get; set; }
+        public long TotalKeys { get; set; }
+        public double KpsSum { get; set; }
+        public int KpsSampleCount { get; set; }
+        public double MaxKps { get; set; }
+        public int ScoreCount { get; set; }
+        public double TotalPp { get; set; }
+        public long TotalDurationMs { get; set; }
+    }
+
+    public sealed class PartitionManiaKeyStats
+    {
+        public int KeyCount { get; set; }
+        public long TotalKeys { get; set; }
+        public double KpsSum { get; set; }
+        public int KpsSampleCount { get; set; }
+        public double MaxKps { get; set; }
+        public int ScoreCount { get; set; }
+        public double TotalPp { get; set; }
+        public long TotalDurationMs { get; set; }
+    }
+
+    public sealed class PartitionManiaColumnStats
+    {
+        public int KeyCount { get; set; }
+        public int ColumnIndex { get; set; }
+        public long TotalKeys { get; set; }
+        public double KpsSum { get; set; }
+        public int KpsSampleCount { get; set; }
+        public double MaxKps { get; set; }
+        public int ScoreCount { get; set; }
+    }
+
+    public sealed class PartitionGradeCount
+    {
+        public int RulesetId { get; set; }
+        public int Rank { get; set; }
+        public int Count { get; set; }
+    }
+
+    public sealed class PartitionStarPlayCount
+    {
+        public int RulesetId { get; set; }
+        public int StarBucket { get; set; }
+        public int Count { get; set; }
+    }
+
+    public sealed class PartitionStdAttrAffinity
+    {
+        public int Attr { get; set; }
+        public double Value { get; set; }
+        public int PlayCount { get; set; }
+        public int HighGradeCount { get; set; }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileRoundedBar.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileRoundedBar.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Overlays;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    /// <summary>
+    /// Horizontal track + rounded fill bar (profile chart style).
+    /// </summary>
+    public partial class EzLocalProfileRoundedBar : Container
+    {
+        private readonly float fillRatio;
+
+        public EzLocalProfileRoundedBar(float fillRatio)
+        {
+            this.fillRatio = float.IsFinite(fillRatio) ? Math.Clamp(fillRatio, 0f, 1f) : 0;
+            RelativeSizeAxes = Axes.Both;
+            Masking = true;
+            CornerRadius = 6;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colours)
+        {
+            Children = new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = colours.Background6,
+                },
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Width = fillRatio,
+                    Colour = colours.Highlight1,
+                }
+            };
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileSection.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileSection.cs
@@ -1,0 +1,112 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Effects;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    /// <summary>
+    /// Profile-section style card (rounded, shadowed, title underline).
+    /// </summary>
+    public partial class EzLocalProfileSection : Container
+    {
+        private const float outer_gutter_width = 10;
+
+        private readonly LocalisableString title;
+        private readonly Drawable body;
+        private Box background = null!;
+        private Box underscore = null!;
+
+        public EzLocalProfileSection(LocalisableString title, Drawable body)
+        {
+            this.title = title;
+            this.body = body;
+
+            AutoSizeAxes = Axes.Y;
+            RelativeSizeAxes = Axes.X;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            InternalChildren = new Drawable[]
+            {
+                new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Masking = true,
+                    CornerRadius = 10,
+                    EdgeEffect = new EdgeEffectParameters
+                    {
+                        Type = EdgeEffectType.Shadow,
+                        Offset = new Vector2(0, 1),
+                        Radius = 3,
+                        Colour = Colour4.Black.Opacity(0.25f),
+                    },
+                    Child = background = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    },
+                },
+                new FillFlowContainer
+                {
+                    Direction = FillDirection.Vertical,
+                    AutoSizeAxes = Axes.Y,
+                    RelativeSizeAxes = Axes.X,
+                    Children = new Drawable[]
+                    {
+                        new Container
+                        {
+                            AutoSizeAxes = Axes.Both,
+                            Margin = new MarginPadding
+                            {
+                                Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING - outer_gutter_width,
+                                Top = 20,
+                                Bottom = 12,
+                            },
+                            Children = new Drawable[]
+                            {
+                                new OsuSpriteText
+                                {
+                                    Text = title,
+                                    Font = OsuFont.GetFont(size: 16, weight: FontWeight.Bold),
+                                },
+                                underscore = new Box
+                                {
+                                    Anchor = Anchor.BottomCentre,
+                                    Origin = Anchor.TopCentre,
+                                    Margin = new MarginPadding { Top = 4 },
+                                    RelativeSizeAxes = Axes.X,
+                                    Height = 2,
+                                }
+                            }
+                        },
+                        new Container
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Padding = new MarginPadding
+                            {
+                                Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING - outer_gutter_width,
+                                Bottom = 20
+                            },
+                            Child = body
+                        }
+                    }
+                }
+            };
+
+            background.Colour = colourProvider.Background4;
+            underscore.Colour = colourProvider.Highlight1;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileService.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileService.cs
@@ -39,6 +39,8 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
         public IReadOnlyList<string> GetPreviouslyIncludedUsernames() => store.LoadIncludedUsernames();
 
+        public bool HasOnlineScoreContributions() => store.LoadOnlineScoreContributions().Count > 0;
+
         public Task ComputeAsync(IReadOnlyCollection<string> includedUsernames, CancellationToken cancellationToken = default)
         {
             lock (computeLock)
@@ -54,7 +56,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
                     try
                     {
                         token.ThrowIfCancellationRequested();
-                        var result = aggregator.Aggregate(includedUsernames);
+                        var result = aggregator.Aggregate(includedUsernames, store.LoadOnlineScoreContributions());
                         token.ThrowIfCancellationRequested();
                         store.ReplaceAll(result);
                     }

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileService.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileService.cs
@@ -3,10 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Bindables;
 using osu.Framework.Logging;
+using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.EzOsuGame.Analysis;
 using osu.Game.EzOsuGame.Configuration;
@@ -28,10 +30,10 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
         public BindableBool IsComputing { get; } = new BindableBool();
 
-        public EzLocalProfileService(Storage storage, RealmAccess realm, EzAnalysisPersistentStore analysisStore)
+        public EzLocalProfileService(Storage storage, RealmAccess realm, EzAnalysisPersistentStore analysisStore, BeatmapManager beatmapManager)
         {
             store = new EzLocalProfileStore(storage);
-            aggregator = new EzLocalProfileAggregator(realm, analysisStore);
+            aggregator = new EzLocalProfileAggregator(realm, analysisStore, beatmapManager);
             Snapshot.Value = store.LoadSnapshot();
         }
 
@@ -41,7 +43,18 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
         public bool HasOnlineScoreContributions() => store.LoadOnlineScoreContributions().Count > 0;
 
-        public Task ComputeAsync(IReadOnlyCollection<string> includedUsernames, CancellationToken cancellationToken = default)
+        /// <param name="usernamesToRecompute">Names whose score stats will be recalculated and overwrite their stored slice.</param>
+        /// <param name="replaceOtherUsernames">
+        /// If true, drop stored slices for names not in <paramref name="usernamesToRecompute"/>.
+        /// If false, leave other names' slices untouched.
+        /// </param>
+        /// <param name="progress">Optional progress reporter for UI notifications.</param>
+        /// <param name="cancellationToken">Cancels in-flight aggregation; partial results are not written.</param>
+        public Task ComputeAsync(
+            IReadOnlyCollection<string> usernamesToRecompute,
+            bool replaceOtherUsernames = false,
+            IProgress<EzLocalProfileComputeProgress>? progress = null,
+            CancellationToken cancellationToken = default)
         {
             lock (computeLock)
             {
@@ -56,13 +69,29 @@ namespace osu.Game.EzOsuGame.LocalProfile
                     try
                     {
                         token.ThrowIfCancellationRequested();
-                        var result = aggregator.Aggregate(includedUsernames, store.LoadOnlineScoreContributions());
+
+                        var selected = usernamesToRecompute
+                                       .Where(n => !string.IsNullOrWhiteSpace(n))
+                                       .Distinct(StringComparer.Ordinal)
+                                       .ToList();
+
+                        // Online-only refresh path: no local usernames selected, just rebuild display from existing partitions + online.
+                        var byUser = selected.Count > 0
+                            ? aggregator.AggregateByUsername(selected, progress, token)
+                            : new Dictionary<string, EzLocalProfileAggregationResult>(StringComparer.Ordinal);
+
                         token.ThrowIfCancellationRequested();
-                        store.ReplaceAll(result);
+
+                        // Signal UI that aggregation is done and we are persisting (may include a Realm scan).
+                        progress?.Report(new EzLocalProfileComputeProgress(1, 1, Saving: true));
+
+                        var online = store.LoadOnlineScoreContributions();
+                        var localOnlineIds = aggregator.CollectLocalOnlineScoreIds();
+                        store.ApplyUsernamePartitions(byUser, replaceOtherUsernames, online, localOnlineIds);
                     }
                     catch (OperationCanceledException)
                     {
-                        // ignored
+                        throw;
                     }
                     catch (Exception ex)
                     {

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileService.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileService.cs
@@ -1,0 +1,90 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using osu.Framework.Bindables;
+using osu.Framework.Logging;
+using osu.Game.Database;
+using osu.Game.EzOsuGame.Analysis;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Framework.Platform;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    /// <summary>
+    /// DI façade for the single shared local profile store and aggregation.
+    /// </summary>
+    public class EzLocalProfileService : IDisposable
+    {
+        private readonly EzLocalProfileStore store;
+        private readonly EzLocalProfileAggregator aggregator;
+        private readonly object computeLock = new object();
+        private CancellationTokenSource? computeCts;
+
+        public Bindable<EzLocalProfileSnapshot> Snapshot { get; } = new Bindable<EzLocalProfileSnapshot>(new EzLocalProfileSnapshot());
+
+        public BindableBool IsComputing { get; } = new BindableBool();
+
+        public EzLocalProfileService(Storage storage, RealmAccess realm, EzAnalysisPersistentStore analysisStore)
+        {
+            store = new EzLocalProfileStore(storage);
+            aggregator = new EzLocalProfileAggregator(realm, analysisStore);
+            Snapshot.Value = store.LoadSnapshot();
+        }
+
+        public IReadOnlyList<EzLocalProfileUsernameCount> ScanUsernameCounts() => aggregator.ScanUsernameCounts();
+
+        public IReadOnlyList<string> GetPreviouslyIncludedUsernames() => store.LoadIncludedUsernames();
+
+        public Task ComputeAsync(IReadOnlyCollection<string> includedUsernames, CancellationToken cancellationToken = default)
+        {
+            lock (computeLock)
+            {
+                computeCts?.Cancel();
+                computeCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                var token = computeCts.Token;
+
+                IsComputing.Value = true;
+
+                return Task.Run(() =>
+                {
+                    try
+                    {
+                        token.ThrowIfCancellationRequested();
+                        var result = aggregator.Aggregate(includedUsernames);
+                        token.ThrowIfCancellationRequested();
+                        store.ReplaceAll(result);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // ignored
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error(ex, "[EzLocalProfile] Failed to compute local profile statistics.", Ez2ConfigManager.LOGGER_NAME);
+                        throw;
+                    }
+                    finally
+                    {
+                        IsComputing.Value = false;
+                    }
+                }, token);
+            }
+        }
+
+        public void ReloadFromDisk()
+        {
+            Snapshot.Value = store.LoadSnapshot();
+        }
+
+        public void Dispose()
+        {
+            computeCts?.Cancel();
+            computeCts?.Dispose();
+            store.Dispose();
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileStarBars.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileStarBars.cs
@@ -1,0 +1,106 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    public partial class EzLocalProfileStarBars : FillFlowContainer
+    {
+        public EzLocalProfileStarBars(IEnumerable<EzLocalProfileStarPlayCount> stars)
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            Direction = FillDirection.Vertical;
+            Spacing = new Vector2(0, 10);
+
+            var list = stars.OrderBy(s => s.StarBucket).ToList();
+
+            if (list.Count == 0)
+            {
+                Add(new OsuSpriteText
+                {
+                    Text = EzSettingsStrings.LOCAL_PROFILE_NO_RULESET_DATA,
+                    Font = OsuFont.GetFont(size: 14),
+                });
+                return;
+            }
+
+            int max = list.Max(s => s.Count);
+
+            var barFlow = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(0, 8),
+            };
+
+            foreach (var star in list)
+                barFlow.Add(new StarBarRow(star.StarBucket, star.Count, max));
+
+            Add(barFlow);
+            Add(new EzLocalProfileLabeledLineChart(
+                list.Select(s => (float)s.Count).ToArray(),
+                list.Select(s => $"{s.StarBucket}★").ToArray()));
+        }
+
+        private partial class StarBarRow : Container
+        {
+            private readonly int bucket;
+            private readonly int count;
+            private readonly int max;
+
+            public StarBarRow(int bucket, int count, int max)
+            {
+                this.bucket = bucket;
+                this.count = count;
+                this.max = max;
+
+                RelativeSizeAxes = Axes.X;
+                Height = 22;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colours)
+            {
+                float ratio = max <= 0 ? 0 : (float)count / max;
+
+                Children = new Drawable[]
+                {
+                    new OsuSpriteText
+                    {
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Text = $"{bucket}★–{bucket + 1}★",
+                        Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
+                        Width = 72,
+                    },
+                    new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Padding = new MarginPadding { Left = 80, Right = 56 },
+                        Child = new EzLocalProfileRoundedBar(ratio),
+                    },
+                    new OsuSpriteText
+                    {
+                        Anchor = Anchor.CentreRight,
+                        Origin = Anchor.CentreRight,
+                        Text = count.ToString("N0"),
+                        Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
+                        Colour = colours.Content2,
+                    }
+                };
+            }
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileStdAffinityBlock.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileStdAffinityBlock.cs
@@ -1,0 +1,143 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Profile.Sections;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    public partial class EzLocalProfileStdAffinityBlock : FillFlowContainer
+    {
+        public EzLocalProfileStdAffinityBlock(EzLocalProfileSnapshot snapshot)
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            Direction = FillDirection.Vertical;
+            Spacing = new Vector2(0, 14);
+
+            Add(createGroup(EzSettingsStrings.LOCAL_PROFILE_BEST_AR, snapshot.StdAttrAffinities.Where(a => a.Attr == EzLocalProfileStdAttr.ApproachRate)));
+            Add(createGroup(EzSettingsStrings.LOCAL_PROFILE_BEST_CS, snapshot.StdAttrAffinities.Where(a => a.Attr == EzLocalProfileStdAttr.CircleSize)));
+        }
+
+        private static Drawable createGroup(LocalisableString title, IEnumerable<EzLocalProfileStdAttrAffinity> affinities)
+        {
+            var ordered = affinities
+                          .OrderByDescending(a => a.PlayCount)
+                          .ThenByDescending(a => a.HighGradeCount)
+                          .Take(3)
+                          .ToList();
+
+            var flow = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(0, 6),
+                Children = new Drawable[]
+                {
+                    new OsuSpriteText
+                    {
+                        Text = title,
+                        Font = OsuFont.GetFont(size: 14, weight: FontWeight.Bold),
+                    }
+                }
+            };
+
+            if (ordered.Count == 0)
+            {
+                flow.Add(new OsuSpriteText
+                {
+                    Text = EzSettingsStrings.LOCAL_PROFILE_NO_RULESET_DATA,
+                    Font = OsuFont.GetFont(size: 14),
+                });
+                return flow;
+            }
+
+            for (int i = 0; i < ordered.Count; i++)
+                flow.Add(new AffinityRow(ordered[i], isTop: i == 0, dimmed: i > 0));
+
+            return flow;
+        }
+
+        private partial class AffinityRow : Container
+        {
+            private readonly EzLocalProfileStdAttrAffinity affinity;
+            private readonly bool isTop;
+            private readonly bool dimmed;
+            private Box? accent;
+
+            public AffinityRow(EzLocalProfileStdAttrAffinity affinity, bool isTop, bool dimmed)
+            {
+                this.affinity = affinity;
+                this.isTop = isTop;
+                this.dimmed = dimmed;
+
+                RelativeSizeAxes = Axes.X;
+                AutoSizeAxes = Axes.Y;
+                Alpha = dimmed ? 0.7f : 1;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colours)
+            {
+                var pill = new CounterPill();
+                pill.Current.Value = affinity.PlayCount;
+
+                Children = new Drawable[]
+                {
+                    accent = new Box
+                    {
+                        RelativeSizeAxes = Axes.Y,
+                        Width = 3,
+                        Colour = colours.Highlight1,
+                        Alpha = isTop ? 1 : 0,
+                    },
+                    new FillFlowContainer
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Direction = FillDirection.Horizontal,
+                        Spacing = new Vector2(12, 0),
+                        Padding = new MarginPadding { Left = 10, Vertical = 4 },
+                        Children = new Drawable[]
+                        {
+                            new OsuSpriteText
+                            {
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                                Text = affinity.Value.ToString("0.0", CultureInfo.InvariantCulture),
+                                Font = OsuFont.GetFont(size: 16, weight: isTop ? FontWeight.Bold : FontWeight.Regular),
+                                Width = 40,
+                            },
+                            pill.With(p =>
+                            {
+                                p.Anchor = Anchor.CentreLeft;
+                                p.Origin = Anchor.CentreLeft;
+                            }),
+                            new OsuSpriteText
+                            {
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                                Text = $"{affinity.HighGradeCount} S+",
+                                Font = OsuFont.GetFont(size: 12),
+                                Colour = colours.Content2,
+                            }
+                        }
+                    }
+                };
+            }
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileStore.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileStore.cs
@@ -107,6 +107,67 @@ namespace osu.Game.EzOsuGame.LocalProfile
             }
         }
 
+        public void UpsertOnlineScoreContribution(EzLocalProfileOnlineScoreContribution contribution)
+        {
+            lock (sync)
+            {
+                ensureInitialised();
+                using var connection = openConnection();
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = """
+                                  INSERT INTO online_score_contributions
+                                      (online_id, ruleset_id, rank, star_rating, circle_size, approach_rate, key_count)
+                                  VALUES
+                                      ($online_id, $ruleset_id, $rank, $star_rating, $circle_size, $approach_rate, $key_count)
+                                  ON CONFLICT(online_id) DO UPDATE SET
+                                      ruleset_id = excluded.ruleset_id,
+                                      rank = excluded.rank,
+                                      star_rating = excluded.star_rating,
+                                      circle_size = excluded.circle_size,
+                                      approach_rate = excluded.approach_rate,
+                                      key_count = excluded.key_count;
+                                  """;
+                cmd.Parameters.AddWithValue("$online_id", contribution.OnlineId);
+                cmd.Parameters.AddWithValue("$ruleset_id", contribution.RulesetId);
+                cmd.Parameters.AddWithValue("$rank", (int)contribution.Rank);
+                cmd.Parameters.AddWithValue("$star_rating", contribution.StarRating);
+                cmd.Parameters.AddWithValue("$circle_size", contribution.CircleSize);
+                cmd.Parameters.AddWithValue("$approach_rate", contribution.ApproachRate);
+                cmd.Parameters.AddWithValue("$key_count", contribution.KeyCount);
+                cmd.ExecuteNonQuery();
+            }
+        }
+
+        public IReadOnlyList<EzLocalProfileOnlineScoreContribution> LoadOnlineScoreContributions()
+        {
+            lock (sync)
+            {
+                ensureInitialised();
+                using var connection = openConnection();
+                var list = new List<EzLocalProfileOnlineScoreContribution>();
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = """
+                                  SELECT online_id, ruleset_id, rank, star_rating, circle_size, approach_rate, key_count
+                                  FROM online_score_contributions;
+                                  """;
+                using var reader = cmd.ExecuteReader();
+
+                while (reader.Read())
+                {
+                    list.Add(new EzLocalProfileOnlineScoreContribution(
+                        reader.GetInt64(0),
+                        reader.GetInt32(1),
+                        (ScoreRank)reader.GetInt32(2),
+                        reader.GetDouble(3),
+                        (float)reader.GetDouble(4),
+                        (float)reader.GetDouble(5),
+                        reader.GetInt64(6)));
+                }
+
+                return list;
+            }
+        }
+
         public void ReplaceAll(EzLocalProfileAggregationResult result)
         {
             lock (sync)
@@ -298,6 +359,15 @@ namespace osu.Game.EzOsuGame.LocalProfile
                                       play_count INTEGER NOT NULL,
                                       high_grade_count INTEGER NOT NULL,
                                       PRIMARY KEY (attr, value)
+                                  );
+                                  CREATE TABLE IF NOT EXISTS online_score_contributions (
+                                      online_id INTEGER PRIMARY KEY NOT NULL,
+                                      ruleset_id INTEGER NOT NULL,
+                                      rank INTEGER NOT NULL,
+                                      star_rating REAL NOT NULL,
+                                      circle_size REAL NOT NULL,
+                                      approach_rate REAL NOT NULL,
+                                      key_count INTEGER NOT NULL
                                   );
                                   """;
                 cmd.ExecuteNonQuery();

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileStore.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileStore.cs
@@ -83,13 +83,18 @@ namespace osu.Game.EzOsuGame.LocalProfile
             }
         }
 
-        public int GetMostPlayedOffset(int rulesetId)
+        public int GetMostPlayedOffset(int rulesetId) => GetPullOffset(EzLocalProfileOnlinePullKind.MostPlayed, rulesetId);
+
+        public void SetMostPlayedOffset(int rulesetId, int offset) =>
+            SetPullOffset(EzLocalProfileOnlinePullKind.MostPlayed, rulesetId, offset);
+
+        public int GetPullOffset(EzLocalProfileOnlinePullKind kind, int rulesetId)
         {
             lock (sync)
             {
                 ensureInitialised();
                 using var connection = openConnection();
-                string? raw = tryGetMeta(connection, mostPlayedOffsetKey(rulesetId));
+                string? raw = tryGetMeta(connection, pullOffsetKey(kind, rulesetId));
                 if (string.IsNullOrEmpty(raw) || !int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out int offset))
                     return 0;
 
@@ -97,13 +102,13 @@ namespace osu.Game.EzOsuGame.LocalProfile
             }
         }
 
-        public void SetMostPlayedOffset(int rulesetId, int offset)
+        public void SetPullOffset(EzLocalProfileOnlinePullKind kind, int rulesetId, int offset)
         {
             lock (sync)
             {
                 ensureInitialised();
                 using var connection = openConnection();
-                setMeta(connection, mostPlayedOffsetKey(rulesetId), Math.Max(0, offset).ToString(CultureInfo.InvariantCulture));
+                setMeta(connection, pullOffsetKey(kind, rulesetId), Math.Max(0, offset).ToString(CultureInfo.InvariantCulture));
             }
         }
 
@@ -564,7 +569,10 @@ namespace osu.Game.EzOsuGame.LocalProfile
             return list;
         }
 
-        private static string mostPlayedOffsetKey(int rulesetId) => $"online_mp_offset_{rulesetId}";
+        private static string pullOffsetKey(EzLocalProfileOnlinePullKind kind, int rulesetId) =>
+            kind == EzLocalProfileOnlinePullKind.Best
+                ? $"online_bp_offset_{rulesetId}"
+                : $"online_mp_offset_{rulesetId}";
 
         private static void setMeta(SqliteConnection connection, string key, string value)
         {

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileStore.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileStore.cs
@@ -1,0 +1,493 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.Json;
+using Microsoft.Data.Sqlite;
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.Scoring;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    /// <summary>
+    /// Single shared local profile statistics store (not keyed by login username).
+    /// </summary>
+    public class EzLocalProfileStore : IDisposable
+    {
+        public const string DATABASE_FILENAME = "ez-local-profile.sqlite";
+        public const int SCHEMA_VERSION = 1;
+
+        private readonly Storage storage;
+        private readonly object sync = new object();
+        private bool initialised;
+        private string dbPath = string.Empty;
+        private bool isDisposed;
+
+        public EzLocalProfileStore(Storage storage)
+        {
+            this.storage = storage;
+        }
+
+        public EzLocalProfileSnapshot LoadSnapshot()
+        {
+            lock (sync)
+            {
+                try
+                {
+                    ensureInitialised();
+
+                    using var connection = openConnection();
+
+                    if (!hasComputedData(connection))
+                    {
+                        return new EzLocalProfileSnapshot
+                        {
+                            HasData = false,
+                            IncludedUsernames = readIncludedUsernames(connection),
+                        };
+                    }
+
+                    return new EzLocalProfileSnapshot
+                    {
+                        HasData = true,
+                        LastComputedAt = tryReadLastComputedAt(connection),
+                        IncludedUsernames = readIncludedUsernames(connection),
+                        RulesetStats = readRulesetStats(connection),
+                        ManiaKeyStats = readManiaKeyStats(connection),
+                        ManiaColumnStats = readManiaColumnStats(connection),
+                        GradeCounts = readGradeCounts(connection),
+                        StarPlayCounts = readStarPlayCounts(connection),
+                        StdAttrAffinities = readStdAttrAffinities(connection),
+                    };
+                }
+                catch (Exception ex)
+                {
+                    Logger.Log($"[EzLocalProfile] Failed to load snapshot (recompute required): {ex.Message}", Ez2ConfigManager.LOGGER_NAME);
+                    return new EzLocalProfileSnapshot { HasData = false };
+                }
+            }
+        }
+
+        public IReadOnlyList<string> LoadIncludedUsernames()
+        {
+            lock (sync)
+            {
+                ensureInitialised();
+                using var connection = openConnection();
+                return readIncludedUsernames(connection);
+            }
+        }
+
+        public void ReplaceAll(EzLocalProfileAggregationResult result)
+        {
+            lock (sync)
+            {
+                ensureInitialised();
+
+                using var connection = openConnection();
+                using var transaction = connection.BeginTransaction();
+
+                clearTables(connection);
+                // Recreate column table so the current single-version schema is always applied on recompute.
+                recreateManiaColumnTable(connection);
+
+                setMeta(connection, "schema_version", SCHEMA_VERSION.ToString(CultureInfo.InvariantCulture));
+                setMeta(connection, "last_computed_at", result.ComputedAt.ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture));
+                setMeta(connection, "included_usernames_json", JsonSerializer.Serialize(result.IncludedUsernames.ToList()));
+
+                foreach (var (rulesetId, stats) in result.RulesetStats)
+                {
+                    using var cmd = connection.CreateCommand();
+                    cmd.CommandText = """
+                                      INSERT INTO ruleset_stats (ruleset_id, total_keys, avg_kps, max_kps, score_count, kps_sample_count)
+                                      VALUES ($ruleset_id, $total_keys, $avg_kps, $max_kps, $score_count, $kps_sample_count);
+                                      """;
+                    cmd.Parameters.AddWithValue("$ruleset_id", rulesetId);
+                    cmd.Parameters.AddWithValue("$total_keys", stats.TotalKeys);
+                    cmd.Parameters.AddWithValue("$avg_kps", stats.KpsSampleCount > 0 ? stats.KpsSum / stats.KpsSampleCount : 0);
+                    cmd.Parameters.AddWithValue("$max_kps", stats.MaxKps);
+                    cmd.Parameters.AddWithValue("$score_count", stats.ScoreCount);
+                    cmd.Parameters.AddWithValue("$kps_sample_count", stats.KpsSampleCount);
+                    cmd.ExecuteNonQuery();
+                }
+
+                foreach (var (keyCount, stats) in result.ManiaKeyStats)
+                {
+                    using var cmd = connection.CreateCommand();
+                    cmd.CommandText = """
+                                      INSERT INTO mania_key_stats (key_count, total_keys, avg_kps, max_kps, score_count, kps_sample_count)
+                                      VALUES ($key_count, $total_keys, $avg_kps, $max_kps, $score_count, $kps_sample_count);
+                                      """;
+                    cmd.Parameters.AddWithValue("$key_count", keyCount);
+                    cmd.Parameters.AddWithValue("$total_keys", stats.TotalKeys);
+                    cmd.Parameters.AddWithValue("$avg_kps", stats.KpsSampleCount > 0 ? stats.KpsSum / stats.KpsSampleCount : 0);
+                    cmd.Parameters.AddWithValue("$max_kps", stats.MaxKps);
+                    cmd.Parameters.AddWithValue("$score_count", stats.ScoreCount);
+                    cmd.Parameters.AddWithValue("$kps_sample_count", stats.KpsSampleCount);
+                    cmd.ExecuteNonQuery();
+                }
+
+                foreach (var ((keyCount, column), stats) in result.ManiaColumnStats)
+                {
+                    using var cmd = connection.CreateCommand();
+                    cmd.CommandText = """
+                                      INSERT INTO mania_column_stats (key_count, column_index, total_keys, avg_kps, max_kps, score_count, kps_sample_count)
+                                      VALUES ($key_count, $column_index, $total_keys, $avg_kps, $max_kps, $score_count, $kps_sample_count);
+                                      """;
+                    cmd.Parameters.AddWithValue("$key_count", keyCount);
+                    cmd.Parameters.AddWithValue("$column_index", column);
+                    cmd.Parameters.AddWithValue("$total_keys", stats.TotalKeys);
+                    cmd.Parameters.AddWithValue("$avg_kps", stats.KpsSampleCount > 0 ? stats.KpsSum / stats.KpsSampleCount : 0);
+                    cmd.Parameters.AddWithValue("$max_kps", stats.MaxKps);
+                    cmd.Parameters.AddWithValue("$score_count", stats.ScoreCount);
+                    cmd.Parameters.AddWithValue("$kps_sample_count", stats.KpsSampleCount);
+                    cmd.ExecuteNonQuery();
+                }
+
+                foreach (var ((rulesetId, rank), count) in result.GradeCounts)
+                {
+                    using var cmd = connection.CreateCommand();
+                    cmd.CommandText = """
+                                      INSERT INTO grade_counts (ruleset_id, rank, count)
+                                      VALUES ($ruleset_id, $rank, $count);
+                                      """;
+                    cmd.Parameters.AddWithValue("$ruleset_id", rulesetId);
+                    cmd.Parameters.AddWithValue("$rank", (int)rank);
+                    cmd.Parameters.AddWithValue("$count", count);
+                    cmd.ExecuteNonQuery();
+                }
+
+                foreach (var ((rulesetId, starBucket), count) in result.StarPlayCounts)
+                {
+                    using var cmd = connection.CreateCommand();
+                    cmd.CommandText = """
+                                      INSERT INTO star_play_counts (ruleset_id, star_bucket, count)
+                                      VALUES ($ruleset_id, $star_bucket, $count);
+                                      """;
+                    cmd.Parameters.AddWithValue("$ruleset_id", rulesetId);
+                    cmd.Parameters.AddWithValue("$star_bucket", starBucket);
+                    cmd.Parameters.AddWithValue("$count", count);
+                    cmd.ExecuteNonQuery();
+                }
+
+                foreach (var ((attr, value), stats) in result.StdAttrAffinities)
+                {
+                    using var cmd = connection.CreateCommand();
+                    cmd.CommandText = """
+                                      INSERT INTO std_attr_affinity (attr, value, play_count, high_grade_count)
+                                      VALUES ($attr, $value, $play_count, $high_grade_count);
+                                      """;
+                    cmd.Parameters.AddWithValue("$attr", (int)attr);
+                    cmd.Parameters.AddWithValue("$value", value);
+                    cmd.Parameters.AddWithValue("$play_count", stats.PlayCount);
+                    cmd.Parameters.AddWithValue("$high_grade_count", stats.HighGradeCount);
+                    cmd.ExecuteNonQuery();
+                }
+
+                transaction.Commit();
+            }
+        }
+
+        public void Dispose()
+        {
+            if (isDisposed)
+                return;
+
+            isDisposed = true;
+            SqliteConnection.ClearAllPools();
+        }
+
+        private void ensureInitialised()
+        {
+            if (initialised)
+                return;
+
+            dbPath = storage.GetFullPath(DATABASE_FILENAME, true);
+
+            using var connection = openConnection();
+            ensureSchema(connection);
+            initialised = true;
+        }
+
+        private SqliteConnection openConnection()
+        {
+            var connection = new SqliteConnection($"Data Source={dbPath};Cache=Shared;Mode=ReadWriteCreate");
+            connection.Open();
+            return connection;
+        }
+
+        private static void ensureSchema(SqliteConnection connection)
+        {
+            using (var cmd = connection.CreateCommand())
+            {
+                cmd.CommandText = """
+                                  CREATE TABLE IF NOT EXISTS meta (
+                                      key TEXT PRIMARY KEY NOT NULL,
+                                      value TEXT NOT NULL
+                                  );
+                                  CREATE TABLE IF NOT EXISTS ruleset_stats (
+                                      ruleset_id INTEGER PRIMARY KEY NOT NULL,
+                                      total_keys INTEGER NOT NULL,
+                                      avg_kps REAL NOT NULL,
+                                      max_kps REAL NOT NULL,
+                                      score_count INTEGER NOT NULL,
+                                      kps_sample_count INTEGER NOT NULL
+                                  );
+                                  CREATE TABLE IF NOT EXISTS mania_key_stats (
+                                      key_count INTEGER PRIMARY KEY NOT NULL,
+                                      total_keys INTEGER NOT NULL,
+                                      avg_kps REAL NOT NULL,
+                                      max_kps REAL NOT NULL,
+                                      score_count INTEGER NOT NULL,
+                                      kps_sample_count INTEGER NOT NULL
+                                  );
+                                  CREATE TABLE IF NOT EXISTS mania_column_stats (
+                                      key_count INTEGER NOT NULL,
+                                      column_index INTEGER NOT NULL,
+                                      total_keys INTEGER NOT NULL,
+                                      avg_kps REAL NOT NULL,
+                                      max_kps REAL NOT NULL,
+                                      score_count INTEGER NOT NULL,
+                                      kps_sample_count INTEGER NOT NULL,
+                                      PRIMARY KEY (key_count, column_index)
+                                  );
+                                  CREATE TABLE IF NOT EXISTS grade_counts (
+                                      ruleset_id INTEGER NOT NULL,
+                                      rank INTEGER NOT NULL,
+                                      count INTEGER NOT NULL,
+                                      PRIMARY KEY (ruleset_id, rank)
+                                  );
+                                  CREATE TABLE IF NOT EXISTS star_play_counts (
+                                      ruleset_id INTEGER NOT NULL,
+                                      star_bucket INTEGER NOT NULL,
+                                      count INTEGER NOT NULL,
+                                      PRIMARY KEY (ruleset_id, star_bucket)
+                                  );
+                                  CREATE TABLE IF NOT EXISTS std_attr_affinity (
+                                      attr INTEGER NOT NULL,
+                                      value REAL NOT NULL,
+                                      play_count INTEGER NOT NULL,
+                                      high_grade_count INTEGER NOT NULL,
+                                      PRIMARY KEY (attr, value)
+                                  );
+                                  """;
+                cmd.ExecuteNonQuery();
+            }
+
+            setMeta(connection, "schema_version", SCHEMA_VERSION.ToString(CultureInfo.InvariantCulture));
+        }
+
+        private static void recreateManiaColumnTable(SqliteConnection connection)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = """
+                              DROP TABLE IF EXISTS mania_column_stats;
+                              CREATE TABLE mania_column_stats (
+                                  key_count INTEGER NOT NULL,
+                                  column_index INTEGER NOT NULL,
+                                  total_keys INTEGER NOT NULL,
+                                  avg_kps REAL NOT NULL,
+                                  max_kps REAL NOT NULL,
+                                  score_count INTEGER NOT NULL,
+                                  kps_sample_count INTEGER NOT NULL,
+                                  PRIMARY KEY (key_count, column_index)
+                              );
+                              """;
+            cmd.ExecuteNonQuery();
+        }
+
+        /// <summary>
+        /// Full wipe before <see cref="ReplaceAll"/> rewrite. <c>WHERE TRUE</c> keeps the intentional clear explicit for SQL analyzers.
+        /// </summary>
+        private static void clearTables(SqliteConnection connection)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = """
+                              DELETE FROM ruleset_stats WHERE TRUE;
+                              DELETE FROM mania_key_stats WHERE TRUE;
+                              DELETE FROM mania_column_stats WHERE TRUE;
+                              DELETE FROM grade_counts WHERE TRUE;
+                              DELETE FROM star_play_counts WHERE TRUE;
+                              DELETE FROM std_attr_affinity WHERE TRUE;
+                              """;
+            cmd.ExecuteNonQuery();
+        }
+
+        private static bool hasComputedData(SqliteConnection connection)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT COUNT(*) FROM ruleset_stats;";
+            return Convert.ToInt64(cmd.ExecuteScalar()) > 0;
+        }
+
+        private static DateTimeOffset? tryReadLastComputedAt(SqliteConnection connection)
+        {
+            string? raw = tryGetMeta(connection, "last_computed_at");
+            if (string.IsNullOrEmpty(raw) || !long.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out long ms))
+                return null;
+
+            return DateTimeOffset.FromUnixTimeMilliseconds(ms);
+        }
+
+        private static IReadOnlyList<string> readIncludedUsernames(SqliteConnection connection)
+        {
+            string? json = tryGetMeta(connection, "included_usernames_json");
+            if (string.IsNullOrEmpty(json))
+                return Array.Empty<string>();
+
+            try
+            {
+                return JsonSerializer.Deserialize<List<string>>(json) ?? new List<string>();
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"[EzLocalProfile] Failed to parse included usernames: {ex.Message}", Ez2ConfigManager.LOGGER_NAME);
+                return Array.Empty<string>();
+            }
+        }
+
+        private static IReadOnlyList<EzLocalProfileRulesetStats> readRulesetStats(SqliteConnection connection)
+        {
+            var list = new List<EzLocalProfileRulesetStats>();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT ruleset_id, total_keys, avg_kps, max_kps, score_count, kps_sample_count FROM ruleset_stats ORDER BY ruleset_id;";
+            using var reader = cmd.ExecuteReader();
+
+            while (reader.Read())
+            {
+                list.Add(new EzLocalProfileRulesetStats(
+                    reader.GetInt32(0),
+                    reader.GetInt64(1),
+                    reader.GetDouble(2),
+                    reader.GetDouble(3),
+                    reader.GetInt32(4),
+                    reader.GetInt32(5)));
+            }
+
+            return list;
+        }
+
+        private static IReadOnlyList<EzLocalProfileManiaKeyStats> readManiaKeyStats(SqliteConnection connection)
+        {
+            var list = new List<EzLocalProfileManiaKeyStats>();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT key_count, total_keys, avg_kps, max_kps, score_count, kps_sample_count FROM mania_key_stats ORDER BY key_count;";
+            using var reader = cmd.ExecuteReader();
+
+            while (reader.Read())
+            {
+                list.Add(new EzLocalProfileManiaKeyStats(
+                    reader.GetInt32(0),
+                    reader.GetInt64(1),
+                    reader.GetDouble(2),
+                    reader.GetDouble(3),
+                    reader.GetInt32(4),
+                    reader.GetInt32(5)));
+            }
+
+            return list;
+        }
+
+        private static IReadOnlyList<EzLocalProfileManiaColumnStats> readManiaColumnStats(SqliteConnection connection)
+        {
+            var list = new List<EzLocalProfileManiaColumnStats>();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT key_count, column_index, total_keys, avg_kps, max_kps, score_count, kps_sample_count FROM mania_column_stats ORDER BY key_count, column_index;";
+            using var reader = cmd.ExecuteReader();
+
+            while (reader.Read())
+            {
+                list.Add(new EzLocalProfileManiaColumnStats(
+                    reader.GetInt32(0),
+                    reader.GetInt32(1),
+                    reader.GetInt64(2),
+                    reader.GetDouble(3),
+                    reader.GetDouble(4),
+                    reader.GetInt32(5),
+                    reader.GetInt32(6)));
+            }
+
+            return list;
+        }
+
+        private static IReadOnlyList<EzLocalProfileGradeCount> readGradeCounts(SqliteConnection connection)
+        {
+            var list = new List<EzLocalProfileGradeCount>();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT ruleset_id, rank, count FROM grade_counts ORDER BY ruleset_id, rank DESC;";
+            using var reader = cmd.ExecuteReader();
+
+            while (reader.Read())
+            {
+                list.Add(new EzLocalProfileGradeCount(
+                    reader.GetInt32(0),
+                    (ScoreRank)reader.GetInt32(1),
+                    reader.GetInt32(2)));
+            }
+
+            return list;
+        }
+
+        private static IReadOnlyList<EzLocalProfileStarPlayCount> readStarPlayCounts(SqliteConnection connection)
+        {
+            var list = new List<EzLocalProfileStarPlayCount>();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT ruleset_id, star_bucket, count FROM star_play_counts ORDER BY ruleset_id, star_bucket;";
+            using var reader = cmd.ExecuteReader();
+
+            while (reader.Read())
+            {
+                list.Add(new EzLocalProfileStarPlayCount(
+                    reader.GetInt32(0),
+                    reader.GetInt32(1),
+                    reader.GetInt32(2)));
+            }
+
+            return list;
+        }
+
+        private static IReadOnlyList<EzLocalProfileStdAttrAffinity> readStdAttrAffinities(SqliteConnection connection)
+        {
+            var list = new List<EzLocalProfileStdAttrAffinity>();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT attr, value, play_count, high_grade_count FROM std_attr_affinity ORDER BY attr, play_count DESC;";
+            using var reader = cmd.ExecuteReader();
+
+            while (reader.Read())
+            {
+                list.Add(new EzLocalProfileStdAttrAffinity(
+                    (EzLocalProfileStdAttr)reader.GetInt32(0),
+                    reader.GetDouble(1),
+                    reader.GetInt32(2),
+                    reader.GetInt32(3)));
+            }
+
+            return list;
+        }
+
+        private static void setMeta(SqliteConnection connection, string key, string value)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = """
+                              INSERT INTO meta (key, value) VALUES ($key, $value)
+                              ON CONFLICT(key) DO UPDATE SET value = excluded.value;
+                              """;
+            cmd.Parameters.AddWithValue("$key", key);
+            cmd.Parameters.AddWithValue("$value", value);
+            cmd.ExecuteNonQuery();
+        }
+
+        private static string? tryGetMeta(SqliteConnection connection, string key)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT value FROM meta WHERE key = $key;";
+            cmd.Parameters.AddWithValue("$key", key);
+            return cmd.ExecuteScalar() as string;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileStore.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileStore.cs
@@ -83,6 +83,30 @@ namespace osu.Game.EzOsuGame.LocalProfile
             }
         }
 
+        public int GetMostPlayedOffset(int rulesetId)
+        {
+            lock (sync)
+            {
+                ensureInitialised();
+                using var connection = openConnection();
+                string? raw = tryGetMeta(connection, mostPlayedOffsetKey(rulesetId));
+                if (string.IsNullOrEmpty(raw) || !int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out int offset))
+                    return 0;
+
+                return Math.Max(0, offset);
+            }
+        }
+
+        public void SetMostPlayedOffset(int rulesetId, int offset)
+        {
+            lock (sync)
+            {
+                ensureInitialised();
+                using var connection = openConnection();
+                setMeta(connection, mostPlayedOffsetKey(rulesetId), Math.Max(0, offset).ToString(CultureInfo.InvariantCulture));
+            }
+        }
+
         public void ReplaceAll(EzLocalProfileAggregationResult result)
         {
             lock (sync)
@@ -469,6 +493,8 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
             return list;
         }
+
+        private static string mostPlayedOffsetKey(int rulesetId) => $"online_mp_offset_{rulesetId}";
 
         private static void setMeta(SqliteConnection connection, string key, string value)
         {

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileStore.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileStore.cs
@@ -20,7 +20,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
     public class EzLocalProfileStore : IDisposable
     {
         public const string DATABASE_FILENAME = "ez-local-profile.sqlite";
-        public const int SCHEMA_VERSION = 1;
+        public const int SCHEMA_VERSION = 3;
 
         private readonly Storage storage;
         private readonly object sync = new object();
@@ -121,16 +121,18 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 using var cmd = connection.CreateCommand();
                 cmd.CommandText = """
                                   INSERT INTO online_score_contributions
-                                      (online_id, ruleset_id, rank, star_rating, circle_size, approach_rate, key_count)
+                                      (online_id, ruleset_id, rank, star_rating, circle_size, approach_rate, key_count, pp, duration_ms)
                                   VALUES
-                                      ($online_id, $ruleset_id, $rank, $star_rating, $circle_size, $approach_rate, $key_count)
+                                      ($online_id, $ruleset_id, $rank, $star_rating, $circle_size, $approach_rate, $key_count, $pp, $duration_ms)
                                   ON CONFLICT(online_id) DO UPDATE SET
                                       ruleset_id = excluded.ruleset_id,
                                       rank = excluded.rank,
                                       star_rating = excluded.star_rating,
                                       circle_size = excluded.circle_size,
                                       approach_rate = excluded.approach_rate,
-                                      key_count = excluded.key_count;
+                                      key_count = excluded.key_count,
+                                      pp = excluded.pp,
+                                      duration_ms = excluded.duration_ms;
                                   """;
                 cmd.Parameters.AddWithValue("$online_id", contribution.OnlineId);
                 cmd.Parameters.AddWithValue("$ruleset_id", contribution.RulesetId);
@@ -139,6 +141,8 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 cmd.Parameters.AddWithValue("$circle_size", contribution.CircleSize);
                 cmd.Parameters.AddWithValue("$approach_rate", contribution.ApproachRate);
                 cmd.Parameters.AddWithValue("$key_count", contribution.KeyCount);
+                cmd.Parameters.AddWithValue("$pp", contribution.Pp);
+                cmd.Parameters.AddWithValue("$duration_ms", contribution.DurationMs);
                 cmd.ExecuteNonQuery();
             }
         }
@@ -152,7 +156,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 var list = new List<EzLocalProfileOnlineScoreContribution>();
                 using var cmd = connection.CreateCommand();
                 cmd.CommandText = """
-                                  SELECT online_id, ruleset_id, rank, star_rating, circle_size, approach_rate, key_count
+                                  SELECT online_id, ruleset_id, rank, star_rating, circle_size, approach_rate, key_count, pp, duration_ms
                                   FROM online_score_contributions;
                                   """;
                 using var reader = cmd.ExecuteReader();
@@ -166,7 +170,9 @@ namespace osu.Game.EzOsuGame.LocalProfile
                         reader.GetDouble(3),
                         (float)reader.GetDouble(4),
                         (float)reader.GetDouble(5),
-                        reader.GetInt64(6)));
+                        reader.GetInt64(6),
+                        reader.GetDouble(7),
+                        reader.GetInt64(8)));
                 }
 
                 return list;
@@ -194,8 +200,8 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 {
                     using var cmd = connection.CreateCommand();
                     cmd.CommandText = """
-                                      INSERT INTO ruleset_stats (ruleset_id, total_keys, avg_kps, max_kps, score_count, kps_sample_count)
-                                      VALUES ($ruleset_id, $total_keys, $avg_kps, $max_kps, $score_count, $kps_sample_count);
+                                      INSERT INTO ruleset_stats (ruleset_id, total_keys, avg_kps, max_kps, score_count, kps_sample_count, total_pp, total_duration_ms)
+                                      VALUES ($ruleset_id, $total_keys, $avg_kps, $max_kps, $score_count, $kps_sample_count, $total_pp, $total_duration_ms);
                                       """;
                     cmd.Parameters.AddWithValue("$ruleset_id", rulesetId);
                     cmd.Parameters.AddWithValue("$total_keys", stats.TotalKeys);
@@ -203,6 +209,8 @@ namespace osu.Game.EzOsuGame.LocalProfile
                     cmd.Parameters.AddWithValue("$max_kps", stats.MaxKps);
                     cmd.Parameters.AddWithValue("$score_count", stats.ScoreCount);
                     cmd.Parameters.AddWithValue("$kps_sample_count", stats.KpsSampleCount);
+                    cmd.Parameters.AddWithValue("$total_pp", stats.TotalPp);
+                    cmd.Parameters.AddWithValue("$total_duration_ms", stats.TotalDurationMs);
                     cmd.ExecuteNonQuery();
                 }
 
@@ -210,8 +218,8 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 {
                     using var cmd = connection.CreateCommand();
                     cmd.CommandText = """
-                                      INSERT INTO mania_key_stats (key_count, total_keys, avg_kps, max_kps, score_count, kps_sample_count)
-                                      VALUES ($key_count, $total_keys, $avg_kps, $max_kps, $score_count, $kps_sample_count);
+                                      INSERT INTO mania_key_stats (key_count, total_keys, avg_kps, max_kps, score_count, kps_sample_count, total_pp, total_duration_ms)
+                                      VALUES ($key_count, $total_keys, $avg_kps, $max_kps, $score_count, $kps_sample_count, $total_pp, $total_duration_ms);
                                       """;
                     cmd.Parameters.AddWithValue("$key_count", keyCount);
                     cmd.Parameters.AddWithValue("$total_keys", stats.TotalKeys);
@@ -219,6 +227,8 @@ namespace osu.Game.EzOsuGame.LocalProfile
                     cmd.Parameters.AddWithValue("$max_kps", stats.MaxKps);
                     cmd.Parameters.AddWithValue("$score_count", stats.ScoreCount);
                     cmd.Parameters.AddWithValue("$kps_sample_count", stats.KpsSampleCount);
+                    cmd.Parameters.AddWithValue("$total_pp", stats.TotalPp);
+                    cmd.Parameters.AddWithValue("$total_duration_ms", stats.TotalDurationMs);
                     cmd.ExecuteNonQuery();
                 }
 
@@ -283,6 +293,210 @@ namespace osu.Game.EzOsuGame.LocalProfile
             }
         }
 
+        /// <summary>
+        /// Overwrite partitions for recomputed usernames, optionally drop other partitions, then rebuild display totals.
+        /// </summary>
+        public void ApplyUsernamePartitions(
+            IReadOnlyDictionary<string, EzLocalProfileAggregationResult> recomputedByUsername,
+            bool replaceOtherUsernames,
+            IReadOnlyList<EzLocalProfileOnlineScoreContribution> onlineContributions,
+            HashSet<long> localOnlineScoreIds)
+        {
+            lock (sync)
+            {
+                ensureInitialised();
+
+                using var connection = openConnection();
+                using var transaction = connection.BeginTransaction();
+
+                if (replaceOtherUsernames)
+                {
+                    var keep = new HashSet<string>(recomputedByUsername.Keys, StringComparer.Ordinal);
+                    using var listCmd = connection.CreateCommand();
+                    listCmd.CommandText = "SELECT username FROM username_partitions;";
+                    var toDelete = new List<string>();
+
+                    using (var reader = listCmd.ExecuteReader())
+                    {
+                        while (reader.Read())
+                        {
+                            string name = reader.GetString(0);
+                            if (!keep.Contains(name))
+                                toDelete.Add(name);
+                        }
+                    }
+
+                    foreach (string name in toDelete)
+                    {
+                        using var del = connection.CreateCommand();
+                        del.CommandText = "DELETE FROM username_partitions WHERE username = $username;";
+                        del.Parameters.AddWithValue("$username", name);
+                        del.ExecuteNonQuery();
+                    }
+                }
+
+                long updatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+                foreach (var (username, result) in recomputedByUsername)
+                {
+                    var payload = EzLocalProfilePartitionPayload.FromAggregation(result);
+                    string json = JsonSerializer.Serialize(payload);
+
+                    using var upsert = connection.CreateCommand();
+                    upsert.CommandText = """
+                                         INSERT INTO username_partitions (username, payload_json, updated_at)
+                                         VALUES ($username, $payload_json, $updated_at)
+                                         ON CONFLICT(username) DO UPDATE SET
+                                             payload_json = excluded.payload_json,
+                                             updated_at = excluded.updated_at;
+                                         """;
+                    upsert.Parameters.AddWithValue("$username", username);
+                    upsert.Parameters.AddWithValue("$payload_json", json);
+                    upsert.Parameters.AddWithValue("$updated_at", updatedAt);
+                    upsert.ExecuteNonQuery();
+                }
+
+                var merged = new EzLocalProfileAggregationResult
+                {
+                    ComputedAt = DateTimeOffset.UtcNow,
+                };
+
+                var included = new List<string>();
+
+                using (var read = connection.CreateCommand())
+                {
+                    read.CommandText = "SELECT username, payload_json FROM username_partitions ORDER BY username;";
+                    using var reader = read.ExecuteReader();
+
+                    while (reader.Read())
+                    {
+                        string username = reader.GetString(0);
+                        string json = reader.GetString(1);
+                        included.Add(username);
+
+                        try
+                        {
+                            var payload = JsonSerializer.Deserialize<EzLocalProfilePartitionPayload>(json);
+                            payload?.MergeInto(merged);
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.Log($"[EzLocalProfile] Bad partition for {username}: {ex.Message}", Ez2ConfigManager.LOGGER_NAME);
+                        }
+                    }
+                }
+
+                merged.IncludedUsernames = included;
+                EzLocalProfileAggregator.MergeOnlineContributions(merged, onlineContributions, localOnlineScoreIds);
+
+                clearTables(connection);
+                recreateManiaColumnTable(connection);
+                writeAggregationTables(connection, merged);
+
+                setMeta(connection, "schema_version", SCHEMA_VERSION.ToString(CultureInfo.InvariantCulture));
+                setMeta(connection, "last_computed_at", merged.ComputedAt.ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture));
+                setMeta(connection, "included_usernames_json", JsonSerializer.Serialize(included));
+
+                transaction.Commit();
+            }
+        }
+
+        private static void writeAggregationTables(SqliteConnection connection, EzLocalProfileAggregationResult result)
+        {
+            foreach (var (rulesetId, stats) in result.RulesetStats)
+            {
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = """
+                                  INSERT INTO ruleset_stats (ruleset_id, total_keys, avg_kps, max_kps, score_count, kps_sample_count, total_pp, total_duration_ms)
+                                  VALUES ($ruleset_id, $total_keys, $avg_kps, $max_kps, $score_count, $kps_sample_count, $total_pp, $total_duration_ms);
+                                  """;
+                cmd.Parameters.AddWithValue("$ruleset_id", rulesetId);
+                cmd.Parameters.AddWithValue("$total_keys", stats.TotalKeys);
+                cmd.Parameters.AddWithValue("$avg_kps", stats.KpsSampleCount > 0 ? stats.KpsSum / stats.KpsSampleCount : 0);
+                cmd.Parameters.AddWithValue("$max_kps", stats.MaxKps);
+                cmd.Parameters.AddWithValue("$score_count", stats.ScoreCount);
+                cmd.Parameters.AddWithValue("$kps_sample_count", stats.KpsSampleCount);
+                cmd.Parameters.AddWithValue("$total_pp", stats.TotalPp);
+                cmd.Parameters.AddWithValue("$total_duration_ms", stats.TotalDurationMs);
+                cmd.ExecuteNonQuery();
+            }
+
+            foreach (var (keyCount, stats) in result.ManiaKeyStats)
+            {
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = """
+                                  INSERT INTO mania_key_stats (key_count, total_keys, avg_kps, max_kps, score_count, kps_sample_count, total_pp, total_duration_ms)
+                                  VALUES ($key_count, $total_keys, $avg_kps, $max_kps, $score_count, $kps_sample_count, $total_pp, $total_duration_ms);
+                                  """;
+                cmd.Parameters.AddWithValue("$key_count", keyCount);
+                cmd.Parameters.AddWithValue("$total_keys", stats.TotalKeys);
+                cmd.Parameters.AddWithValue("$avg_kps", stats.KpsSampleCount > 0 ? stats.KpsSum / stats.KpsSampleCount : 0);
+                cmd.Parameters.AddWithValue("$max_kps", stats.MaxKps);
+                cmd.Parameters.AddWithValue("$score_count", stats.ScoreCount);
+                cmd.Parameters.AddWithValue("$kps_sample_count", stats.KpsSampleCount);
+                cmd.Parameters.AddWithValue("$total_pp", stats.TotalPp);
+                cmd.Parameters.AddWithValue("$total_duration_ms", stats.TotalDurationMs);
+                cmd.ExecuteNonQuery();
+            }
+
+            foreach (var ((keyCount, column), stats) in result.ManiaColumnStats)
+            {
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = """
+                                  INSERT INTO mania_column_stats (key_count, column_index, total_keys, avg_kps, max_kps, score_count, kps_sample_count)
+                                  VALUES ($key_count, $column_index, $total_keys, $avg_kps, $max_kps, $score_count, $kps_sample_count);
+                                  """;
+                cmd.Parameters.AddWithValue("$key_count", keyCount);
+                cmd.Parameters.AddWithValue("$column_index", column);
+                cmd.Parameters.AddWithValue("$total_keys", stats.TotalKeys);
+                cmd.Parameters.AddWithValue("$avg_kps", stats.KpsSampleCount > 0 ? stats.KpsSum / stats.KpsSampleCount : 0);
+                cmd.Parameters.AddWithValue("$max_kps", stats.MaxKps);
+                cmd.Parameters.AddWithValue("$score_count", stats.ScoreCount);
+                cmd.Parameters.AddWithValue("$kps_sample_count", stats.KpsSampleCount);
+                cmd.ExecuteNonQuery();
+            }
+
+            foreach (var ((rulesetId, rank), count) in result.GradeCounts)
+            {
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = """
+                                  INSERT INTO grade_counts (ruleset_id, rank, count)
+                                  VALUES ($ruleset_id, $rank, $count);
+                                  """;
+                cmd.Parameters.AddWithValue("$ruleset_id", rulesetId);
+                cmd.Parameters.AddWithValue("$rank", (int)rank);
+                cmd.Parameters.AddWithValue("$count", count);
+                cmd.ExecuteNonQuery();
+            }
+
+            foreach (var ((rulesetId, starBucket), count) in result.StarPlayCounts)
+            {
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = """
+                                  INSERT INTO star_play_counts (ruleset_id, star_bucket, count)
+                                  VALUES ($ruleset_id, $star_bucket, $count);
+                                  """;
+                cmd.Parameters.AddWithValue("$ruleset_id", rulesetId);
+                cmd.Parameters.AddWithValue("$star_bucket", starBucket);
+                cmd.Parameters.AddWithValue("$count", count);
+                cmd.ExecuteNonQuery();
+            }
+
+            foreach (var ((attr, value), stats) in result.StdAttrAffinities)
+            {
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = """
+                                  INSERT INTO std_attr_affinity (attr, value, play_count, high_grade_count)
+                                  VALUES ($attr, $value, $play_count, $high_grade_count);
+                                  """;
+                cmd.Parameters.AddWithValue("$attr", (int)attr);
+                cmd.Parameters.AddWithValue("$value", value);
+                cmd.Parameters.AddWithValue("$play_count", stats.PlayCount);
+                cmd.Parameters.AddWithValue("$high_grade_count", stats.HighGradeCount);
+                cmd.ExecuteNonQuery();
+            }
+        }
+
         public void Dispose()
         {
             if (isDisposed)
@@ -326,7 +540,9 @@ namespace osu.Game.EzOsuGame.LocalProfile
                                       avg_kps REAL NOT NULL,
                                       max_kps REAL NOT NULL,
                                       score_count INTEGER NOT NULL,
-                                      kps_sample_count INTEGER NOT NULL
+                                      kps_sample_count INTEGER NOT NULL,
+                                      total_pp REAL NOT NULL DEFAULT 0,
+                                      total_duration_ms INTEGER NOT NULL DEFAULT 0
                                   );
                                   CREATE TABLE IF NOT EXISTS mania_key_stats (
                                       key_count INTEGER PRIMARY KEY NOT NULL,
@@ -334,7 +550,9 @@ namespace osu.Game.EzOsuGame.LocalProfile
                                       avg_kps REAL NOT NULL,
                                       max_kps REAL NOT NULL,
                                       score_count INTEGER NOT NULL,
-                                      kps_sample_count INTEGER NOT NULL
+                                      kps_sample_count INTEGER NOT NULL,
+                                      total_pp REAL NOT NULL DEFAULT 0,
+                                      total_duration_ms INTEGER NOT NULL DEFAULT 0
                                   );
                                   CREATE TABLE IF NOT EXISTS mania_column_stats (
                                       key_count INTEGER NOT NULL,
@@ -372,13 +590,46 @@ namespace osu.Game.EzOsuGame.LocalProfile
                                       star_rating REAL NOT NULL,
                                       circle_size REAL NOT NULL,
                                       approach_rate REAL NOT NULL,
-                                      key_count INTEGER NOT NULL
+                                      key_count INTEGER NOT NULL,
+                                      pp REAL NOT NULL DEFAULT 0,
+                                      duration_ms INTEGER NOT NULL DEFAULT 0
+                                  );
+                                  CREATE TABLE IF NOT EXISTS username_partitions (
+                                      username TEXT PRIMARY KEY NOT NULL,
+                                      payload_json TEXT NOT NULL,
+                                      updated_at INTEGER NOT NULL
                                   );
                                   """;
                 cmd.ExecuteNonQuery();
             }
 
+            ensureColumn(connection, "ruleset_stats", "total_pp", "REAL NOT NULL DEFAULT 0");
+            ensureColumn(connection, "ruleset_stats", "total_duration_ms", "INTEGER NOT NULL DEFAULT 0");
+            ensureColumn(connection, "mania_key_stats", "total_pp", "REAL NOT NULL DEFAULT 0");
+            ensureColumn(connection, "mania_key_stats", "total_duration_ms", "INTEGER NOT NULL DEFAULT 0");
+            ensureColumn(connection, "online_score_contributions", "pp", "REAL NOT NULL DEFAULT 0");
+            ensureColumn(connection, "online_score_contributions", "duration_ms", "INTEGER NOT NULL DEFAULT 0");
+
             setMeta(connection, "schema_version", SCHEMA_VERSION.ToString(CultureInfo.InvariantCulture));
+        }
+
+        private static void ensureColumn(SqliteConnection connection, string table, string column, string typeSql)
+        {
+            using var check = connection.CreateCommand();
+            check.CommandText = $"PRAGMA table_info({table});";
+            using var reader = check.ExecuteReader();
+
+            while (reader.Read())
+            {
+                if (string.Equals(reader.GetString(1), column, StringComparison.OrdinalIgnoreCase))
+                    return;
+            }
+
+            reader.Close();
+
+            using var alter = connection.CreateCommand();
+            alter.CommandText = $"ALTER TABLE {table} ADD COLUMN {column} {typeSql};";
+            alter.ExecuteNonQuery();
         }
 
         private static void recreateManiaColumnTable(SqliteConnection connection)
@@ -454,7 +705,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
         {
             var list = new List<EzLocalProfileRulesetStats>();
             using var cmd = connection.CreateCommand();
-            cmd.CommandText = "SELECT ruleset_id, total_keys, avg_kps, max_kps, score_count, kps_sample_count FROM ruleset_stats ORDER BY ruleset_id;";
+            cmd.CommandText = "SELECT ruleset_id, total_keys, avg_kps, max_kps, score_count, kps_sample_count, total_pp, total_duration_ms FROM ruleset_stats ORDER BY ruleset_id;";
             using var reader = cmd.ExecuteReader();
 
             while (reader.Read())
@@ -465,7 +716,9 @@ namespace osu.Game.EzOsuGame.LocalProfile
                     reader.GetDouble(2),
                     reader.GetDouble(3),
                     reader.GetInt32(4),
-                    reader.GetInt32(5)));
+                    reader.GetInt32(5),
+                    reader.GetDouble(6),
+                    reader.GetInt64(7)));
             }
 
             return list;
@@ -475,7 +728,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
         {
             var list = new List<EzLocalProfileManiaKeyStats>();
             using var cmd = connection.CreateCommand();
-            cmd.CommandText = "SELECT key_count, total_keys, avg_kps, max_kps, score_count, kps_sample_count FROM mania_key_stats ORDER BY key_count;";
+            cmd.CommandText = "SELECT key_count, total_keys, avg_kps, max_kps, score_count, kps_sample_count, total_pp, total_duration_ms FROM mania_key_stats ORDER BY key_count;";
             using var reader = cmd.ExecuteReader();
 
             while (reader.Read())
@@ -486,7 +739,9 @@ namespace osu.Game.EzOsuGame.LocalProfile
                     reader.GetDouble(2),
                     reader.GetDouble(3),
                     reader.GetInt32(4),
-                    reader.GetInt32(5)));
+                    reader.GetInt32(5),
+                    reader.GetDouble(6),
+                    reader.GetInt64(7)));
             }
 
             return list;

--- a/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
@@ -754,7 +754,7 @@ namespace osu.Game.EzOsuGame.Localization
             "Allows local account login without password. Skip all score submissions and online account checks.");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_COMPUTE =
-            new EzLocalizationManager.EzLocalisableString("计算本地个人数据", "Compute Local Profile Stats");
+            new EzLocalizationManager.EzLocalisableString("计算本地个人成绩", "Compute Local Profile Stats");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_COMPUTE_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
             "扫描本地成绩，按玩家名勾选导入后写入共享个人统计存档（与当前登录名无关）。",
@@ -774,13 +774,13 @@ namespace osu.Game.EzOsuGame.Localization
             new EzLocalizationManager.EzLocalisableString("取消", "Cancel");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_COMPUTE_STARTED =
-            new EzLocalizationManager.EzLocalisableString("正在计算本地个人数据…", "Computing local profile stats…");
+            new EzLocalizationManager.EzLocalisableString("正在计算本地个人成绩…", "Computing local profile stats…");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_COMPUTE_DONE =
-            new EzLocalizationManager.EzLocalisableString("本地个人数据已更新。", "Local profile stats updated.");
+            new EzLocalizationManager.EzLocalisableString("本地个人成绩已更新。", "Local profile stats updated.");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_COMPUTE_FAILED =
-            new EzLocalizationManager.EzLocalisableString("本地个人数据计算失败。", "Failed to compute local profile stats.");
+            new EzLocalizationManager.EzLocalisableString("本地个人成绩计算失败。", "Failed to compute local profile stats.");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_NO_SCORES =
             new EzLocalizationManager.EzLocalisableString("未找到可导入的本地成绩。", "No local scores found to import.");
@@ -804,7 +804,7 @@ namespace osu.Game.EzOsuGame.Localization
             new EzLocalizationManager.EzLocalisableString("账号", "Account");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_EMPTY_HINT =
-            new EzLocalizationManager.EzLocalisableString("暂无统计。请到 设置 → Ez → 实验性功能 中点击「计算本地个人数据」。", "No stats yet. Open Settings → Ez → Experimental and run “Compute Local Profile Stats”.");
+            new EzLocalizationManager.EzLocalisableString("暂无统计。请到 设置 → Ez → 实验性功能 中点击「计算本地个人成绩」。", "No stats yet. Open Settings → Ez → Experimental and run “Compute Local Profile Stats”.");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SECTION_KEYS =
             new EzLocalizationManager.EzLocalisableString("按键与 KPS", "Keys & KPS");
@@ -852,17 +852,17 @@ namespace osu.Game.EzOsuGame.Localization
             new EzLocalizationManager.EzLocalisableString("各键数平均 KPS", "Avg KPS by key count");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL =
-            new EzLocalizationManager.EzLocalisableString("从线上拉取成绩（实验）", "Pull Online Scores (Experimental)");
+            new EzLocalizationManager.EzLocalisableString("从线上下载成绩或谱面（实验）", "Download Online Scores or Beatmaps (Experimental)");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
             "需 Online 登录。下拉模式过滤 BP / 玩过的图；每批 50（BP100=两次）。可选下载缺图并加入「BP」或「玩过的图」收藏夹。",
             "Requires Online login. Ruleset filters BP / most-played; batch size 50 (BP100 = two runs). Optionally download missing maps into the BP or most-played collection.");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_HEADER =
-            new EzLocalizationManager.EzLocalisableString("从线上拉取成绩", "Pull Online Scores");
+            new EzLocalizationManager.EzLocalisableString("从线上下载成绩或谱面", "Download Online Scores or Beatmaps");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_BODY = new EzLocalizationManager.EzLocalisableString(
-            "模式对两种来源都生效。每批 50：BP 用 offset 0 与 50 各拉一次即可凑满约 100。玩过的图同样按起始 offset 推进。勾选下载缺图时，边下边加入对应收藏夹（仅「BP」「玩过的图」两个，不重复创建）。",
+            "模式对两种来源都生效。每批 50：BP 用 offset 0 与 50 各下载一次即可凑满约 100。玩过的图同样按起始 offset 推进。勾选下载缺图时，边下边加入对应收藏夹（仅「BP」「玩过的图」两个，不重复创建）。",
             "Ruleset applies to both sources. Batch size 50: run BP at offset 0 then 50 for ~100. Most-played advances the same way. With download enabled, maps are added to the matching collection as they finish (only “BP” / “玩过的图”, no duplicates).");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_RULESET =
@@ -890,22 +890,21 @@ namespace osu.Game.EzOsuGame.Localization
                 "Download missing maps into collection (BP→“BP” / most-played→“玩过的图”, throttled)");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_CONFIRM =
-            new EzLocalizationManager.EzLocalisableString("开始拉取", "Start Pull");
+            new EzLocalizationManager.EzLocalisableString("开始下载", "Start Download");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_NEED_ONLINE =
             new EzLocalizationManager.EzLocalisableString("请先 Online 登录自己的账号（不能用本地账号模式）。", "Online login as yourself is required (not local-only mode).");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_BUSY =
-            new EzLocalizationManager.EzLocalisableString("正在拉取线上成绩…", "Pulling online scores…");
+            new EzLocalizationManager.EzLocalisableString("正在下载线上成绩…", "Downloading online scores…");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_DONE =
             new EzLocalizationManager.EzLocalisableString(
-                "线上拉取完成：候选 {0}，成绩导入 {1}，已有成绩 {2}，无回放 {3}，缺图成绩 {4}，失败 {5}，统计写入 {6}，下图 {7}，本地已有图 {8}，收藏夹新增 {9}。",
-                "Online pull done: candidates {0}, scores imported {1}, owned {2}, no replay {3}, missing map scores {4}, failed {5}, stats {6}, maps downloaded {7}, maps already local {8}, collection adds {9}.");
+                "线上下载完成：候选 {0}，成绩导入 {1}，已有成绩 {2}，无回放 {3}，缺图成绩 {4}，失败 {5}，统计写入 {6}，下图 {7}，本地已有图 {8}，收藏夹新增 {9}。",
+                "Online download done: candidates {0}, scores imported {1}, owned {2}, no replay {3}, missing map scores {4}, failed {5}, stats {6}, maps downloaded {7}, maps already local {8}, collection adds {9}.");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_FAILED =
-            new EzLocalizationManager.EzLocalisableString("线上成绩拉取失败。", "Failed to pull online scores.");
-
+            new EzLocalizationManager.EzLocalisableString("线上成绩下载失败。", "Failed to download online scores.");
         #endregion
     }
 }

--- a/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
@@ -764,8 +764,13 @@ namespace osu.Game.EzOsuGame.Localization
             new EzLocalizationManager.EzLocalisableString("选择要导入的玩家名", "Select player names to import");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_IMPORT_BODY = new EzLocalizationManager.EzLocalisableString(
-            "勾选成绩所属的玩家名。统计会合并进同一份本地个人存档。",
-            "Tick player names whose scores should be included. Stats merge into one shared local profile.");
+            "勾选要【重新计算】的玩家名：只覆盖这些名称对应的统计切片，其它已计算名称不受影响。打开「替换模式」会删除未勾选名称的旧切片。",
+            "Check names to recompute: only those players’ stat slices are overwritten; other computed names stay. Enable replace mode to drop unchecked names’ old slices.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_IMPORT_REPLACE =
+            new EzLocalizationManager.EzLocalisableString(
+                "替换模式：删除未勾选名称的旧统计（不保留）",
+                "Replace mode: delete old stats for unchecked names");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_IMPORT_CONFIRM =
             new EzLocalizationManager.EzLocalisableString("开始计算", "Compute");
@@ -775,6 +780,12 @@ namespace osu.Game.EzOsuGame.Localization
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_COMPUTE_STARTED =
             new EzLocalizationManager.EzLocalisableString("正在计算本地个人成绩…", "Computing local profile stats…");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_COMPUTE_PROGRESS =
+            new EzLocalizationManager.EzLocalisableString("正在计算个人成绩 PP… {0}/{1}", "Computing profile PP… {0}/{1}");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_COMPUTE_SAVING =
+            new EzLocalizationManager.EzLocalisableString("正在写入本地个人成绩…", "Saving local profile stats…");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_COMPUTE_DONE =
             new EzLocalizationManager.EzLocalisableString("本地个人成绩已更新。", "Local profile stats updated.");
@@ -809,6 +820,9 @@ namespace osu.Game.EzOsuGame.Localization
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SECTION_KEYS =
             new EzLocalizationManager.EzLocalisableString("按键与 KPS", "Keys & KPS");
 
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SECTION_PERFORMANCE =
+            new EzLocalizationManager.EzLocalisableString("成绩表现", "Performance");
+
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SECTION_MANIA =
             new EzLocalizationManager.EzLocalisableString("Mania 键数 / 列", "Mania Keys / Columns");
 
@@ -832,6 +846,12 @@ namespace osu.Game.EzOsuGame.Localization
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SCORE_COUNT =
             new EzLocalizationManager.EzLocalisableString("成绩数", "Scores");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_TOTAL_PP =
+            new EzLocalizationManager.EzLocalisableString("PP 合计", "Total PP");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_TOTAL_DURATION =
+            new EzLocalizationManager.EzLocalisableString("游戏时长", "Play Time");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_BEST_AR =
             new EzLocalizationManager.EzLocalisableString("最擅长 AR", "Best AR");
@@ -905,6 +925,7 @@ namespace osu.Game.EzOsuGame.Localization
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_FAILED =
             new EzLocalizationManager.EzLocalisableString("线上成绩下载失败。", "Failed to download online scores.");
+
         #endregion
     }
 }

--- a/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
@@ -753,6 +753,104 @@ namespace osu.Game.EzOsuGame.Localization
             "允许无密码登录本地账户。跳过一切成绩上传、网络账户检查。",
             "Allows local account login without password. Skip all score submissions and online account checks.");
 
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_COMPUTE =
+            new EzLocalizationManager.EzLocalisableString("计算本地个人数据", "Compute Local Profile Stats");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_COMPUTE_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "扫描本地成绩，按玩家名勾选导入后写入共享个人统计存档（与当前登录名无关）。",
+            "Scan local scores, pick player names to include, then write into the shared local profile archive (independent of the logged-in name).");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_IMPORT_HEADER =
+            new EzLocalizationManager.EzLocalisableString("选择要导入的玩家名", "Select player names to import");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_IMPORT_BODY = new EzLocalizationManager.EzLocalisableString(
+            "勾选成绩所属的玩家名。统计会合并进同一份本地个人存档。",
+            "Tick player names whose scores should be included. Stats merge into one shared local profile.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_IMPORT_CONFIRM =
+            new EzLocalizationManager.EzLocalisableString("开始计算", "Compute");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_IMPORT_CANCEL =
+            new EzLocalizationManager.EzLocalisableString("取消", "Cancel");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_COMPUTE_STARTED =
+            new EzLocalizationManager.EzLocalisableString("正在计算本地个人数据…", "Computing local profile stats…");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_COMPUTE_DONE =
+            new EzLocalizationManager.EzLocalisableString("本地个人数据已更新。", "Local profile stats updated.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_COMPUTE_FAILED =
+            new EzLocalizationManager.EzLocalisableString("本地个人数据计算失败。", "Failed to compute local profile stats.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_NO_SCORES =
+            new EzLocalizationManager.EzLocalisableString("未找到可导入的本地成绩。", "No local scores found to import.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_NONE_SELECTED =
+            new EzLocalizationManager.EzLocalisableString("请至少勾选一个玩家名。", "Select at least one player name.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_TITLE =
+            new EzLocalizationManager.EzLocalisableString("本地个人主页", "Local Profile");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_DESCRIPTION =
+            new EzLocalizationManager.EzLocalisableString("共享本地游玩统计", "Shared local play statistics");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SHARED_HINT =
+            new EzLocalizationManager.EzLocalisableString("本地统计（共享存档）", "Local stats (shared archive)");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_BADGE =
+            new EzLocalizationManager.EzLocalisableString("本地", "Local");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ACCOUNT_BUTTON =
+            new EzLocalizationManager.EzLocalisableString("账号", "Account");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_EMPTY_HINT =
+            new EzLocalizationManager.EzLocalisableString("暂无统计。请到 设置 → Ez → 实验性功能 中点击「计算本地个人数据」。", "No stats yet. Open Settings → Ez → Experimental and run “Compute Local Profile Stats”.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SECTION_KEYS =
+            new EzLocalizationManager.EzLocalisableString("按键与 KPS", "Keys & KPS");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SECTION_MANIA =
+            new EzLocalizationManager.EzLocalisableString("Mania 键数 / 列", "Mania Keys / Columns");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SECTION_STD =
+            new EzLocalizationManager.EzLocalisableString("最擅长 AR / CS", "Best AR / CS");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SECTION_GRADES =
+            new EzLocalizationManager.EzLocalisableString("成绩评级", "Grades");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SECTION_STARS =
+            new EzLocalizationManager.EzLocalisableString("难度游玩次数", "Plays by difficulty");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_TOTAL_KEYS =
+            new EzLocalizationManager.EzLocalisableString("按键总数", "Total keys");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_AVG_KPS =
+            new EzLocalizationManager.EzLocalisableString("平均 KPS", "Avg KPS");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_MAX_KPS =
+            new EzLocalizationManager.EzLocalisableString("最大 KPS", "Max KPS");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SCORE_COUNT =
+            new EzLocalizationManager.EzLocalisableString("成绩数", "Scores");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_BEST_AR =
+            new EzLocalizationManager.EzLocalisableString("最擅长 AR", "Best AR");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_BEST_CS =
+            new EzLocalizationManager.EzLocalisableString("最擅长 CS", "Best CS");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_NO_RULESET_DATA =
+            new EzLocalizationManager.EzLocalisableString("此模式暂无数据。", "No data for this ruleset.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_COL_HEADER =
+            new EzLocalizationManager.EzLocalisableString("列", "Col");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_MANIA_PLAYS_BY_KEY =
+            new EzLocalizationManager.EzLocalisableString("各键数游玩次数", "Plays by key count");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_MANIA_AVG_KPS_LINE =
+            new EzLocalizationManager.EzLocalisableString("各键数平均 KPS", "Avg KPS by key count");
+
         #endregion
     }
 }

--- a/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
@@ -851,6 +851,51 @@ namespace osu.Game.EzOsuGame.Localization
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_MANIA_AVG_KPS_LINE =
             new EzLocalizationManager.EzLocalisableString("各键数平均 KPS", "Avg KPS by key count");
 
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL =
+            new EzLocalizationManager.EzLocalisableString("从线上拉取成绩（实验）", "Pull Online Scores (Experimental)");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "需 Online 登录自己的账号。可选指定模式 BP100，或分批拉取玩过的图成绩并下载有回放的 .osr。不自动重算本地档案。",
+            "Requires Online login as yourself. Pull BP100 for a ruleset, or batch most-played map scores and download replays when available. Does not recompute the local profile archive.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_HEADER =
+            new EzLocalizationManager.EzLocalisableString("从线上拉取成绩", "Pull Online Scores");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_BODY = new EzLocalizationManager.EzLocalisableString(
+            "选择模式与来源。BP100 一次拉满；玩过的图按批次推进 offset，可多次慢慢拉。仅导入本地尚无、且有回放的成绩；缺图会跳过。",
+            "Pick ruleset and source. BP100 is one shot; most-played advances an offset in batches. Only imports missing scores that have replays; missing beatmaps are skipped.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_RULESET =
+            new EzLocalizationManager.EzLocalisableString("模式", "Ruleset");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_KIND =
+            new EzLocalizationManager.EzLocalisableString("来源", "Source");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_OFFSET_HINT =
+            new EzLocalizationManager.EzLocalisableString(
+                "玩过的图下次从 offset {1} 开始（{0}，每批 {2}）",
+                "Most-played next offset {1} ({0}, batch {2})");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_RESET_OFFSET =
+            new EzLocalizationManager.EzLocalisableString("重置玩过的图进度（offset→0）", "Reset most-played progress (offset→0)");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_CONFIRM =
+            new EzLocalizationManager.EzLocalisableString("开始拉取", "Start Pull");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_NEED_ONLINE =
+            new EzLocalizationManager.EzLocalisableString("请先 Online 登录自己的账号（不能用本地账号模式）。", "Online login as yourself is required (not local-only mode).");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_BUSY =
+            new EzLocalizationManager.EzLocalisableString("正在拉取线上成绩…", "Pulling online scores…");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_DONE =
+            new EzLocalizationManager.EzLocalisableString(
+                "线上拉取完成：候选 {0}，导入 {1}，已有 {2}，无回放 {3}，缺图 {4}，失败 {5}。可用「计算本地个人数据」更新档案。",
+                "Online pull done: candidates {0}, imported {1}, owned {2}, no replay {3}, missing map {4}, failed {5}. Use “Compute Local Profile Stats” to refresh the archive.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_FAILED =
+            new EzLocalizationManager.EzLocalisableString("线上成绩拉取失败。", "Failed to pull online scores.");
+
         #endregion
     }
 }

--- a/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
@@ -855,15 +855,15 @@ namespace osu.Game.EzOsuGame.Localization
             new EzLocalizationManager.EzLocalisableString("从线上拉取成绩（实验）", "Pull Online Scores (Experimental)");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
-            "需 Online 登录。下拉所选模式用于 BP100 / 玩过的图过滤。可分批拉取并尝试导入 .osr；缺图时可只写统计。",
-            "Requires Online login. The selected ruleset filters BP100 / most-played. Batch pull and try .osr import; optionally write stats without a local map.");
+            "需 Online 登录。下拉模式过滤 BP / 玩过的图；每批 50（BP100=两次）。可选下载缺图并加入「BP」或「玩过的图」收藏夹。",
+            "Requires Online login. Ruleset filters BP / most-played; batch size 50 (BP100 = two runs). Optionally download missing maps into the BP or most-played collection.");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_HEADER =
             new EzLocalizationManager.EzLocalisableString("从线上拉取成绩", "Pull Online Scores");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_BODY = new EzLocalizationManager.EzLocalisableString(
-            "模式对 BP100 与「玩过的图」同样生效。BP100 一次拉满；玩过的图按下方起始 offset 分批推进（改数字即改起点，填 0 从头拉）。",
-            "Ruleset applies to both BP100 and most-played. BP100 is one shot; most-played uses the start offset below (edit to change; 0 = from the start).");
+            "模式对两种来源都生效。每批 50：BP 用 offset 0 与 50 各拉一次即可凑满约 100。玩过的图同样按起始 offset 推进。勾选下载缺图时，边下边加入对应收藏夹（仅「BP」「玩过的图」两个，不重复创建）。",
+            "Ruleset applies to both sources. Batch size 50: run BP at offset 0 then 50 for ~100. Most-played advances the same way. With download enabled, maps are added to the matching collection as they finish (only “BP” / “玩过的图”, no duplicates).");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_RULESET =
             new EzLocalizationManager.EzLocalisableString("模式（过滤）", "Ruleset (filter)");
@@ -873,8 +873,8 @@ namespace osu.Game.EzOsuGame.Localization
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_OFFSET_HINT =
             new EzLocalizationManager.EzLocalisableString(
-                "所选模式已存进度 offset = {0}（每批 {1}）。下方可改本次起始值。",
-                "Stored offset for selected ruleset = {0} (batch {1}). Edit the start value below.");
+                "当前来源+模式已存进度 offset = {0}（每批 {1}）。下方可改本次起始值。",
+                "Stored offset for current source+ruleset = {0} (batch {1}). Edit the start value below.");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_OFFSET_INPUT =
             new EzLocalizationManager.EzLocalisableString("起始 offset（填 0 重置）", "Start offset (0 = reset)");
@@ -883,6 +883,11 @@ namespace osu.Game.EzOsuGame.Localization
             new EzLocalizationManager.EzLocalisableString(
                 "缺图也写入个人统计（用 API 元数据，无 KPS；默认开）",
                 "Also write profile stats without local map (API metadata, no KPS; on by default)");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_DOWNLOAD_MAPS =
+            new EzLocalizationManager.EzLocalisableString(
+                "下载缺失谱面并加入收藏夹（BP→「BP」/ 玩过的图→「玩过的图」，节流）",
+                "Download missing maps into collection (BP→“BP” / most-played→“玩过的图”, throttled)");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_CONFIRM =
             new EzLocalizationManager.EzLocalisableString("开始拉取", "Start Pull");
@@ -895,8 +900,8 @@ namespace osu.Game.EzOsuGame.Localization
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_DONE =
             new EzLocalizationManager.EzLocalisableString(
-                "线上拉取完成：候选 {0}，导入 {1}，已有 {2}，无回放 {3}，缺图 {4}，失败 {5}，统计写入 {6}。可用「计算本地个人数据」更新档案。",
-                "Online pull done: candidates {0}, imported {1}, owned {2}, no replay {3}, missing map {4}, failed {5}, stats recorded {6}. Use “Compute Local Profile Stats” to refresh the archive.");
+                "线上拉取完成：候选 {0}，成绩导入 {1}，已有成绩 {2}，无回放 {3}，缺图成绩 {4}，失败 {5}，统计写入 {6}，下图 {7}，本地已有图 {8}，收藏夹新增 {9}。",
+                "Online pull done: candidates {0}, scores imported {1}, owned {2}, no replay {3}, missing map scores {4}, failed {5}, stats {6}, maps downloaded {7}, maps already local {8}, collection adds {9}.");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_FAILED =
             new EzLocalizationManager.EzLocalisableString("线上成绩拉取失败。", "Failed to pull online scores.");

--- a/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
@@ -855,29 +855,34 @@ namespace osu.Game.EzOsuGame.Localization
             new EzLocalizationManager.EzLocalisableString("从线上拉取成绩（实验）", "Pull Online Scores (Experimental)");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
-            "需 Online 登录自己的账号。可选指定模式 BP100，或分批拉取玩过的图成绩并下载有回放的 .osr。不自动重算本地档案。",
-            "Requires Online login as yourself. Pull BP100 for a ruleset, or batch most-played map scores and download replays when available. Does not recompute the local profile archive.");
+            "需 Online 登录。下拉所选模式用于 BP100 / 玩过的图过滤。可分批拉取并尝试导入 .osr；缺图时可只写统计。",
+            "Requires Online login. The selected ruleset filters BP100 / most-played. Batch pull and try .osr import; optionally write stats without a local map.");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_HEADER =
             new EzLocalizationManager.EzLocalisableString("从线上拉取成绩", "Pull Online Scores");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_BODY = new EzLocalizationManager.EzLocalisableString(
-            "选择模式与来源。BP100 一次拉满；玩过的图按批次推进 offset，可多次慢慢拉。仅导入本地尚无、且有回放的成绩；缺图会跳过。",
-            "Pick ruleset and source. BP100 is one shot; most-played advances an offset in batches. Only imports missing scores that have replays; missing beatmaps are skipped.");
+            "模式对 BP100 与「玩过的图」同样生效。BP100 一次拉满；玩过的图按下方起始 offset 分批推进（改数字即改起点，填 0 从头拉）。",
+            "Ruleset applies to both BP100 and most-played. BP100 is one shot; most-played uses the start offset below (edit to change; 0 = from the start).");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_RULESET =
-            new EzLocalizationManager.EzLocalisableString("模式", "Ruleset");
+            new EzLocalizationManager.EzLocalisableString("模式（过滤）", "Ruleset (filter)");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_KIND =
             new EzLocalizationManager.EzLocalisableString("来源", "Source");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_OFFSET_HINT =
             new EzLocalizationManager.EzLocalisableString(
-                "玩过的图下次从 offset {1} 开始（{0}，每批 {2}）",
-                "Most-played next offset {1} ({0}, batch {2})");
+                "所选模式已存进度 offset = {0}（每批 {1}）。下方可改本次起始值。",
+                "Stored offset for selected ruleset = {0} (batch {1}). Edit the start value below.");
 
-        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_RESET_OFFSET =
-            new EzLocalizationManager.EzLocalisableString("重置玩过的图进度（offset→0）", "Reset most-played progress (offset→0)");
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_OFFSET_INPUT =
+            new EzLocalizationManager.EzLocalisableString("起始 offset（填 0 重置）", "Start offset (0 = reset)");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_INCLUDE_STATS =
+            new EzLocalizationManager.EzLocalisableString(
+                "缺图也写入个人统计（用 API 元数据，无 KPS；默认开）",
+                "Also write profile stats without local map (API metadata, no KPS; on by default)");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_CONFIRM =
             new EzLocalizationManager.EzLocalisableString("开始拉取", "Start Pull");
@@ -890,8 +895,8 @@ namespace osu.Game.EzOsuGame.Localization
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_DONE =
             new EzLocalizationManager.EzLocalisableString(
-                "线上拉取完成：候选 {0}，导入 {1}，已有 {2}，无回放 {3}，缺图 {4}，失败 {5}。可用「计算本地个人数据」更新档案。",
-                "Online pull done: candidates {0}, imported {1}, owned {2}, no replay {3}, missing map {4}, failed {5}. Use “Compute Local Profile Stats” to refresh the archive.");
+                "线上拉取完成：候选 {0}，导入 {1}，已有 {2}，无回放 {3}，缺图 {4}，失败 {5}，统计写入 {6}。可用「计算本地个人数据」更新档案。",
+                "Online pull done: candidates {0}, imported {1}, owned {2}, no replay {3}, missing map {4}, failed {5}, stats recorded {6}. Use “Compute Local Profile Stats” to refresh the archive.");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_FAILED =
             new EzLocalizationManager.EzLocalisableString("线上成绩拉取失败。", "Failed to pull online scores.");

--- a/osu.Game/EzOsuGame/Overlays/EzExperimentalSettings.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzExperimentalSettings.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Database;
@@ -14,6 +15,7 @@ using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Overlays.Settings;
+using osu.Game.Rulesets;
 
 namespace osu.Game.EzOsuGame.Overlays
 {
@@ -27,7 +29,9 @@ namespace osu.Game.EzOsuGame.Overlays
                           EzAnalysisWarmupProcessor? analysisWarmupProcessor,
                           IDialogOverlay? dialogOverlay,
                           INotificationOverlay? notifications,
-                          EzLocalProfileService? localProfileService)
+                          EzLocalProfileService? localProfileService,
+                          EzLocalProfileOnlinePullService? onlinePullService,
+                          RulesetStore? rulesetStore)
         {
             EzDataRebuildSettingsSection.AddTo(this, backgroundDataStoreProcessor, analysisWarmupProcessor, dialogOverlay, notifications);
 
@@ -37,6 +41,14 @@ namespace osu.Game.EzOsuGame.Overlays
                 TooltipText = EzSettingsStrings.LOCAL_PROFILE_COMPUTE_TOOLTIP,
                 Keywords = new[] { "local", "profile", "stats", "kps", "个人", "本地", "统计", "成绩" },
                 Action = () => requestComputeLocalProfile(localProfileService, dialogOverlay, notifications),
+            });
+
+            Add(new SettingsButtonV2
+            {
+                Text = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL,
+                TooltipText = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_TOOLTIP,
+                Keywords = new[] { "online", "bp", "most played", "osr", "拉取", "线上", "成绩", "回放" },
+                Action = () => requestOnlinePull(onlinePullService, rulesetStore, dialogOverlay, notifications),
             });
 
             AddRange(new Drawable[]
@@ -141,6 +153,86 @@ namespace osu.Game.EzOsuGame.Overlays
 
                         localProfileService.ReloadFromDisk();
                         notifications?.Post(new SimpleNotification { Text = EzSettingsStrings.LOCAL_PROFILE_COMPUTE_DONE });
+                    }));
+                }));
+        }
+
+        private void requestOnlinePull(
+            EzLocalProfileOnlinePullService? onlinePullService,
+            RulesetStore? rulesetStore,
+            IDialogOverlay? dialogOverlay,
+            INotificationOverlay? notifications)
+        {
+            if (onlinePullService == null || rulesetStore == null || dialogOverlay == null)
+            {
+                notifications?.Post(new SimpleErrorNotification { Text = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_FAILED });
+                return;
+            }
+
+            if (onlinePullService.IsPulling.Value)
+            {
+                notifications?.Post(new SimpleNotification { Text = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_BUSY });
+                return;
+            }
+
+            dialogOverlay.Push(new EzLocalProfileOnlinePullDialog(
+                rulesetStore,
+                onlinePullService.PeekMostPlayedOffset,
+                request =>
+                {
+                    if (onlinePullService.IsPulling.Value)
+                    {
+                        notifications?.Post(new SimpleNotification { Text = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_BUSY });
+                        return;
+                    }
+
+                    notifications?.Post(new SimpleNotification { Text = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_BUSY });
+
+                    onlinePullService.PullAsync(request).ContinueWith(t => Schedule(() =>
+                    {
+                        if (t.IsFaulted)
+                        {
+                            notifications?.Post(new SimpleErrorNotification { Text = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_FAILED });
+                            return;
+                        }
+
+                        if (t.IsCanceled)
+                            return;
+
+                        var result = t.GetResultSafely();
+
+                        if (result.ErrorMessage == "need_online")
+                        {
+                            notifications?.Post(new SimpleErrorNotification { Text = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_NEED_ONLINE });
+                            return;
+                        }
+
+                        if (result.ErrorMessage == "already_pulling")
+                        {
+                            notifications?.Post(new SimpleNotification { Text = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_BUSY });
+                            return;
+                        }
+
+                        if (!string.IsNullOrEmpty(result.ErrorMessage) && result.ErrorMessage != "cancelled")
+                        {
+                            notifications?.Post(new SimpleErrorNotification { Text = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_FAILED });
+                            return;
+                        }
+
+                        if (result.ErrorMessage == "cancelled")
+                            return;
+
+                        notifications?.Post(new SimpleNotification
+                        {
+                            Text = string.Format(
+                                EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_DONE.ToString(),
+                                result.Candidates,
+                                result.Imported,
+                                result.AlreadyOwned,
+                                result.NoReplay,
+                                result.MissingBeatmap,
+                                result.Failed),
+                        });
                     }));
                 }));
         }

--- a/osu.Game/EzOsuGame/Overlays/EzExperimentalSettings.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzExperimentalSettings.cs
@@ -48,7 +48,7 @@ namespace osu.Game.EzOsuGame.Overlays
             {
                 Text = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL,
                 TooltipText = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_TOOLTIP,
-                Keywords = new[] { "online", "bp", "most played", "osr", "拉取", "线上", "成绩", "回放" },
+                Keywords = new[] { "online", "bp", "most played", "osr", "下载", "拉取", "线上", "成绩", "谱面", "回放" },
                 Action = () => requestOnlinePull(onlinePullService, localProfileService, rulesetStore, dialogOverlay, notifications),
             });
 

--- a/osu.Game/EzOsuGame/Overlays/EzExperimentalSettings.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzExperimentalSettings.cs
@@ -8,9 +8,11 @@ using osu.Game.Database;
 using osu.Game.EzOsuGame.Analysis;
 using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.Localization;
+using osu.Game.EzOsuGame.LocalProfile;
 using osu.Game.EzOsuGame.Scoring;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Overlays;
+using osu.Game.Overlays.Notifications;
 using osu.Game.Overlays.Settings;
 
 namespace osu.Game.EzOsuGame.Overlays
@@ -24,9 +26,18 @@ namespace osu.Game.EzOsuGame.Overlays
                           BackgroundDataStoreProcessor? backgroundDataStoreProcessor,
                           EzAnalysisWarmupProcessor? analysisWarmupProcessor,
                           IDialogOverlay? dialogOverlay,
-                          INotificationOverlay? notifications)
+                          INotificationOverlay? notifications,
+                          EzLocalProfileService? localProfileService)
         {
             EzDataRebuildSettingsSection.AddTo(this, backgroundDataStoreProcessor, analysisWarmupProcessor, dialogOverlay, notifications);
+
+            Add(new SettingsButtonV2
+            {
+                Text = EzSettingsStrings.LOCAL_PROFILE_COMPUTE,
+                TooltipText = EzSettingsStrings.LOCAL_PROFILE_COMPUTE_TOOLTIP,
+                Keywords = new[] { "local", "profile", "stats", "kps", "个人", "本地", "统计", "成绩" },
+                Action = () => requestComputeLocalProfile(localProfileService, dialogOverlay, notifications),
+            });
 
             AddRange(new Drawable[]
             {
@@ -77,6 +88,61 @@ namespace osu.Game.EzOsuGame.Overlays
                     Keywords = new[] { "race", "feed", "batch", "stream", "角逐", "预建" }
                 },
             });
+        }
+
+        private void requestComputeLocalProfile(
+            EzLocalProfileService? localProfileService,
+            IDialogOverlay? dialogOverlay,
+            INotificationOverlay? notifications)
+        {
+            if (localProfileService == null || dialogOverlay == null)
+            {
+                notifications?.Post(new SimpleErrorNotification { Text = EzSettingsStrings.LOCAL_PROFILE_COMPUTE_FAILED });
+                return;
+            }
+
+            if (localProfileService.IsComputing.Value)
+            {
+                notifications?.Post(new SimpleNotification { Text = EzSettingsStrings.LOCAL_PROFILE_COMPUTE_STARTED });
+                return;
+            }
+
+            var counts = localProfileService.ScanUsernameCounts();
+
+            if (counts.Count == 0)
+            {
+                notifications?.Post(new SimpleNotification { Text = EzSettingsStrings.LOCAL_PROFILE_NO_SCORES });
+                return;
+            }
+
+            dialogOverlay.Push(new EzLocalProfileImportDialog(
+                counts,
+                localProfileService.GetPreviouslyIncludedUsernames(),
+                selected =>
+                {
+                    if (selected.Count == 0)
+                    {
+                        notifications?.Post(new SimpleNotification { Text = EzSettingsStrings.LOCAL_PROFILE_NONE_SELECTED });
+                        return;
+                    }
+
+                    notifications?.Post(new SimpleNotification { Text = EzSettingsStrings.LOCAL_PROFILE_COMPUTE_STARTED });
+
+                    localProfileService.ComputeAsync(selected).ContinueWith(t => Schedule(() =>
+                    {
+                        if (t.IsFaulted)
+                        {
+                            notifications?.Post(new SimpleErrorNotification { Text = EzSettingsStrings.LOCAL_PROFILE_COMPUTE_FAILED });
+                            return;
+                        }
+
+                        if (t.IsCanceled)
+                            return;
+
+                        localProfileService.ReloadFromDisk();
+                        notifications?.Post(new SimpleNotification { Text = EzSettingsStrings.LOCAL_PROFILE_COMPUTE_DONE });
+                    }));
+                }));
         }
 
         internal static readonly LocalisableString EZ_EXPERIMENTAL_SECTION_HEADER = new EzLocalizationManager.EzLocalisableString(

--- a/osu.Game/EzOsuGame/Overlays/EzExperimentalSettings.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzExperimentalSettings.cs
@@ -5,7 +5,9 @@ using osu.Framework.Allocation;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
+using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using osu.Game.Database;
 using osu.Game.EzOsuGame.Analysis;
 using osu.Game.EzOsuGame.Configuration;
@@ -130,46 +132,122 @@ namespace osu.Game.EzOsuGame.Overlays
                     return;
                 }
 
-                notifications?.Post(new SimpleNotification { Text = EzSettingsStrings.LOCAL_PROFILE_COMPUTE_STARTED });
-                runCompute(localProfileService, localProfileService.GetPreviouslyIncludedUsernames(), notifications);
+                runCompute(localProfileService, localProfileService.GetPreviouslyIncludedUsernames(), replaceIncludedUsernames: false, notifications);
                 return;
             }
 
             dialogOverlay.Push(new EzLocalProfileImportDialog(
                 counts,
                 localProfileService.GetPreviouslyIncludedUsernames(),
-                selected =>
+                (selected, replaceMode) =>
                 {
-                    if (selected.Count == 0 && !localProfileService.HasOnlineScoreContributions())
+                    if (selected.Count == 0 && !localProfileService.HasOnlineScoreContributions()
+                                            && (replaceMode || localProfileService.GetPreviouslyIncludedUsernames().Count == 0))
                     {
                         notifications?.Post(new SimpleNotification { Text = EzSettingsStrings.LOCAL_PROFILE_NONE_SELECTED });
                         return;
                     }
 
-                    notifications?.Post(new SimpleNotification { Text = EzSettingsStrings.LOCAL_PROFILE_COMPUTE_STARTED });
-                    runCompute(localProfileService, selected, notifications);
+                    runCompute(localProfileService, selected, replaceMode, notifications);
                 }));
         }
 
         private void runCompute(
             EzLocalProfileService localProfileService,
             IReadOnlyCollection<string> selected,
+            bool replaceIncludedUsernames,
             INotificationOverlay? notifications)
         {
-            localProfileService.ComputeAsync(selected).ContinueWith(t => Schedule(() =>
+            if (notifications == null)
             {
-                if (t.IsFaulted)
+                localProfileService.ComputeAsync(selected, replaceIncludedUsernames).ContinueWith(t => Schedule(() =>
                 {
-                    notifications?.Post(new SimpleErrorNotification { Text = EzSettingsStrings.LOCAL_PROFILE_COMPUTE_FAILED });
+                    if (!t.IsFaulted && !t.IsCanceled)
+                        localProfileService.ReloadFromDisk();
+                }));
+                return;
+            }
+
+            var notification = new ProgressNotification
+            {
+                Text = EzSettingsStrings.LOCAL_PROFILE_COMPUTE_STARTED,
+                CompletionText = EzSettingsStrings.LOCAL_PROFILE_COMPUTE_DONE,
+                State = ProgressNotificationState.Active,
+            };
+
+            notifications.Post(notification);
+
+            // Do not use Progress<T> (SyncContext flood). Update the notification directly —
+            // its Text/Progress/State setters marshal via the notification's own Scheduler,
+            // which keeps running even if the settings panel is closed.
+            var progress = new DirectLocalProfileComputeProgress(notification);
+
+            localProfileService.ComputeAsync(selected, replaceIncludedUsernames, progress, notification.CancellationToken)
+                              .ContinueWith(t => finishComputeNotification(t, localProfileService, notification, notifications));
+        }
+
+        /// <summary>
+        /// Forwards compute progress to a <see cref="ProgressNotification"/> from any thread.
+        /// </summary>
+        private sealed class DirectLocalProfileComputeProgress : IProgress<EzLocalProfileComputeProgress>
+        {
+            private readonly ProgressNotification notification;
+
+            public DirectLocalProfileComputeProgress(ProgressNotification notification)
+            {
+                this.notification = notification;
+            }
+
+            public void Report(EzLocalProfileComputeProgress value)
+            {
+                if (notification.State is ProgressNotificationState.Cancelled or ProgressNotificationState.Completed)
+                    return;
+
+                if (value.Saving)
+                {
+                    notification.Text = EzSettingsStrings.LOCAL_PROFILE_COMPUTE_SAVING;
+                    notification.Progress = 0.99f;
                     return;
                 }
 
-                if (t.IsCanceled)
-                    return;
+                int total = Math.Max(1, value.Total);
+                int processed = Math.Clamp(value.Processed, 0, total);
 
-                localProfileService.ReloadFromDisk();
-                notifications?.Post(new SimpleNotification { Text = EzSettingsStrings.LOCAL_PROFILE_COMPUTE_DONE });
-            }));
+                // Keep bar under 100% until we explicitly Complete — avoids a stuck spinner at 1.0 Active.
+                notification.Text = LocalisableString.Format(
+                    EzSettingsStrings.LOCAL_PROFILE_COMPUTE_PROGRESS.ToString(),
+                    processed,
+                    total);
+                notification.Progress = Math.Min(0.99f, (float)processed / total);
+            }
+        }
+
+        private static void finishComputeNotification(
+            Task computeTask,
+            EzLocalProfileService localProfileService,
+            ProgressNotification notification,
+            INotificationOverlay notifications)
+        {
+            if (notification.State == ProgressNotificationState.Cancelled)
+                return;
+
+            if (computeTask.IsFaulted)
+            {
+                notification.State = ProgressNotificationState.Cancelled;
+                notifications.Post(new SimpleErrorNotification { Text = EzSettingsStrings.LOCAL_PROFILE_COMPUTE_FAILED });
+                return;
+            }
+
+            if (computeTask.IsCanceled)
+            {
+                notification.State = ProgressNotificationState.Cancelled;
+                return;
+            }
+
+            localProfileService.ReloadFromDisk();
+            notification.Progress = 1f;
+            notification.CompletionText = EzSettingsStrings.LOCAL_PROFILE_COMPUTE_DONE;
+            notification.State = ProgressNotificationState.Completed;
         }
 
         private void requestOnlinePull(
@@ -255,7 +333,7 @@ namespace osu.Game.EzOsuGame.Overlays
                         });
 
                         if (result.StatsRecorded > 0 && localProfileService is not null && !localProfileService.IsComputing.Value)
-                            runCompute(localProfileService, localProfileService.GetPreviouslyIncludedUsernames(), notifications);
+                            runCompute(localProfileService, localProfileService.GetPreviouslyIncludedUsernames(), replaceIncludedUsernames: false, notifications);
                     }));
                 }));
         }

--- a/osu.Game/EzOsuGame/Overlays/EzExperimentalSettings.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzExperimentalSettings.cs
@@ -193,7 +193,7 @@ namespace osu.Game.EzOsuGame.Overlays
 
             dialogOverlay.Push(new EzLocalProfileOnlinePullDialog(
                 rulesetStore,
-                onlinePullService.PeekMostPlayedOffset,
+                onlinePullService.PeekPullOffset,
                 request =>
                 {
                     if (onlinePullService.IsPulling.Value)
@@ -248,7 +248,10 @@ namespace osu.Game.EzOsuGame.Overlays
                                 result.NoReplay,
                                 result.MissingBeatmap,
                                 result.Failed,
-                                result.StatsRecorded),
+                                result.StatsRecorded,
+                                result.MapsDownloaded,
+                                result.MapsAlreadyLocal,
+                                result.CollectionAdds),
                         });
 
                         if (result.StatsRecorded > 0 && localProfileService is not null && !localProfileService.IsComputing.Value)

--- a/osu.Game/EzOsuGame/Overlays/EzExperimentalSettings.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzExperimentalSettings.cs
@@ -5,6 +5,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
+using System.Collections.Generic;
 using osu.Game.Database;
 using osu.Game.EzOsuGame.Analysis;
 using osu.Game.EzOsuGame.Configuration;
@@ -48,7 +49,7 @@ namespace osu.Game.EzOsuGame.Overlays
                 Text = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL,
                 TooltipText = EzSettingsStrings.LOCAL_PROFILE_ONLINE_PULL_TOOLTIP,
                 Keywords = new[] { "online", "bp", "most played", "osr", "拉取", "线上", "成绩", "回放" },
-                Action = () => requestOnlinePull(onlinePullService, rulesetStore, dialogOverlay, notifications),
+                Action = () => requestOnlinePull(onlinePullService, localProfileService, rulesetStore, dialogOverlay, notifications),
             });
 
             AddRange(new Drawable[]
@@ -123,7 +124,14 @@ namespace osu.Game.EzOsuGame.Overlays
 
             if (counts.Count == 0)
             {
-                notifications?.Post(new SimpleNotification { Text = EzSettingsStrings.LOCAL_PROFILE_NO_SCORES });
+                if (!localProfileService.HasOnlineScoreContributions())
+                {
+                    notifications?.Post(new SimpleNotification { Text = EzSettingsStrings.LOCAL_PROFILE_NO_SCORES });
+                    return;
+                }
+
+                notifications?.Post(new SimpleNotification { Text = EzSettingsStrings.LOCAL_PROFILE_COMPUTE_STARTED });
+                runCompute(localProfileService, localProfileService.GetPreviouslyIncludedUsernames(), notifications);
                 return;
             }
 
@@ -132,33 +140,41 @@ namespace osu.Game.EzOsuGame.Overlays
                 localProfileService.GetPreviouslyIncludedUsernames(),
                 selected =>
                 {
-                    if (selected.Count == 0)
+                    if (selected.Count == 0 && !localProfileService.HasOnlineScoreContributions())
                     {
                         notifications?.Post(new SimpleNotification { Text = EzSettingsStrings.LOCAL_PROFILE_NONE_SELECTED });
                         return;
                     }
 
                     notifications?.Post(new SimpleNotification { Text = EzSettingsStrings.LOCAL_PROFILE_COMPUTE_STARTED });
-
-                    localProfileService.ComputeAsync(selected).ContinueWith(t => Schedule(() =>
-                    {
-                        if (t.IsFaulted)
-                        {
-                            notifications?.Post(new SimpleErrorNotification { Text = EzSettingsStrings.LOCAL_PROFILE_COMPUTE_FAILED });
-                            return;
-                        }
-
-                        if (t.IsCanceled)
-                            return;
-
-                        localProfileService.ReloadFromDisk();
-                        notifications?.Post(new SimpleNotification { Text = EzSettingsStrings.LOCAL_PROFILE_COMPUTE_DONE });
-                    }));
+                    runCompute(localProfileService, selected, notifications);
                 }));
+        }
+
+        private void runCompute(
+            EzLocalProfileService localProfileService,
+            IReadOnlyCollection<string> selected,
+            INotificationOverlay? notifications)
+        {
+            localProfileService.ComputeAsync(selected).ContinueWith(t => Schedule(() =>
+            {
+                if (t.IsFaulted)
+                {
+                    notifications?.Post(new SimpleErrorNotification { Text = EzSettingsStrings.LOCAL_PROFILE_COMPUTE_FAILED });
+                    return;
+                }
+
+                if (t.IsCanceled)
+                    return;
+
+                localProfileService.ReloadFromDisk();
+                notifications?.Post(new SimpleNotification { Text = EzSettingsStrings.LOCAL_PROFILE_COMPUTE_DONE });
+            }));
         }
 
         private void requestOnlinePull(
             EzLocalProfileOnlinePullService? onlinePullService,
+            EzLocalProfileService? localProfileService,
             RulesetStore? rulesetStore,
             IDialogOverlay? dialogOverlay,
             INotificationOverlay? notifications)
@@ -231,8 +247,12 @@ namespace osu.Game.EzOsuGame.Overlays
                                 result.AlreadyOwned,
                                 result.NoReplay,
                                 result.MissingBeatmap,
-                                result.Failed),
+                                result.Failed,
+                                result.StatsRecorded),
                         });
+
+                        if (result.StatsRecorded > 0 && localProfileService is not null && !localProfileService.IsComputing.Value)
+                            runCompute(localProfileService, localProfileService.GetPreviouslyIncludedUsernames(), notifications);
                     }));
                 }));
         }

--- a/osu.Game/Online/API/Requests/GetUserBeatmapScoreRequest.cs
+++ b/osu.Game/Online/API/Requests/GetUserBeatmapScoreRequest.cs
@@ -1,0 +1,38 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.IO.Network;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Rulesets;
+
+namespace osu.Game.Online.API.Requests
+{
+    /// <summary>
+    /// GET /beatmaps/{beatmap}/scores/users/{user}
+    /// </summary>
+    public class GetUserBeatmapScoreRequest : APIRequest<APIScoreWithPosition>
+    {
+        private readonly int beatmapId;
+        private readonly long userId;
+        private readonly RulesetInfo? ruleset;
+
+        public GetUserBeatmapScoreRequest(int beatmapId, long userId, RulesetInfo? ruleset = null)
+        {
+            this.beatmapId = beatmapId;
+            this.userId = userId;
+            this.ruleset = ruleset;
+        }
+
+        protected override WebRequest CreateWebRequest()
+        {
+            var req = base.CreateWebRequest();
+
+            if (ruleset != null)
+                req.AddParameter("mode", ruleset.ShortName);
+
+            return req;
+        }
+
+        protected override string Target => $@"beatmaps/{beatmapId}/scores/users/{userId}";
+    }
+}

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -45,6 +45,7 @@ using osu.Game.EzOsuGame.Edit;
 using osu.Game.EzOsuGame.Analysis;
 using osu.Game.EzOsuGame.Background.Pixiv;
 using osu.Game.EzOsuGame.Layout;
+using osu.Game.EzOsuGame.LocalProfile;
 using osu.Game.EzOsuGame.Overlays;
 using osu.Game.EzOsuGame.Performance;
 using osu.Game.EzOsuGame.Pets;
@@ -146,6 +147,8 @@ namespace osu.Game
         private NewsOverlay news;
 
         private UserProfileOverlay userProfile;
+
+        private EzLocalProfileOverlay ezLocalProfile;
 
         private LoginOverlay loginOverlay;
 
@@ -620,7 +623,16 @@ namespace osu.Game
         /// Show a user's profile as an overlay.
         /// </summary>
         /// <param name="user">The user to display.</param>
-        public void ShowUser(IUser user) => waitForReady(() => userProfile, _ => userProfile.ShowUser(user));
+        public void ShowUser(IUser user) => waitForReady(() => userProfile, _ =>
+        {
+            if (API.IsLocalOnly && ReferenceEquals(user, API.LocalUser.Value))
+            {
+                ezLocalProfile.Show();
+                return;
+            }
+
+            userProfile.ShowUser(user);
+        });
 
         /// <summary>
         /// Show a beatmap's set as an overlay, displaying the given beatmap.
@@ -1277,6 +1289,7 @@ namespace osu.Game
             loadComponentSingleFile(Settings = new SettingsOverlay(), leftFloatingOverlayContent.Add, true);
             loadComponentSingleFile(changelogOverlay = new ChangelogOverlay(), overlayContent.Add, true);
             loadComponentSingleFile(userProfile = new UserProfileOverlay(), overlayContent.Add, true);
+            loadComponentSingleFile(ezLocalProfile = new EzLocalProfileOverlay(), overlayContent.Add, true);
             loadComponentSingleFile(beatmapSetOverlay = new BeatmapSetOverlay(), overlayContent.Add, true);
             loadComponentSingleFile(wikiOverlay = new WikiOverlay(), overlayContent.Add, true);
             loadComponentSingleFile(ezLayoutLayer = new EzLayoutLayer(), screenCaptureContent.Add, true);
@@ -1347,7 +1360,7 @@ namespace osu.Game
             }
 
             // eventually informational overlays should be displayed in a stack, but for now let's only allow one to stay open at a time.
-            var informationalOverlays = new OverlayContainer[] { beatmapSetOverlay, userProfile };
+            var informationalOverlays = new OverlayContainer[] { beatmapSetOverlay, userProfile, ezLocalProfile };
 
             foreach (var overlay in informationalOverlays)
             {
@@ -1730,10 +1743,18 @@ namespace osu.Game
                     return true;
 
                 case GlobalAction.ToggleProfile:
-                    if (userProfile.State.Value == Visibility.Visible)
+                    if (API.IsLocalOnly)
+                    {
+                        if (ezLocalProfile.State.Value == Visibility.Visible)
+                            ezLocalProfile.Hide();
+                        else
+                            ezLocalProfile.Show();
+                    }
+                    else if (userProfile.State.Value == Visibility.Visible)
                         userProfile.Hide();
                     else
                         ShowUser(API.LocalUser.Value);
+
                     return true;
 
                 case GlobalAction.RandomSkin:

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -51,6 +51,7 @@ using osu.Game.EzOsuGame;
 using osu.Game.EzOsuGame.Analysis;
 using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.Input;
+using osu.Game.EzOsuGame.LocalProfile;
 using osu.Game.EzOsuGame.Online;
 using osu.Game.EzOsuGame.Scoring;
 using osu.Game.Localisation;
@@ -406,6 +407,7 @@ namespace osu.Game
             dependencies.Cache(ezAnalysisPersistentStore);
             dependencies.Cache(ezAnalysisDatabase);
             dependencies.Cache(ezAnalysisCache = new EzAnalysisCache());
+            dependencies.Cache(new EzLocalProfileService(Storage, realm, ezAnalysisPersistentStore));
 
             ReplaySession = new EzReplaySessionRouter(RulesetStore.AvailableRulesets);
             dependencies.CacheAs<IEzReplaySession>(ReplaySession);

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -407,7 +407,7 @@ namespace osu.Game
             dependencies.Cache(ezAnalysisPersistentStore);
             dependencies.Cache(ezAnalysisDatabase);
             dependencies.Cache(ezAnalysisCache = new EzAnalysisCache());
-            dependencies.Cache(new EzLocalProfileService(Storage, realm, ezAnalysisPersistentStore));
+            dependencies.Cache(new EzLocalProfileService(Storage, realm, ezAnalysisPersistentStore, BeatmapManager));
             dependencies.Cache(new EzLocalProfileOnlinePullService(API, ScoreManager, BeatmapManager, realm, Storage));
 
             ReplaySession = new EzReplaySessionRouter(RulesetStore.AvailableRulesets);

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -408,7 +408,7 @@ namespace osu.Game
             dependencies.Cache(ezAnalysisDatabase);
             dependencies.Cache(ezAnalysisCache = new EzAnalysisCache());
             dependencies.Cache(new EzLocalProfileService(Storage, realm, ezAnalysisPersistentStore));
-            dependencies.Cache(new EzLocalProfileOnlinePullService(API, ScoreManager, Storage));
+            dependencies.Cache(new EzLocalProfileOnlinePullService(API, ScoreManager, BeatmapManager, realm, Storage));
 
             ReplaySession = new EzReplaySessionRouter(RulesetStore.AvailableRulesets);
             dependencies.CacheAs<IEzReplaySession>(ReplaySession);

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -408,6 +408,7 @@ namespace osu.Game
             dependencies.Cache(ezAnalysisDatabase);
             dependencies.Cache(ezAnalysisCache = new EzAnalysisCache());
             dependencies.Cache(new EzLocalProfileService(Storage, realm, ezAnalysisPersistentStore));
+            dependencies.Cache(new EzLocalProfileOnlinePullService(API, ScoreManager, Storage));
 
             ReplaySession = new EzReplaySessionRouter(RulesetStore.AvailableRulesets);
             dependencies.CacheAs<IEzReplaySession>(ReplaySession);

--- a/osu.Game/Overlays/Toolbar/ToolbarUserButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarUserButton.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.EzOsuGame.LocalProfile;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
@@ -35,14 +36,22 @@ namespace osu.Game.Overlays.Toolbar
 
         private OsuSpriteText usernameText = null!;
 
+        private IAPIProvider api = null!;
+        private LoginOverlay? loginOverlay;
+        private EzLocalProfileOverlay? localProfileOverlay;
+
         public ToolbarUserButton()
         {
             ButtonContent.AutoSizeAxes = Axes.X;
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours, IAPIProvider api, LoginOverlay? login)
+        private void load(OsuColour colours, IAPIProvider api, LoginOverlay? login, EzLocalProfileOverlay? localProfile)
         {
+            this.api = api;
+            loginOverlay = login;
+            localProfileOverlay = localProfile;
+
             Flow.AddRange(new Drawable[]
             {
                 usernameText = new OsuSpriteText
@@ -101,7 +110,15 @@ namespace osu.Game.Overlays.Toolbar
             localUser = api.LocalUser.GetBoundCopy();
             localUser.BindValueChanged(userChanged, true);
 
-            StateContainer = login;
+            updateOverlayTarget();
+        }
+
+        private void updateOverlayTarget()
+        {
+            if (api.IsLocalOnly && localProfileOverlay != null)
+                StateContainer = localProfileOverlay;
+            else if (loginOverlay != null)
+                StateContainer = loginOverlay;
         }
 
         private void userChanged(ValueChangedEvent<APIUser> user) => Schedule(() =>
@@ -143,6 +160,8 @@ namespace osu.Game.Overlays.Toolbar
                 default:
                     throw new ArgumentOutOfRangeException(nameof(state.NewValue));
             }
+
+            updateOverlayTarget();
         });
     }
 }


### PR DESCRIPTION
## Summary
- 共享本地个人档案（`ez-local-profile.sqlite`，非 Realm）：按规则集汇总键数/KPS、评级、星级、PP、游玩时长（谱面 Length）、Mania 分键与 Std AR/CS。
- 本地重算改为按玩家名分区增量覆盖：只重算勾选名并覆盖其切片；未勾选名保留；可选「替换」删除未勾选分区。`schema_version` 仍为 1（未发版）。
- 实验性线上拉取：Online 登录后按模式分批（50）拉 BP100 / Most Played；可缺图写统计；缺图下载进收藏夹「BP」/「玩过的图」并限速。
- 计算进度通知：条上显示进度；写入阶段单独文案；完成后立即收尾。避免 `Progress<T>` 刷屏卡死，以及并行 `GetWorkingBeatmap` 死锁导致进度停在中段。

## Test plan
- [x] 实验设置 →「计算本地个人成绩」：勾选玩家名，进度能跑完并马上变成完成提示（不会卡在 200 多或写完后转圈很久）。
- [x] 先算 A，再只算 B：A 的统计仍在，B 被覆盖更新。
- [x] 勾选「替换/删除未选玩家」后重算：未勾选名的分区消失。
- [x] Overlay 各模式可见 PP 与游玩时长；Mania 分键行同步有。
- [ ] Online 登录 →「从线上下载成绩或谱面」：BP100 / Most Played 分批 50；缺图进「BP」/「玩过的图」；缺图写统计时档案有评级/星级（无 KPS）。
- [x] LocalOnline 下点头像打开本地档案；线上拉取应提示需 Online。
- [x] 取消计算：不写库；对话框尺寸正常、不撑出窗口。