### PR TITLE
Acrylic chrome: exclusive M/N frosted UI (clean rebuild)

### DIFF
--- a/osu.Game/EzOsuGame/Acrylic/AcrylicCaptureScope.cs
+++ b/osu.Game/EzOsuGame/Acrylic/AcrylicCaptureScope.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Allocation;
 using osu.Framework.Development;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -22,6 +23,7 @@ namespace osu.Game.EzOsuGame.Acrylic
     /// wrap around song-select backgrounds makes nested blur/dim look sharp or ineffective.
     /// Pixel alignment stays on <c>AcrylicBackdropDrawable</c> effect buffers instead.
     /// </remarks>
+    [Cached(typeof(IAcrylicCaptureRegistrar))]
     public partial class AcrylicCaptureScope : CompositeDrawable, IAcrylicCaptureRegistrar
     {
         private int captureRefCount;

--- a/osu.Game/EzOsuGame/Acrylic/EzAcrylicCaptureController.cs
+++ b/osu.Game/EzOsuGame/Acrylic/EzAcrylicCaptureController.cs
@@ -2,25 +2,24 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Rendering;
 using osuTK;
 
 namespace osu.Game.EzOsuGame.Acrylic
 {
     /// <summary>
     /// Shared acquire/release logic for <see cref="AcrylicBackdropDrawable"/> consumers.
+    /// Always uses <see cref="IAcrylicCaptureRegistrar"/> so footer / overlays share the same
+    /// BufferedContainer path as song-select wedges (backbuffer region copy is unreliable for late-drawn chrome).
     /// </summary>
     internal sealed class EzAcrylicCaptureController
     {
         private readonly IAcrylicCaptureRegistrar? registrar;
-        private readonly IRenderer renderer;
         private readonly AcrylicBackdropDrawable acrylicBackdrop;
         private bool captureAcquired;
 
-        public EzAcrylicCaptureController(IAcrylicCaptureRegistrar? registrar, IRenderer renderer, AcrylicBackdropDrawable acrylicBackdrop)
+        public EzAcrylicCaptureController(IAcrylicCaptureRegistrar? registrar, AcrylicBackdropDrawable acrylicBackdrop)
         {
             this.registrar = registrar;
-            this.renderer = renderer;
             this.acrylicBackdrop = acrylicBackdrop;
         }
 
@@ -28,30 +27,15 @@ namespace osu.Game.EzOsuGame.Acrylic
         {
             acrylicBackdrop.BlurSigma = new Vector2(blurStrength);
 
-            bool needsScopeCapture = wantsCapture && !renderer.SupportsBackbufferRegionCopy;
-
             if (wantsCapture)
             {
-                if (needsScopeCapture)
+                if (!captureAcquired && registrar != null)
                 {
-                    if (!captureAcquired && registrar != null)
-                    {
-                        registrar.AcquireCapture();
-                        captureAcquired = true;
-                    }
-
-                    acrylicBackdrop.EffectEnabled = captureAcquired;
+                    registrar.AcquireCapture();
+                    captureAcquired = true;
                 }
-                else
-                {
-                    if (captureAcquired && registrar != null)
-                    {
-                        registrar.ReleaseCapture();
-                        captureAcquired = false;
-                    }
 
-                    acrylicBackdrop.EffectEnabled = true;
-                }
+                acrylicBackdrop.EffectEnabled = captureAcquired || registrar == null;
             }
             else
             {

--- a/osu.Game/EzOsuGame/Acrylic/EzAcrylicStyle.cs
+++ b/osu.Game/EzOsuGame/Acrylic/EzAcrylicStyle.cs
@@ -1,0 +1,32 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.EzOsuGame.Acrylic
+{
+    /// <summary>
+    /// Acrylic glass (N) appearance constants only — tune for hot reload.
+    /// Classic chrome (M) is never half-alpha; use <see cref="UI.EzAcrylicOverlayAlpha.BindExclusive"/>.
+    /// </summary>
+    public static class EzAcrylicStyle
+    {
+        /// <summary>Cool dark veil over blurred backdrop (wedges / preview).</summary>
+        public static readonly Color4 Veil = new Color4(8 / 255f, 10 / 255f, 14 / 255f, 0.40f);
+
+        /// <summary>Full-page mod / sheared overlay veil.</summary>
+        public static readonly Color4 ModPageVeil = new Color4(6 / 255f, 8 / 255f, 12 / 255f, 0.50f);
+
+        /// <summary>Carousel panel veil — dark enough that bright song-select BGs do not wash cards.</summary>
+        public static readonly Color4 PanelVeil = new Color4(5 / 255f, 7 / 255f, 11 / 255f, 0.72f);
+
+        /// <summary>
+        /// Scheme-coloured tint on the frosted footer bar (applied to N's TintBox, not classic M).
+        /// </summary>
+        public const float FooterSchemeTintAlpha = 0.45f;
+
+        /// <summary>Downscale panel acrylic blur to limit cost with many visible cards.</summary>
+        public static readonly Vector2 PanelFrameBufferScale = new Vector2(0.5f);
+    }
+}

--- a/osu.Game/EzOsuGame/Acrylic/EzAcrylicStyle.cs
+++ b/osu.Game/EzOsuGame/Acrylic/EzAcrylicStyle.cs
@@ -21,10 +21,14 @@ namespace osu.Game.EzOsuGame.Acrylic
         /// <summary>Carousel panel veil — dark enough that bright song-select BGs do not wash cards.</summary>
         public static readonly Color4 PanelVeil = new Color4(5 / 255f, 7 / 255f, 11 / 255f, 0.72f);
 
+        /// <summary>Footer glass veil — cool dark so blur stays readable (not the same hue as solid Background5).</summary>
+        public static readonly Color4 FooterVeil = new Color4(8 / 255f, 10 / 255f, 14 / 255f, 0.50f);
+
         /// <summary>
-        /// Scheme-coloured tint on the frosted footer bar (applied to N's TintBox, not classic M).
+        /// Light scheme wash on the frosted footer TintBox. Kept low so blur is not masked
+        /// into looking like solid Background5.
         /// </summary>
-        public const float FooterSchemeTintAlpha = 0.45f;
+        public const float FooterSchemeTintAlpha = 0.22f;
 
         /// <summary>Downscale panel acrylic blur to limit cost with many visible cards.</summary>
         public static readonly Vector2 PanelFrameBufferScale = new Vector2(0.5f);

--- a/osu.Game/EzOsuGame/HUD/EzBoxElement.cs
+++ b/osu.Game/EzOsuGame/HUD/EzBoxElement.cs
@@ -6,7 +6,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Configuration;
 using osu.Game.EzOsuGame.Acrylic;
@@ -76,9 +75,6 @@ namespace osu.Game.EzOsuGame.HUD
         [Resolved(canBeNull: true)]
         private IAcrylicCaptureRegistrar? acrylicCaptureRegistrar { get; set; }
 
-        [Resolved]
-        private IRenderer renderer { get; set; } = null!;
-
         public EzBoxElement()
         {
             Size = new Vector2(400, 80);
@@ -104,7 +100,7 @@ namespace osu.Game.EzOsuGame.HUD
         {
             base.LoadComplete();
 
-            captureController = new EzAcrylicCaptureController(acrylicCaptureRegistrar, renderer, acrylicBackdrop);
+            captureController = new EzAcrylicCaptureController(acrylicCaptureRegistrar, acrylicBackdrop);
 
             BoxWidth.BindValueChanged(v => Width = v.NewValue, true);
             BoxHeight.BindValueChanged(v => Height = v.NewValue, true);

--- a/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDScoreCompareBars.cs
@@ -11,7 +11,6 @@ using osu.Framework.Extensions;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
@@ -126,9 +125,6 @@ namespace osu.Game.EzOsuGame.HUD
         [Resolved(canBeNull: true)]
         private IAcrylicCaptureRegistrar? acrylicCaptureRegistrar { get; set; }
 
-        [Resolved]
-        private IRenderer renderer { get; set; } = null!;
-
         public EzHUDScoreCompareBars()
         {
             Width = 3 * BarWidth.Value + 2 * bar_spacing + container_padding * 2;
@@ -158,7 +154,7 @@ namespace osu.Game.EzOsuGame.HUD
 
         protected override void LoadComplete()
         {
-            captureController = new EzAcrylicCaptureController(acrylicCaptureRegistrar, renderer, acrylicBackdrop);
+            captureController = new EzAcrylicCaptureController(acrylicCaptureRegistrar, acrylicBackdrop);
 
             barsContainer = new Container
             {

--- a/osu.Game/EzOsuGame/UI/EzAcrylicOverlayAlpha.cs
+++ b/osu.Game/EzOsuGame/UI/EzAcrylicOverlayAlpha.cs
@@ -1,0 +1,51 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+
+namespace osu.Game.EzOsuGame.UI
+{
+    /// <summary>
+    /// Acrylic UI switch helpers: classic M vs glass N are mutually exclusive (never half-alpha M).
+    /// </summary>
+    public static class EzAcrylicOverlayAlpha
+    {
+        /// <summary>
+        /// ON: hide classic M, show glass N. OFF: hide N, show M.
+        /// Both sides ClearTransforms so leftover fades cannot leave chrome invisible.
+        /// </summary>
+        public static void BindExclusive(Drawable classicM, Drawable glassN, Bindable<bool> acrylicEnabled)
+        {
+            acrylicEnabled.BindValueChanged(e =>
+            {
+                classicM.ClearTransforms();
+                glassN.ClearTransforms();
+
+                if (e.NewValue)
+                {
+                    classicM.Alpha = 0f;
+                    glassN.Alpha = 1f;
+                }
+                else
+                {
+                    glassN.Alpha = 0f;
+                    classicM.Alpha = 1f;
+                }
+            }, true);
+        }
+
+        /// <summary>
+        /// ON: hide classic chrome with no paired glass sibling (e.g. song-select right gradient).
+        /// OFF: restore Alpha 1.
+        /// </summary>
+        public static void BindHiddenWhenAcrylic(Drawable classicM, Bindable<bool> acrylicEnabled)
+        {
+            acrylicEnabled.BindValueChanged(e =>
+            {
+                classicM.ClearTransforms();
+                classicM.Alpha = e.NewValue ? 0f : 1f;
+            }, true);
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/UI/EzAcrylicPanelBackground.cs
+++ b/osu.Game/EzOsuGame/UI/EzAcrylicPanelBackground.cs
@@ -5,7 +5,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.EzOsuGame.Acrylic;
 using osu.Game.EzOsuGame.Configuration;
@@ -37,9 +36,6 @@ namespace osu.Game.EzOsuGame.UI
         [Resolved(canBeNull: true)]
         private IAcrylicCaptureRegistrar? acrylicCaptureRegistrar { get; set; }
 
-        [Resolved]
-        private IRenderer renderer { get; set; } = null!;
-
         public EzAcrylicPanelBackground(Color4 initialTint)
         {
             RelativeSizeAxes = Axes.Both;
@@ -66,7 +62,7 @@ namespace osu.Game.EzOsuGame.UI
             acrylicUiEnabled = ezConfig.GetBindable<bool>(Ez2Setting.AcrylicUiEnabled);
             acrylicUiBlurStrength = ezConfig.GetBindable<double>(Ez2Setting.AcrylicUiBlurStrength);
 
-            captureController = new EzAcrylicCaptureController(acrylicCaptureRegistrar, renderer, acrylicBackdrop);
+            captureController = new EzAcrylicCaptureController(acrylicCaptureRegistrar, acrylicBackdrop);
         }
 
         protected override void LoadComplete()

--- a/osu.Game/EzOsuGame/UI/EzAcrylicPanelBackground.cs
+++ b/osu.Game/EzOsuGame/UI/EzAcrylicPanelBackground.cs
@@ -14,12 +14,13 @@ using osuTK.Graphics;
 namespace osu.Game.EzOsuGame.UI
 {
     /// <summary>
-    /// 可配置穿透虚化的面板背景（Acrylic +  tint）。
+    /// Acrylic glass panel (N): blur backdrop + tint. Visibility is owned by the host via
+    /// <see cref="EzAcrylicOverlayAlpha.BindExclusive"/> (do not half-alpha classic M over this).
     /// </summary>
     public partial class EzAcrylicPanelBackground : Container, IAcrylicBackdropConsumer
     {
         /// <summary>
-        /// 宿主面板是否处于需要采样的可见状态（例如预览展开）。收起时应为 false 以释放离屏承载层引用。
+        /// Host panel is in a state that should sample capture (e.g. preview expanded).
         /// </summary>
         public bool AcrylicCaptureVisible { get; set; }
 
@@ -36,7 +37,9 @@ namespace osu.Game.EzOsuGame.UI
         [Resolved(canBeNull: true)]
         private IAcrylicCaptureRegistrar? acrylicCaptureRegistrar { get; set; }
 
-        public EzAcrylicPanelBackground(Color4 initialTint)
+        /// <param name="initialTint">Veil colour drawn over the blurred backdrop.</param>
+        /// <param name="frameBufferScale">Optional downscale for the blur pass (panels use 0.5).</param>
+        public EzAcrylicPanelBackground(Color4 initialTint, Vector2? frameBufferScale = null)
         {
             RelativeSizeAxes = Axes.Both;
 
@@ -46,7 +49,7 @@ namespace osu.Game.EzOsuGame.UI
                 {
                     RelativeSizeAxes = Axes.Both,
                     EffectEnabled = false,
-                    FrameBufferScale = Vector2.One,
+                    FrameBufferScale = frameBufferScale ?? Vector2.One,
                 },
                 TintBox = new Box
                 {

--- a/osu.Game/EzOsuGame/UI/EzSongSelectWedgeBackground.cs
+++ b/osu.Game/EzOsuGame/UI/EzSongSelectWedgeBackground.cs
@@ -4,7 +4,6 @@
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Rendering;
 using osu.Game.EzOsuGame.Acrylic;
 using osu.Game.EzOsuGame.Configuration;
 using osu.Game.Graphics;
@@ -36,9 +35,6 @@ namespace osu.Game.EzOsuGame.UI
         [Resolved(canBeNull: true)]
         private IAcrylicCaptureRegistrar? acrylicCaptureRegistrar { get; set; }
 
-        [Resolved]
-        private IRenderer renderer { get; set; } = null!;
-
         [BackgroundDependencyLoader]
         private void load(Ez2ConfigManager ezConfig)
         {
@@ -64,7 +60,7 @@ namespace osu.Game.EzOsuGame.UI
                 },
             };
 
-            captureController = new EzAcrylicCaptureController(acrylicCaptureRegistrar, renderer, acrylicBackdrop);
+            captureController = new EzAcrylicCaptureController(acrylicCaptureRegistrar, acrylicBackdrop);
         }
 
         protected override void LoadComplete()

--- a/osu.Game/EzOsuGame/UI/EzSongSelectWedgeBackground.cs
+++ b/osu.Game/EzOsuGame/UI/EzSongSelectWedgeBackground.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Shapes;
 using osu.Game.EzOsuGame.Acrylic;
 using osu.Game.EzOsuGame.Configuration;
 using osu.Game.Graphics;
@@ -13,7 +14,8 @@ using osuTK;
 namespace osu.Game.EzOsuGame.UI
 {
     /// <summary>
-    /// 选歌界面面板背景：关闭时为原版 <see cref="WedgeBackground"/>；开启时在底层叠加穿透虚化。
+    /// Song-select wedge background: OFF = classic <see cref="WedgeBackground"/> (M);
+    /// ON = blur + dark veil (N), classic wedge fully hidden.
     /// </summary>
     public partial class EzSongSelectWedgeBackground : InputBlockingContainer, IAcrylicBackdropConsumer
     {
@@ -26,6 +28,7 @@ namespace osu.Game.EzOsuGame.UI
         public bool WantsAcrylicCapture => acrylicUiEnabled?.Value ?? false;
 
         private AcrylicBackdropDrawable acrylicBackdrop = null!;
+        private Box darkVeil = null!;
         private WedgeBackground wedgeBackground = null!;
         private EzAcrylicCaptureController? captureController;
 
@@ -51,6 +54,12 @@ namespace osu.Game.EzOsuGame.UI
                     EffectEnabled = false,
                     FrameBufferScale = Vector2.One,
                 },
+                darkVeil = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = EzAcrylicStyle.Veil,
+                    Alpha = 0,
+                },
                 wedgeBackground = new WedgeBackground
                 {
                     RelativeSizeAxes = Axes.Both,
@@ -67,6 +76,8 @@ namespace osu.Game.EzOsuGame.UI
         {
             base.LoadComplete();
 
+            // N = blur (via Sync) + darkVeil; M = classic wedgeBackground.
+            EzAcrylicOverlayAlpha.BindExclusive(wedgeBackground, darkVeil, acrylicUiEnabled);
             acrylicUiEnabled.BindValueChanged(_ => syncAcrylicState(), true);
             acrylicUiBlurStrength.BindValueChanged(_ => syncAcrylicState(), true);
         }

--- a/osu.Game/Graphics/Carousel/Carousel.cs
+++ b/osu.Game/Graphics/Carousel/Carousel.cs
@@ -1168,6 +1168,11 @@ namespace osu.Game.Graphics.Carousel
             carouselPanel.Expanded.Value = false;
         }
 
+        /// <summary>
+        /// Force <see cref="refreshAfterSelection"/> so panel Y positions recompute (e.g. spacing policy change).
+        /// </summary>
+        protected void InvalidateSelectionLayout() => selectionValid.Invalidate();
+
         protected override bool OnInvalidate(Invalidation invalidation, InvalidationSource source)
         {
             // handles the vertical size of the carousel changing (ie. on window resize when aspect ratio has changed).

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1166,31 +1166,41 @@ namespace osu.Game
                             Children = new Drawable[]
                             {
                                 backReceptor = new ScreenFooter.BackReceptor(),
+                                // Footer / Mod overlays sit outside ScreenStack but must share the same
+                                // offscreen buffer so AcrylicBackdropDrawable can sample song-select chrome.
                                 acrylicCaptureScope = new AcrylicCaptureScope(screenCaptureContent = new Container
                                 {
                                     RelativeSizeAxes = Axes.Both,
-                                    Child = ScreenStack = new OsuScreenStack { RelativeSizeAxes = Axes.Both },
-                                }),
-                                logoContainer = new Container { RelativeSizeAxes = Axes.Both },
-                                // TODO: what is this? why is this?
-                                // TODO: this is being screen scaled even though it's probably AN OVERLAY.
-                                footerBasedOverlayContent = new Container
-                                {
-                                    Depth = -1,
-                                    RelativeSizeAxes = Axes.Both,
-                                },
-                                new PopoverContainer
-                                {
-                                    // Ensure the footer is displayed above any content and/or overlays.
-                                    Depth = -1,
-                                    RelativeSizeAxes = Axes.Both,
-                                    Child = screenStackFooter = new ScreenStackFooter(ScreenStack, backReceptor)
+                                    Children = new Drawable[]
                                     {
-                                        // TODO: this is really really weird and should not exist.
-                                        RequestLogoInFront = inFront => ScreenContainer.ChangeChildDepth(logoContainer, inFront ? float.MinValue : 0),
-                                        BackButtonPressed = handleBackButton
-                                    },
-                                },
+                                        ScreenStack = new OsuScreenStack
+                                        {
+                                            RelativeSizeAxes = Axes.Both,
+                                            // Behind logo / footer overlays inside the capture buffer.
+                                            Depth = 1,
+                                        },
+                                        logoContainer = new Container { RelativeSizeAxes = Axes.Both },
+                                        // TODO: what is this? why is this?
+                                        // TODO: this is being screen scaled even though it's probably AN OVERLAY.
+                                        footerBasedOverlayContent = new Container
+                                        {
+                                            Depth = -1,
+                                            RelativeSizeAxes = Axes.Both,
+                                        },
+                                        new PopoverContainer
+                                        {
+                                            // Ensure the footer is displayed above any content and/or overlays.
+                                            Depth = -1,
+                                            RelativeSizeAxes = Axes.Both,
+                                            Child = screenStackFooter = new ScreenStackFooter(ScreenStack, backReceptor)
+                                            {
+                                                // TODO: this is really really weird and should not exist.
+                                                RequestLogoInFront = inFront => screenCaptureContent.ChangeChildDepth(logoContainer, inFront ? float.MinValue : 0),
+                                                BackButtonPressed = handleBackButton
+                                            },
+                                        },
+                                    }
+                                }),
                             }
                         },
                     }
@@ -1292,7 +1302,8 @@ namespace osu.Game
             loadComponentSingleFile(ezLocalProfile = new EzLocalProfileOverlay(), overlayContent.Add, true);
             loadComponentSingleFile(beatmapSetOverlay = new BeatmapSetOverlay(), overlayContent.Add, true);
             loadComponentSingleFile(wikiOverlay = new WikiOverlay(), overlayContent.Add, true);
-            loadComponentSingleFile(ezLayoutLayer = new EzLayoutLayer(), screenCaptureContent.Add, true);
+            // Above screens, below logo / footer / sheared overlays (higher Depth = further back).
+            loadComponentSingleFile(ezLayoutLayer = new EzLayoutLayer { Depth = 0.5f }, screenCaptureContent.Add, true);
             loadComponentSingleFile(skinEditor = new SkinEditorOverlay(ScreenContainer), overlayContent.Add, true);
             loadComponentSingleFile(ezLayoutEditor = new EzLayoutEditorOverlay(ScreenContainer, ezLayoutLayer), topMostOverlayContent.Add, true);
 

--- a/osu.Game/Overlays/Mods/ShearedOverlayContainer.cs
+++ b/osu.Game/Overlays/Mods/ShearedOverlayContainer.cs
@@ -8,6 +8,9 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
+using osu.Game.EzOsuGame.Acrylic;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.UI;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Screens.Footer;
@@ -70,17 +73,33 @@ namespace osu.Game.Overlays.Mods
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(Ez2ConfigManager ezConfig)
         {
+            var acrylicUiEnabled = ezConfig.GetBindable<bool>(Ez2Setting.AcrylicUiEnabled);
+
+            Box pageDim;
+            EzAcrylicPanelBackground pageAcrylic;
+
             Child = TopLevelContent = new Container
             {
                 RelativeSizeAxes = Axes.Both,
                 Children = new Drawable[]
                 {
-                    new Box
+                    new Container
                     {
                         RelativeSizeAxes = Axes.Both,
-                        Colour = ColourProvider.Background6.Opacity(0.75f),
+                        Children = new Drawable[]
+                        {
+                            pageAcrylic = new EzAcrylicPanelBackground(EzAcrylicStyle.ModPageVeil)
+                            {
+                                AcrylicCaptureVisible = true,
+                            },
+                            pageDim = new Box
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Colour = ColourProvider.Background6.Opacity(0.75f),
+                            },
+                        }
                     },
                     Header = new ShearedOverlayHeader
                     {
@@ -100,6 +119,8 @@ namespace osu.Game.Overlays.Mods
                     },
                 }
             };
+
+            EzAcrylicOverlayAlpha.BindExclusive(pageDim, pageAcrylic, acrylicUiEnabled);
         }
 
         public VisibilityContainer? DisplayedFooterContent { get; private set; }

--- a/osu.Game/Screens/Footer/ScreenFooter.cs
+++ b/osu.Game/Screens/Footer/ScreenFooter.cs
@@ -6,13 +6,14 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Threading;
 using osu.Game.EzOsuGame.Acrylic;
 using osu.Game.EzOsuGame.Configuration;
@@ -54,6 +55,7 @@ namespace osu.Game.Screens.Footer
 
         private Box background = null!;
         private EzAcrylicPanelBackground footerAcrylic = null!;
+        private Bindable<bool> acrylicUiEnabled = null!;
         private FillFlowContainer<ScreenFooterButton> buttonsFlow = null!;
         private Container overlayContentContainer = null!;
         private Container<ScreenFooterButton> hiddenButtonsContainer = null!;
@@ -85,7 +87,7 @@ namespace osu.Game.Screens.Footer
         [BackgroundDependencyLoader]
         private void load(Ez2ConfigManager ezConfig)
         {
-            var acrylicUiEnabled = ezConfig.GetBindable<bool>(Ez2Setting.AcrylicUiEnabled);
+            acrylicUiEnabled = ezConfig.GetBindable<bool>(Ez2Setting.AcrylicUiEnabled);
 
             InternalChildren = new Drawable[]
             {
@@ -94,8 +96,8 @@ namespace osu.Game.Screens.Footer
                     RelativeSizeAxes = Axes.Both,
                     Children = new Drawable[]
                     {
-                        // N: frosted glass with scheme-coloured tint.
-                        footerAcrylic = new EzAcrylicPanelBackground(colourProvider.Background5.Opacity(EzAcrylicStyle.FooterSchemeTintAlpha))
+                        // N: frosted glass — cool FooterVeil so blur reads (not same hue as solid M).
+                        footerAcrylic = new EzAcrylicPanelBackground(EzAcrylicStyle.FooterVeil)
                         {
                             AcrylicCaptureVisible = true,
                         },
@@ -165,6 +167,11 @@ namespace osu.Game.Screens.Footer
                     f.Position = new Vector2(-76, -36);
                 })),
             };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
 
             // ON: hide M, show N. OFF: hide N, show M.
             EzAcrylicOverlayAlpha.BindExclusive(background, footerAcrylic, acrylicUiEnabled);
@@ -356,6 +363,7 @@ namespace osu.Game.Screens.Footer
             colourProvider.ChangeColourScheme(hue);
 
             background.FadeColour(colourProvider.Background5, 150, Easing.OutQuint);
+            // Light scheme wash only — keep frost readable (do not retint to opaque Background5).
             footerAcrylic.TintBox.FadeColour(colourProvider.Background5.Opacity(EzAcrylicStyle.FooterSchemeTintAlpha), 150, Easing.OutQuint);
 
             foreach (var button in buttonsFlow)

--- a/osu.Game/Screens/Footer/ScreenFooter.cs
+++ b/osu.Game/Screens/Footer/ScreenFooter.cs
@@ -12,7 +12,11 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Threading;
+using osu.Game.EzOsuGame.Acrylic;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.UI;
 using osu.Game.Graphics.Containers;
 using osu.Game.Input.Bindings;
 using osu.Game.Overlays;
@@ -49,6 +53,7 @@ namespace osu.Game.Screens.Footer
         private readonly List<OverlayContainer> overlays = new List<OverlayContainer>();
 
         private Box background = null!;
+        private EzAcrylicPanelBackground footerAcrylic = null!;
         private FillFlowContainer<ScreenFooterButton> buttonsFlow = null!;
         private Container overlayContentContainer = null!;
         private Container<ScreenFooterButton> hiddenButtonsContainer = null!;
@@ -78,14 +83,29 @@ namespace osu.Game.Screens.Footer
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(Ez2ConfigManager ezConfig)
         {
+            var acrylicUiEnabled = ezConfig.GetBindable<bool>(Ez2Setting.AcrylicUiEnabled);
+
             InternalChildren = new Drawable[]
             {
-                background = new Box
+                new Container
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = colourProvider.Background5
+                    Children = new Drawable[]
+                    {
+                        // N: frosted glass with scheme-coloured tint.
+                        footerAcrylic = new EzAcrylicPanelBackground(colourProvider.Background5.Opacity(EzAcrylicStyle.FooterSchemeTintAlpha))
+                        {
+                            AcrylicCaptureVisible = true,
+                        },
+                        // M: classic solid fill.
+                        background = new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = colourProvider.Background5
+                        },
+                    }
                 },
                 new GridContainer
                 {
@@ -145,6 +165,9 @@ namespace osu.Game.Screens.Footer
                     f.Position = new Vector2(-76, -36);
                 })),
             };
+
+            // ON: hide M, show N. OFF: hide N, show M.
+            EzAcrylicOverlayAlpha.BindExclusive(background, footerAcrylic, acrylicUiEnabled);
         }
 
         private ScheduledDelegate? changeLogoDepthDelegate;
@@ -333,6 +356,7 @@ namespace osu.Game.Screens.Footer
             colourProvider.ChangeColourScheme(hue);
 
             background.FadeColour(colourProvider.Background5, 150, Easing.OutQuint);
+            footerAcrylic.TintBox.FadeColour(colourProvider.Background5.Opacity(EzAcrylicStyle.FooterSchemeTintAlpha), 150, Easing.OutQuint);
 
             foreach (var button in buttonsFlow)
                 button.UpdateDisplay();

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -62,6 +62,7 @@ namespace osu.Game.Screens.Select
         private IBindableList<BeatmapSetInfo> detachedBeatmaps = null!;
         private Bindable<bool> ezAnalysisFilter = null!;
         private Bindable<bool> ezAnalysisSqliteEnabled = null!; // PP 等 sqlite 消费端；不 gate xxy SR
+        private Bindable<bool> acrylicUiEnabled = null!;
         private IBindable<int> activeSongsBranchVersion = null!;
         private readonly AsyncLocal<Dictionary<Guid, double>?> operationDifficultyCache = new AsyncLocal<Dictionary<Guid, double>?>();
         private readonly AsyncLocal<Dictionary<Guid, double>?> operationPpCache = new AsyncLocal<Dictionary<Guid, double>?>();
@@ -122,7 +123,8 @@ namespace osu.Game.Screens.Select
                     return SPACING * 2;
             }
 
-            return -SPACING;
+            // Ez: acrylic uses a hairline gap; classic overlapping -SPACING when acrylic is off.
+            return acrylicUiEnabled is { Value: true } ? 1f : -SPACING;
         }
 
         public BeatmapCarousel()
@@ -174,6 +176,7 @@ namespace osu.Game.Screens.Select
             loadSamples(audio);
             ezAnalysisFilter = ezConfig.GetBindable<bool>(Ez2Setting.EzAnalysisFilter);
             ezAnalysisSqliteEnabled = ezConfig.GetBindable<bool>(Ez2Setting.EzAnalysisSqliteEnabled);
+            acrylicUiEnabled = ezConfig.GetBindable<bool>(Ez2Setting.AcrylicUiEnabled);
             config.BindWith(OsuSetting.RandomSelectAlgorithm, randomAlgorithm);
         }
 
@@ -298,6 +301,8 @@ namespace osu.Game.Screens.Select
         {
             base.LoadComplete();
             detachedBeatmaps.BindCollectionChanged(beatmapSetsChanged, true);
+
+            acrylicUiEnabled.BindValueChanged(_ => InvalidateSelectionLayout());
 
             activeSongsBranchVersion = ezAnalysisCache.ActiveSongsBranchVersion.GetBoundCopy();
             activeSongsBranchVersion.BindValueChanged(_ =>

--- a/osu.Game/Screens/Select/BeatmapTitleWedge.DifficultyDisplay.cs
+++ b/osu.Game/Screens/Select/BeatmapTitleWedge.DifficultyDisplay.cs
@@ -20,6 +20,7 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.EzOsuGame.Analysis;
 using osu.Game.EzOsuGame.Beatmaps;
+using osu.Game.EzOsuGame.UI;
 using osu.Game.EzOsuGame.UserInterface;
 using osu.Game.Localisation;
 using osu.Game.Online;
@@ -83,7 +84,7 @@ namespace osu.Game.Screens.Select
 
                 InternalChildren = new Drawable[]
                 {
-                    new WedgeBackground(),
+                    new EzSongSelectWedgeBackground(),
                     new FillFlowContainer
                     {
                         RelativeSizeAxes = Axes.X,

--- a/osu.Game/Screens/Select/Panel.cs
+++ b/osu.Game/Screens/Select/Panel.cs
@@ -20,6 +20,9 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Carousel;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.EzOsuGame.Acrylic;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.UI;
 using osu.Game.Overlays;
 using osuTK;
 using osuTK.Graphics;
@@ -45,6 +48,13 @@ namespace osu.Game.Screens.Select
         private Drawable keyboardSelectionLayer = null!;
 
         private PulsatingBox selectionLayer = null!;
+        private SelectionGlowPulser selectionGlowPulser = null!;
+
+        /// <summary>
+        /// Full-bleed acrylic glass (N). Visibility is driven by <see cref="acrylicUiEnabled"/>;
+        /// subclasses hide classic colour overlays via <see cref="EzAcrylicOverlayAlpha.BindHiddenWhenAcrylic"/>.
+        /// </summary>
+        protected EzAcrylicPanelBackground PanelGlass { get; private set; } = null!;
 
         public Container TopLevelContent { get; private set; } = null!;
 
@@ -96,9 +106,12 @@ namespace osu.Game.Screens.Select
         [Resolved]
         private BeatmapCarousel? carousel { get; set; }
 
+        private Bindable<bool> acrylicUiEnabled = null!;
+
         [BackgroundDependencyLoader]
-        private void load(OverlayColourProvider colourProvider, OsuColour colours)
+        private void load(OverlayColourProvider colourProvider, OsuColour colours, Ez2ConfigManager ezConfig)
         {
+            acrylicUiEnabled = ezConfig.GetBindable<bool>(Ez2Setting.AcrylicUiEnabled);
             Anchor = Anchor.TopRight;
             Origin = Anchor.TopRight;
 
@@ -113,6 +126,13 @@ namespace osu.Game.Screens.Select
                 X = CORNER_RADIUS,
                 Children = new[]
                 {
+                    // Full-bleed under accent strip + Content so Content's left corner radius
+                    // reveals the same glass (no (| crescent seam against a strip-only background).
+                    PanelGlass = new EzAcrylicPanelBackground(EzAcrylicStyle.PanelVeil, EzAcrylicStyle.PanelFrameBufferScale)
+                    {
+                        AcrylicCaptureVisible = true,
+                        Alpha = 0,
+                    },
                     backgroundContainer = new Container
                     {
                         RelativeSizeAxes = Axes.Both,
@@ -149,6 +169,10 @@ namespace osu.Game.Screens.Select
                         Anchor = Anchor.TopRight,
                         Origin = Anchor.TopRight,
                     },
+                    selectionGlowPulser = new SelectionGlowPulser
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    },
                     keyboardSelectionLayer = new Box
                     {
                         Alpha = 0,
@@ -166,6 +190,11 @@ namespace osu.Game.Screens.Select
                     new HoverSounds(),
                 }
             };
+
+            selectionGlowPulser.GlowTarget = TopLevelContent;
+            selectionGlowPulser.GetGlowColour = () => accentColour ?? Color4Extensions.FromHex(@"4EBFFF");
+            // Acrylic-only outer glow pulse; classic UI uses PulsatingBox instead.
+            selectionGlowPulser.ShouldPulse = () => acrylicUiEnabled.Value && (Expanded.Value || Selected.Value);
         }
 
         public partial class PulsatingBox : BeatSyncedContainer
@@ -206,6 +235,48 @@ namespace osu.Game.Screens.Select
             }
         }
 
+        /// <summary>
+        /// BPM-syncs an outer glow on <see cref="GlowTarget"/> (acrylic selection feedback).
+        /// </summary>
+        public partial class SelectionGlowPulser : BeatSyncedContainer
+        {
+            public int FlashOffset;
+
+            public Container GlowTarget { get; set; } = null!;
+
+            public Func<Color4>? GetGlowColour { get; set; }
+
+            public Func<bool>? ShouldPulse { get; set; }
+
+            public SelectionGlowPulser()
+            {
+                EarlyActivationMilliseconds = 40;
+            }
+
+            protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, ChannelAmplitudes amplitudes)
+            {
+                base.OnNewBeat(beatIndex, timingPoint, effectPoint, amplitudes);
+
+                if (ShouldPulse?.Invoke() != true)
+                    return;
+
+                if (beatIndex % Math.Pow(2, FlashOffset) != 0)
+                    return;
+
+                double length = timingPoint.BeatLength;
+
+                while (length < 250)
+                    length *= 2;
+
+                var colour = GetGlowColour?.Invoke() ?? Color4.White;
+
+                GlowTarget
+                    .FadeEdgeEffectTo(colour.Opacity(0.25f), 40, Easing.Out)
+                    .Then()
+                    .FadeEdgeEffectTo(colour.Opacity(0.4f), length, Easing.Out);
+            }
+        }
+
         protected override void LoadComplete()
         {
             base.LoadComplete();
@@ -235,6 +306,14 @@ namespace osu.Game.Screens.Select
 
                 updateXOffset();
             }, true);
+
+            // ON: show glass N. OFF: hide N. Classic overlays are hidden separately per-subclass.
+            acrylicUiEnabled.BindValueChanged(e =>
+            {
+                PanelGlass.ClearTransforms();
+                PanelGlass.Alpha = e.NewValue ? 1f : 0f;
+                updateSelectedState(animated: false);
+            }, true);
         }
 
         protected override void PrepareForUse()
@@ -244,6 +323,7 @@ namespace osu.Game.Screens.Select
             // Slightly offset the flash animation based on the panel depth.
             // This assumes a minimum depth of -2 (groups).
             selectionLayer.FlashOffset = -Item!.DepthLayer;
+            selectionGlowPulser.FlashOffset = -Item!.DepthLayer;
 
             updateAccentColour();
 
@@ -286,35 +366,63 @@ namespace osu.Game.Screens.Select
         private void updateSelectedState(bool animated = true)
         {
             bool selectedOrExpanded = Expanded.Value || Selected.Value;
+            double duration = animated ? DURATION : 0;
 
-            var edgeEffectColour = accentColour ?? Color4Extensions.FromHex(@"4EBFFF");
-
-            if (selectedOrExpanded)
+            if (acrylicUiEnabled.Value)
             {
-                TopLevelContent.EdgeEffect = new EdgeEffectParameters
+                // Acrylic: hollow outer glow on selection; no drop shadows (they flicker on blur).
+                selectionLayer.FadeOut(animated ? 200 : 0, Easing.OutQuint);
+
+                if (selectedOrExpanded)
                 {
-                    Type = EdgeEffectType.Shadow,
-                    Radius = 2f,
-                    Hollow = true,
-                };
+                    TopLevelContent.EdgeEffect = new EdgeEffectParameters
+                    {
+                        Type = EdgeEffectType.Glow,
+                        Radius = 3,
+                        Roundness = 1f,
+                        Hollow = true,
+                    };
+                    var edgeEffectColour = accentColour ?? Color4Extensions.FromHex(@"4EBFFF");
+                    TopLevelContent.FadeEdgeEffectTo(edgeEffectColour.Opacity(0.5f), duration, Easing.OutQuint);
+                }
+                else
+                {
+                    TopLevelContent.EdgeEffect = new EdgeEffectParameters();
+                    TopLevelContent.FadeEdgeEffectTo(Color4.Transparent, duration, Easing.OutQuint);
+                }
             }
             else
             {
-                TopLevelContent.EdgeEffect = new EdgeEffectParameters
+                // Classic: right-edge BPM flash + coloured/drop shadows.
+                var edgeEffectColour = accentColour ?? Color4Extensions.FromHex(@"4EBFFF");
+
+                if (selectedOrExpanded)
                 {
-                    Type = EdgeEffectType.Shadow,
-                    Radius = 4f,
-                    Hollow = true,
-                    Offset = new Vector2(0f, 1f),
-                };
+                    TopLevelContent.EdgeEffect = new EdgeEffectParameters
+                    {
+                        Type = EdgeEffectType.Shadow,
+                        Radius = 2f,
+                        Hollow = true,
+                    };
+                }
+                else
+                {
+                    TopLevelContent.EdgeEffect = new EdgeEffectParameters
+                    {
+                        Type = EdgeEffectType.Shadow,
+                        Radius = 4f,
+                        Hollow = true,
+                        Offset = new Vector2(0f, 1f),
+                    };
+                }
+
+                TopLevelContent.FadeEdgeEffectTo(selectedOrExpanded ? edgeEffectColour.Opacity(0.8f) : Color4.Black.Opacity(0.2f), duration, Easing.OutQuint);
+
+                if (selectedOrExpanded)
+                    selectionLayer.FadeIn(100, Easing.OutQuint);
+                else
+                    selectionLayer.FadeOut(200, Easing.OutQuint);
             }
-
-            TopLevelContent.FadeEdgeEffectTo(selectedOrExpanded ? edgeEffectColour.Opacity(0.8f) : Color4.Black.Opacity(0.2f), animated ? DURATION : 0, Easing.OutQuint);
-
-            if (selectedOrExpanded)
-                selectionLayer.FadeIn(100, Easing.OutQuint);
-            else
-                selectionLayer.FadeOut(200, Easing.OutQuint);
         }
 
         private void updateXOffset(bool animated = true)
@@ -351,6 +459,31 @@ namespace osu.Game.Screens.Select
         {
             base.Update();
             contentPaddingContainer.Padding = contentPaddingContainer.Padding with { Left = iconContainer.DrawWidth };
+        }
+
+        /// <summary>
+        /// Under acrylic, keep an accent column that fades rightward into the frosted card so the
+        /// icon-strip join and Content corner radius do not read as a hard seam.
+        /// </summary>
+        protected void ApplyAcrylicIconStripBackground(Box background, bool acrylicEnabled, Color4 stripColour)
+        {
+            if (acrylicEnabled)
+            {
+                background.RelativeSizeAxes = Axes.Y;
+                background.Height = 1;
+                background.Width = Math.Max(iconContainer.DrawWidth, 1f) + CORNER_RADIUS;
+                background.Colour = ColourInfo.GradientHorizontal(stripColour.Opacity(0.8f), stripColour.Opacity(0).Darken(0.8f));
+            }
+            else
+            {
+                if (background.RelativeSizeAxes != Axes.Both)
+                {
+                    background.RelativeSizeAxes = Axes.Both;
+                    background.Width = 1;
+                }
+
+                background.Colour = stripColour;
+            }
         }
 
         public abstract MenuItem[]? ContextMenuItems { get; }
@@ -390,6 +523,11 @@ namespace osu.Game.Screens.Select
 
         public virtual void Activated()
         {
+            // Under acrylic, keep selection feedback to the hollow outer rim only —
+            // a full-panel white flash reads as the whole card brightening.
+            if (acrylicUiEnabled.Value)
+                return;
+
             activationFlash.FadeOutFromOne(1000, Easing.OutQuint);
         }
 

--- a/osu.Game/Screens/Select/PanelBeatmap.cs
+++ b/osu.Game/Screens/Select/PanelBeatmap.cs
@@ -27,6 +27,7 @@ using osu.Game.Configuration;
 using osu.Game.EzOsuGame.Analysis;
 using osu.Game.EzOsuGame.Beatmaps;
 using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.UI;
 using osu.Game.Screens.Select.Filter;
 using osu.Game.EzOsuGame.UserInterface;
 using osu.Game.Overlays;
@@ -68,6 +69,8 @@ namespace osu.Game.Screens.Select
         private CancellationTokenSource? ezAnalysisCancellationSource;
 
         private string? scratchText;
+
+        private Bindable<bool> acrylicUiEnabled = null!;
 
         [Resolved]
         private Ez2ConfigManager ezConfig { get; set; } = null!;
@@ -125,23 +128,33 @@ namespace osu.Game.Screens.Select
                 RelativeSizeAxes = Axes.Both,
             };
 
+            acrylicUiEnabled = ezConfig.GetBindable<bool>(Ez2Setting.AcrylicUiEnabled);
+            Container colourOverlays;
+
             Content.Children = new Drawable[]
             {
-                new Box
+                colourOverlays = new Container
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = ColourInfo.GradientHorizontal(colourProvider.Background3, colourProvider.Background4),
-                },
-                backgroundDifficultyTint = new Box
-                {
-                    RelativeSizeAxes = Axes.Both,
-                },
-                triangles = new TrianglesV2
-                {
-                    ScaleAdjust = 1.2f,
-                    Thickness = 0.01f,
-                    Velocity = 0.3f,
-                    RelativeSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = ColourInfo.GradientHorizontal(colourProvider.Background3, colourProvider.Background4),
+                        },
+                        backgroundDifficultyTint = new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                        },
+                        triangles = new TrianglesV2
+                        {
+                            ScaleAdjust = 1.2f,
+                            Thickness = 0.01f,
+                            Velocity = 0.3f,
+                            RelativeSizeAxes = Axes.Both,
+                        },
+                    }
                 },
                 new FillFlowContainer
                 {
@@ -265,6 +278,9 @@ namespace osu.Game.Screens.Select
                     }
                 }
             };
+
+            // Glass N lives on Panel; hide classic M overlays when acrylic is on.
+            EzAcrylicOverlayAlpha.BindHiddenWhenAcrylic(colourOverlays, acrylicUiEnabled);
         }
 
         protected override void LoadComplete()
@@ -516,12 +532,13 @@ namespace osu.Game.Screens.Select
                 starCounter.Colour = starColour;
 
             if (AccentColour != diffColour)
-            {
                 AccentColour = diffColour;
 
-                backgroundBorder.Colour = diffColour;
-                backgroundDifficultyTint.Colour = ColourInfo.GradientHorizontal(diffColour.Opacity(0.25f), diffColour.Opacity(0f));
+            ApplyAcrylicIconStripBackground(backgroundBorder, acrylicUiEnabled.Value, diffColour);
 
+            if (!acrylicUiEnabled.Value)
+            {
+                backgroundDifficultyTint.Colour = ColourInfo.GradientHorizontal(diffColour.Opacity(0.25f), diffColour.Opacity(0f));
                 triangles.Colour = ColourInfo.GradientVertical(diffColour.Opacity(0.25f), diffColour.Opacity(0f));
             }
 

--- a/osu.Game/Screens/Select/PanelBeatmapSet.cs
+++ b/osu.Game/Screens/Select/PanelBeatmapSet.cs
@@ -27,6 +27,7 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
 using osu.Game.Online.API;
 using osu.Game.Overlays;
+using osu.Game.EzOsuGame.Configuration;
 using osu.Game.Rulesets;
 using osuTK;
 using osuTK.Graphics;
@@ -53,6 +54,11 @@ namespace osu.Game.Screens.Select
 
         [Resolved]
         private OverlayColourProvider colourProvider { get; set; } = null!;
+
+        [Resolved]
+        private Ez2ConfigManager ezConfig { get; set; } = null!;
+
+        private Bindable<bool> acrylicUiEnabled = null!;
 
         [Resolved]
         private BeatmapSetOverlay? beatmapOverlay { get; set; }
@@ -90,6 +96,8 @@ namespace osu.Game.Screens.Select
         private void load()
         {
             Height = HEIGHT;
+
+            acrylicUiEnabled = ezConfig.GetBindable<bool>(Ez2Setting.AcrylicUiEnabled);
 
             Icon = chevronIcon = new Container
             {
@@ -171,20 +179,49 @@ namespace osu.Game.Screens.Select
             base.LoadComplete();
 
             Expanded.BindValueChanged(_ => onExpanded(), true);
+            acrylicUiEnabled.BindValueChanged(_ => onExpanded());
             KeyboardSelected.BindValueChanged(k => KeyboardSelected.Value = k.NewValue, true);
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            // Keep accent strip width in sync while the chevron icon animates open/closed.
+            if (acrylicUiEnabled.Value)
+                ApplyAcrylicIconStripBackground(chevronBackground, true, colourProvider.Highlight1);
         }
 
         private void onExpanded()
         {
+            bool acrylic = acrylicUiEnabled.Value;
+
+            // Cancel size/alpha fades before retargeting — a FadeIn started while still full-bleed white
+            // is what washed the whole set card under acrylic.
+            chevronBackground.ClearTransforms();
+
+            if (acrylic)
+            {
+                ApplyAcrylicIconStripBackground(chevronBackground, true, colourProvider.Highlight1);
+                chevronBackground.Alpha = Expanded.Value ? 1f : 0f;
+            }
+            else
+            {
+                ApplyAcrylicIconStripBackground(chevronBackground, false, Color4.White);
+
+                if (Expanded.Value)
+                    chevronBackground.FadeIn(DURATION / 2, Easing.OutQuint);
+                else
+                    chevronBackground.FadeOut(DURATION, Easing.OutQuint);
+            }
+
             if (Expanded.Value)
             {
-                chevronBackground.FadeIn(DURATION / 2, Easing.OutQuint);
                 chevronIcon.ResizeWidthTo(18, DURATION * 1.5f, Easing.OutElasticQuarter);
                 chevronIcon.FadeTo(1f, DURATION, Easing.OutQuint);
             }
             else
             {
-                chevronBackground.FadeOut(DURATION, Easing.OutQuint);
                 chevronIcon.ResizeWidthTo(0f, DURATION, Easing.OutQuint);
                 chevronIcon.FadeTo(0f, DURATION, Easing.OutQuint);
             }

--- a/osu.Game/Screens/Select/PanelBeatmapStandalone.cs
+++ b/osu.Game/Screens/Select/PanelBeatmapStandalone.cs
@@ -22,6 +22,8 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.EzOsuGame.Analysis;
 using osu.Game.EzOsuGame.Beatmaps;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.UI;
 using osu.Game.EzOsuGame.UserInterface;
 using osu.Game.Overlays;
 using osu.Game.Resources.Localisation.Web;
@@ -60,6 +62,9 @@ namespace osu.Game.Screens.Select
         #region Ez功能
 
         [Resolved]
+        private Ez2ConfigManager ezConfig { get; set; } = null!;
+
+        [Resolved]
         private EzAnalysisCache ezAnalysisCache { get; set; } = null!;
 
         [Resolved]
@@ -75,6 +80,8 @@ namespace osu.Game.Screens.Select
         private CancellationTokenSource? ezAnalysisCancellationSource;
 
         private string? scratchText;
+
+        private Bindable<bool> acrylicUiEnabled = null!;
 
         private bool supportsEzAnalysis => EzAnalysisProviderBridge.HasAnalysisProvider(ruleset.Value);
 
@@ -114,6 +121,8 @@ namespace osu.Game.Screens.Select
         private void load()
         {
             Height = HEIGHT;
+
+            acrylicUiEnabled = ezConfig.GetBindable<bool>(Ez2Setting.AcrylicUiEnabled);
 
             Icon = difficultyIcon = new ConstrainedIconContainer
             {
@@ -273,6 +282,9 @@ namespace osu.Game.Screens.Select
                     }
                 }
             };
+
+            // Cover art is skipped under acrylic; the dim layer is only useful over panel sprites.
+            EzAcrylicOverlayAlpha.BindHiddenWhenAcrylic(backgroundDim, acrylicUiEnabled);
         }
 
         protected override void LoadComplete()
@@ -514,7 +526,7 @@ namespace osu.Game.Screens.Select
             AccentColour = diffColour;
             // spreadDisplay.Current.Colour = starColour;
 
-            backgroundBorder.Colour = diffColour;
+            ApplyAcrylicIconStripBackground(backgroundBorder, acrylicUiEnabled.Value, diffColour);
             difficultyIcon.Colour = starRatingDisplay.DisplayedDifficultyTextColour;
         }
 

--- a/osu.Game/Screens/Select/PanelGroup.cs
+++ b/osu.Game/Screens/Select/PanelGroup.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
@@ -17,6 +18,8 @@ using osu.Game.Graphics.Backgrounds;
 using osu.Game.Graphics.Carousel;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.UI;
 using osu.Game.Overlays;
 using osuTK;
 using osuTK.Graphics;
@@ -38,10 +41,18 @@ namespace osu.Game.Screens.Select
         [Resolved]
         private OverlayColourProvider colourProvider { get; set; } = null!;
 
+        [Resolved]
+        private Ez2ConfigManager ezConfig { get; set; } = null!;
+
+        private Bindable<bool> acrylicUiEnabled = null!;
+        private Box backgroundBorder = null!;
+
         [BackgroundDependencyLoader]
         private void load()
         {
             Height = HEIGHT;
+
+            acrylicUiEnabled = ezConfig.GetBindable<bool>(Ez2Setting.AcrylicUiEnabled);
 
             Icon = iconContainer = new Container
             {
@@ -58,32 +69,42 @@ namespace osu.Game.Screens.Select
                 },
             };
 
-            Background = new Box
+            Background = backgroundBorder = new Box
             {
                 RelativeSizeAxes = Axes.Both,
                 Colour = colourProvider.Highlight1,
             };
 
             AccentColour = colourProvider.Highlight1;
+
+            Container colourOverlays;
+
             Content.Children = new Drawable[]
             {
-                new Box
+                colourOverlays = new Container
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = colourProvider.Background5,
-                },
-                triangles = new TrianglesV2
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Thickness = 0.02f,
-                    SpawnRatio = 0.6f,
-                    Colour = ColourInfo.GradientHorizontal(colourProvider.Background6, colourProvider.Background5)
-                },
-                glow = new Box
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Width = 0.5f,
-                    Colour = ColourInfo.GradientHorizontal(colourProvider.Highlight1, colourProvider.Highlight1.Opacity(0f)),
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = colourProvider.Background5,
+                        },
+                        triangles = new TrianglesV2
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Thickness = 0.02f,
+                            SpawnRatio = 0.6f,
+                            Colour = ColourInfo.GradientHorizontal(colourProvider.Background6, colourProvider.Background5)
+                        },
+                        glow = new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Width = 0.5f,
+                            Colour = ColourInfo.GradientHorizontal(colourProvider.Highlight1, colourProvider.Highlight1.Opacity(0f)),
+                        },
+                    }
                 },
                 titleText = new OsuSpriteText
                 {
@@ -117,6 +138,8 @@ namespace osu.Game.Screens.Select
                     },
                 },
             };
+
+            EzAcrylicOverlayAlpha.BindHiddenWhenAcrylic(colourOverlays, acrylicUiEnabled);
         }
 
         protected override void LoadComplete()
@@ -124,6 +147,13 @@ namespace osu.Game.Screens.Select
             base.LoadComplete();
 
             Expanded.BindValueChanged(_ => onExpanded(), true);
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            ApplyAcrylicIconStripBackground(backgroundBorder, acrylicUiEnabled.Value, colourProvider.Highlight1);
         }
 
         private void onExpanded()

--- a/osu.Game/Screens/Select/PanelGroupRankDisplay.cs
+++ b/osu.Game/Screens/Select/PanelGroupRankDisplay.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
@@ -16,6 +17,8 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Backgrounds;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.UI;
 using osu.Game.Online.Leaderboards;
 using osu.Game.Overlays;
 using osu.Game.Scoring;
@@ -41,10 +44,17 @@ namespace osu.Game.Screens.Select
         private TrianglesV2 triangles = null!;
         private Box glow = null!;
 
+        [Resolved]
+        private Ez2ConfigManager ezConfig { get; set; } = null!;
+
+        private Bindable<bool> acrylicUiEnabled = null!;
+
         [BackgroundDependencyLoader]
         private void load()
         {
             Height = PanelGroup.HEIGHT;
+
+            acrylicUiEnabled = ezConfig.GetBindable<bool>(Ez2Setting.AcrylicUiEnabled);
 
             Icon = iconContainer = new Container
             {
@@ -67,24 +77,34 @@ namespace osu.Game.Screens.Select
             };
 
             AccentColour = colourProvider.Highlight1;
+
+            Container colourOverlays;
+
             Content.Children = new Drawable[]
             {
-                contentBackground = new Box
+                colourOverlays = new Container
                 {
                     RelativeSizeAxes = Axes.Both,
-                },
-                triangles = new TrianglesV2
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Thickness = 0.02f,
-                    SpawnRatio = 0.6f,
-                    Colour = ColourInfo.GradientHorizontal(colourProvider.Background6, colourProvider.Background5)
-                },
-                glow = new Box
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Width = 0.5f,
-                    Colour = ColourInfo.GradientHorizontal(colourProvider.Highlight1, colourProvider.Highlight1.Opacity(0f)),
+                    Children = new Drawable[]
+                    {
+                        contentBackground = new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                        },
+                        triangles = new TrianglesV2
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Thickness = 0.02f,
+                            SpawnRatio = 0.6f,
+                            Colour = ColourInfo.GradientHorizontal(colourProvider.Background6, colourProvider.Background5)
+                        },
+                        glow = new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Width = 0.5f,
+                            Colour = ColourInfo.GradientHorizontal(colourProvider.Highlight1, colourProvider.Highlight1.Opacity(0f)),
+                        },
+                    }
                 },
                 new FillFlowContainer
                 {
@@ -128,6 +148,8 @@ namespace osu.Game.Screens.Select
                     },
                 }
             };
+
+            EzAcrylicOverlayAlpha.BindHiddenWhenAcrylic(colourOverlays, acrylicUiEnabled);
         }
 
         protected override void LoadComplete()
@@ -204,6 +226,8 @@ namespace osu.Game.Screens.Select
         protected override void Update()
         {
             base.Update();
+
+            ApplyAcrylicIconStripBackground(backgroundBorder, acrylicUiEnabled.Value, AccentColour ?? colourProvider.Highlight1);
 
             // Move the count pill in the opposite direction to keep it pinned to the screen regardless of the X position of TopLevelContent.
             countPill.X = -TopLevelContent.X;

--- a/osu.Game/Screens/Select/PanelGroupRankedStatus.cs
+++ b/osu.Game/Screens/Select/PanelGroupRankedStatus.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
@@ -17,6 +18,8 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Backgrounds;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.UI;
 using osu.Game.Overlays;
 using osuTK;
 using osuTK.Graphics;
@@ -43,10 +46,17 @@ namespace osu.Game.Screens.Select
         [Resolved]
         private OsuColour colours { get; set; } = null!;
 
+        [Resolved]
+        private Ez2ConfigManager ezConfig { get; set; } = null!;
+
+        private Bindable<bool> acrylicUiEnabled = null!;
+
         [BackgroundDependencyLoader]
         private void load()
         {
             Height = PanelGroup.HEIGHT;
+
+            acrylicUiEnabled = ezConfig.GetBindable<bool>(Ez2Setting.AcrylicUiEnabled);
 
             Icon = iconContainer = new Container
             {
@@ -69,24 +79,34 @@ namespace osu.Game.Screens.Select
             };
 
             AccentColour = colourProvider.Highlight1;
+
+            Container colourOverlays;
+
             Content.Children = new Drawable[]
             {
-                contentBackground = new Box
+                colourOverlays = new Container
                 {
                     RelativeSizeAxes = Axes.Both,
-                },
-                triangles = new TrianglesV2
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Thickness = 0.02f,
-                    SpawnRatio = 0.6f,
-                    Colour = ColourInfo.GradientHorizontal(colourProvider.Background6, colourProvider.Background5)
-                },
-                glow = new Box
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Width = 0.5f,
-                    Colour = ColourInfo.GradientHorizontal(colourProvider.Highlight1, colourProvider.Highlight1.Opacity(0f)),
+                    Children = new Drawable[]
+                    {
+                        contentBackground = new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                        },
+                        triangles = new TrianglesV2
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Thickness = 0.02f,
+                            SpawnRatio = 0.6f,
+                            Colour = ColourInfo.GradientHorizontal(colourProvider.Background6, colourProvider.Background5)
+                        },
+                        glow = new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Width = 0.5f,
+                            Colour = ColourInfo.GradientHorizontal(colourProvider.Highlight1, colourProvider.Highlight1.Opacity(0f)),
+                        },
+                    }
                 },
                 new FillFlowContainer
                 {
@@ -130,6 +150,8 @@ namespace osu.Game.Screens.Select
                     },
                 }
             };
+
+            EzAcrylicOverlayAlpha.BindHiddenWhenAcrylic(colourOverlays, acrylicUiEnabled);
         }
 
         protected override void LoadComplete()
@@ -194,6 +216,8 @@ namespace osu.Game.Screens.Select
         protected override void Update()
         {
             base.Update();
+
+            ApplyAcrylicIconStripBackground(backgroundBorder, acrylicUiEnabled.Value, AccentColour ?? colourProvider.Highlight1);
 
             // Move the count pill in the opposite direction to keep it pinned to the screen regardless of the X position of TopLevelContent.
             countPill.X = -TopLevelContent.X;

--- a/osu.Game/Screens/Select/PanelGroupStarDifficulty.cs
+++ b/osu.Game/Screens/Select/PanelGroupStarDifficulty.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
@@ -16,6 +17,8 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Backgrounds;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.UI;
 using osu.Game.Overlays;
 using osuTK;
 using osuTK.Graphics;
@@ -42,10 +45,17 @@ namespace osu.Game.Screens.Select
         private TrianglesV2 triangles = null!;
         private Box glow = null!;
 
+        [Resolved]
+        private Ez2ConfigManager ezConfig { get; set; } = null!;
+
+        private Bindable<bool> acrylicUiEnabled = null!;
+
         [BackgroundDependencyLoader]
         private void load()
         {
             Height = PanelGroup.HEIGHT;
+
+            acrylicUiEnabled = ezConfig.GetBindable<bool>(Ez2Setting.AcrylicUiEnabled);
 
             Icon = iconContainer = new Container
             {
@@ -68,24 +78,34 @@ namespace osu.Game.Screens.Select
             };
 
             AccentColour = colourProvider.Highlight1;
+
+            Container colourOverlays;
+
             Content.Children = new Drawable[]
             {
-                contentBackground = new Box
+                colourOverlays = new Container
                 {
                     RelativeSizeAxes = Axes.Both,
-                },
-                triangles = new TrianglesV2
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Thickness = 0.02f,
-                    SpawnRatio = 0.6f,
-                    Colour = ColourInfo.GradientHorizontal(colourProvider.Background6, colourProvider.Background5)
-                },
-                glow = new Box
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Width = 0.5f,
-                    Colour = ColourInfo.GradientHorizontal(colourProvider.Highlight1, colourProvider.Highlight1.Opacity(0f)),
+                    Children = new Drawable[]
+                    {
+                        contentBackground = new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                        },
+                        triangles = new TrianglesV2
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Thickness = 0.02f,
+                            SpawnRatio = 0.6f,
+                            Colour = ColourInfo.GradientHorizontal(colourProvider.Background6, colourProvider.Background5)
+                        },
+                        glow = new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Width = 0.5f,
+                            Colour = ColourInfo.GradientHorizontal(colourProvider.Highlight1, colourProvider.Highlight1.Opacity(0f)),
+                        },
+                    }
                 },
                 new FillFlowContainer
                 {
@@ -129,6 +149,8 @@ namespace osu.Game.Screens.Select
                     },
                 }
             };
+
+            EzAcrylicOverlayAlpha.BindHiddenWhenAcrylic(colourOverlays, acrylicUiEnabled);
         }
 
         protected override void LoadComplete()
@@ -186,6 +208,8 @@ namespace osu.Game.Screens.Select
         protected override void Update()
         {
             base.Update();
+
+            ApplyAcrylicIconStripBackground(backgroundBorder, acrylicUiEnabled.Value, AccentColour ?? colourProvider.Highlight1);
 
             // Move the count pill in the opposite direction to keep it pinned to the screen regardless of the X position of TopLevelContent.
             countPill.X = -TopLevelContent.X;

--- a/osu.Game/Screens/Select/PanelSetBackground.cs
+++ b/osu.Game/Screens/Select/PanelSetBackground.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Extensions.PolygonExtensions;
 using osu.Framework.Graphics;
@@ -13,6 +14,8 @@ using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Beatmaps;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.UI;
 using osu.Game.Overlays;
 using osuTK;
 using osuTK.Graphics;
@@ -31,6 +34,9 @@ namespace osu.Game.Screens.Select
         private CancellationTokenSource? loadCancellation;
 
         private double timeSinceUnpool;
+
+        private Bindable<bool> acrylicUiEnabled = null!;
+        private Container colourOverlays = null!;
 
         public WorkingBeatmap? Beatmap
         {
@@ -87,52 +93,91 @@ namespace osu.Game.Screens.Select
         }
 
         [BackgroundDependencyLoader]
-        private void load(OverlayColourProvider colourProvider)
+        private void load(OverlayColourProvider colourProvider, Ez2ConfigManager ezConfig)
         {
+            acrylicUiEnabled = ezConfig.GetBindable<bool>(Ez2Setting.AcrylicUiEnabled);
+
             InternalChildren = new Drawable[]
             {
-                new Box
+                colourOverlays = new Container
                 {
                     Depth = 1,
                     RelativeSizeAxes = Axes.Both,
-                    Colour = ColourInfo.GradientHorizontal(colourProvider.Background3, colourProvider.Background4),
-                },
-                new FillFlowContainer
-                {
-                    Depth = -1,
-                    RelativeSizeAxes = Axes.Both,
-                    Direction = FillDirection.Horizontal,
-                    // This makes the gradient not be perfectly horizontal, but diagonal at a ~40° angle
-                    Shear = new Vector2(0.8f, 0),
-                    Children = new[]
+                    Children = new Drawable[]
                     {
-                        // The left half with no gradient applied
                         new Box
                         {
                             RelativeSizeAxes = Axes.Both,
-                            Colour = Color4.Black.Opacity(0.5f),
-                            Width = 0.4f,
+                            Colour = ColourInfo.GradientHorizontal(colourProvider.Background3, colourProvider.Background4),
                         },
-                        new Box
+                        new FillFlowContainer
                         {
                             RelativeSizeAxes = Axes.Both,
-                            Colour = ColourInfo.GradientHorizontal(Color4.Black.Opacity(0.5f), Color4.Black.Opacity(0.3f)),
-                            Width = 0.2f,
-                        },
-                        new Box
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            Colour = ColourInfo.GradientHorizontal(Color4.Black.Opacity(0.3f), Color4.Black.Opacity(0.2f)),
-                            // Slightly more than 1.0 in total to account for shear.
-                            Width = 0.45f,
+                            Direction = FillDirection.Horizontal,
+                            // This makes the gradient not be perfectly horizontal, but diagonal at a ~40° angle
+                            Shear = new Vector2(0.8f, 0),
+                            Children = new[]
+                            {
+                                // The left half with no gradient applied
+                                new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Colour = Color4.Black.Opacity(0.5f),
+                                    Width = 0.4f,
+                                },
+                                new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Colour = ColourInfo.GradientHorizontal(Color4.Black.Opacity(0.5f), Color4.Black.Opacity(0.3f)),
+                                    Width = 0.2f,
+                                },
+                                new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Colour = ColourInfo.GradientHorizontal(Color4.Black.Opacity(0.3f), Color4.Black.Opacity(0.2f)),
+                                    // Slightly more than 1.0 in total to account for shear.
+                                    Width = 0.45f,
+                                },
+                            }
                         },
                     }
                 },
             };
+
+            // Glass N is on Panel parent; hide classic colour overlays when acrylic is on.
+            EzAcrylicOverlayAlpha.BindHiddenWhenAcrylic(colourOverlays, acrylicUiEnabled);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            acrylicUiEnabled.BindValueChanged(e =>
+            {
+                if (e.NewValue)
+                {
+                    // Penetrate to the global song-select background — drop panel cover art.
+                    loadCancellation?.Cancel();
+                    loadCancellation = null;
+                    sprite?.Expire();
+                    sprite = null;
+                }
+                else
+                {
+                    // Restore classic cover art after acrylic is turned off.
+                    timeSinceUnpool = 0;
+                    loadCancellation?.Cancel();
+                    loadCancellation = null;
+                }
+            }, true);
         }
 
         private void loadContentIfRequired()
         {
+            // Acrylic UI: skip panel cover textures and let the backdrop blur sample the global background.
+            if (acrylicUiEnabled.Value)
+                return;
+
             // A load is already in progress if the cancellation token is non-null.
             if (loadCancellation != null || working == null)
                 return;
@@ -168,6 +213,12 @@ namespace osu.Game.Screens.Select
                 FillMode = FillMode.Fill,
             }, s =>
             {
+                if (acrylicUiEnabled.Value)
+                {
+                    s.Expire();
+                    return;
+                }
+
                 AddInternal(sprite = s);
                 bool spriteOnScreen = beatmapCarousel?.ScreenSpaceDrawQuad.Intersects(sprite.ScreenSpaceDrawQuad) != false;
                 sprite.FadeInFromZero(spriteOnScreen ? 400 : 0, Easing.OutQuint);

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -40,6 +40,7 @@ using osu.Game.Input.Bindings;
 using osu.Game.EzOsuGame.Audio;
 using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.Overlays;
+using osu.Game.EzOsuGame.UI;
 using osu.Game.EzOsuGame.UserInterface;
 using osu.Game.Localisation;
 using osu.Game.Online.API;
@@ -337,6 +338,8 @@ namespace osu.Game.Screens.Select
             });
 
             LoadComponent(modSelectOverlay = CreateModSelectOverlay());
+
+            EzAcrylicOverlayAlpha.BindHiddenWhenAcrylic(rightGradientBackground, ezConfig.GetBindable<bool>(Ez2Setting.AcrylicUiEnabled));
 
             acrylicUiEnabled = ezConfig.GetBindable<bool>(Ez2Setting.AcrylicUiEnabled);
             acrylicUiEnabled.BindValueChanged(_ =>


### PR DESCRIPTION
## Summary
- Rebuild song-select acrylic chrome from master with exclusive classic/glass swap (ON hide M show N; OFF hide N show M)—no half-alpha classic overlays.
- Expand capture scope to footer/mod chrome, add shared `EzAcrylicStyle` + `BindExclusive`, frosted footer/panels/sheared overlay/wedges, spacing gate, and right-gradient hide.
- Footer frost uses cool `FooterVeil` plus a light scheme wash so blur stays readable.

## Test plan
- [x] Acrylic ON: footer shows blur (not solid bar); panels/wedges/mod page glass readable; carousel hairline spacing; right gradient hidden
- [x] Acrylic OFF: footer solid, panels covers/overlays, spacing `-SPACING`, right gradient visible—matches master classic
- [x] Toggle acrylic several times: footer never disappears; panels do not wash white
- [x] `dotnet build` osu.Game
