### PR TITLE
本地个人档案：钻取成绩持久化与详情 UI 重构

### DIFF
--- a/osu.Game.Tests/EzOsuGame/LocalProfile/EzLocalProfileScoreDrillQueryTest.cs
+++ b/osu.Game.Tests/EzOsuGame/LocalProfile/EzLocalProfileScoreDrillQueryTest.cs
@@ -1,0 +1,128 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.EzOsuGame.LocalProfile;
+using osu.Game.Rulesets;
+using osu.Game.Scoring;
+using osu.Game.Tests.Database;
+
+namespace osu.Game.Tests.EzOsuGame.LocalProfile
+{
+    [TestFixture]
+    public class EzLocalProfileScoreDrillQueryTest
+    {
+        [Test]
+        public void TestFilterMatchesTitle()
+        {
+            var scores = new List<EzLocalProfileDrillScoreRow>
+            {
+                createRow(rulesetId: 0, pp: 120, title: "Unique Drill Title"),
+                createRow(rulesetId: 0, pp: 80, title: "Other Title"),
+            };
+
+            var filtered = EzLocalProfileScoreDrillQuery.Filter(scores, "Unique Drill");
+
+            Assert.That(filtered, Has.Count.EqualTo(1));
+            Assert.That(filtered[0].PpResolved, Is.EqualTo(120));
+        }
+
+        [Test]
+        public void TestFilterEmptySearchReturnsAll()
+        {
+            var scores = new List<EzLocalProfileDrillScoreRow>
+            {
+                createRow(rulesetId: 0, pp: 100, title: "A"),
+                createRow(rulesetId: 0, pp: 90, title: "B"),
+            };
+
+            Assert.That(EzLocalProfileScoreDrillQuery.Filter(scores, string.Empty), Has.Count.EqualTo(2));
+            Assert.That(EzLocalProfileScoreDrillQuery.Filter(scores, "   "), Has.Count.EqualTo(2));
+        }
+
+        [Test]
+        public void TestPeersOnSameBeatmapMatchesHashAndVersion()
+        {
+            var target = createRow(rulesetId: 0, pp: 100, title: "Song", beatmapHash: "hash-a", difficultyName: "Insane");
+            var same = createRow(rulesetId: 0, pp: 90, title: "Song", beatmapHash: "hash-a", difficultyName: "Insane");
+            var otherVersion = createRow(rulesetId: 0, pp: 80, title: "Song", beatmapHash: "hash-a", difficultyName: "Hard");
+
+            var peers = EzLocalProfileScoreDrillQuery.PeersOnSameBeatmap(target, new[] { target, same, otherVersion });
+
+            Assert.That(peers, Has.Count.EqualTo(2));
+        }
+
+        [Test]
+        public void TestLoadDrillScoresFiltersByRuleset()
+        {
+            using var storage = new TemporaryNativeStorage($"ez-drill-{Guid.NewGuid():N}");
+            using var store = new EzLocalProfileStore(storage);
+
+            var result = new EzLocalProfileAggregationResult();
+            result.DrillScores.Add(createRow(rulesetId: 0, pp: 100, title: "Osu 1"));
+            result.DrillScores.Add(createRow(rulesetId: 0, pp: 90, title: "Osu 2"));
+            result.DrillScores.Add(createRow(rulesetId: 3, pp: 50, title: "Mania"));
+            store.ReplaceAll(result);
+
+            var osuScores = store.LoadDrillScores(0);
+            Assert.That(osuScores, Has.Count.EqualTo(2));
+            Assert.That(osuScores.All(s => s.RulesetId == 0), Is.True);
+
+            var maniaScores = store.LoadDrillScores(3);
+            Assert.That(maniaScores, Has.Count.EqualTo(1));
+            Assert.That(maniaScores[0].RulesetId, Is.EqualTo(3));
+        }
+
+        private static EzLocalProfileDrillScoreRow createRow(
+            int rulesetId,
+            double pp,
+            string title,
+            string beatmapHash = "test-hash",
+            string difficultyName = "Insane")
+        {
+            return new EzLocalProfileDrillScoreRow
+            {
+                ScoreId = Guid.NewGuid(),
+                Username = "tester",
+                RulesetId = rulesetId,
+                Rank = ScoreRank.S,
+                PpResolved = pp,
+                Accuracy = 0.98,
+                MaxCombo = 100,
+                MaxAchievableCombo = 100,
+                BeatmapHash = beatmapHash,
+                BeatmapId = Guid.NewGuid(),
+                Title = title,
+                Artist = "Artist",
+                DifficultyName = difficultyName,
+                MapperUsername = "Mapper",
+                BeatmapStatus = BeatmapOnlineStatus.Ranked,
+                StarRating = 5,
+                Date = DateTimeOffset.UtcNow,
+            };
+        }
+    }
+
+    [TestFixture]
+    public class EzLocalProfileRealmLinqGuardTest : RealmTest
+    {
+        [Test]
+        public void TestRealmRejectsNestedRulesetOnlineIdLinq()
+        {
+            RunTestWithRealm((realm, storage) =>
+            {
+                using var _ = new RealmRulesetStore(realm, storage);
+
+                Assert.Throws<NotSupportedException>(() =>
+                {
+                    realm.Run(r => r.All<ScoreInfo>().Where(s => s.Ruleset.OnlineID == 0).ToList());
+                });
+            });
+        }
+    }
+}

--- a/osu.Game.Tests/EzOsuGame/LocalProfile/EzLocalProfileScoreDrillQueryTest.cs
+++ b/osu.Game.Tests/EzOsuGame/LocalProfile/EzLocalProfileScoreDrillQueryTest.cs
@@ -9,6 +9,7 @@ using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.EzOsuGame.LocalProfile;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Tests.Database;
 
@@ -76,6 +77,28 @@ namespace osu.Game.Tests.EzOsuGame.LocalProfile
             var maniaScores = store.LoadDrillScores(3);
             Assert.That(maniaScores, Has.Count.EqualTo(1));
             Assert.That(maniaScores[0].RulesetId, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void TestComputeAvgAbsOffsetMsReturnsNullWithoutHitEvents()
+        {
+            var score = new ScoreInfo();
+            Assert.That(EzLocalProfileDrillScoreRow.ComputeAvgAbsOffsetMs(score), Is.Null);
+        }
+
+        [Test]
+        public void TestComputeAvgAbsOffsetMsAveragesAbsoluteOffsets()
+        {
+            var score = new ScoreInfo
+            {
+                HitEvents =
+                {
+                    new HitEvent(-10, null, HitResult.Great, null!, null, null),
+                    new HitEvent(6, null, HitResult.Great, null!, null, null),
+                },
+            };
+
+            Assert.That(EzLocalProfileDrillScoreRow.ComputeAvgAbsOffsetMs(score), Is.EqualTo(8).Within(0.001));
         }
 
         private static EzLocalProfileDrillScoreRow createRow(

--- a/osu.Game.Tests/Visual/EzOsuGame/TestSceneEzLocalProfileOverlay.cs
+++ b/osu.Game.Tests/Visual/EzOsuGame/TestSceneEzLocalProfileOverlay.cs
@@ -1,0 +1,160 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Platform;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+using osu.Game.EzOsuGame.Analysis;
+using osu.Game.EzOsuGame.LocalProfile;
+using osu.Game.Scoring;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Tests.Visual.EzOsuGame
+{
+    public partial class TestSceneEzLocalProfileOverlay : OsuTestScene
+    {
+        private EzLocalProfileOverlay overlay = null!;
+        private TemporaryNativeStorage profileStorage = null!;
+        private EzLocalProfileService profileService = null!;
+
+        [Resolved]
+        private RealmAccess realm { get; set; } = null!;
+
+        [Resolved]
+        private BeatmapManager beatmapManager { get; set; } = null!;
+
+        [Resolved]
+        private EzAnalysisPersistentStore analysisStore { get; set; } = null!;
+
+        [Test]
+        public void TestFullProfile()
+        {
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            profileStorage = new TemporaryNativeStorage($"ez-local-profile-{Guid.NewGuid():N}");
+
+            using (var seedStore = new EzLocalProfileStore(profileStorage))
+                seedStore.ReplaceAll(EzLocalProfileOverlayTestData.CreateMockResult());
+
+            profileService = new EzLocalProfileService(profileStorage, realm, analysisStore, beatmapManager);
+            overlay = new EzLocalProfileOverlay();
+
+            Child = new DependencyProvidingContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                CachedDependencies = new (Type, object)[]
+                {
+                    (typeof(EzLocalProfileService), profileService),
+                },
+                Child = overlay,
+            };
+
+            overlay.Show();
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            profileService?.Dispose();
+            profileStorage?.Dispose();
+            base.Dispose(isDisposing);
+        }
+    }
+
+    internal static class EzLocalProfileOverlayTestData
+    {
+        public static EzLocalProfileAggregationResult CreateMockResult()
+        {
+            var result = new EzLocalProfileAggregationResult
+            {
+                IncludedUsernames = new[] { "peppy" },
+                ComputedAt = DateTimeOffset.UtcNow,
+            };
+
+            result.RulesetStats[EzLocalProfileConstants.OSU_RULESET_ID] = new EzLocalProfileAggregationResult.MutableRulesetStats
+            {
+                ScoreCount = 42,
+                TotalPp = 5123.4,
+                TotalKeys = 18_000,
+                KpsSampleCount = 40,
+                KpsSum = 320,
+                MaxKps = 12.5,
+                TotalDurationMs = 3_600_000,
+            };
+
+            result.GradeCounts[(EzLocalProfileConstants.OSU_RULESET_ID, ScoreRank.S)] = 18;
+            result.GradeCounts[(EzLocalProfileConstants.OSU_RULESET_ID, ScoreRank.A)] = 12;
+            result.GradeCounts[(EzLocalProfileConstants.OSU_RULESET_ID, ScoreRank.B)] = 8;
+
+            foreach (int bucket in new[] { 3, 4, 5, 6, 7 })
+                result.StarPlayCounts[(EzLocalProfileConstants.OSU_RULESET_ID, bucket)] = bucket * 4;
+
+            result.StdAttrAffinities[(EzLocalProfileStdAttr.ApproachRate, 8.0)] = new EzLocalProfileAggregationResult.MutableStdAttr
+            {
+                PlayCount = 24,
+                HighGradeCount = 12,
+            };
+            result.StdAttrAffinities[(EzLocalProfileStdAttr.CircleSize, 4.0)] = new EzLocalProfileAggregationResult.MutableStdAttr
+            {
+                PlayCount = 18,
+                HighGradeCount = 9,
+            };
+
+            result.DrillScores.AddRange(createDrillScores());
+
+            return result;
+        }
+
+        private static IEnumerable<EzLocalProfileDrillScoreRow> createDrillScores()
+        {
+            var beatmapId = Guid.NewGuid();
+            const string beatmapHash = "mock-beatmap-hash";
+
+            yield return createDrillRow(beatmapId, beatmapHash, "Visual Test Song With A Long Title", 234.56, withMods: true);
+            yield return createDrillRow(beatmapId, beatmapHash, "Second Score On Same Map", 210.0, withMods: false);
+            yield return createDrillRow(Guid.NewGuid(), "other-hash", "Another Beatmap", 180.0, withMods: false);
+        }
+
+        private static EzLocalProfileDrillScoreRow createDrillRow(Guid beatmapId, string beatmapHash, string title, double pp, bool withMods)
+        {
+            return new EzLocalProfileDrillScoreRow
+            {
+                ScoreId = Guid.NewGuid(),
+                Username = "peppy",
+                RulesetId = EzLocalProfileConstants.OSU_RULESET_ID,
+                Rank = ScoreRank.S,
+                PpResolved = pp,
+                Accuracy = 0.9876,
+                MaxCombo = 512,
+                MaxAchievableCombo = 512,
+                TotalScore = 1_500_000,
+                ModsJson = withMods ? "[{\"Acronym\":\"HD\"},{\"Acronym\":\"DT\"}]" : "[]",
+                TotalKeys = 1200,
+                BeatmapHash = beatmapHash,
+                BeatmapId = beatmapId,
+                Title = title,
+                Artist = "Test Artist",
+                DifficultyName = "Insane",
+                MapperUsername = "Mapper",
+                BeatmapStatus = BeatmapOnlineStatus.Ranked,
+                StarRating = 5.42,
+                XxyStarRating = -1,
+                MapPerformancePoints = 120,
+                KpsAvg = 8.75,
+                KpsMax = 12.3,
+                AvgAbsOffsetMs = 4.5,
+                Date = DateTimeOffset.UtcNow,
+            };
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/EzOsuGame/TestSceneEzLocalProfileOverlay.cs
+++ b/osu.Game.Tests/Visual/EzOsuGame/TestSceneEzLocalProfileOverlay.cs
@@ -6,15 +6,13 @@ using System.Collections.Generic;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Platform;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.EzOsuGame.Analysis;
 using osu.Game.EzOsuGame.LocalProfile;
+using osu.Game.EzOsuGame.Scoring;
 using osu.Game.Scoring;
-using osu.Game.Tests.Visual;
 
 namespace osu.Game.Tests.Visual.EzOsuGame
 {
@@ -33,6 +31,12 @@ namespace osu.Game.Tests.Visual.EzOsuGame
         [Resolved]
         private EzAnalysisPersistentStore analysisStore { get; set; } = null!;
 
+        [Resolved]
+        private ScoreManager scoreManager { get; set; } = null!;
+
+        [Resolved]
+        private IEzReplaySession replaySession { get; set; } = null!;
+
         [Test]
         public void TestFullProfile()
         {
@@ -47,7 +51,7 @@ namespace osu.Game.Tests.Visual.EzOsuGame
             using (var seedStore = new EzLocalProfileStore(profileStorage))
                 seedStore.ReplaceAll(EzLocalProfileOverlayTestData.CreateMockResult());
 
-            profileService = new EzLocalProfileService(profileStorage, realm, analysisStore, beatmapManager);
+            profileService = new EzLocalProfileService(profileStorage, realm, analysisStore, beatmapManager, scoreManager, replaySession);
             overlay = new EzLocalProfileOverlay();
 
             Child = new DependencyProvidingContainer
@@ -65,8 +69,8 @@ namespace osu.Game.Tests.Visual.EzOsuGame
 
         protected override void Dispose(bool isDisposing)
         {
-            profileService?.Dispose();
-            profileStorage?.Dispose();
+            profileService.Dispose();
+            profileStorage.Dispose();
             base.Dispose(isDisposing);
         }
     }
@@ -79,22 +83,26 @@ namespace osu.Game.Tests.Visual.EzOsuGame
             {
                 IncludedUsernames = new[] { "peppy" },
                 ComputedAt = DateTimeOffset.UtcNow,
+                RulesetStats =
+                {
+                    [EzLocalProfileConstants.OSU_RULESET_ID] = new EzLocalProfileAggregationResult.MutableRulesetStats
+                    {
+                        ScoreCount = 42,
+                        TotalPp = 5123.4,
+                        TotalKeys = 18_000,
+                        KpsSampleCount = 40,
+                        KpsSum = 320,
+                        MaxKps = 12.5,
+                        TotalDurationMs = 3_600_000,
+                    }
+                },
+                GradeCounts =
+                {
+                    [(EzLocalProfileConstants.OSU_RULESET_ID, ScoreRank.S)] = 18,
+                    [(EzLocalProfileConstants.OSU_RULESET_ID, ScoreRank.A)] = 12,
+                    [(EzLocalProfileConstants.OSU_RULESET_ID, ScoreRank.B)] = 8
+                }
             };
-
-            result.RulesetStats[EzLocalProfileConstants.OSU_RULESET_ID] = new EzLocalProfileAggregationResult.MutableRulesetStats
-            {
-                ScoreCount = 42,
-                TotalPp = 5123.4,
-                TotalKeys = 18_000,
-                KpsSampleCount = 40,
-                KpsSum = 320,
-                MaxKps = 12.5,
-                TotalDurationMs = 3_600_000,
-            };
-
-            result.GradeCounts[(EzLocalProfileConstants.OSU_RULESET_ID, ScoreRank.S)] = 18;
-            result.GradeCounts[(EzLocalProfileConstants.OSU_RULESET_ID, ScoreRank.A)] = 12;
-            result.GradeCounts[(EzLocalProfileConstants.OSU_RULESET_ID, ScoreRank.B)] = 8;
 
             foreach (int bucket in new[] { 3, 4, 5, 6, 7 })
                 result.StarPlayCounts[(EzLocalProfileConstants.OSU_RULESET_ID, bucket)] = bucket * 4;
@@ -118,10 +126,10 @@ namespace osu.Game.Tests.Visual.EzOsuGame
         private static IEnumerable<EzLocalProfileDrillScoreRow> createDrillScores()
         {
             var beatmapId = Guid.NewGuid();
-            const string beatmapHash = "mock-beatmap-hash";
+            const string beatmap_hash = "mock-beatmap-hash";
 
-            yield return createDrillRow(beatmapId, beatmapHash, "Visual Test Song With A Long Title", 234.56, withMods: true);
-            yield return createDrillRow(beatmapId, beatmapHash, "Second Score On Same Map", 210.0, withMods: false);
+            yield return createDrillRow(beatmapId, beatmap_hash, "Visual Test Song With A Long Title", 234.56, withMods: true);
+            yield return createDrillRow(beatmapId, beatmap_hash, "Second Score On Same Map", 210.0, withMods: false);
             yield return createDrillRow(Guid.NewGuid(), "other-hash", "Another Beatmap", 180.0, withMods: false);
         }
 

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileAggregator.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileAggregator.cs
@@ -5,12 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.EzOsuGame.Analysis;
-using osu.Game.EzOsuGame.Configuration;
-using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using Realms;
@@ -22,12 +19,14 @@ namespace osu.Game.EzOsuGame.LocalProfile
         private readonly RealmAccess realm;
         private readonly EzAnalysisPersistentStore analysisStore;
         private readonly BeatmapManager beatmapManager;
+        private readonly EzLocalProfilePpResolver ppResolver;
 
         public EzLocalProfileAggregator(RealmAccess realm, EzAnalysisPersistentStore analysisStore, BeatmapManager beatmapManager)
         {
             this.realm = realm;
             this.analysisStore = analysisStore;
             this.beatmapManager = beatmapManager;
+            ppResolver = new EzLocalProfilePpResolver(beatmapManager);
         }
 
         public IReadOnlyList<EzLocalProfileUsernameCount> ScanUsernameCounts()
@@ -102,7 +101,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
             report();
 
             var scoreList = detachedScores.Select(s => s.Score).ToList();
-            double[] resolvedPp = resolveAllPp(scoreList, progress, total, cancellationToken);
+            double[] resolvedPp = ppResolver.ResolveAll(scoreList, progress, total, cancellationToken);
             processed = scoreList.Count;
             report();
 
@@ -122,6 +121,13 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 double pp = resolvedPp[i];
                 long durationMs = beatmap.Length > 0 ? (long)beatmap.Length : 0;
 
+                result.DrillScores.Add(EzLocalProfileDrillScoreRow.FromScore(
+                    score,
+                    username,
+                    pp,
+                    hasKps ? analysis : default,
+                    hasKps));
+
                 var rulesetStats = getOrCreate(result.RulesetStats, rulesetId, () => new EzLocalProfileAggregationResult.MutableRulesetStats());
                 rulesetStats.TotalKeys += keys;
                 rulesetStats.ScoreCount++;
@@ -138,6 +144,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
                 incrementGrade(result, rulesetId, score.Rank);
                 incrementStar(result, rulesetId, beatmap.StarRating);
+                incrementXxy(result, rulesetId, resolveXxyStarRating(beatmap, analysis, hasKps));
 
                 if (rulesetId == EzLocalProfileConstants.MANIA_RULESET_ID)
                     accumulateMania(result, beatmap, analysis, hasKps, keys, avgKps, maxKps, pp, durationMs);
@@ -168,123 +175,6 @@ namespace osu.Game.EzOsuGame.LocalProfile
             HashSet<long> localOnlineIds)
         {
             mergeOnlineContributions(result, contributions, localOnlineIds);
-        }
-
-        private double[] resolveAllPp(
-            IReadOnlyList<ScoreInfo> scores,
-            IProgress<EzLocalProfileComputeProgress>? progress,
-            int progressTotal,
-            CancellationToken cancellationToken)
-        {
-            double[] values = new double[scores.Count];
-            if (scores.Count == 0)
-                return values;
-
-            var attributeCache = new Dictionary<string, DifficultyAttributes?>(StringComparer.Ordinal);
-            int failures = 0;
-            int loggedFailures = 0;
-            const int max_logged_failures = 8;
-
-            // Sequential on purpose: WorkingBeatmapCache locks around Realm reads; Parallel.For
-            // deadlocks easily once scores without stored PP start loading beatmaps.
-            int reportEvery = Math.Max(10, progressTotal / 100);
-
-            for (int i = 0; i < scores.Count; i++)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                values[i] = resolvePp(scores[i], attributeCache, ref failures, ref loggedFailures, max_logged_failures);
-
-                int current = i + 1;
-                if (current == scores.Count || current % reportEvery == 0)
-                    progress?.Report(new EzLocalProfileComputeProgress(current, progressTotal, Saving: false));
-            }
-
-            if (failures > 0)
-            {
-                Logger.Log(
-                    $"[EzLocalProfile] PP calc finished with {failures} failure(s) out of {scores.Count} score(s).",
-                    Ez2ConfigManager.LOGGER_NAME);
-            }
-
-            return values;
-        }
-
-        /// <summary>
-        /// Prefer a positive stored PP; otherwise calculate from detached score + cached difficulty attributes.
-        /// </summary>
-        private double resolvePp(
-            ScoreInfo score,
-            Dictionary<string, DifficultyAttributes?> attributeCache,
-            ref int failures,
-            ref int loggedFailures,
-            int maxLoggedFailures)
-        {
-            if (score.PP is > 0)
-                return score.PP.Value;
-
-            // Failed plays contribute no PP for profile totals.
-            if (score.Rank == ScoreRank.F)
-                return 0;
-
-            if (score.BeatmapInfo == null)
-                return 0;
-
-            try
-            {
-                var ruleset = score.Ruleset.CreateInstance();
-                var calculator = ruleset.CreatePerformanceCalculator();
-                if (calculator == null)
-                    return 0;
-
-                string cacheKey = buildAttributeCacheKey(score);
-                if (!attributeCache.TryGetValue(cacheKey, out var attributes))
-                {
-                    attributes = tryCalculateAttributes(score, ruleset);
-                    attributeCache[cacheKey] = attributes;
-                }
-
-                if (attributes == null)
-                    return 0;
-
-                return Math.Max(0, calculator.Calculate(score, attributes).Total);
-            }
-            catch (Exception ex)
-            {
-                failures++;
-
-                if (++loggedFailures <= maxLoggedFailures)
-                {
-                    Logger.Log(
-                        $"[EzLocalProfile] PP calc failed for score {score.ID}: {ex.Message}",
-                        Ez2ConfigManager.LOGGER_NAME);
-                }
-
-                return 0;
-            }
-        }
-
-        private DifficultyAttributes? tryCalculateAttributes(ScoreInfo score, Rulesets.Ruleset ruleset)
-        {
-            try
-            {
-                var working = beatmapManager.GetWorkingBeatmap(score.BeatmapInfo);
-                return ruleset.CreateDifficultyCalculator(working).Calculate(score.Mods);
-            }
-            catch (Exception ex)
-            {
-                Logger.Log(
-                    $"[EzLocalProfile] Difficulty attrs failed ({score.BeatmapInfo?.ID}): {ex.Message}",
-                    Ez2ConfigManager.LOGGER_NAME,
-                    LogLevel.Verbose);
-                return null;
-            }
-        }
-
-        private static string buildAttributeCacheKey(ScoreInfo score)
-        {
-            // ModsJson is stable and cheaper than formatting Mod[].
-            return $"{score.BeatmapInfo?.ID:N}|{score.Ruleset.ShortName}|{score.ModsJson}";
         }
 
         private static void mergeOnlineContributions(
@@ -418,6 +308,35 @@ namespace osu.Game.EzOsuGame.LocalProfile
             var key = (rulesetId, bucket);
             result.StarPlayCounts.TryGetValue(key, out int existing);
             result.StarPlayCounts[key] = existing + 1;
+        }
+
+        private static void incrementXxy(EzLocalProfileAggregationResult result, int rulesetId, double xxyStarRating)
+        {
+            if (xxyStarRating < 0)
+                return;
+
+            int bucket = (int)Math.Floor(xxyStarRating);
+            var key = (rulesetId, bucket);
+            result.XxyPlayCounts.TryGetValue(key, out int existing);
+            result.XxyPlayCounts[key] = existing + 1;
+        }
+
+        /// <summary>
+        /// Resolve xxy SR for bucket counting: Realm field, then ez-analysis, then official SR for supported rulesets.
+        /// </summary>
+        private static double resolveXxyStarRating(BeatmapInfo beatmap, EzAnalysisResult analysis, bool hasKps)
+        {
+            if (beatmap.XxyStarRating >= 0)
+                return beatmap.XxyStarRating;
+
+            if (hasKps && analysis.ManiaSummary?.XxySr is double analysisXxy && analysisXxy >= 0)
+                return analysisXxy;
+
+            // Align play counts with official star buckets when dedicated xxy is unavailable.
+            if (beatmap.StarRating >= 0)
+                return beatmap.StarRating;
+
+            return -1;
         }
 
         private static IQueryable<ScoreInfo> queryValidScores(Realm realm)

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileAggregator.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileAggregator.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.EzOsuGame.Analysis;
+using osu.Game.EzOsuGame.Scoring;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using Realms;
@@ -19,13 +20,22 @@ namespace osu.Game.EzOsuGame.LocalProfile
         private readonly RealmAccess realm;
         private readonly EzAnalysisPersistentStore analysisStore;
         private readonly BeatmapManager beatmapManager;
+        private readonly ScoreManager scoreManager;
+        private readonly IEzReplaySession replaySession;
         private readonly EzLocalProfilePpResolver ppResolver;
 
-        public EzLocalProfileAggregator(RealmAccess realm, EzAnalysisPersistentStore analysisStore, BeatmapManager beatmapManager)
+        public EzLocalProfileAggregator(
+            RealmAccess realm,
+            EzAnalysisPersistentStore analysisStore,
+            BeatmapManager beatmapManager,
+            ScoreManager scoreManager,
+            IEzReplaySession replaySession)
         {
             this.realm = realm;
             this.analysisStore = analysisStore;
             this.beatmapManager = beatmapManager;
+            this.scoreManager = scoreManager;
+            this.replaySession = replaySession;
             ppResolver = new EzLocalProfilePpResolver(beatmapManager);
         }
 
@@ -95,8 +105,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
             int total = Math.Max(1, detachedScores.Count);
             int processed = 0;
 
-            void report() =>
-                progress?.Report(new EzLocalProfileComputeProgress(processed, total, Saving: false));
+            void report() => progress?.Report(new EzLocalProfileComputeProgress(processed, total, Saving: false));
 
             report();
 
@@ -121,12 +130,21 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 double pp = resolvedPp[i];
                 long durationMs = beatmap.Length > 0 ? (long)beatmap.Length : 0;
 
+                double? avgAbsOffsetMs = EzLocalProfileHitEventResolver.ResolveAvgAbsOffsetMs(
+                    score,
+                    realm,
+                    scoreManager,
+                    beatmapManager,
+                    replaySession,
+                    cancellationToken);
+
                 result.DrillScores.Add(EzLocalProfileDrillScoreRow.FromScore(
                     score,
                     username,
                     pp,
                     hasKps ? analysis : default,
-                    hasKps));
+                    hasKps,
+                    avgAbsOffsetMs));
 
                 var rulesetStats = getOrCreate(result.RulesetStats, rulesetId, () => new EzLocalProfileAggregationResult.MutableRulesetStats());
                 rulesetStats.TotalKeys += keys;
@@ -378,8 +396,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
         private static double roundAttr(float value) => Math.Round(value, 1, MidpointRounding.AwayFromZero);
 
-        private static bool isHighGrade(ScoreRank rank) =>
-            rank is ScoreRank.S or ScoreRank.SH or ScoreRank.X or ScoreRank.XH;
+        private static bool isHighGrade(ScoreRank rank) => rank is ScoreRank.S or ScoreRank.SH or ScoreRank.X or ScoreRank.XH;
 
         private static TValue getOrCreate<TKey, TValue>(Dictionary<TKey, TValue> dict, TKey key, Func<TValue> factory)
             where TKey : notnull

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileBeatmapPerformance.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileBeatmapPerformance.cs
@@ -4,10 +4,17 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Localisation;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
 using osu.Game.EzOsuGame.Localization;
+using osu.Game.EzOsuGame.Scoring;
+using osu.Game.Scoring;
 using osuTK;
 
 namespace osu.Game.EzOsuGame.LocalProfile
@@ -17,25 +24,22 @@ namespace osu.Game.EzOsuGame.LocalProfile
         private const float card_spacing = 8;
 
         private readonly FillFlowContainer cardsFlow;
+        private readonly Dictionary<Guid, double?> resolvedOffsets = new Dictionary<Guid, double?>();
+        private CancellationTokenSource? offsetLoadCts;
+        private EzLocalProfileDrillScoreRow? pendingCurrent;
+        private IReadOnlyList<EzLocalProfileDrillScoreRow> pendingAllScores = Array.Empty<EzLocalProfileDrillScoreRow>();
 
-        private static readonly MetricDefinition[] metrics =
-        {
-            new MetricDefinition(
-                EzSettingsStrings.LOCAL_PROFILE_BEATMAP_PERF_PP,
-                row => row.PpResolved > 0 ? row.PpResolved : null,
-                EzLocalProfileFormat.FormatPp,
-                "pp"),
-            new MetricDefinition(
-                EzSettingsStrings.LOCAL_PROFILE_BEATMAP_PERF_ACC,
-                row => row.Accuracy,
-                v => $"{v * 100:0.00}%",
-                string.Empty),
-            new MetricDefinition(
-                EzSettingsStrings.LOCAL_PROFILE_BEATMAP_PERF_OFF,
-                row => row.AvgAbsOffsetMs,
-                v => $"{v:0} ms",
-                string.Empty),
-        };
+        [Resolved]
+        private RealmAccess realm { get; set; } = null!;
+
+        [Resolved]
+        private ScoreManager scoreManager { get; set; } = null!;
+
+        [Resolved]
+        private BeatmapManager beatmapManager { get; set; } = null!;
+
+        [Resolved]
+        private IEzReplaySession replaySession { get; set; } = null!;
 
         public EzLocalProfileBeatmapPerformance()
         {
@@ -53,7 +57,60 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
         public void Update(EzLocalProfileDrillScoreRow? current, IReadOnlyList<EzLocalProfileDrillScoreRow> allScores)
         {
+            offsetLoadCts?.Cancel();
+            offsetLoadCts = null;
+            pendingCurrent = current;
+            pendingAllScores = allScores;
+
+            rebuildCards();
+
+            if (current == null)
+                return;
+
+            var peers = EzLocalProfileScoreDrillQuery.PeersOnSameBeatmap(current, allScores);
+            var missing = peers.Where(row => resolveOffset(row) == null).Select(row => row.ScoreId).Distinct().ToList();
+
+            if (missing.Count == 0)
+                return;
+
+            var localCancellation = offsetLoadCts = new CancellationTokenSource();
+
+            Task.Run(async () =>
+            {
+                foreach (var scoreId in missing)
+                {
+                    localCancellation.Token.ThrowIfCancellationRequested();
+
+                    double? offset = await EzLocalProfileHitEventResolver.ResolveAvgAbsOffsetMsAsync(
+                        scoreId,
+                        realm,
+                        scoreManager,
+                        beatmapManager,
+                        replaySession,
+                        localCancellation.Token).ConfigureAwait(false);
+
+                    resolvedOffsets[scoreId] = offset;
+                }
+            }, localCancellation.Token).ContinueWith(task => Schedule(() =>
+            {
+                if (task.IsCanceled || pendingCurrent == null)
+                    return;
+
+                rebuildCards();
+            }), localCancellation.Token);
+        }
+
+        protected override void UpdateAfterChildren()
+        {
+            base.UpdateAfterChildren();
+            distributeCardWidths();
+        }
+
+        private void rebuildCards()
+        {
             cardsFlow.Clear();
+
+            var current = pendingCurrent;
 
             if (current == null)
             {
@@ -61,19 +118,42 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 return;
             }
 
-            var peers = EzLocalProfileScoreDrillQuery.PeersOnSameBeatmap(current, allScores);
+            var peers = EzLocalProfileScoreDrillQuery.PeersOnSameBeatmap(current, pendingAllScores);
 
-            foreach (var metric in metrics)
+            foreach (var metric in createMetrics())
                 cardsFlow.Add(createCard(metric, current, peers));
 
             Show();
             distributeCardWidths();
         }
 
-        protected override void UpdateAfterChildren()
+        private IEnumerable<MetricDefinition> createMetrics()
         {
-            base.UpdateAfterChildren();
-            distributeCardWidths();
+            yield return new MetricDefinition(
+                EzSettingsStrings.LOCAL_PROFILE_BEATMAP_PERF_PP,
+                row => row.PpResolved > 0 ? row.PpResolved : null,
+                EzLocalProfileFormat.FormatPp,
+                "pp");
+
+            yield return new MetricDefinition(
+                EzSettingsStrings.LOCAL_PROFILE_BEATMAP_PERF_ACC,
+                row => row.Accuracy,
+                v => $"{v * 100:0.00}%",
+                string.Empty);
+
+            yield return new MetricDefinition(
+                EzSettingsStrings.LOCAL_PROFILE_BEATMAP_PERF_OFFSET,
+                resolveOffset,
+                v => $"{v:0} ms",
+                string.Empty);
+        }
+
+        private double? resolveOffset(EzLocalProfileDrillScoreRow row)
+        {
+            if (row.AvgAbsOffsetMs is double stored)
+                return stored;
+
+            return resolvedOffsets.GetValueOrDefault(row.ScoreId);
         }
 
         private void distributeCardWidths()

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileBeatmapPerformance.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileBeatmapPerformance.cs
@@ -1,0 +1,139 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Localisation;
+using osu.Game.EzOsuGame.Localization;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    public partial class EzLocalProfileBeatmapPerformance : CompositeDrawable
+    {
+        private const float card_spacing = 8;
+
+        private readonly FillFlowContainer cardsFlow;
+
+        private static readonly MetricDefinition[] metrics =
+        {
+            new MetricDefinition(
+                EzSettingsStrings.LOCAL_PROFILE_BEATMAP_PERF_PP,
+                row => row.PpResolved > 0 ? row.PpResolved : null,
+                EzLocalProfileFormat.FormatPp,
+                "pp"),
+            new MetricDefinition(
+                EzSettingsStrings.LOCAL_PROFILE_BEATMAP_PERF_ACC,
+                row => row.Accuracy,
+                v => $"{v * 100:0.00}%",
+                string.Empty),
+            new MetricDefinition(
+                EzSettingsStrings.LOCAL_PROFILE_BEATMAP_PERF_OFF,
+                row => row.AvgAbsOffsetMs,
+                v => $"{v:0} ms",
+                string.Empty),
+        };
+
+        public EzLocalProfileBeatmapPerformance()
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+
+            InternalChild = cardsFlow = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Horizontal,
+                Spacing = new Vector2(card_spacing, 0),
+            };
+        }
+
+        public void Update(EzLocalProfileDrillScoreRow? current, IReadOnlyList<EzLocalProfileDrillScoreRow> allScores)
+        {
+            cardsFlow.Clear();
+
+            if (current == null)
+            {
+                Hide();
+                return;
+            }
+
+            var peers = EzLocalProfileScoreDrillQuery.PeersOnSameBeatmap(current, allScores);
+
+            foreach (var metric in metrics)
+                cardsFlow.Add(createCard(metric, current, peers));
+
+            Show();
+            distributeCardWidths();
+        }
+
+        protected override void UpdateAfterChildren()
+        {
+            base.UpdateAfterChildren();
+            distributeCardWidths();
+        }
+
+        private void distributeCardWidths()
+        {
+            if (cardsFlow.Count == 0)
+                return;
+
+            float availableWidth = cardsFlow.DrawWidth > 0 ? cardsFlow.DrawWidth : DrawWidth;
+
+            if (availableWidth <= 0)
+                return;
+
+            float cardWidth = (availableWidth - card_spacing * (cardsFlow.Count - 1)) / cardsFlow.Count;
+
+            foreach (var card in cardsFlow.Children)
+            {
+                card.RelativeSizeAxes = Axes.None;
+                card.Width = cardWidth;
+            }
+        }
+
+        private static EzLocalProfileScrollFlagCard createCard(MetricDefinition metric, EzLocalProfileDrillScoreRow current, IReadOnlyList<EzLocalProfileDrillScoreRow> peers)
+        {
+            var peerValues = peers
+                             .Select(metric.SelectValue)
+                             .Where(v => v != null)
+                             .Select(v => v!.Value)
+                             .ToList();
+
+            string headerValue = formatValue(metric, metric.SelectValue(current));
+            string maxValue = peerValues.Count > 0 ? formatValue(metric, peerValues.Max()) : "—";
+            string minValue = peerValues.Count > 0 ? formatValue(metric, peerValues.Min()) : "—";
+            string avgValue = peerValues.Count > 0 ? formatValue(metric, peerValues.Average()) : "—";
+
+            return new EzLocalProfileScrollFlagCard(metric.Title, headerValue, maxValue, minValue, avgValue);
+        }
+
+        private static string formatValue(MetricDefinition metric, double? value)
+        {
+            if (value is not double resolved)
+                return "—";
+
+            string suffix = string.IsNullOrEmpty(metric.Suffix) ? string.Empty : $" {metric.Suffix}";
+            return $"{metric.Format(resolved)}{suffix}";
+        }
+
+        private readonly struct MetricDefinition
+        {
+            public LocalisableString Title { get; }
+            public Func<EzLocalProfileDrillScoreRow, double?> SelectValue { get; }
+            public Func<double, string> Format { get; }
+            public string Suffix { get; }
+
+            public MetricDefinition(LocalisableString title, Func<EzLocalProfileDrillScoreRow, double?> selectValue, Func<double, string> format, string suffix)
+            {
+                Title = title;
+                SelectValue = selectValue;
+                Format = format;
+                Suffix = suffix;
+            }
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileBucketBars.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileBucketBars.cs
@@ -1,0 +1,103 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    /// <summary>
+    /// Horizontal rounded bar list for bucketed play counts (official star, xxy SR, etc.).
+    /// </summary>
+    public partial class EzLocalProfileBucketBars : FillFlowContainer
+    {
+        public EzLocalProfileBucketBars(IEnumerable<(int bucket, int count)> buckets, Func<int, string> formatBucketLabel)
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            Direction = FillDirection.Vertical;
+            Spacing = new Vector2(0, 8);
+
+            var list = buckets.OrderBy(b => b.bucket).ToList();
+
+            if (list.Count == 0)
+            {
+                Add(new OsuSpriteText
+                {
+                    Text = EzSettingsStrings.LOCAL_PROFILE_NO_RULESET_DATA,
+                    Font = OsuFont.GetFont(size: 14),
+                });
+                return;
+            }
+
+            int max = list.Max(b => b.count);
+
+            foreach (var (bucket, count) in list)
+                Add(new BucketBarRow(bucket, count, max, formatBucketLabel));
+        }
+
+        public static EzLocalProfileBucketBars FromStarPlayCounts(IEnumerable<EzLocalProfileStarPlayCount> stars) =>
+            new EzLocalProfileBucketBars(
+                stars.Select(s => (s.StarBucket, s.Count)),
+                bucket => $"{bucket}★–{bucket + 1}★");
+
+        public static EzLocalProfileBucketBars FromXxyPlayCounts(IEnumerable<EzLocalProfileXxyPlayCount> plays) =>
+            new EzLocalProfileBucketBars(
+                plays.Select(s => (s.StarBucket, s.Count)),
+                bucket => $"{bucket}xxy–{bucket + 1}xxy");
+
+        private partial class BucketBarRow : Container
+        {
+            public BucketBarRow(int bucket, int count, int max, Func<int, string> formatBucketLabel)
+            {
+                RelativeSizeAxes = Axes.X;
+                Height = 22;
+                Padding = new MarginPadding { Horizontal = 4 };
+
+                float ratio = max <= 0 ? 0 : (float)count / max;
+
+                Children = new Drawable[]
+                {
+                    new OsuSpriteText
+                    {
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Text = formatBucketLabel(bucket),
+                        Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
+                        Width = 72,
+                    },
+                    new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Padding = new MarginPadding { Left = 80, Right = 56 },
+                        Child = new EzLocalProfileRoundedBar(ratio),
+                    },
+                    new CountText(count),
+                };
+            }
+
+            private partial class CountText : OsuSpriteText
+            {
+                public CountText(int count)
+                {
+                    Anchor = Anchor.CentreRight;
+                    Origin = Anchor.CentreRight;
+                    Text = count.ToString("N0");
+                    Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold);
+                }
+
+                [BackgroundDependencyLoader]
+                private void load(OverlayColourProvider colours) => Colour = colours.Content2;
+            }
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileCareerBody.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileCareerBody.cs
@@ -1,0 +1,27 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    /// <summary>
+    /// Merged career summary: PP, duration, keys, KPS, and score count on one row; grades below.
+    /// </summary>
+    public partial class EzLocalProfileCareerBody : FillFlowContainer
+    {
+        public EzLocalProfileCareerBody(EzLocalProfileRulesetStats rulesetStats, IEnumerable<EzLocalProfileGradeCount> gradeCounts)
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            Direction = FillDirection.Vertical;
+            Spacing = new Vector2(0, 12);
+
+            Add(new EzLocalProfileCareerSummaryRow(rulesetStats));
+            Add(new EzLocalProfileGradeRow(gradeCounts));
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileChartCard.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileChartCard.cs
@@ -1,0 +1,78 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    /// <summary>
+    /// Rounded background shell shared by line charts and horizontal bar chart columns.
+    /// </summary>
+    public partial class EzLocalProfileChartCard : Container
+    {
+        public const float HORIZONTAL_PADDING = 8f;
+        public const float VERTICAL_PADDING = 8f;
+
+        public EzLocalProfileChartCard(LocalisableString title, Drawable body)
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            Masking = true;
+            CornerRadius = 8;
+
+            var flow = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(0, 6),
+                Children = new Drawable[]
+                {
+                    new OsuSpriteText
+                    {
+                        Text = title,
+                        Font = OsuFont.GetFont(size: 13, weight: FontWeight.Bold),
+                        Padding = new MarginPadding
+                        {
+                            Horizontal = HORIZONTAL_PADDING,
+                            Top = VERTICAL_PADDING,
+                        },
+                    },
+                    new Container
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Padding = new MarginPadding
+                        {
+                            Horizontal = HORIZONTAL_PADDING,
+                            Bottom = VERTICAL_PADDING,
+                        },
+                        Child = body,
+                    },
+                }
+            };
+
+            body.RelativeSizeAxes = Axes.X;
+            Child = flow;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colours)
+        {
+            AddInternal(new Box
+            {
+                RelativeSizeAxes = Axes.Both,
+                Colour = colours.Background5,
+                Depth = float.MaxValue,
+            });
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileDrillMods.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileDrillMods.cs
@@ -1,0 +1,44 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using osu.Game.Online.API;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    public static class EzLocalProfileDrillMods
+    {
+        public static Mod[] Resolve(EzLocalProfileDrillScoreRow row, RulesetStore rulesets)
+        {
+            if (string.IsNullOrEmpty(row.ModsJson))
+                return Array.Empty<Mod>();
+
+            var ruleset = rulesets.GetRuleset(row.RulesetId)?.CreateInstance();
+            if (ruleset == null)
+                return Array.Empty<Mod>();
+
+            try
+            {
+                var apiMods = JsonConvert.DeserializeObject<APIMod[]>(row.ModsJson) ?? Array.Empty<APIMod>();
+                var mods = new List<Mod>();
+
+                foreach (var apiMod in apiMods)
+                {
+                    var mod = ruleset.CreateModFromAcronym(apiMod.Acronym);
+                    if (mod != null)
+                        mods.Add(mod);
+                }
+
+                return mods.ToArray();
+            }
+            catch
+            {
+                return Array.Empty<Mod>();
+            }
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileDrillScoreRow.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileDrillScoreRow.cs
@@ -1,0 +1,163 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using osu.Game.Beatmaps;
+using osu.Game.EzOsuGame.Analysis;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    /// <summary>
+    /// One drill score row persisted in <c>ez-local-profile.sqlite</c> and used by the overlay at runtime.
+    /// </summary>
+    public sealed class EzLocalProfileDrillScoreRow
+    {
+        public Guid ScoreId { get; init; }
+        public string ScoreHash { get; init; } = string.Empty;
+        public string Username { get; init; } = string.Empty;
+        public int RulesetId { get; init; }
+        public ScoreRank Rank { get; init; }
+        public double PpResolved { get; init; }
+        public double Accuracy { get; init; }
+        public int MaxCombo { get; init; }
+        public int MaxAchievableCombo { get; init; }
+        public long TotalScore { get; init; }
+        public string ModsJson { get; init; } = string.Empty;
+        public long TotalKeys { get; init; }
+        public string BeatmapHash { get; init; } = string.Empty;
+        public Guid BeatmapId { get; init; }
+        public Guid? BeatmapSetId { get; init; }
+        public string Title { get; init; } = string.Empty;
+        public string Artist { get; init; } = string.Empty;
+        public string DifficultyName { get; init; } = string.Empty;
+        public string MapperUsername { get; init; } = string.Empty;
+        public BeatmapOnlineStatus BeatmapStatus { get; init; }
+        public double StarRating { get; init; }
+        public double XxyStarRating { get; init; }
+        public double MapPerformancePoints { get; init; }
+        public double KpsAvg { get; init; }
+        public double KpsMax { get; init; }
+        public string KpsListJson { get; init; } = "[]";
+        public string ColumnCountsJson { get; init; } = "{}";
+        public string HoldCountsJson { get; init; } = "{}";
+        public double? AvgAbsOffsetMs { get; init; }
+        public bool HasVideo { get; init; }
+        public bool HasStoryboard { get; init; }
+        public DateTimeOffset Date { get; init; }
+
+        public string FormatPpText() => PpResolved > 0 ? $"{EzLocalProfileFormat.FormatPp(PpResolved)}pp" : "—";
+
+        public IReadOnlyList<double> ReadKpsList()
+        {
+            try
+            {
+                return JsonSerializer.Deserialize<List<double>>(KpsListJson) ?? new List<double>();
+            }
+            catch
+            {
+                return Array.Empty<double>();
+            }
+        }
+
+        public EzManiaSummary ReadManiaSummary()
+        {
+            try
+            {
+                var columns = JsonSerializer.Deserialize<Dictionary<int, int>>(ColumnCountsJson) ?? new Dictionary<int, int>();
+                var holds = JsonSerializer.Deserialize<Dictionary<int, int>>(HoldCountsJson) ?? new Dictionary<int, int>();
+                return new EzManiaSummary(columns, holds, XxyStarRating >= 0 ? XxyStarRating : null);
+            }
+            catch
+            {
+                return EzManiaSummary.EMPTY;
+            }
+        }
+
+        public static EzLocalProfileDrillScoreRow FromScore(
+            ScoreInfo score,
+            string username,
+            double ppResolved,
+            EzAnalysisResult analysis,
+            bool hasKps)
+        {
+            var beatmap = score.BeatmapInfo!;
+            var metadata = beatmap.Metadata;
+            var maniaSummary = analysis.ManiaSummary;
+
+            return new EzLocalProfileDrillScoreRow
+            {
+                ScoreId = score.ID,
+                ScoreHash = score.Hash,
+                Username = username,
+                RulesetId = score.Ruleset.OnlineID,
+                Rank = score.Rank,
+                PpResolved = ppResolved,
+                Accuracy = score.Accuracy,
+                MaxCombo = score.MaxCombo,
+                MaxAchievableCombo = score.GetMaximumAchievableCombo(),
+                TotalScore = score.TotalScore,
+                ModsJson = score.ModsJson,
+                TotalKeys = countKeys(score),
+                BeatmapHash = score.BeatmapHash,
+                BeatmapId = beatmap.ID,
+                BeatmapSetId = beatmap.BeatmapSet?.ID,
+                Title = metadata.Title ?? "?",
+                Artist = metadata.Artist ?? string.Empty,
+                DifficultyName = beatmap.DifficultyName,
+                MapperUsername = metadata.Author.Username ?? string.Empty,
+                BeatmapStatus = beatmap.Status,
+                StarRating = beatmap.StarRating,
+                XxyStarRating = beatmap.XxyStarRating,
+                MapPerformancePoints = beatmap.PerformancePoints,
+                KpsAvg = hasKps ? analysis.AverageKps : 0,
+                KpsMax = hasKps ? analysis.MaxKps : 0,
+                KpsListJson = JsonSerializer.Serialize(hasKps ? analysis.KpsList.ToList() : new List<double>()),
+                ColumnCountsJson = JsonSerializer.Serialize(maniaSummary?.ColumnCounts ?? new Dictionary<int, int>()),
+                HoldCountsJson = JsonSerializer.Serialize(maniaSummary?.HoldNoteCounts ?? new Dictionary<int, int>()),
+                AvgAbsOffsetMs = computeAvgAbsOffset(score),
+                HasVideo = beatmap.HasVideo == true,
+                HasStoryboard = beatmap.HasStoryboard == true,
+                Date = score.Date,
+            };
+        }
+
+        private static double? computeAvgAbsOffset(ScoreInfo score)
+        {
+            if (score.HitEvents.Count == 0)
+                return null;
+
+            var hits = score.HitEvents.Where(e => e.Result.IsBasic() && e.Result.IsHit()).ToList();
+            if (hits.Count == 0)
+                return null;
+
+            return hits.Average(e => Math.Abs(e.TimeOffset));
+        }
+
+        private static long countKeys(ScoreInfo score)
+        {
+            long fromMaximum = sumCountable(score.MaximumStatistics);
+            if (fromMaximum > 0)
+                return fromMaximum;
+
+            return sumCountable(score.Statistics);
+        }
+
+        private static long sumCountable(IReadOnlyDictionary<HitResult, int> statistics)
+        {
+            long total = 0;
+
+            foreach (var (result, count) in statistics)
+            {
+                if (result.IsScorable() && !result.IsBonus())
+                    total += count;
+            }
+
+            return total;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileDrillScoreRow.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileDrillScoreRow.cs
@@ -83,7 +83,8 @@ namespace osu.Game.EzOsuGame.LocalProfile
             string username,
             double ppResolved,
             EzAnalysisResult analysis,
-            bool hasKps)
+            bool hasKps,
+            double? avgAbsOffsetMs = null)
         {
             var beatmap = score.BeatmapInfo!;
             var metadata = beatmap.Metadata;
@@ -106,10 +107,10 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 BeatmapHash = score.BeatmapHash,
                 BeatmapId = beatmap.ID,
                 BeatmapSetId = beatmap.BeatmapSet?.ID,
-                Title = metadata.Title ?? "?",
-                Artist = metadata.Artist ?? string.Empty,
+                Title = metadata.Title,
+                Artist = metadata.Artist,
                 DifficultyName = beatmap.DifficultyName,
-                MapperUsername = metadata.Author.Username ?? string.Empty,
+                MapperUsername = metadata.Author.Username,
                 BeatmapStatus = beatmap.Status,
                 StarRating = beatmap.StarRating,
                 XxyStarRating = beatmap.XxyStarRating,
@@ -119,14 +120,14 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 KpsListJson = JsonSerializer.Serialize(hasKps ? analysis.KpsList.ToList() : new List<double>()),
                 ColumnCountsJson = JsonSerializer.Serialize(maniaSummary?.ColumnCounts ?? new Dictionary<int, int>()),
                 HoldCountsJson = JsonSerializer.Serialize(maniaSummary?.HoldNoteCounts ?? new Dictionary<int, int>()),
-                AvgAbsOffsetMs = computeAvgAbsOffset(score),
+                AvgAbsOffsetMs = avgAbsOffsetMs ?? ComputeAvgAbsOffsetMs(score),
                 HasVideo = beatmap.HasVideo == true,
                 HasStoryboard = beatmap.HasStoryboard == true,
                 Date = score.Date,
             };
         }
 
-        private static double? computeAvgAbsOffset(ScoreInfo score)
+        public static double? ComputeAvgAbsOffsetMs(ScoreInfo score)
         {
             if (score.HitEvents.Count == 0)
                 return null;

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileExpandableRow.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileExpandableRow.cs
@@ -20,24 +20,23 @@ namespace osu.Game.EzOsuGame.LocalProfile
 {
     public partial class EzLocalProfileExpandableRow : CompositeDrawable
     {
-        private readonly string header;
+        private readonly EzLocalProfileManiaKeyStats keyStats;
         private readonly IReadOnlyList<EzLocalProfileManiaColumnStats> columns;
         private Container detailFlow = null!;
         private SpriteIcon chevron = null!;
+        private FillFlowContainer headerMetrics = null!;
         private bool expanded;
 
         public EzLocalProfileExpandableRow(EzLocalProfileManiaKeyStats keyStats, IReadOnlyList<EzLocalProfileManiaColumnStats> columns)
         {
+            this.keyStats = keyStats;
             this.columns = columns;
-            header =
-                $"{keyStats.KeyCount}K  ·  {keyStats.TotalKeys:N0} keys  ·  avg {keyStats.AvgKps.ToString("0.00", CultureInfo.InvariantCulture)}  ·  max {keyStats.MaxKps.ToString("0.00", CultureInfo.InvariantCulture)}  ·  {keyStats.ScoreCount} plays  ·  {EzLocalProfileFormat.FormatPp(keyStats.TotalPp)}pp  ·  {EzLocalProfileFormat.FormatDuration(keyStats.TotalDurationMs)}";
-
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
         }
 
         [BackgroundDependencyLoader]
-        private void load(OverlayColourProvider colours)
+        private void load(OverlayColourProvider colours, OsuColour osuColours)
         {
             InternalChild = new FillFlowContainer
             {
@@ -65,15 +64,15 @@ namespace osu.Game.EzOsuGame.LocalProfile
                                     Origin = Anchor.CentreLeft,
                                     Colour = colours.Content2,
                                 },
-                                new OsuSpriteText
+                                headerMetrics = new FillFlowContainer
                                 {
-                                    Text = header,
-                                    Font = OsuFont.GetFont(size: 13),
-                                    Colour = colours.Content1,
                                     Anchor = Anchor.CentreLeft,
                                     Origin = Anchor.CentreLeft,
                                     Margin = new MarginPadding { Left = 22 },
-                                }
+                                    AutoSizeAxes = Axes.Both,
+                                    Direction = FillDirection.Horizontal,
+                                    Spacing = new Vector2(10, 0),
+                                },
                             }
                         }
                     },
@@ -87,13 +86,41 @@ namespace osu.Game.EzOsuGame.LocalProfile
                     }
                 }
             };
+
+            rebuildHeader(colours, osuColours);
         }
+
+        private void rebuildHeader(OverlayColourProvider colours, OsuColour osuColours)
+        {
+            headerMetrics.Clear();
+
+            headerMetrics.Add(createSegment($"{keyStats.KeyCount}K", colours.Highlight1));
+            headerMetrics.Add(createSegment($"{keyStats.TotalKeys:N0} keys", osuColours.BlueLight));
+            headerMetrics.Add(createSegment(
+                $"{EzSettingsStrings.LOCAL_PROFILE_AVG_KPS} {formatKps(keyStats.AvgKps)} KPS",
+                osuColours.Orange1));
+            headerMetrics.Add(createSegment(
+                $"{EzSettingsStrings.LOCAL_PROFILE_MAX_KPS} {formatKps(keyStats.MaxKps)} KPS",
+                osuColours.Yellow));
+            headerMetrics.Add(createSegment($"{keyStats.ScoreCount} plays", colours.Content1));
+            headerMetrics.Add(createSegment($"{EzLocalProfileFormat.FormatPp(keyStats.TotalPp)}pp", osuColours.PinkLight));
+            headerMetrics.Add(createSegment(EzLocalProfileFormat.FormatDuration(keyStats.TotalDurationMs), osuColours.Lime1));
+        }
+
+        private static OsuSpriteText createSegment(string text, osuTK.Graphics.Color4 colour) => new OsuSpriteText
+        {
+            Text = text,
+            Font = OsuFont.GetFont(size: 13),
+            Colour = colour,
+        };
+
+        private static string formatKps(double value) => value.ToString("0.00", CultureInfo.InvariantCulture);
 
         private void toggle()
         {
             expanded = !expanded;
             detailFlow.FadeTo(expanded ? 1 : 0, 150, Easing.OutQuint);
-            chevron.RotateTo(expanded ? 90 : 0, 150, Easing.OutQuint);
+            chevron.RotateTo(expanded ? 90 : 0,  150, Easing.OutQuint);
         }
 
         private partial class HeaderButton : OsuClickableContainer
@@ -155,12 +182,6 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
             int maxPlays = ordered.Max(k => k.ScoreCount);
 
-            Add(new OsuSpriteText
-            {
-                Text = EzSettingsStrings.LOCAL_PROFILE_MANIA_PLAYS_BY_KEY,
-                Font = OsuFont.GetFont(size: 13, weight: FontWeight.Bold),
-            });
-
             var barFlow = new FillFlowContainer
             {
                 RelativeSizeAxes = Axes.X,
@@ -175,41 +196,26 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 barFlow.Add(new KeyPlayBarRow($"{key.KeyCount}K", key.ScoreCount, ratio));
             }
 
-            Add(barFlow);
+            Add(new EzLocalProfileChartCard(EzSettingsStrings.LOCAL_PROFILE_MANIA_PLAYS_BY_KEY, barFlow));
 
-            Add(new OsuSpriteText
-            {
-                Text = EzSettingsStrings.LOCAL_PROFILE_MANIA_AVG_KPS_LINE,
-                Font = OsuFont.GetFont(size: 13, weight: FontWeight.Bold),
-                Margin = new MarginPadding { Top = 4 },
-            });
-
-            Add(new EzLocalProfileLabeledLineChart(
-                ordered.Select(k => (float)k.AvgKps).ToArray(),
-                ordered.Select(k => $"{k.KeyCount}K").ToArray())
-            {
-                RelativeSizeAxes = Axes.X,
-            });
+            Add(new EzLocalProfileChartCard(
+                EzSettingsStrings.LOCAL_PROFILE_MANIA_AVG_KPS_LINE,
+                new EzLocalProfileLabeledLineChart(
+                    ordered.Select(k => (float)k.AvgKps).ToArray(),
+                    ordered.Select(k => $"{k.KeyCount}K").ToArray())
+                {
+                    RelativeSizeAxes = Axes.X,
+                }));
         }
 
         private partial class KeyPlayBarRow : Container
         {
-            private readonly string label;
-            private readonly int plays;
-            private readonly float ratio;
-
             public KeyPlayBarRow(string label, int plays, float ratio)
             {
-                this.label = label;
-                this.plays = plays;
-                this.ratio = ratio;
                 RelativeSizeAxes = Axes.X;
                 Height = 20;
-            }
+                Padding = new MarginPadding { Horizontal = 4 };
 
-            [BackgroundDependencyLoader]
-            private void load(OverlayColourProvider colours)
-            {
                 Children = new Drawable[]
                 {
                     new OsuSpriteText
@@ -226,15 +232,22 @@ namespace osu.Game.EzOsuGame.LocalProfile
                         Padding = new MarginPadding { Left = 40, Right = 48 },
                         Child = new EzLocalProfileRoundedBar(ratio),
                     },
-                    new OsuSpriteText
-                    {
-                        Anchor = Anchor.CentreRight,
-                        Origin = Anchor.CentreRight,
-                        Text = plays.ToString("N0"),
-                        Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
-                        Colour = colours.Content2,
-                    }
+                    new CountText(plays),
                 };
+            }
+
+            private partial class CountText : OsuSpriteText
+            {
+                public CountText(int plays)
+                {
+                    Anchor = Anchor.CentreRight;
+                    Origin = Anchor.CentreRight;
+                    Text = plays.ToString("N0");
+                    Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold);
+                }
+
+                [BackgroundDependencyLoader]
+                private void load(OverlayColourProvider colours) => Colour = colours.Content2;
             }
         }
     }

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileHitEventResolver.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileHitEventResolver.cs
@@ -1,0 +1,89 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+using osu.Game.EzOsuGame.Scoring;
+using osu.Game.Scoring;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    /// <summary>
+    /// Resolves average absolute hit offset from stored or replay-generated <see cref="ScoreInfo.HitEvents"/>.
+    /// </summary>
+    public static class EzLocalProfileHitEventResolver
+    {
+        public static async Task<ScoreInfo?> LoadScoreWithHitEventsAsync(
+            Guid scoreId,
+            RealmAccess realm,
+            ScoreManager scoreManager,
+            BeatmapManager beatmapManager,
+            IEzReplaySession replaySession,
+            CancellationToken cancellationToken = default)
+        {
+            var detached = realm.Run(r => r.Find<ScoreInfo>(scoreId)?.DeepClone());
+            if (detached == null)
+                return null;
+
+            await ensureHitEventsAsync(detached, scoreManager, beatmapManager, replaySession, cancellationToken).ConfigureAwait(false);
+            return detached;
+        }
+
+        public static async Task<double?> ResolveAvgAbsOffsetMsAsync(
+            Guid scoreId,
+            RealmAccess realm,
+            ScoreManager scoreManager,
+            BeatmapManager beatmapManager,
+            IEzReplaySession replaySession,
+            CancellationToken cancellationToken = default)
+        {
+            var detached = await LoadScoreWithHitEventsAsync(scoreId, realm, scoreManager, beatmapManager, replaySession, cancellationToken).ConfigureAwait(false);
+            return detached == null ? null : EzLocalProfileDrillScoreRow.ComputeAvgAbsOffsetMs(detached);
+        }
+
+        public static double? ResolveAvgAbsOffsetMs(
+            ScoreInfo score,
+            RealmAccess realm,
+            ScoreManager scoreManager,
+            BeatmapManager beatmapManager,
+            IEzReplaySession replaySession,
+            CancellationToken cancellationToken = default)
+        {
+            if (score.HitEvents.Count > 0)
+                return EzLocalProfileDrillScoreRow.ComputeAvgAbsOffsetMs(score);
+
+            return ResolveAvgAbsOffsetMsAsync(score.ID, realm, scoreManager, beatmapManager, replaySession, cancellationToken)
+                   .GetAwaiter()
+                   .GetResult();
+        }
+
+        private static async Task<bool> ensureHitEventsAsync(
+            ScoreInfo detached,
+            ScoreManager scoreManager,
+            BeatmapManager beatmapManager,
+            IEzReplaySession replaySession,
+            CancellationToken cancellationToken)
+        {
+            if (detached.HitEvents.Count > 0)
+                return true;
+
+            var databasedScore = scoreManager.GetScore(detached);
+            if (databasedScore == null)
+                return false;
+
+            var workingBeatmap = beatmapManager.GetWorkingBeatmap(detached.BeatmapInfo);
+            var playable = workingBeatmap.GetPlayableBeatmap(detached.Ruleset, detached.Mods);
+            var generated = await replaySession.RunHitEventsAsync(databasedScore, playable, ReplayRunPurpose.ForStored, cancellationToken).ConfigureAwait(false);
+
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+            if (generated == null)
+                return false;
+
+            detached.HitEvents = generated;
+            return true;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileManiaKeyPlayBars.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileManiaKeyPlayBars.cs
@@ -1,0 +1,93 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    /// <summary>
+    /// Mania play-count bars grouped by key mode (bar portion of former <see cref="EzLocalProfileManiaOverview"/>).
+    /// </summary>
+    public partial class EzLocalProfileManiaKeyPlayBars : FillFlowContainer
+    {
+        public EzLocalProfileManiaKeyPlayBars(IReadOnlyList<EzLocalProfileManiaKeyStats> keyStats)
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            Direction = FillDirection.Vertical;
+            Spacing = new Vector2(0, 6);
+
+            var ordered = keyStats.OrderBy(k => k.KeyCount).ToList();
+
+            if (ordered.Count == 0)
+            {
+                Add(new OsuSpriteText
+                {
+                    Text = EzSettingsStrings.LOCAL_PROFILE_NO_RULESET_DATA,
+                    Font = OsuFont.GetFont(size: 14),
+                });
+                return;
+            }
+
+            int maxPlays = ordered.Max(k => k.ScoreCount);
+
+            foreach (var key in ordered)
+            {
+                float ratio = maxPlays <= 0 ? 0 : (float)key.ScoreCount / maxPlays;
+                Add(new KeyPlayBarRow($"{key.KeyCount}K", key.ScoreCount, ratio));
+            }
+        }
+
+        private partial class KeyPlayBarRow : Container
+        {
+            public KeyPlayBarRow(string label, int plays, float ratio)
+            {
+                RelativeSizeAxes = Axes.X;
+                Height = 20;
+                Padding = new MarginPadding { Horizontal = 4 };
+
+                Children = new Drawable[]
+                {
+                    new OsuSpriteText
+                    {
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Text = label,
+                        Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
+                        Width = 36,
+                    },
+                    new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Padding = new MarginPadding { Left = 40, Right = 48 },
+                        Child = new EzLocalProfileRoundedBar(ratio),
+                    },
+                    new CountText(plays),
+                };
+            }
+
+            private partial class CountText : OsuSpriteText
+            {
+                public CountText(int plays)
+                {
+                    Anchor = Anchor.CentreRight;
+                    Origin = Anchor.CentreRight;
+                    Text = plays.ToString("N0");
+                    Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold);
+                }
+
+                [BackgroundDependencyLoader]
+                private void load(OverlayColourProvider colours) => Colour = colours.Content2;
+            }
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileMetricRow.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileMetricRow.cs
@@ -16,6 +16,39 @@ using osuTK;
 
 namespace osu.Game.EzOsuGame.LocalProfile
 {
+    /// <summary>
+    /// Single-row career chips: PP, duration, keys, KPS, and score count.
+    /// </summary>
+    public partial class EzLocalProfileCareerSummaryRow : FillFlowContainer
+    {
+        public EzLocalProfileCareerSummaryRow(EzLocalProfileRulesetStats stats)
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            Direction = FillDirection.Full;
+            Spacing = new Vector2(10);
+
+            if (stats.ScoreCount == 0 && stats.TotalKeys == 0 && stats.TotalPp <= 0 && stats.TotalDurationMs <= 0)
+            {
+                Add(new OsuSpriteText
+                {
+                    Text = EzSettingsStrings.LOCAL_PROFILE_NO_RULESET_DATA,
+                    Font = OsuFont.GetFont(size: 14),
+                });
+                return;
+            }
+
+            Add(EzLocalProfileMetricChip.Create(EzSettingsStrings.LOCAL_PROFILE_TOTAL_PP, EzLocalProfileFormat.FormatPp(stats.TotalPp)));
+            Add(EzLocalProfileMetricChip.Create(EzSettingsStrings.LOCAL_PROFILE_TOTAL_DURATION, EzLocalProfileFormat.FormatDuration(stats.TotalDurationMs)));
+            Add(EzLocalProfileMetricChip.Create(EzSettingsStrings.LOCAL_PROFILE_TOTAL_KEYS, stats.TotalKeys.ToString("N0")));
+            Add(EzLocalProfileMetricChip.Create(EzSettingsStrings.LOCAL_PROFILE_AVG_KPS, formatKps(stats.AvgKps)));
+            Add(EzLocalProfileMetricChip.Create(EzSettingsStrings.LOCAL_PROFILE_MAX_KPS, formatKps(stats.MaxKps)));
+            Add(EzLocalProfileMetricChip.Create(EzSettingsStrings.LOCAL_PROFILE_SCORE_COUNT, stats.ScoreCount.ToString("N0")));
+        }
+
+        private static string formatKps(double value) => value.ToString("0.00", CultureInfo.InvariantCulture);
+    }
+
     public partial class EzLocalProfileMetricRow : FillFlowContainer
     {
         public EzLocalProfileMetricRow(EzLocalProfileRulesetStats stats)

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileModeDataBody.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileModeDataBody.cs
@@ -1,0 +1,181 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Localisation;
+using osu.Game.EzOsuGame.Analysis;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    /// <summary>
+    /// Career mode-specific distribution: line charts, horizontal bar columns, and ruleset blocks.
+    /// </summary>
+    public partial class EzLocalProfileModeDataBody : FillFlowContainer
+    {
+        private readonly EzLocalProfileSnapshot snapshot;
+        private readonly int rulesetId;
+
+        public EzLocalProfileModeDataBody(EzLocalProfileSnapshot snapshot, int rulesetId)
+        {
+            this.snapshot = snapshot;
+            this.rulesetId = rulesetId;
+
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            Direction = FillDirection.Vertical;
+            Spacing = new Vector2(0, 16);
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(RulesetStore rulesets)
+        {
+            var ruleset = rulesets.GetRuleset(rulesetId);
+            bool showXxy = rulesetId == EzLocalProfileConstants.MANIA_RULESET_ID
+                           || (ruleset != null && EzXxyStarRatingSupport.SupportsRuleset(ruleset));
+
+            var lineSection = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(0, 12),
+            };
+
+            addLineChart(lineSection, EzSettingsStrings.LOCAL_PROFILE_STAR_PLAY_LINE, createStarLineChart());
+            if (showXxy)
+                addLineChart(lineSection, EzSettingsStrings.LOCAL_PROFILE_XXY_PLAY_LINE, createXxyLineChart());
+
+            if (rulesetId == EzLocalProfileConstants.MANIA_RULESET_ID)
+                addLineChart(lineSection, EzSettingsStrings.LOCAL_PROFILE_MANIA_AVG_KPS_LINE, createManiaKpsLineChart());
+
+            Add(lineSection);
+
+            var barColumns = new List<Drawable>();
+
+            barColumns.Add(createBarColumn(
+                EzSettingsStrings.LOCAL_PROFILE_SECTION_STARS,
+                EzLocalProfileBucketBars.FromStarPlayCounts(snapshot.StarPlayCounts.Where(s => s.RulesetId == rulesetId))));
+
+            if (showXxy)
+            {
+                barColumns.Add(createBarColumn(
+                    EzSettingsStrings.LOCAL_PROFILE_XXY_PLAY_DISTRIBUTION,
+                    EzLocalProfileBucketBars.FromXxyPlayCounts(snapshot.XxyPlayCounts.Where(s => s.RulesetId == rulesetId))));
+            }
+
+            if (rulesetId == EzLocalProfileConstants.MANIA_RULESET_ID)
+            {
+                barColumns.Add(createBarColumn(
+                    EzSettingsStrings.LOCAL_PROFILE_MANIA_PLAYS_BY_KEY,
+                    new EzLocalProfileManiaKeyPlayBars(snapshot.ManiaKeyStats.ToList())));
+            }
+
+            Add(new GridContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) },
+                ColumnDimensions = barColumns.Select(_ => new Dimension(GridSizeMode.Distributed)).ToArray(),
+                Content = new[] { barColumns.ToArray() },
+            });
+
+            if (rulesetId == EzLocalProfileConstants.MANIA_RULESET_ID)
+                Add(createManiaExpandableBlock());
+
+            if (rulesetId == EzLocalProfileConstants.OSU_RULESET_ID)
+                Add(new EzLocalProfileStdAffinityBlock(snapshot));
+        }
+
+        private Drawable createManiaExpandableBlock()
+        {
+            var flow = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(0, 12),
+            };
+
+            var keyStats = snapshot.ManiaKeyStats.OrderBy(k => k.KeyCount).ToList();
+
+            if (keyStats.Count == 0)
+            {
+                flow.Add(new OsuSpriteText
+                {
+                    Text = EzSettingsStrings.LOCAL_PROFILE_NO_RULESET_DATA,
+                    Font = OsuFont.GetFont(size: 14),
+                });
+                return flow;
+            }
+
+            foreach (var key in keyStats)
+            {
+                var columns = snapshot.ManiaColumnStats
+                                      .Where(c => c.KeyCount == key.KeyCount)
+                                      .OrderBy(c => c.ColumnIndex)
+                                      .ToList();
+                flow.Add(new EzLocalProfileExpandableRow(key, columns));
+            }
+
+            return flow;
+        }
+
+        private EzLocalProfileLabeledLineChart? createStarLineChart()
+        {
+            var list = snapshot.StarPlayCounts.Where(s => s.RulesetId == rulesetId).OrderBy(s => s.StarBucket).ToList();
+            if (list.Count == 0)
+                return null;
+
+            return new EzLocalProfileLabeledLineChart(
+                list.Select(s => (float)s.Count).ToArray(),
+                list.Select(s => $"{s.StarBucket}★").ToArray());
+        }
+
+        private EzLocalProfileLabeledLineChart? createXxyLineChart()
+        {
+            var list = snapshot.XxyPlayCounts.Where(s => s.RulesetId == rulesetId).OrderBy(s => s.StarBucket).ToList();
+            if (list.Count == 0)
+                return null;
+
+            return new EzLocalProfileLabeledLineChart(
+                list.Select(s => (float)s.Count).ToArray(),
+                list.Select(s => $"{s.StarBucket}xxy").ToArray());
+        }
+
+        private EzLocalProfileLabeledLineChart? createManiaKpsLineChart()
+        {
+            var ordered = snapshot.ManiaKeyStats.OrderBy(k => k.KeyCount).ToList();
+            if (ordered.Count == 0)
+                return null;
+
+            return new EzLocalProfileLabeledLineChart(
+                ordered.Select(k => (float)k.AvgKps).ToArray(),
+                ordered.Select(k => $"{k.KeyCount}K").ToArray());
+        }
+
+        private static void addLineChart(FillFlowContainer parent, LocalisableString title, EzLocalProfileLabeledLineChart? chart)
+        {
+            if (chart == null)
+                return;
+
+            parent.Add(new OsuSpriteText
+            {
+                Text = title,
+                Font = OsuFont.GetFont(size: 13, weight: FontWeight.Bold),
+            });
+            parent.Add(chart);
+        }
+
+        private static Drawable createBarColumn(LocalisableString title, Drawable body) =>
+            new EzLocalProfileChartCard(title, body);
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileModels.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileModels.cs
@@ -31,7 +31,9 @@ namespace osu.Game.EzOsuGame.LocalProfile
         public IReadOnlyList<EzLocalProfileManiaColumnStats> ManiaColumnStats { get; init; } = Array.Empty<EzLocalProfileManiaColumnStats>();
         public IReadOnlyList<EzLocalProfileGradeCount> GradeCounts { get; init; } = Array.Empty<EzLocalProfileGradeCount>();
         public IReadOnlyList<EzLocalProfileStarPlayCount> StarPlayCounts { get; init; } = Array.Empty<EzLocalProfileStarPlayCount>();
+        public IReadOnlyList<EzLocalProfileXxyPlayCount> XxyPlayCounts { get; init; } = Array.Empty<EzLocalProfileXxyPlayCount>();
         public IReadOnlyList<EzLocalProfileStdAttrAffinity> StdAttrAffinities { get; init; } = Array.Empty<EzLocalProfileStdAttrAffinity>();
+        public IReadOnlyList<EzLocalProfileDrillScoreRow> DrillScores { get; init; } = Array.Empty<EzLocalProfileDrillScoreRow>();
     }
 
     public readonly record struct EzLocalProfileRulesetStats(
@@ -66,6 +68,11 @@ namespace osu.Game.EzOsuGame.LocalProfile
     public readonly record struct EzLocalProfileGradeCount(int RulesetId, ScoreRank Rank, int Count);
 
     public readonly record struct EzLocalProfileStarPlayCount(int RulesetId, int StarBucket, int Count);
+
+    /// <summary>
+    /// xxy SR play distribution; bucket semantics mirror <see cref="EzLocalProfileStarPlayCount"/>.
+    /// </summary>
+    public readonly record struct EzLocalProfileXxyPlayCount(int RulesetId, int StarBucket, int Count);
 
     public enum EzLocalProfileStdAttr
     {
@@ -105,7 +112,9 @@ namespace osu.Game.EzOsuGame.LocalProfile
         public Dictionary<(int KeyCount, int Column), MutableManiaColumnStats> ManiaColumnStats { get; } = new Dictionary<(int KeyCount, int Column), MutableManiaColumnStats>();
         public Dictionary<(int RulesetId, ScoreRank Rank), int> GradeCounts { get; } = new Dictionary<(int RulesetId, ScoreRank Rank), int>();
         public Dictionary<(int RulesetId, int StarBucket), int> StarPlayCounts { get; } = new Dictionary<(int RulesetId, int StarBucket), int>();
+        public Dictionary<(int RulesetId, int StarBucket), int> XxyPlayCounts { get; } = new Dictionary<(int RulesetId, int StarBucket), int>();
         public Dictionary<(EzLocalProfileStdAttr Attr, double Value), MutableStdAttr> StdAttrAffinities { get; } = new Dictionary<(EzLocalProfileStdAttr Attr, double Value), MutableStdAttr>();
+        public List<EzLocalProfileDrillScoreRow> DrillScores { get; } = new List<EzLocalProfileDrillScoreRow>();
 
         public sealed class MutableRulesetStats
         {

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOverlay.Drill.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOverlay.Drill.cs
@@ -1,0 +1,92 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    public partial class EzLocalProfileOverlay
+    {
+        private readonly Bindable<EzLocalProfileDrillScoreRow?> currentDrillScore = new Bindable<EzLocalProfileDrillScoreRow?>();
+        private string drillSearchQuery = string.Empty;
+
+        private void refreshDrillContent(EzLocalProfileSnapshot snapshot, int rulesetId)
+        {
+            var allScores = profileService.LoadDrillScores(rulesetId);
+            var filteredScores = EzLocalProfileScoreDrillQuery.Filter(allScores, drillSearchQuery);
+
+            var searchBox = new EzLocalProfileScoreSearchBox();
+            if (!string.IsNullOrEmpty(drillSearchQuery))
+                searchBox.Text = drillSearchQuery;
+
+            searchBox.Current.BindValueChanged(e =>
+            {
+                drillSearchQuery = e.NewValue ?? string.Empty;
+                Schedule(refreshContent);
+            });
+
+            var selector = new EzLocalProfileScoreSelector { Current = { BindTarget = currentDrillScore } };
+            selector.SetScores(filteredScores);
+
+            var detailColumn = new EzLocalProfileScoreDetailColumn(currentDrillScore, allScores);
+
+            contentFlow.Add(new EzLocalProfileSection(
+                EzSettingsStrings.LOCAL_PROFILE_SECTION_SCORE_DRILL,
+                new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Vertical,
+                    Spacing = new Vector2(0, 12),
+                    Children = new Drawable[]
+                    {
+                        searchBox,
+                        filteredScores.Count == 0
+                            ? new OsuSpriteText
+                            {
+                                Text = EzSettingsStrings.LOCAL_PROFILE_DRILL_NO_MATCHES,
+                                Font = OsuFont.GetFont(size: 14),
+                            }
+                            : new GridContainer
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y,
+                                RowDimensions = new[]
+                                {
+                                    new Dimension(GridSizeMode.AutoSize),
+                                },
+                                ColumnDimensions = new[]
+                                {
+                                    new Dimension(GridSizeMode.Absolute, EzLocalProfileScoreSelector.WIDTH),
+                                    new Dimension(),
+                                },
+                                Content = new[]
+                                {
+                                    new Drawable[]
+                                    {
+                                        selector,
+                                        new Container
+                                        {
+                                            RelativeSizeAxes = Axes.X,
+                                            AutoSizeAxes = Axes.Y,
+                                            Margin = new MarginPadding { Left = 12 },
+                                            Child = detailColumn,
+                                        },
+                                    },
+                                },
+                            }
+                    }
+                }));
+
+            contentFlow.Add(new EzLocalProfileSection(
+                EzSettingsStrings.LOCAL_PROFILE_SECTION_TRENDS,
+                new EzLocalProfileScoreTrendPanel(currentDrillScore)));
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOverlay.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOverlay.cs
@@ -8,9 +8,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.EzOsuGame.Localization;
-using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
-using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
 using osu.Game.Rulesets;
 using osuTK;
@@ -159,58 +157,15 @@ namespace osu.Game.EzOsuGame.LocalProfile
             int rulesetId = ruleset.Value?.OnlineID ?? 0;
             var rulesetStats = snapshot.RulesetStats.FirstOrDefault(s => s.RulesetId == rulesetId);
 
-            contentFlow.Add(new EzLocalProfileSection(EzSettingsStrings.LOCAL_PROFILE_SECTION_PERFORMANCE, new EzLocalProfilePerformanceRow(rulesetStats)));
-            contentFlow.Add(new EzLocalProfileSection(EzSettingsStrings.LOCAL_PROFILE_SECTION_KEYS, new EzLocalProfileMetricRow(rulesetStats)));
-
-            if (rulesetId == EzLocalProfileConstants.MANIA_RULESET_ID)
-                contentFlow.Add(new EzLocalProfileSection(EzSettingsStrings.LOCAL_PROFILE_SECTION_MANIA, createManiaContent(snapshot)));
-
-            if (rulesetId == EzLocalProfileConstants.OSU_RULESET_ID)
-                contentFlow.Add(new EzLocalProfileSection(EzSettingsStrings.LOCAL_PROFILE_SECTION_STD, new EzLocalProfileStdAffinityBlock(snapshot)));
+            contentFlow.Add(new EzLocalProfileSection(
+                EzSettingsStrings.LOCAL_PROFILE_SECTION_CAREER,
+                new EzLocalProfileCareerBody(rulesetStats, snapshot.GradeCounts.Where(g => g.RulesetId == rulesetId))));
 
             contentFlow.Add(new EzLocalProfileSection(
-                EzSettingsStrings.LOCAL_PROFILE_SECTION_GRADES,
-                new EzLocalProfileGradeRow(snapshot.GradeCounts.Where(g => g.RulesetId == rulesetId))));
+                EzSettingsStrings.LOCAL_PROFILE_SECTION_MODE_DATA,
+                new EzLocalProfileModeDataBody(snapshot, rulesetId)));
 
-            contentFlow.Add(new EzLocalProfileSection(
-                EzSettingsStrings.LOCAL_PROFILE_SECTION_STARS,
-                new EzLocalProfileStarBars(snapshot.StarPlayCounts.Where(s => s.RulesetId == rulesetId))));
-        }
-
-        private static Drawable createManiaContent(EzLocalProfileSnapshot snapshot)
-        {
-            var flow = new FillFlowContainer
-            {
-                RelativeSizeAxes = Axes.X,
-                AutoSizeAxes = Axes.Y,
-                Direction = FillDirection.Vertical,
-                Spacing = new Vector2(0, 12),
-            };
-
-            var keyStats = snapshot.ManiaKeyStats.OrderBy(k => k.KeyCount).ToList();
-
-            if (keyStats.Count == 0)
-            {
-                flow.Add(new OsuSpriteText
-                {
-                    Text = EzSettingsStrings.LOCAL_PROFILE_NO_RULESET_DATA,
-                    Font = OsuFont.GetFont(size: 14),
-                });
-                return flow;
-            }
-
-            flow.Add(new EzLocalProfileManiaOverview(keyStats));
-
-            foreach (var key in keyStats)
-            {
-                var columns = snapshot.ManiaColumnStats
-                                      .Where(c => c.KeyCount == key.KeyCount)
-                                      .OrderBy(c => c.ColumnIndex)
-                                      .ToList();
-                flow.Add(new EzLocalProfileExpandableRow(key, columns));
-            }
-
-            return flow;
+            refreshDrillContent(snapshot, rulesetId);
         }
     }
 }

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfilePanelSetBackground.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfilePanelSetBackground.cs
@@ -1,0 +1,133 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Beatmaps;
+using osu.Game.Overlays;
+using osu.Game.Screens.Select;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    /// <summary>
+    /// Song-select style panel background for the local profile drill card.
+    /// Unlike <see cref="PanelSetBackground"/>, always loads cover art (no acrylic/carousel deferral).
+    /// </summary>
+    public partial class EzLocalProfilePanelSetBackground : Container
+    {
+        private WorkingBeatmap? working;
+        private Sprite? sprite;
+        private CancellationTokenSource? loadCancellation;
+
+        public WorkingBeatmap? Beatmap
+        {
+            get => working;
+            set
+            {
+                if (getBackgroundFileHash(working) == getBackgroundFileHash(value))
+                    return;
+
+                working = value;
+
+                loadCancellation?.Cancel();
+                loadCancellation = null;
+
+                sprite?.Expire();
+                sprite = null;
+
+                if (IsLoaded)
+                    beginLoad();
+            }
+        }
+
+        public EzLocalProfilePanelSetBackground()
+        {
+            RelativeSizeAxes = Axes.Both;
+            CornerRadius = Panel.CORNER_RADIUS;
+            Masking = true;
+            MaskingSmoothness = 2f;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            InternalChild = new Container
+            {
+                Depth = 1,
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = ColourInfo.GradientHorizontal(colourProvider.Background3, colourProvider.Background4),
+                    },
+                    new FillFlowContainer
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Direction = FillDirection.Horizontal,
+                        Shear = new Vector2(0.8f, 0),
+                        Children = new[]
+                        {
+                            new Box
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Colour = Color4.Black.Opacity(0.5f),
+                                Width = 0.4f,
+                            },
+                            new Box
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Colour = ColourInfo.GradientHorizontal(Color4.Black.Opacity(0.5f), Color4.Black.Opacity(0.3f)),
+                                Width = 0.2f,
+                            },
+                            new Box
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Colour = ColourInfo.GradientHorizontal(Color4.Black.Opacity(0.3f), Color4.Black.Opacity(0.2f)),
+                                Width = 0.45f,
+                            },
+                        },
+                    },
+                },
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            beginLoad();
+        }
+
+        private void beginLoad()
+        {
+            if (working == null || loadCancellation != null)
+                return;
+
+            loadCancellation = new CancellationTokenSource();
+
+            LoadComponentAsync(new PanelSetBackground.PanelBeatmapBackground(working)
+            {
+                RelativeSizeAxes = Axes.Both,
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                FillMode = FillMode.Fill,
+            }, s =>
+            {
+                AddInternal(sprite = s);
+                sprite.FadeInFromZero(400, Easing.OutQuint);
+            }, loadCancellation.Token);
+        }
+
+        private static string? getBackgroundFileHash(WorkingBeatmap? working)
+            => working?.BeatmapSetInfo.GetFile(working.Metadata.BackgroundFile)?.File.Hash;
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfilePartitionPayload.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfilePartitionPayload.cs
@@ -17,7 +17,9 @@ namespace osu.Game.EzOsuGame.LocalProfile
         public List<PartitionManiaColumnStats> ManiaColumnStats { get; set; } = new List<PartitionManiaColumnStats>();
         public List<PartitionGradeCount> GradeCounts { get; set; } = new List<PartitionGradeCount>();
         public List<PartitionStarPlayCount> StarPlayCounts { get; set; } = new List<PartitionStarPlayCount>();
+        public List<PartitionXxyPlayCount> XxyPlayCounts { get; set; } = new List<PartitionXxyPlayCount>();
         public List<PartitionStdAttrAffinity> StdAttrAffinities { get; set; } = new List<PartitionStdAttrAffinity>();
+        public List<EzLocalProfileDrillScoreRow> DrillScores { get; set; } = new List<EzLocalProfileDrillScoreRow>();
 
         public static EzLocalProfilePartitionPayload FromAggregation(EzLocalProfileAggregationResult result)
         {
@@ -73,6 +75,9 @@ namespace osu.Game.EzOsuGame.LocalProfile
             foreach (var ((rulesetId, starBucket), count) in result.StarPlayCounts)
                 payload.StarPlayCounts.Add(new PartitionStarPlayCount { RulesetId = rulesetId, StarBucket = starBucket, Count = count });
 
+            foreach (var ((rulesetId, starBucket), count) in result.XxyPlayCounts)
+                payload.XxyPlayCounts.Add(new PartitionXxyPlayCount { RulesetId = rulesetId, StarBucket = starBucket, Count = count });
+
             foreach (var ((attr, value), stats) in result.StdAttrAffinities)
             {
                 payload.StdAttrAffinities.Add(new PartitionStdAttrAffinity
@@ -83,6 +88,8 @@ namespace osu.Game.EzOsuGame.LocalProfile
                     HighGradeCount = stats.HighGradeCount,
                 });
             }
+
+            payload.DrillScores.AddRange(result.DrillScores);
 
             return payload;
         }
@@ -140,6 +147,13 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 target.StarPlayCounts[key] = existing + row.Count;
             }
 
+            foreach (var row in XxyPlayCounts)
+            {
+                var key = (row.RulesetId, row.StarBucket);
+                target.XxyPlayCounts.TryGetValue(key, out int existing);
+                target.XxyPlayCounts[key] = existing + row.Count;
+            }
+
             foreach (var row in StdAttrAffinities)
             {
                 var key = ((EzLocalProfileStdAttr)row.Attr, row.Value);
@@ -147,6 +161,8 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 stats.PlayCount += row.PlayCount;
                 stats.HighGradeCount += row.HighGradeCount;
             }
+
+            target.DrillScores.AddRange(DrillScores);
         }
 
         private static TValue getOrCreate<TKey, TValue>(Dictionary<TKey, TValue> dict, TKey key, Func<TValue> factory)
@@ -205,6 +221,13 @@ namespace osu.Game.EzOsuGame.LocalProfile
     }
 
     public sealed class PartitionStarPlayCount
+    {
+        public int RulesetId { get; set; }
+        public int StarBucket { get; set; }
+        public int Count { get; set; }
+    }
+
+    public sealed class PartitionXxyPlayCount
     {
         public int RulesetId { get; set; }
         public int StarBucket { get; set; }

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfilePpResolver.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfilePpResolver.cs
@@ -1,0 +1,138 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Logging;
+using osu.Game.Beatmaps;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.Rulesets.Difficulty;
+using osu.Game.Scoring;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    /// <summary>
+    /// Shared PP resolution for career aggregation and drill score snapshots.
+    /// </summary>
+    public sealed class EzLocalProfilePpResolver
+    {
+        private readonly BeatmapManager beatmapManager;
+
+        public EzLocalProfilePpResolver(BeatmapManager beatmapManager)
+        {
+            this.beatmapManager = beatmapManager;
+        }
+
+        public double[] ResolveAll(
+            IReadOnlyList<ScoreInfo> scores,
+            IProgress<EzLocalProfileComputeProgress>? progress = null,
+            int progressTotal = 0,
+            System.Threading.CancellationToken cancellationToken = default)
+        {
+            double[] values = new double[scores.Count];
+            if (scores.Count == 0)
+                return values;
+
+            var attributeCache = new Dictionary<string, DifficultyAttributes?>(StringComparer.Ordinal);
+            int failures = 0;
+            int loggedFailures = 0;
+            const int max_logged_failures = 8;
+            int reportEvery = Math.Max(10, Math.Max(1, progressTotal) / 100);
+
+            for (int i = 0; i < scores.Count; i++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                values[i] = resolvePp(scores[i], attributeCache, ref failures, ref loggedFailures, max_logged_failures);
+
+                int current = i + 1;
+                if (progress != null && (current == scores.Count || current % reportEvery == 0))
+                    progress.Report(new EzLocalProfileComputeProgress(current, progressTotal, Saving: false));
+            }
+
+            if (failures > 0)
+            {
+                Logger.Log(
+                    $"[EzLocalProfile] PP calc finished with {failures} failure(s) out of {scores.Count} score(s).",
+                    Ez2ConfigManager.LOGGER_NAME);
+            }
+
+            return values;
+        }
+
+        public double ResolvePp(ScoreInfo score)
+        {
+            int failures = 0;
+            int loggedFailures = 0;
+            return resolvePp(score, new Dictionary<string, DifficultyAttributes?>(StringComparer.Ordinal), ref failures, ref loggedFailures, maxLoggedFailures: 0);
+        }
+
+        private double resolvePp(
+            ScoreInfo score,
+            Dictionary<string, DifficultyAttributes?> attributeCache,
+            ref int failures,
+            ref int loggedFailures,
+            int maxLoggedFailures)
+        {
+            if (score.PP is > 0)
+                return score.PP.Value;
+
+            if (score.Rank == ScoreRank.F)
+                return 0;
+
+            if (score.BeatmapInfo == null)
+                return 0;
+
+            try
+            {
+                var ruleset = score.Ruleset.CreateInstance();
+                var calculator = ruleset.CreatePerformanceCalculator();
+                if (calculator == null)
+                    return 0;
+
+                string cacheKey = buildAttributeCacheKey(score);
+
+                if (!attributeCache.TryGetValue(cacheKey, out var attributes))
+                {
+                    attributes = tryCalculateAttributes(score, ruleset);
+                    attributeCache[cacheKey] = attributes;
+                }
+
+                if (attributes == null)
+                    return 0;
+
+                return Math.Max(0, calculator.Calculate(score, attributes).Total);
+            }
+            catch (Exception ex)
+            {
+                failures++;
+
+                if (maxLoggedFailures > 0 && ++loggedFailures <= maxLoggedFailures)
+                {
+                    Logger.Log($"[EzLocalProfile] PP calc failed for score {score.ID}: {ex.Message}", Ez2ConfigManager.LOGGER_NAME);
+                }
+
+                return 0;
+            }
+        }
+
+        private DifficultyAttributes? tryCalculateAttributes(ScoreInfo score, Rulesets.Ruleset ruleset)
+        {
+            try
+            {
+                var working = beatmapManager.GetWorkingBeatmap(score.BeatmapInfo);
+                return ruleset.CreateDifficultyCalculator(working).Calculate(score.Mods);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log(
+                    $"[EzLocalProfile] Difficulty attrs failed ({score.BeatmapInfo?.ID}): {ex.Message}",
+                    Ez2ConfigManager.LOGGER_NAME,
+                    LogLevel.Verbose);
+                return null;
+            }
+        }
+
+        private static string buildAttributeCacheKey(ScoreInfo score) => $"{score.BeatmapInfo?.ID:N}|{score.Ruleset.ShortName}|{score.ModsJson}";
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileScoreDetailPanels.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileScoreDetailPanels.cs
@@ -81,7 +81,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
     {
         public const float HEIGHT = PanelBeatmapStandalone.HEIGHT;
 
-        private PanelSetBackground beatmapBackground = null!;
+        private EzLocalProfilePanelSetBackground beatmapBackground = null!;
         private UpdateableRank rankDisplay = null!;
         private StarRatingDisplay starRatingDisplay = null!;
         private OsuSpriteText titleText = null!;
@@ -112,7 +112,8 @@ namespace osu.Game.EzOsuGame.LocalProfile
         {
             InternalChildren = new Drawable[]
             {
-                beatmapBackground = new PanelSetBackground(),
+                beatmapBackground = new EzLocalProfilePanelSetBackground(),
+                // Match song-select panel dimming over cover art.
                 new Box
                 {
                     RelativeSizeAxes = Axes.Both,

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileScoreDetailPanels.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileScoreDetailPanels.cs
@@ -1,0 +1,465 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.Drawables;
+using osu.Game.EzOsuGame.Analysis;
+using osu.Game.EzOsuGame.UserInterface;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Online.Leaderboards;
+using osu.Game.Overlays;
+using osu.Game.Resources.Localisation.Web;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.UI;
+using osu.Game.Scoring;
+using osu.Game.Screens.Select;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    public readonly struct EzLocalProfileScoreDisplayData
+    {
+        public ScoreRank Rank { get; }
+        public double? Pp { get; }
+        public string AccuracyText { get; }
+        public bool PerfectAccuracy { get; }
+        public int MaxCombo { get; }
+        public int MaxAchievableCombo { get; }
+        public long TotalScore { get; }
+        public string Username { get; }
+        public Mod[] Mods { get; }
+
+        private EzLocalProfileScoreDisplayData(
+            ScoreRank rank,
+            double? pp,
+            string accuracyText,
+            bool perfectAccuracy,
+            int maxCombo,
+            int maxAchievableCombo,
+            long totalScore,
+            string username,
+            Mod[] mods)
+        {
+            Rank = rank;
+            Pp = pp;
+            AccuracyText = accuracyText;
+            PerfectAccuracy = perfectAccuracy;
+            MaxCombo = maxCombo;
+            MaxAchievableCombo = maxAchievableCombo;
+            TotalScore = totalScore;
+            Username = username;
+            Mods = mods;
+        }
+
+        public static EzLocalProfileScoreDisplayData? From(EzLocalProfileDrillScoreRow row, Mod[] mods)
+        {
+            return new EzLocalProfileScoreDisplayData(
+                row.Rank,
+                row.PpResolved > 0 ? row.PpResolved : null,
+                $"{row.Accuracy * 100:0.00}%",
+                row.Accuracy == 1,
+                row.MaxCombo,
+                row.MaxAchievableCombo,
+                row.TotalScore,
+                row.Username,
+                mods);
+        }
+    }
+
+    public partial class EzLocalProfileScoreBeatmapCard : CompositeDrawable
+    {
+        public const float HEIGHT = PanelBeatmapStandalone.HEIGHT;
+
+        private PanelSetBackground beatmapBackground = null!;
+        private UpdateableRank rankDisplay = null!;
+        private StarRatingDisplay starRatingDisplay = null!;
+        private OsuSpriteText titleText = null!;
+        private OsuSpriteText artistText = null!;
+        private BeatmapSetOnlineStatusPill statusPill = null!;
+        private OsuSpriteText difficultyText = null!;
+        private OsuSpriteText authorText = null!;
+        private EzDisplayKpsGraph ezDisplayKpsGraph = null!;
+        private EzDisplayKps ezDisplayKps = null!;
+        private EzDisplayKpc ezDisplayKpc = null!;
+        private EzDisplaySR displaySR = null!;
+        private EzDisplayTag ezDisplayTag = null!;
+        private Box accentStrip = null!;
+
+        [Resolved]
+        private BeatmapManager beatmapManager { get; set; } = null!;
+
+        public EzLocalProfileScoreBeatmapCard()
+        {
+            RelativeSizeAxes = Axes.X;
+            Height = HEIGHT;
+            Masking = true;
+            CornerRadius = 10;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            InternalChildren = new Drawable[]
+            {
+                beatmapBackground = new PanelSetBackground(),
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = Color4.Black.Opacity(0.3f),
+                },
+                accentStrip = new Box
+                {
+                    RelativeSizeAxes = Axes.Y,
+                    Width = 4,
+                },
+                new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Masking = true,
+                    Padding = new MarginPadding { Left = 10.5f },
+                    Child = new FillFlowContainer
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Direction = FillDirection.Horizontal,
+                        Spacing = new Vector2(5),
+                        Children = new Drawable[]
+                        {
+                            rankDisplay = new UpdateableRank(animate: false)
+                            {
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                                Size = new Vector2(40, 20),
+                                Scale = new Vector2(0.8f),
+                            },
+                            new Container
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Masking = true,
+                                Child = new FillFlowContainer
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    Anchor = Anchor.CentreLeft,
+                                    Origin = Anchor.CentreLeft,
+                                    Direction = FillDirection.Vertical,
+                                    Padding = new MarginPadding { Bottom = 4.8f },
+                                    Children = new Drawable[]
+                                    {
+                                        titleText = new TruncatingSpriteText
+                                        {
+                                            RelativeSizeAxes = Axes.X,
+                                            Font = OsuFont.Style.Heading2.With(typeface: Typeface.TorusAlternate, weight: FontWeight.Bold),
+                                        },
+                                        artistText = new TruncatingSpriteText
+                                        {
+                                            RelativeSizeAxes = Axes.X,
+                                            Font = OsuFont.Style.Caption1.With(weight: FontWeight.SemiBold),
+                                            Padding = new MarginPadding { Top = -2 },
+                                        },
+                                        new FillFlowContainer
+                                        {
+                                            RelativeSizeAxes = Axes.X,
+                                            AutoSizeAxes = Axes.Y,
+                                            Direction = FillDirection.Horizontal,
+                                            Padding = new MarginPadding { Top = 2, Bottom = 2 },
+                                            Spacing = new Vector2(6),
+                                            Children = new Drawable[]
+                                            {
+                                                statusPill = new BeatmapSetOnlineStatusPill
+                                                {
+                                                    Anchor = Anchor.CentreLeft,
+                                                    Origin = Anchor.CentreLeft,
+                                                    Animated = false,
+                                                    TextSize = OsuFont.Style.Caption2.Size,
+                                                    Margin = new MarginPadding { Right = 4f },
+                                                },
+                                                difficultyText = new OsuSpriteText
+                                                {
+                                                    Anchor = Anchor.CentreLeft,
+                                                    Origin = Anchor.CentreLeft,
+                                                    Font = OsuFont.Style.Body.With(weight: FontWeight.SemiBold),
+                                                    Margin = new MarginPadding { Right = 3f },
+                                                },
+                                                authorText = new TruncatingSpriteText
+                                                {
+                                                    Anchor = Anchor.CentreLeft,
+                                                    Origin = Anchor.CentreLeft,
+                                                    RelativeSizeAxes = Axes.X,
+                                                    Colour = colourProvider.Content2,
+                                                    Font = OsuFont.Style.Caption1.With(weight: FontWeight.SemiBold),
+                                                },
+                                            },
+                                        },
+                                        new FillFlowContainer
+                                        {
+                                            RelativeSizeAxes = Axes.X,
+                                            AutoSizeAxes = Axes.Y,
+                                            Direction = FillDirection.Horizontal,
+                                            Padding = new MarginPadding { Top = 2, Bottom = 2 },
+                                            Spacing = new Vector2(3),
+                                            Children = new Drawable[]
+                                            {
+                                                starRatingDisplay = new StarRatingDisplay(default, StarRatingDisplaySize.Small, animated: true)
+                                                {
+                                                    Anchor = Anchor.CentreLeft,
+                                                    Origin = Anchor.CentreLeft,
+                                                    Scale = new Vector2(0.875f),
+                                                },
+                                                displaySR = new EzDisplaySR(EzManiaSummary.EMPTY, StarRatingDisplaySize.Small, animated: true)
+                                                {
+                                                    Anchor = Anchor.CentreLeft,
+                                                    Origin = Anchor.CentreLeft,
+                                                    Scale = new Vector2(0.875f),
+                                                },
+                                                ezDisplayKps = new EzDisplayKps
+                                                {
+                                                    Anchor = Anchor.CentreLeft,
+                                                    Origin = Anchor.CentreLeft,
+                                                    Scale = new Vector2(0.875f),
+                                                },
+                                                ezDisplayKpc = new EzDisplayKpc
+                                                {
+                                                    Anchor = Anchor.CentreLeft,
+                                                    Origin = Anchor.CentreLeft,
+                                                },
+                                            },
+                                        },
+                                        ezDisplayTag = new EzDisplayTag
+                                        {
+                                            Margin = new MarginPadding { Top = 2 },
+                                            Alpha = 0.9f,
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+
+            // Drill detail column is narrow; keep KPS metrics numeric only.
+            ezDisplayKpsGraph = new EzDisplayKpsGraph();
+        }
+
+        public void Update(EzLocalProfileDrillScoreRow row)
+        {
+            rankDisplay.Rank = row.Rank;
+            rankDisplay.Alpha = 1;
+
+            var beatmap = beatmapManager.QueryBeatmap(b => b.ID == row.BeatmapId);
+            beatmapBackground.Beatmap = beatmap != null ? beatmapManager.GetWorkingBeatmap(beatmap) : null;
+
+            titleText.Text = row.Title;
+            artistText.Text = row.Artist;
+            statusPill.Status = row.BeatmapStatus;
+            difficultyText.Text = row.DifficultyName;
+            authorText.Text = BeatmapsetsStrings.ShowDetailsMappedBy(row.MapperUsername);
+
+            starRatingDisplay.Current.Value = new StarDifficulty(row.StarRating, 0);
+            accentStrip.Colour = starRatingDisplay.DisplayedDifficultyColour;
+
+            bool showXxy = row.RulesetId == EzLocalProfileConstants.MANIA_RULESET_ID && row.XxyStarRating >= 0;
+            var maniaSummary = row.ReadManiaSummary();
+
+            if (showXxy)
+            {
+                displaySR.Show();
+                displaySR.Current.Value = maniaSummary;
+            }
+            else
+            {
+                displaySR.Current.Value = EzManiaSummary.EMPTY;
+                displaySR.Hide();
+            }
+
+            ezDisplayTag.Beatmap = beatmap;
+            ezDisplayKps.SetPp(row.MapPerformancePoints > 0 ? row.MapPerformancePoints : null);
+
+            var metrics = new EzSongSelectAnalysisDisplay.PanelMetrics(row.KpsAvg, row.KpsMax, row.ReadKpsList().ToArray(), maniaSummary);
+            applyPanelKps(metrics);
+
+            if (showXxy && maniaSummary.ColumnCounts.Count > 0)
+            {
+                ezDisplayKpc.ManiaSummary = maniaSummary;
+                ezDisplayKpc.Show();
+            }
+            else
+            {
+                ezDisplayKpc.ManiaSummary = null;
+                ezDisplayKpc.Hide();
+            }
+        }
+
+        public void Clear()
+        {
+            rankDisplay.Rank = null;
+            rankDisplay.Alpha = 0;
+            beatmapBackground.Beatmap = null;
+            ezDisplayTag.Beatmap = null;
+        }
+
+        private void applyPanelKps(in EzSongSelectAnalysisDisplay.PanelMetrics metrics)
+        {
+            ezDisplayKpsGraph.SetPoints(metrics.KpsList);
+            ezDisplayKps.SetKpsMetrics(metrics);
+        }
+    }
+
+    public partial class EzLocalProfileScoreDetailRow : CompositeDrawable
+    {
+        private TruncatingSpriteText usernameText = null!;
+        private FillFlowContainer modsFlow = null!;
+
+        public EzLocalProfileScoreDetailRow()
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            Masking = true;
+            CornerRadius = 8;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            InternalChildren = new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = colourProvider.Background5,
+                },
+                new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Vertical,
+                    Padding = new MarginPadding { Horizontal = 10, Vertical = 6 },
+                    Spacing = new Vector2(0, 14),
+                    Children = new Drawable[]
+                    {
+                        usernameText = new TruncatingSpriteText
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            Font = OsuFont.Style.Heading2,
+                            Colour = colourProvider.Content1,
+                        },
+                        modsFlow = new FillFlowContainer
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Direction = FillDirection.Horizontal,
+                            Spacing = new Vector2(4, 0),
+                        },
+                    },
+                },
+            };
+        }
+
+        public void Update(EzLocalProfileScoreDisplayData? data)
+        {
+            if (data == null)
+            {
+                Alpha = 0;
+                return;
+            }
+
+            Alpha = 1;
+            usernameText.Text = data.Value.Username;
+
+            modsFlow.Clear();
+
+            foreach (var mod in data.Value.Mods.AsOrdered())
+            {
+                modsFlow.Add(new ModIcon(mod)
+                {
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    Scale = new Vector2(0.3f),
+                    Height = ModIcon.MOD_ICON_SIZE.Y * 3 / 4f,
+                });
+            }
+
+            modsFlow.Alpha = modsFlow.Count > 0 ? 1 : 0;
+        }
+    }
+
+    public partial class EzLocalProfileScoreDetailColumn : CompositeDrawable
+    {
+        private readonly Bindable<EzLocalProfileDrillScoreRow?> scoreSource;
+        private readonly IReadOnlyList<EzLocalProfileDrillScoreRow> allScores;
+
+        private EzLocalProfileScoreBeatmapCard beatmapCard = null!;
+        private EzLocalProfileScoreDetailRow scoreRow = null!;
+        private EzLocalProfileScoreKeysRow keysRow = null!;
+        private EzLocalProfileBeatmapPerformance beatmapPerformance = null!;
+
+        [Resolved]
+        private RulesetStore rulesets { get; set; } = null!;
+
+        public EzLocalProfileScoreDetailColumn(Bindable<EzLocalProfileDrillScoreRow?> scoreSource, IReadOnlyList<EzLocalProfileDrillScoreRow> allScores)
+        {
+            this.scoreSource = scoreSource;
+            this.allScores = allScores;
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            // Match OsuTextBox inner text inset (LeftRightPadding 10 + margin) on the drill search row.
+            Padding = new MarginPadding { Right = 10 };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            InternalChild = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(0, 12),
+                Children = new Drawable[]
+                {
+                    beatmapCard = new EzLocalProfileScoreBeatmapCard(),
+                    scoreRow = new EzLocalProfileScoreDetailRow(),
+                    keysRow = new EzLocalProfileScoreKeysRow(),
+                    beatmapPerformance = new EzLocalProfileBeatmapPerformance(),
+                },
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            scoreSource.BindValueChanged(v => updateScore(v.NewValue), true);
+        }
+
+        private void updateScore(EzLocalProfileDrillScoreRow? row)
+        {
+            if (row == null)
+            {
+                this.FadeOut(200);
+                beatmapCard.Clear();
+                scoreRow.Update(null);
+                keysRow.UpdateRow(null);
+                beatmapPerformance.Update(null, allScores);
+                return;
+            }
+
+            this.FadeIn(200);
+            beatmapCard.Update(row);
+            var displayData = EzLocalProfileScoreDisplayData.From(row, EzLocalProfileDrillMods.Resolve(row, rulesets));
+            scoreRow.Update(displayData);
+            keysRow.UpdateRow(row, displayData);
+            beatmapPerformance.Update(row, allScores);
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileScoreDrill.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileScoreDrill.cs
@@ -1,0 +1,238 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.UI;
+using osu.Game.Screens.Select;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    public static class EzLocalProfileScoreDrillQuery
+    {
+        public static List<EzLocalProfileDrillScoreRow> Filter(IReadOnlyList<EzLocalProfileDrillScoreRow> scores, string searchText)
+        {
+            if (scores.Count == 0 || string.IsNullOrWhiteSpace(searchText))
+                return scores.ToList();
+
+            string term = searchText.Trim();
+            var results = new List<EzLocalProfileDrillScoreRow>();
+
+            foreach (var row in scores)
+            {
+                if (matchesSearch(row, term))
+                    results.Add(row);
+            }
+
+            return results;
+        }
+
+        public static List<EzLocalProfileDrillScoreRow> PeersOnSameBeatmap(EzLocalProfileDrillScoreRow? row, IEnumerable<EzLocalProfileDrillScoreRow> allScores)
+        {
+            if (row == null)
+                return new List<EzLocalProfileDrillScoreRow>();
+
+            string hash = row.BeatmapHash;
+            string version = row.DifficultyName;
+            var results = new List<EzLocalProfileDrillScoreRow>();
+
+            foreach (var peer in allScores)
+            {
+                if (peer.BeatmapHash == hash && peer.DifficultyName == version)
+                    results.Add(peer);
+            }
+
+            return results;
+        }
+
+        private static bool matchesSearch(EzLocalProfileDrillScoreRow row, string term)
+        {
+            if (double.TryParse(term, NumberStyles.Float, CultureInfo.InvariantCulture, out double ppTarget)
+                && row.PpResolved > 0
+                && Math.Abs(row.PpResolved - ppTarget) < 0.5)
+            {
+                return true;
+            }
+
+            return row.Title.Contains(term, StringComparison.OrdinalIgnoreCase)
+                   || row.Artist.Contains(term, StringComparison.OrdinalIgnoreCase)
+                   || row.MapperUsername.Contains(term, StringComparison.OrdinalIgnoreCase)
+                   || row.DifficultyName.Contains(term, StringComparison.OrdinalIgnoreCase)
+                   || row.PpResolved.ToString(CultureInfo.InvariantCulture).Contains(term, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    public partial class EzLocalProfileScoreSearchBox : OsuTextBox
+    {
+        public EzLocalProfileScoreSearchBox()
+        {
+            PlaceholderText = EzSettingsStrings.LOCAL_PROFILE_DRILL_SEARCH_PLACEHOLDER;
+            RelativeSizeAxes = Axes.X;
+        }
+    }
+
+    public partial class EzLocalProfileScoreSelector : CompositeDrawable
+    {
+        public Bindable<EzLocalProfileDrillScoreRow?> Current { get; } = new Bindable<EzLocalProfileDrillScoreRow?>();
+
+        private readonly BindableList<EzLocalProfileDrillScoreRow> entries = new BindableList<EzLocalProfileDrillScoreRow>();
+        private FillFlowContainer listFlow = null!;
+
+        [Resolved]
+        private RulesetStore rulesets { get; set; } = null!;
+
+        public const float WIDTH = 280f;
+        public const float HEIGHT = 360f;
+
+        public EzLocalProfileScoreSelector()
+        {
+            Width = WIDTH;
+            Height = HEIGHT;
+        }
+
+        public void SetScores(IEnumerable<EzLocalProfileDrillScoreRow> items)
+        {
+            entries.Clear();
+            entries.AddRange(items);
+
+            rebuildList();
+
+            if (entries.Count == 0)
+            {
+                Current.Value = null;
+                return;
+            }
+
+            if (Current.Value == null || !entries.Any(e => e.ScoreId == Current.Value.ScoreId))
+                Current.Value = entries[0];
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            InternalChild = new OsuScrollContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                Child = listFlow = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Vertical,
+                    Spacing = new Vector2(0, 4),
+                }
+            };
+
+            Current.BindValueChanged(_ => rebuildList(), true);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            rebuildList();
+        }
+
+        private void rebuildList()
+        {
+            if (listFlow == null)
+                return;
+
+            listFlow.Clear();
+
+            foreach (var row in entries)
+                listFlow.Add(new ScoreEntry(row, Current.Value?.ScoreId == row.ScoreId, () => Current.Value = row, rulesets));
+        }
+
+        private partial class ScoreEntry : OsuClickableContainer
+        {
+            private readonly EzLocalProfileDrillScoreRow row;
+            private FillFlowContainer modsFlow = null!;
+
+            public ScoreEntry(EzLocalProfileDrillScoreRow row, bool selected, Action onSelect, RulesetStore rulesets)
+            {
+                this.row = row;
+                RelativeSizeAxes = Axes.X;
+                Height = BeatmapLeaderboardScore.HEIGHT;
+                Action = onSelect;
+                Alpha = selected ? 1 : 0.65f;
+                Masking = true;
+                CornerRadius = 6;
+
+                Child = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Vertical,
+                    Padding = new MarginPadding { Horizontal = 8, Vertical = 6 },
+                    Spacing = new Vector2(0, 2),
+                    Children = new Drawable[]
+                    {
+                        new OsuSpriteText
+                        {
+                            Text = row.FormatPpText(),
+                            Font = OsuFont.GetFont(size: 13, weight: FontWeight.Bold),
+                        },
+                        new TruncatingSpriteText
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            Text = row.Title,
+                            Font = OsuFont.GetFont(size: 11),
+                        },
+                        modsFlow = new FillFlowContainer
+                        {
+                            AutoSizeAxes = Axes.Both,
+                            Direction = FillDirection.Horizontal,
+                            Spacing = new Vector2(-10, 0),
+                        },
+                    }
+                };
+
+                populateMods(EzLocalProfileDrillMods.Resolve(row, rulesets));
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colours)
+            {
+                AddInternal(new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = colours.Background5,
+                    Depth = 1,
+                });
+            }
+
+            private void populateMods(IReadOnlyList<Mod> mods)
+            {
+                modsFlow.Clear();
+
+                foreach (var mod in mods.AsOrdered())
+                {
+                    modsFlow.Add(new ModIcon(mod)
+                    {
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Scale = new Vector2(0.3f),
+                        Height = ModIcon.MOD_ICON_SIZE.Y * 3 / 4f,
+                    });
+                }
+
+                modsFlow.Alpha = modsFlow.Count > 0 ? 1 : 0;
+            }
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileScoreKeysRow.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileScoreKeysRow.cs
@@ -1,0 +1,68 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Globalization;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Localisation;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Resources.Localisation.Web;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    public partial class EzLocalProfileScoreKeysRow : FillFlowContainer
+    {
+        public EzLocalProfileScoreKeysRow()
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            Direction = FillDirection.Horizontal;
+            Spacing = new Vector2(8);
+        }
+
+        public void UpdateRow(EzLocalProfileDrillScoreRow? row, EzLocalProfileScoreDisplayData? data = null)
+        {
+            Clear();
+
+            if (row == null)
+            {
+                Add(new OsuSpriteText
+                {
+                    Text = EzSettingsStrings.LOCAL_PROFILE_SELECT_SCORE,
+                    Font = OsuFont.GetFont(size: 14),
+                });
+                return;
+            }
+
+            if (data != null)
+            {
+                Add(createChip("PP", data.Value.Pp is double pp ? $"{EzLocalProfileFormat.FormatPp(pp)}pp" : "—"));
+                Add(createChip(BeatmapsetsStrings.ShowScoreboardHeadersAccuracy, data.Value.AccuracyText));
+                Add(createChip(
+                    BeatmapsetsStrings.ShowScoreboardHeadersCombo,
+                    $"{data.Value.MaxCombo}x"));
+            }
+
+            string avgKps = row.KpsAvg > 0 ? formatKps(row.KpsAvg) : "—";
+            string maxKps = row.KpsMax > 0 ? formatKps(row.KpsMax) : "—";
+
+            Add(createChip(EzSettingsStrings.LOCAL_PROFILE_TOTAL_KEYS, row.TotalKeys.ToString("N0", CultureInfo.InvariantCulture)));
+            Add(createChip(EzSettingsStrings.LOCAL_PROFILE_AVG_KPS, avgKps));
+            Add(createChip(EzSettingsStrings.LOCAL_PROFILE_MAX_KPS, maxKps));
+            Add(createChip(EzSettingsStrings.LOCAL_PROFILE_SCORE_COUNT, "1"));
+        }
+
+        private static Drawable createChip(LocalisableString title, string value)
+        {
+            var chip = EzLocalProfileMetricChip.Create(title, value);
+            chip.Anchor = Anchor.CentreLeft;
+            chip.Origin = Anchor.CentreLeft;
+            return chip;
+        }
+
+        private static string formatKps(double value) => value.ToString("0.00", CultureInfo.InvariantCulture);
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileScoreTrendPanel.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileScoreTrendPanel.cs
@@ -1,0 +1,156 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.EzOsuGame.Scoring;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
+using osu.Game.Screens.Ranking.Statistics;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    public partial class EzLocalProfileScoreTrendPanel : CompositeDrawable
+    {
+        private const string space_graph_name = "Space Graph";
+
+        private readonly Bindable<EzLocalProfileDrillScoreRow?> currentScore;
+        private FillFlowContainer contentFlow = null!;
+        private CancellationTokenSource? loadCancellation;
+
+        [Resolved]
+        private BeatmapManager beatmapManager { get; set; } = null!;
+
+        [Resolved]
+        private ScoreManager scoreManager { get; set; } = null!;
+
+        [Resolved]
+        private IEzReplaySession replaySession { get; set; } = null!;
+
+        [Resolved]
+        private RealmAccess realm { get; set; } = null!;
+
+        public EzLocalProfileScoreTrendPanel(Bindable<EzLocalProfileDrillScoreRow?> currentScore)
+        {
+            this.currentScore = currentScore;
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            InternalChild = contentFlow = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(0, 12),
+            };
+
+            currentScore.BindValueChanged(_ => Schedule(reloadTrends), true);
+        }
+
+        private void reloadTrends()
+        {
+            loadCancellation?.Cancel();
+            loadCancellation = null;
+            contentFlow.Clear();
+
+            var row = currentScore.Value;
+
+            if (row == null)
+            {
+                contentFlow.Add(createEmptyHint());
+                return;
+            }
+
+            contentFlow.Add(new LoadingSpinner { RelativeSizeAxes = Axes.X, Height = 80 });
+
+            var localCancellation = loadCancellation = new CancellationTokenSource();
+
+            Task.Run(async () =>
+            {
+                var detached = realm.Run(r => r.Find<ScoreInfo>(row.ScoreId)?.DeepClone());
+                if (detached == null)
+                    return null;
+
+                if (detached.HitEvents.Count == 0)
+                {
+                    var databasedScore = scoreManager.GetScore(detached);
+
+                    if (databasedScore != null)
+                    {
+                        var workingBeatmap = beatmapManager.GetWorkingBeatmap(detached.BeatmapInfo);
+                        var playable = workingBeatmap.GetPlayableBeatmap(detached.Ruleset, detached.Mods);
+                        var generated = await replaySession.RunHitEventsAsync(databasedScore, playable, ReplayRunPurpose.ForStored, localCancellation.Token).ConfigureAwait(false);
+
+                        if (generated != null)
+                            detached.HitEvents = generated;
+                    }
+                }
+
+                return detached;
+            }, localCancellation.Token).ContinueWith(task => Schedule(() =>
+            {
+                if (task.IsCanceled)
+                    return;
+
+                contentFlow.Clear();
+
+                if (task.IsFaulted)
+                {
+                    contentFlow.Add(createEmptyHint());
+                    return;
+                }
+
+                var score = task.GetResultSafely();
+
+                if (score == null || score.HitEvents.Count == 0)
+                {
+                    contentFlow.Add(createEmptyHint());
+                    return;
+                }
+
+                var workingBeatmap = beatmapManager.GetWorkingBeatmap(score.BeatmapInfo);
+                var playable = workingBeatmap.GetPlayableBeatmap(score.Ruleset, score.Mods);
+                var ruleset = score.Ruleset.CreateInstance();
+
+                var spaceGraph = ruleset.CreateStatisticsForScore(score, playable)
+                                        .FirstOrDefault(item => item.Name.ToString() == space_graph_name);
+
+                if (spaceGraph != null)
+                {
+                    contentFlow.Add(spaceGraph.CreateContent());
+                    return;
+                }
+
+                var timedHitEvents = score.HitEvents.Where(e => e.Result.IsBasic()).ToList();
+                contentFlow.Add(new HitEventTimingDistributionGraph(timedHitEvents)
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Height = 150,
+                });
+            }), localCancellation.Token);
+        }
+
+        private static OsuSpriteText createEmptyHint() => new OsuSpriteText
+        {
+            Text = EzSettingsStrings.LOCAL_PROFILE_TREND_EMPTY,
+            Font = OsuFont.GetFont(size: 14),
+        };
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileScoreTrendPanel.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileScoreTrendPanel.cs
@@ -82,29 +82,13 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
             var localCancellation = loadCancellation = new CancellationTokenSource();
 
-            Task.Run(async () =>
-            {
-                var detached = realm.Run(r => r.Find<ScoreInfo>(row.ScoreId)?.DeepClone());
-                if (detached == null)
-                    return null;
-
-                if (detached.HitEvents.Count == 0)
-                {
-                    var databasedScore = scoreManager.GetScore(detached);
-
-                    if (databasedScore != null)
-                    {
-                        var workingBeatmap = beatmapManager.GetWorkingBeatmap(detached.BeatmapInfo);
-                        var playable = workingBeatmap.GetPlayableBeatmap(detached.Ruleset, detached.Mods);
-                        var generated = await replaySession.RunHitEventsAsync(databasedScore, playable, ReplayRunPurpose.ForStored, localCancellation.Token).ConfigureAwait(false);
-
-                        if (generated != null)
-                            detached.HitEvents = generated;
-                    }
-                }
-
-                return detached;
-            }, localCancellation.Token).ContinueWith(task => Schedule(() =>
+            Task.Run(async () => await EzLocalProfileHitEventResolver.LoadScoreWithHitEventsAsync(
+                row.ScoreId,
+                realm,
+                scoreManager,
+                beatmapManager,
+                replaySession,
+                localCancellation.Token).ConfigureAwait(false), localCancellation.Token).ContinueWith(task => Schedule(() =>
             {
                 if (task.IsCanceled)
                     return;

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileScrollFlagCard.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileScrollFlagCard.cs
@@ -1,0 +1,141 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    public partial class EzLocalProfileScrollFlagCard : Container
+    {
+        public const float HEADER_HEIGHT = 32;
+        public const float BODY_HEIGHT = 60;
+        public const float CARD_HEIGHT = HEADER_HEIGHT + BODY_HEIGHT;
+
+        public EzLocalProfileScrollFlagCard(LocalisableString title, string headerValue, string max, string min, string avg)
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+
+            InternalChild = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Children = new Drawable[]
+                {
+                    new Header(title, headerValue),
+                    new Body(max, min, avg),
+                },
+            };
+        }
+
+        private partial class Header : Container
+        {
+            private readonly Box background;
+            private readonly OsuTextFlowContainer headerText;
+
+            public Header(LocalisableString title, string headerValue)
+            {
+                RelativeSizeAxes = Axes.X;
+                Height = HEADER_HEIGHT;
+                Masking = true;
+                CornerRadius = 8;
+
+                InternalChildren = new Drawable[]
+                {
+                    background = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    },
+                    headerText = new OsuTextFlowContainer(t => t.Font = OsuFont.GetFont(size: 14, weight: FontWeight.Bold))
+                    {
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        AutoSizeAxes = Axes.Both,
+                        Padding = new MarginPadding { Horizontal = 8, Vertical = 6 },
+                    },
+                };
+
+                headerText.AddText(title);
+                headerText.AddText($" {headerValue}");
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colours)
+            {
+                background.Colour = colours.Highlight1;
+                headerText.Colour = colours.Content1;
+            }
+        }
+
+        private partial class Body : Container
+        {
+            private readonly Box background;
+            private readonly OsuSpriteText maxText;
+            private readonly OsuSpriteText minText;
+            private readonly OsuSpriteText avgText;
+
+            public Body(string max, string min, string avg)
+            {
+                RelativeSizeAxes = Axes.X;
+                Height = BODY_HEIGHT;
+                Masking = true;
+                CornerRadius = 8;
+
+                InternalChildren = new Drawable[]
+                {
+                    background = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    },
+                    new FillFlowContainer
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Direction = FillDirection.Vertical,
+                        Padding = new MarginPadding { Horizontal = 8, Vertical = 8 },
+                        Spacing = new Vector2(0, 2),
+                        Children = new Drawable[]
+                        {
+                            maxText = new OsuSpriteText
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                Text = $"Max  {max}",
+                                Font = OsuFont.GetFont(size: 13),
+                            },
+                            avgText = new OsuSpriteText
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                Text = $"Avg  {avg}",
+                                Font = OsuFont.GetFont(size: 13),
+                            },
+                            minText = new OsuSpriteText
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                Text = $"Min  {min}",
+                                Font = OsuFont.GetFont(size: 13),
+                            },
+                        },
+                    },
+                };
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colours)
+            {
+                background.Colour = colours.Background5;
+                maxText.Colour = colours.Content1;
+                minText.Colour = colours.Content1;
+                avgText.Colour = colours.Content1;
+            }
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileService.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileService.cs
@@ -8,11 +8,13 @@ using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Bindables;
 using osu.Framework.Logging;
+using osu.Framework.Platform;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.EzOsuGame.Analysis;
 using osu.Game.EzOsuGame.Configuration;
-using osu.Framework.Platform;
+using osu.Game.EzOsuGame.Scoring;
+using osu.Game.Scoring;
 
 namespace osu.Game.EzOsuGame.LocalProfile
 {
@@ -30,10 +32,16 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
         public BindableBool IsComputing { get; } = new BindableBool();
 
-        public EzLocalProfileService(Storage storage, RealmAccess realm, EzAnalysisPersistentStore analysisStore, BeatmapManager beatmapManager)
+        public EzLocalProfileService(
+            Storage storage,
+            RealmAccess realm,
+            EzAnalysisPersistentStore analysisStore,
+            BeatmapManager beatmapManager,
+            ScoreManager scoreManager,
+            IEzReplaySession replaySession)
         {
             store = new EzLocalProfileStore(storage);
-            aggregator = new EzLocalProfileAggregator(realm, analysisStore, beatmapManager);
+            aggregator = new EzLocalProfileAggregator(realm, analysisStore, beatmapManager, scoreManager, replaySession);
             Snapshot.Value = store.LoadSnapshot();
         }
 

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileService.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileService.cs
@@ -41,6 +41,8 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
         public IReadOnlyList<string> GetPreviouslyIncludedUsernames() => store.LoadIncludedUsernames();
 
+        public IReadOnlyList<EzLocalProfileDrillScoreRow> LoadDrillScores(int rulesetId) => store.LoadDrillScores(rulesetId);
+
         public bool HasOnlineScoreContributions() => store.LoadOnlineScoreContributions().Count > 0;
 
         /// <param name="usernamesToRecompute">Names whose score stats will be recalculated and overwrite their stored slice.</param>

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileStarBars.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileStarBars.cs
@@ -3,104 +3,17 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using osu.Framework.Allocation;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Game.EzOsuGame.Localization;
-using osu.Game.Graphics;
-using osu.Game.Graphics.Sprites;
-using osu.Game.Overlays;
-using osuTK;
 
 namespace osu.Game.EzOsuGame.LocalProfile
 {
-    public partial class EzLocalProfileStarBars : FillFlowContainer
+    /// <summary>
+    /// Legacy wrapper; bars only. Prefer <see cref="EzLocalProfileBucketBars.FromStarPlayCounts"/>.
+    /// </summary>
+    public partial class EzLocalProfileStarBars : EzLocalProfileBucketBars
     {
         public EzLocalProfileStarBars(IEnumerable<EzLocalProfileStarPlayCount> stars)
+            : base(stars.Select(s => (s.StarBucket, s.Count)), bucket => $"{bucket}★–{bucket + 1}★")
         {
-            RelativeSizeAxes = Axes.X;
-            AutoSizeAxes = Axes.Y;
-            Direction = FillDirection.Vertical;
-            Spacing = new Vector2(0, 10);
-
-            var list = stars.OrderBy(s => s.StarBucket).ToList();
-
-            if (list.Count == 0)
-            {
-                Add(new OsuSpriteText
-                {
-                    Text = EzSettingsStrings.LOCAL_PROFILE_NO_RULESET_DATA,
-                    Font = OsuFont.GetFont(size: 14),
-                });
-                return;
-            }
-
-            int max = list.Max(s => s.Count);
-
-            var barFlow = new FillFlowContainer
-            {
-                RelativeSizeAxes = Axes.X,
-                AutoSizeAxes = Axes.Y,
-                Direction = FillDirection.Vertical,
-                Spacing = new Vector2(0, 8),
-            };
-
-            foreach (var star in list)
-                barFlow.Add(new StarBarRow(star.StarBucket, star.Count, max));
-
-            Add(barFlow);
-            Add(new EzLocalProfileLabeledLineChart(
-                list.Select(s => (float)s.Count).ToArray(),
-                list.Select(s => $"{s.StarBucket}★").ToArray()));
-        }
-
-        private partial class StarBarRow : Container
-        {
-            private readonly int bucket;
-            private readonly int count;
-            private readonly int max;
-
-            public StarBarRow(int bucket, int count, int max)
-            {
-                this.bucket = bucket;
-                this.count = count;
-                this.max = max;
-
-                RelativeSizeAxes = Axes.X;
-                Height = 22;
-            }
-
-            [BackgroundDependencyLoader]
-            private void load(OverlayColourProvider colours)
-            {
-                float ratio = max <= 0 ? 0 : (float)count / max;
-
-                Children = new Drawable[]
-                {
-                    new OsuSpriteText
-                    {
-                        Anchor = Anchor.CentreLeft,
-                        Origin = Anchor.CentreLeft,
-                        Text = $"{bucket}★–{bucket + 1}★",
-                        Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
-                        Width = 72,
-                    },
-                    new Container
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Padding = new MarginPadding { Left = 80, Right = 56 },
-                        Child = new EzLocalProfileRoundedBar(ratio),
-                    },
-                    new OsuSpriteText
-                    {
-                        Anchor = Anchor.CentreRight,
-                        Origin = Anchor.CentreRight,
-                        Text = count.ToString("N0"),
-                        Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
-                        Colour = colours.Content2,
-                    }
-                };
-            }
         }
     }
 }

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileStore.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileStore.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using Microsoft.Data.Sqlite;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
+using osu.Game.Beatmaps;
 using osu.Game.EzOsuGame.Configuration;
 using osu.Game.Scoring;
 
@@ -20,7 +21,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
     public class EzLocalProfileStore : IDisposable
     {
         public const string DATABASE_FILENAME = "ez-local-profile.sqlite";
-        public const int SCHEMA_VERSION = 3;
+        public const int SCHEMA_VERSION = 1;
 
         private readonly Storage storage;
         private readonly object sync = new object();
@@ -62,6 +63,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
                         ManiaColumnStats = readManiaColumnStats(connection),
                         GradeCounts = readGradeCounts(connection),
                         StarPlayCounts = readStarPlayCounts(connection),
+                        XxyPlayCounts = readXxyPlayCounts(connection),
                         StdAttrAffinities = readStdAttrAffinities(connection),
                     };
                 }
@@ -83,10 +85,19 @@ namespace osu.Game.EzOsuGame.LocalProfile
             }
         }
 
+        public IReadOnlyList<EzLocalProfileDrillScoreRow> LoadDrillScores(int rulesetId)
+        {
+            lock (sync)
+            {
+                ensureInitialised();
+                using var connection = openConnection();
+                return readDrillScores(connection, rulesetId);
+            }
+        }
+
         public int GetMostPlayedOffset(int rulesetId) => GetPullOffset(EzLocalProfileOnlinePullKind.MostPlayed, rulesetId);
 
-        public void SetMostPlayedOffset(int rulesetId, int offset) =>
-            SetPullOffset(EzLocalProfileOnlinePullKind.MostPlayed, rulesetId, offset);
+        public void SetMostPlayedOffset(int rulesetId, int offset) => SetPullOffset(EzLocalProfileOnlinePullKind.MostPlayed, rulesetId, offset);
 
         public int GetPullOffset(EzLocalProfileOnlinePullKind kind, int rulesetId)
         {
@@ -275,6 +286,19 @@ namespace osu.Game.EzOsuGame.LocalProfile
                     cmd.ExecuteNonQuery();
                 }
 
+                foreach (var ((rulesetId, starBucket), count) in result.XxyPlayCounts)
+                {
+                    using var cmd = connection.CreateCommand();
+                    cmd.CommandText = """
+                                      INSERT INTO xxy_play_counts (ruleset_id, star_bucket, count)
+                                      VALUES ($ruleset_id, $star_bucket, $count);
+                                      """;
+                    cmd.Parameters.AddWithValue("$ruleset_id", rulesetId);
+                    cmd.Parameters.AddWithValue("$star_bucket", starBucket);
+                    cmd.Parameters.AddWithValue("$count", count);
+                    cmd.ExecuteNonQuery();
+                }
+
                 foreach (var ((attr, value), stats) in result.StdAttrAffinities)
                 {
                     using var cmd = connection.CreateCommand();
@@ -288,6 +312,8 @@ namespace osu.Game.EzOsuGame.LocalProfile
                     cmd.Parameters.AddWithValue("$high_grade_count", stats.HighGradeCount);
                     cmd.ExecuteNonQuery();
                 }
+
+                writeDrillScores(connection, result.DrillScores);
 
                 transaction.Commit();
             }
@@ -482,6 +508,19 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 cmd.ExecuteNonQuery();
             }
 
+            foreach (var ((rulesetId, starBucket), count) in result.XxyPlayCounts)
+            {
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = """
+                                  INSERT INTO xxy_play_counts (ruleset_id, star_bucket, count)
+                                  VALUES ($ruleset_id, $star_bucket, $count);
+                                  """;
+                cmd.Parameters.AddWithValue("$ruleset_id", rulesetId);
+                cmd.Parameters.AddWithValue("$star_bucket", starBucket);
+                cmd.Parameters.AddWithValue("$count", count);
+                cmd.ExecuteNonQuery();
+            }
+
             foreach (var ((attr, value), stats) in result.StdAttrAffinities)
             {
                 using var cmd = connection.CreateCommand();
@@ -495,6 +534,125 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 cmd.Parameters.AddWithValue("$high_grade_count", stats.HighGradeCount);
                 cmd.ExecuteNonQuery();
             }
+
+            writeDrillScores(connection, result.DrillScores);
+        }
+
+        private static void writeDrillScores(SqliteConnection connection, IReadOnlyList<EzLocalProfileDrillScoreRow> rows)
+        {
+            foreach (var row in rows)
+            {
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = """
+                                  INSERT INTO drill_scores (
+                                      score_id, score_hash, username, ruleset_id, rank, pp_resolved, accuracy,
+                                      max_combo, max_achievable_combo, total_score, mods_json, total_keys,
+                                      beatmap_hash, beatmap_id, beatmap_set_id, title, artist, difficulty_name,
+                                      mapper_username, beatmap_status, star_rating, xxy_star_rating, map_performance_points,
+                                      kps_avg, kps_max, kps_list_json, column_counts_json, hold_counts_json,
+                                      avg_abs_offset_ms, has_video, has_storyboard, date_ms)
+                                  VALUES (
+                                      $score_id, $score_hash, $username, $ruleset_id, $rank, $pp_resolved, $accuracy,
+                                      $max_combo, $max_achievable_combo, $total_score, $mods_json, $total_keys,
+                                      $beatmap_hash, $beatmap_id, $beatmap_set_id, $title, $artist, $difficulty_name,
+                                      $mapper_username, $beatmap_status, $star_rating, $xxy_star_rating, $map_performance_points,
+                                      $kps_avg, $kps_max, $kps_list_json, $column_counts_json, $hold_counts_json,
+                                      $avg_abs_offset_ms, $has_video, $has_storyboard, $date_ms);
+                                  """;
+                cmd.Parameters.AddWithValue("$score_id", row.ScoreId.ToString("N"));
+                cmd.Parameters.AddWithValue("$score_hash", row.ScoreHash);
+                cmd.Parameters.AddWithValue("$username", row.Username);
+                cmd.Parameters.AddWithValue("$ruleset_id", row.RulesetId);
+                cmd.Parameters.AddWithValue("$rank", (int)row.Rank);
+                cmd.Parameters.AddWithValue("$pp_resolved", row.PpResolved);
+                cmd.Parameters.AddWithValue("$accuracy", row.Accuracy);
+                cmd.Parameters.AddWithValue("$max_combo", row.MaxCombo);
+                cmd.Parameters.AddWithValue("$max_achievable_combo", row.MaxAchievableCombo);
+                cmd.Parameters.AddWithValue("$total_score", row.TotalScore);
+                cmd.Parameters.AddWithValue("$mods_json", row.ModsJson);
+                cmd.Parameters.AddWithValue("$total_keys", row.TotalKeys);
+                cmd.Parameters.AddWithValue("$beatmap_hash", row.BeatmapHash);
+                cmd.Parameters.AddWithValue("$beatmap_id", row.BeatmapId.ToString("N"));
+                cmd.Parameters.AddWithValue("$beatmap_set_id", row.BeatmapSetId?.ToString("N") ?? (object)DBNull.Value);
+                cmd.Parameters.AddWithValue("$title", row.Title);
+                cmd.Parameters.AddWithValue("$artist", row.Artist);
+                cmd.Parameters.AddWithValue("$difficulty_name", row.DifficultyName);
+                cmd.Parameters.AddWithValue("$mapper_username", row.MapperUsername);
+                cmd.Parameters.AddWithValue("$beatmap_status", (int)row.BeatmapStatus);
+                cmd.Parameters.AddWithValue("$star_rating", row.StarRating);
+                cmd.Parameters.AddWithValue("$xxy_star_rating", row.XxyStarRating);
+                cmd.Parameters.AddWithValue("$map_performance_points", row.MapPerformancePoints);
+                cmd.Parameters.AddWithValue("$kps_avg", row.KpsAvg);
+                cmd.Parameters.AddWithValue("$kps_max", row.KpsMax);
+                cmd.Parameters.AddWithValue("$kps_list_json", row.KpsListJson);
+                cmd.Parameters.AddWithValue("$column_counts_json", row.ColumnCountsJson);
+                cmd.Parameters.AddWithValue("$hold_counts_json", row.HoldCountsJson);
+                cmd.Parameters.AddWithValue("$avg_abs_offset_ms", row.AvgAbsOffsetMs ?? (object)DBNull.Value);
+                cmd.Parameters.AddWithValue("$has_video", row.HasVideo ? 1 : 0);
+                cmd.Parameters.AddWithValue("$has_storyboard", row.HasStoryboard ? 1 : 0);
+                cmd.Parameters.AddWithValue("$date_ms", row.Date.ToUnixTimeMilliseconds());
+                cmd.ExecuteNonQuery();
+            }
+        }
+
+        private static IReadOnlyList<EzLocalProfileDrillScoreRow> readDrillScores(SqliteConnection connection, int rulesetId)
+        {
+            var list = new List<EzLocalProfileDrillScoreRow>();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = """
+                              SELECT score_id, score_hash, username, ruleset_id, rank, pp_resolved, accuracy,
+                                     max_combo, max_achievable_combo, total_score, mods_json, total_keys,
+                                     beatmap_hash, beatmap_id, beatmap_set_id, title, artist, difficulty_name,
+                                     mapper_username, beatmap_status, star_rating, xxy_star_rating, map_performance_points,
+                                     kps_avg, kps_max, kps_list_json, column_counts_json, hold_counts_json,
+                                     avg_abs_offset_ms, has_video, has_storyboard, date_ms
+                              FROM drill_scores
+                              WHERE ruleset_id = $ruleset_id
+                              ORDER BY pp_resolved DESC, date_ms DESC;
+                              """;
+            cmd.Parameters.AddWithValue("$ruleset_id", rulesetId);
+            using var reader = cmd.ExecuteReader();
+
+            while (reader.Read())
+            {
+                list.Add(new EzLocalProfileDrillScoreRow
+                {
+                    ScoreId = Guid.Parse(reader.GetString(0)),
+                    ScoreHash = reader.GetString(1),
+                    Username = reader.GetString(2),
+                    RulesetId = reader.GetInt32(3),
+                    Rank = (ScoreRank)reader.GetInt32(4),
+                    PpResolved = reader.GetDouble(5),
+                    Accuracy = reader.GetDouble(6),
+                    MaxCombo = reader.GetInt32(7),
+                    MaxAchievableCombo = reader.GetInt32(8),
+                    TotalScore = reader.GetInt64(9),
+                    ModsJson = reader.GetString(10),
+                    TotalKeys = reader.GetInt64(11),
+                    BeatmapHash = reader.GetString(12),
+                    BeatmapId = Guid.Parse(reader.GetString(13)),
+                    BeatmapSetId = reader.IsDBNull(14) ? null : Guid.Parse(reader.GetString(14)),
+                    Title = reader.GetString(15),
+                    Artist = reader.GetString(16),
+                    DifficultyName = reader.GetString(17),
+                    MapperUsername = reader.GetString(18),
+                    BeatmapStatus = (BeatmapOnlineStatus)reader.GetInt32(19),
+                    StarRating = reader.GetDouble(20),
+                    XxyStarRating = reader.GetDouble(21),
+                    MapPerformancePoints = reader.GetDouble(22),
+                    KpsAvg = reader.GetDouble(23),
+                    KpsMax = reader.GetDouble(24),
+                    KpsListJson = reader.GetString(25),
+                    ColumnCountsJson = reader.GetString(26),
+                    HoldCountsJson = reader.GetString(27),
+                    AvgAbsOffsetMs = reader.IsDBNull(28) ? null : reader.GetDouble(28),
+                    HasVideo = reader.GetInt32(29) != 0,
+                    HasStoryboard = reader.GetInt32(30) != 0,
+                    Date = DateTimeOffset.FromUnixTimeMilliseconds(reader.GetInt64(31)),
+                });
+            }
+
+            return list;
         }
 
         public void Dispose()
@@ -576,6 +734,12 @@ namespace osu.Game.EzOsuGame.LocalProfile
                                       count INTEGER NOT NULL,
                                       PRIMARY KEY (ruleset_id, star_bucket)
                                   );
+                                  CREATE TABLE IF NOT EXISTS xxy_play_counts (
+                                      ruleset_id INTEGER NOT NULL,
+                                      star_bucket INTEGER NOT NULL,
+                                      count INTEGER NOT NULL,
+                                      PRIMARY KEY (ruleset_id, star_bucket)
+                                  );
                                   CREATE TABLE IF NOT EXISTS std_attr_affinity (
                                       attr INTEGER NOT NULL,
                                       value REAL NOT NULL,
@@ -599,6 +763,42 @@ namespace osu.Game.EzOsuGame.LocalProfile
                                       payload_json TEXT NOT NULL,
                                       updated_at INTEGER NOT NULL
                                   );
+                                  CREATE TABLE IF NOT EXISTS drill_scores (
+                                      score_id TEXT PRIMARY KEY NOT NULL,
+                                      score_hash TEXT NOT NULL,
+                                      username TEXT NOT NULL,
+                                      ruleset_id INTEGER NOT NULL,
+                                      rank INTEGER NOT NULL,
+                                      pp_resolved REAL NOT NULL,
+                                      accuracy REAL NOT NULL,
+                                      max_combo INTEGER NOT NULL,
+                                      max_achievable_combo INTEGER NOT NULL,
+                                      total_score INTEGER NOT NULL,
+                                      mods_json TEXT NOT NULL,
+                                      total_keys INTEGER NOT NULL,
+                                      beatmap_hash TEXT NOT NULL,
+                                      beatmap_id TEXT NOT NULL,
+                                      beatmap_set_id TEXT,
+                                      title TEXT NOT NULL,
+                                      artist TEXT NOT NULL,
+                                      difficulty_name TEXT NOT NULL,
+                                      mapper_username TEXT NOT NULL,
+                                      beatmap_status INTEGER NOT NULL,
+                                      star_rating REAL NOT NULL,
+                                      xxy_star_rating REAL NOT NULL,
+                                      map_performance_points REAL NOT NULL,
+                                      kps_avg REAL NOT NULL,
+                                      kps_max REAL NOT NULL,
+                                      kps_list_json TEXT NOT NULL,
+                                      column_counts_json TEXT NOT NULL,
+                                      hold_counts_json TEXT NOT NULL,
+                                      avg_abs_offset_ms REAL,
+                                      has_video INTEGER NOT NULL,
+                                      has_storyboard INTEGER NOT NULL,
+                                      date_ms INTEGER NOT NULL
+                                  );
+                                  CREATE INDEX IF NOT EXISTS idx_drill_scores_ruleset_pp
+                                      ON drill_scores(ruleset_id, pp_resolved DESC, date_ms DESC);
                                   """;
                 cmd.ExecuteNonQuery();
             }
@@ -663,7 +863,9 @@ namespace osu.Game.EzOsuGame.LocalProfile
                               DELETE FROM mania_column_stats WHERE TRUE;
                               DELETE FROM grade_counts WHERE TRUE;
                               DELETE FROM star_play_counts WHERE TRUE;
+                              DELETE FROM xxy_play_counts WHERE TRUE;
                               DELETE FROM std_attr_affinity WHERE TRUE;
+                              DELETE FROM drill_scores WHERE TRUE;
                               """;
             cmd.ExecuteNonQuery();
         }
@@ -805,6 +1007,24 @@ namespace osu.Game.EzOsuGame.LocalProfile
             return list;
         }
 
+        private static IReadOnlyList<EzLocalProfileXxyPlayCount> readXxyPlayCounts(SqliteConnection connection)
+        {
+            var list = new List<EzLocalProfileXxyPlayCount>();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT ruleset_id, star_bucket, count FROM xxy_play_counts ORDER BY ruleset_id, star_bucket;";
+            using var reader = cmd.ExecuteReader();
+
+            while (reader.Read())
+            {
+                list.Add(new EzLocalProfileXxyPlayCount(
+                    reader.GetInt32(0),
+                    reader.GetInt32(1),
+                    reader.GetInt32(2)));
+            }
+
+            return list;
+        }
+
         private static IReadOnlyList<EzLocalProfileStdAttrAffinity> readStdAttrAffinities(SqliteConnection connection)
         {
             var list = new List<EzLocalProfileStdAttrAffinity>();
@@ -824,10 +1044,9 @@ namespace osu.Game.EzOsuGame.LocalProfile
             return list;
         }
 
-        private static string pullOffsetKey(EzLocalProfileOnlinePullKind kind, int rulesetId) =>
-            kind == EzLocalProfileOnlinePullKind.Best
-                ? $"online_bp_offset_{rulesetId}"
-                : $"online_mp_offset_{rulesetId}";
+        private static string pullOffsetKey(EzLocalProfileOnlinePullKind kind, int rulesetId) => kind == EzLocalProfileOnlinePullKind.Best
+            ? $"online_bp_offset_{rulesetId}"
+            : $"online_mp_offset_{rulesetId}";
 
         private static void setMeta(SqliteConnection connection, string key, string value)
         {

--- a/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
@@ -880,8 +880,8 @@ namespace osu.Game.EzOsuGame.Localization
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_BEATMAP_PERF_ACC =
             new EzLocalizationManager.EzLocalisableString("Acc", "Acc");
 
-        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_BEATMAP_PERF_OFF =
-            new EzLocalizationManager.EzLocalisableString("Off", "Off");
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_BEATMAP_PERF_OFFSET =
+            new EzLocalizationManager.EzLocalisableString("Offset", "Offset");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_TREND_OFFSET =
             new EzLocalizationManager.EzLocalisableString("击打偏移", "Hit offset");

--- a/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
@@ -799,6 +799,9 @@ namespace osu.Game.EzOsuGame.Localization
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_NONE_SELECTED =
             new EzLocalizationManager.EzLocalisableString("请至少勾选一个玩家名。", "Select at least one player name.");
 
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SELECT_SCORE =
+            new EzLocalizationManager.EzLocalisableString("在左侧选择一条成绩", "Select a score on the left");
+
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_TITLE =
             new EzLocalizationManager.EzLocalisableString("本地个人主页", "Local Profile");
 
@@ -836,7 +839,58 @@ namespace osu.Game.EzOsuGame.Localization
             new EzLocalizationManager.EzLocalisableString("成绩评级", "Grades");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SECTION_STARS =
-            new EzLocalizationManager.EzLocalisableString("难度游玩次数", "Plays by difficulty");
+            new EzLocalizationManager.EzLocalisableString("星级分布", "Star rating");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SECTION_CAREER =
+            new EzLocalizationManager.EzLocalisableString("生涯总览", "Career overview");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SECTION_MODE_DATA =
+            new EzLocalizationManager.EzLocalisableString("各模式统计", "Stats by mode");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_XXY_PLAY_DISTRIBUTION =
+            new EzLocalizationManager.EzLocalisableString("xxy 星级分布", "Plays by xxy SR");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_STAR_PLAY_LINE =
+            new EzLocalizationManager.EzLocalisableString("星级游玩分布", "Plays by star rating");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_XXY_PLAY_LINE =
+            new EzLocalizationManager.EzLocalisableString("xxy 游玩分布", "xxy SR distribution");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SECTION_SCORE_DRILL =
+            new EzLocalizationManager.EzLocalisableString("成绩记录", "Score history");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SECTION_BEATMAP_PERF =
+            new EzLocalizationManager.EzLocalisableString("同图对比", "On this beatmap");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SECTION_SCORE_KEYS =
+            new EzLocalizationManager.EzLocalisableString("本局数据", "This score");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SECTION_TRENDS =
+            new EzLocalizationManager.EzLocalisableString("命中趋势", "Hit trends");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_DRILL_SEARCH_PLACEHOLDER =
+            new EzLocalizationManager.EzLocalisableString("按 PP、曲名或艺术家搜索", "Search by PP, title, or artist");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_DRILL_NO_MATCHES =
+            new EzLocalizationManager.EzLocalisableString("没有符合条件的成绩", "No scores match your search");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_BEATMAP_PERF_PP =
+            new EzLocalizationManager.EzLocalisableString("PP", "PP");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_BEATMAP_PERF_ACC =
+            new EzLocalizationManager.EzLocalisableString("Acc", "Acc");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_BEATMAP_PERF_OFF =
+            new EzLocalizationManager.EzLocalisableString("Off", "Off");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_TREND_OFFSET =
+            new EzLocalizationManager.EzLocalisableString("击打偏移", "Hit offset");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_TREND_ACCURACY =
+            new EzLocalizationManager.EzLocalisableString("准确率", "Accuracy");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_TREND_EMPTY =
+            new EzLocalizationManager.EzLocalisableString("暂无趋势数据（需保留本地回放）", "No trend data yet (local replay required).");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_TOTAL_KEYS =
             new EzLocalizationManager.EzLocalisableString("按键总数", "Total keys");

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -407,11 +407,10 @@ namespace osu.Game
             dependencies.Cache(ezAnalysisPersistentStore);
             dependencies.Cache(ezAnalysisDatabase);
             dependencies.Cache(ezAnalysisCache = new EzAnalysisCache());
-            dependencies.Cache(new EzLocalProfileService(Storage, realm, ezAnalysisPersistentStore, BeatmapManager));
-            dependencies.Cache(new EzLocalProfileOnlinePullService(API, ScoreManager, BeatmapManager, realm, Storage));
-
             ReplaySession = new EzReplaySessionRouter(RulesetStore.AvailableRulesets);
             dependencies.CacheAs<IEzReplaySession>(ReplaySession);
+            dependencies.Cache(new EzLocalProfileService(Storage, realm, ezAnalysisPersistentStore, BeatmapManager, ScoreManager, ReplaySession));
+            dependencies.Cache(new EzLocalProfileOnlinePullService(API, ScoreManager, BeatmapManager, realm, Storage));
 
             if (Ez2ConfigManager.Get<bool>(Ez2Setting.EzScoreRaceServiceEnabled))
             {


### PR DESCRIPTION
## Summary

- 在 `EzLocalProfileStore` 持久化钻取成绩（SQLite v1），聚合与 overlay 钻取/趋势/谱面表现均读快照数据
- 重构个人档案职业段：合并指标行、模式数据分区（折线图 + 并排柱状图、Mania 键位、Std 亲和、xxy 分布）
- 新增成绩钻取：搜索、可选列表、自定义详情列（谱面卡、用户名/mods、按键与 PP 芯片、同谱面 PP/Acc/Off 卷轴旗卡）
- 新增异步 replay 驱动的命中趋势图（偏移/准确率 + miss 标记）

## Test plan

- [ ] `dotnet test osu.Game.Tests --filter FullyQualifiedName~EzLocalProfile`
- [ ] 视觉测试 `TestSceneEzLocalProfileOverlay`：钻取段三卡并排、卷轴卡表头/内容对齐、详情列右侧与搜索框对齐
- [ ] 合并一次本地档案后确认钻取列表有数据、切换成绩详情与趋势图正常
