### PR TITLE
Add quick rotation mode with Ranked Play-style card pick

### DIFF
--- a/osu.Game.Tests/EzOsuGame/Rotation/TestEzQuickRotationDifficultyBalancer.cs
+++ b/osu.Game.Tests/EzOsuGame/Rotation/TestEzQuickRotationDifficultyBalancer.cs
@@ -1,0 +1,50 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using NUnit.Framework;
+using osu.Game.EzOsuGame.Screens.Rotation;
+
+namespace osu.Game.Tests.EzOsuGame.Rotation
+{
+    [TestFixture]
+    public class TestEzQuickRotationDifficultyBalancer
+    {
+        [Test]
+        public void TestIterativeStepConvergesWithinTolerance()
+        {
+            const double target = 4.0;
+            const double tolerance = 0.5;
+
+            double accumulatedStep = 0;
+            double speed = 1.0;
+            double measured = measureAtSpeed(1.0);
+
+            for (int i = 0; i < EzQuickRotationDifficultyBalancer.MAX_ITERATIONS; i++)
+            {
+                if (Math.Abs(measured - target) <= tolerance)
+                    break;
+
+                double step = (measured - target) / 10.0;
+                accumulatedStep += step;
+                speed = Math.Clamp(1.0 - accumulatedStep, EzQuickRotationDifficultyHelper.MIN_SPEED, EzQuickRotationDifficultyHelper.MAX_SPEED);
+                measured = measureAtSpeed(speed);
+            }
+
+            Assert.That(speed, Is.EqualTo(0.64).Within(0.001));
+            Assert.That(measured, Is.EqualTo(4.3).Within(0.001));
+            Assert.That(Math.Abs(measured - target), Is.LessThanOrEqualTo(tolerance));
+        }
+
+        private static double measureAtSpeed(double speed)
+        {
+            if (speed >= 0.99)
+                return 6.7;
+
+            if (speed >= 0.7)
+                return 4.9;
+
+            return 4.3;
+        }
+    }
+}

--- a/osu.Game.Tests/EzOsuGame/Rotation/TestEzQuickRotationPoolBuilder.cs
+++ b/osu.Game.Tests/EzOsuGame/Rotation/TestEzQuickRotationPoolBuilder.cs
@@ -1,0 +1,63 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.EzOsuGame.Screens.Rotation;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Osu;
+
+namespace osu.Game.Tests.EzOsuGame.Rotation
+{
+    [TestFixture]
+    public class TestEzQuickRotationPoolBuilder
+    {
+        private RulesetInfo maniaRuleset = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            maniaRuleset = new ManiaRuleset().RulesetInfo;
+        }
+
+        [Test]
+        public void TestCrossKeyModeExcludesTwelveKey()
+        {
+            var constraints = new EzQuickRotationPoolConstraints(null, null, maniaRuleset, null, CrossKeyMode: true);
+
+            Assert.That(EzQuickRotationPoolBuilder.matchesKeyCount(createManiaBeatmap(4), constraints), Is.True);
+            Assert.That(EzQuickRotationPoolBuilder.matchesKeyCount(createManiaBeatmap(7), constraints), Is.True);
+            Assert.That(EzQuickRotationPoolBuilder.matchesKeyCount(createManiaBeatmap(10), constraints), Is.True);
+            Assert.That(EzQuickRotationPoolBuilder.matchesKeyCount(createManiaBeatmap(12), constraints), Is.False);
+            Assert.That(EzQuickRotationPoolBuilder.matchesKeyCount(createManiaBeatmap(3), constraints), Is.False);
+        }
+
+        [Test]
+        public void TestLockedKeyModeOnlyAllowsMatchingKeyCount()
+        {
+            var constraints = new EzQuickRotationPoolConstraints(null, null, maniaRuleset, LockedKeyCount: 7, CrossKeyMode: false);
+
+            Assert.That(EzQuickRotationPoolBuilder.matchesKeyCount(createManiaBeatmap(7), constraints), Is.True);
+            Assert.That(EzQuickRotationPoolBuilder.matchesKeyCount(createManiaBeatmap(4), constraints), Is.False);
+            Assert.That(EzQuickRotationPoolBuilder.matchesKeyCount(createManiaBeatmap(12), constraints), Is.False);
+        }
+
+        [Test]
+        public void TestNonManiaRulesetIgnoresKeyCount()
+        {
+            var osuRuleset = new OsuRuleset().RulesetInfo;
+            var constraints = new EzQuickRotationPoolConstraints(null, null, osuRuleset, LockedKeyCount: 4, CrossKeyMode: true);
+
+            Assert.That(EzQuickRotationPoolBuilder.matchesKeyCount(createManiaBeatmap(12), constraints), Is.True);
+        }
+
+        private static BeatmapInfo createManiaBeatmap(int keyCount) => new BeatmapInfo
+        {
+            Difficulty = new BeatmapDifficulty
+            {
+                CircleSize = keyCount,
+            },
+        };
+    }
+}

--- a/osu.Game/EzOsuGame/Configuration/Ez2ConfigManager.cs
+++ b/osu.Game/EzOsuGame/Configuration/Ez2ConfigManager.cs
@@ -115,6 +115,11 @@ namespace osu.Game.EzOsuGame.Configuration
             SetDefault(Ez2Setting.TurboModeSnapshot, string.Empty);
             SetDefault(Ez2Setting.FlowMode, false);
 
+            SetDefault(Ez2Setting.QuickRotationEnabled, false);
+            SetDefault(Ez2Setting.QuickRotationDifficultyTolerance, 0.5, 0.1, 2.0, 0.1);
+            SetDefault(Ez2Setting.QuickRotationCrossKeyMode, false);
+            SetDefault(Ez2Setting.QuickRotationCandidateCount, 5, 3, 6);
+
             SetDefault(Ez2Setting.StoryboardAutoVideoSize, false);
             SetDefault(Ez2Setting.AcrylicUiEnabled, false);
             SetDefault(Ez2Setting.AcrylicUiBlurStrength, 16.0, 0.0, 40.0, 1.0);
@@ -945,6 +950,26 @@ namespace osu.Game.EzOsuGame.Configuration
         /// 心流（Zen Flow）：从选歌进入的单人游玩结束后跳过结算直接回选歌；选歌界面禁用 Ranking 标签。
         /// </summary>
         FlowMode,
+
+        /// <summary>
+        /// 快速轮换总开关：从选歌进入的单人局结束后在专用界面连续抽卡开下一首。
+        /// </summary>
+        QuickRotationEnabled,
+
+        /// <summary>
+        /// 快速轮换难度平衡容差（相对首次进入时的基准难度）。
+        /// </summary>
+        QuickRotationDifficultyTolerance,
+
+        /// <summary>
+        /// Mania 快速轮换是否允许跨键数（4–10K）；关闭则锁定首轮键数。
+        /// </summary>
+        QuickRotationCrossKeyMode,
+
+        /// <summary>
+        /// 每轮抽卡展示的候选谱面数量（3–6）。
+        /// </summary>
+        QuickRotationCandidateCount,
 
         StoryboardAutoVideoSize,
         AcrylicUiEnabled,

--- a/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
@@ -150,6 +150,37 @@ namespace osu.Game.EzOsuGame.Localization
             "Focus on play, not results."
             + "\nWhen enabled, the game skips the results screen after play. Scores are saved but not shown. Ranking view is disabled in song select.");
 
+        public static readonly EzLocalizationManager.EzLocalisableString QUICK_ROTATION_SECTION_HEADER =
+            new EzLocalizationManager.EzLocalisableString("快速轮换", "Quick Rotation");
+
+        public static readonly EzLocalizationManager.EzLocalisableString QUICK_ROTATION_ENABLED =
+            new EzLocalizationManager.EzLocalisableString("快速轮换", "Quick Rotation");
+
+        public static readonly EzLocalizationManager.EzLocalisableString QUICK_ROTATION_ENABLED_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "从选歌进入的单人局结束后，在专用抽卡界面连续游玩相似难度的谱面，全程不回到选歌界面。",
+            "After solo play from song select, continue in a dedicated card-pick screen with similar difficulty. Never returns to song select until ended.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString QUICK_ROTATION_DIFFICULTY_TOLERANCE =
+            new EzLocalizationManager.EzLocalisableString("难度容差", "Difficulty tolerance");
+
+        public static readonly EzLocalizationManager.EzLocalisableString QUICK_ROTATION_DIFFICULTY_TOLERANCE_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "抽卡后通过 Nice BPM 调速，使有效难度落在首次进入时基准难度的 ± 此值范围内。",
+            "After picking a card, Nice BPM adjusts speed so effective difficulty stays within ± this value of the baseline from your first chart.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString QUICK_ROTATION_CROSS_KEY_MODE =
+            new EzLocalizationManager.EzLocalisableString("跨键数轮换", "Cross key-count rotation");
+
+        public static readonly EzLocalizationManager.EzLocalisableString QUICK_ROTATION_CROSS_KEY_MODE_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "仅 Mania。开启后候选池可含 4–10K；关闭则整段会话锁定首轮谱面的键数。",
+            "Mania only. When enabled, the pool may include 4–10K charts. When disabled, key count is locked to the first chart.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString QUICK_ROTATION_CANDIDATE_COUNT =
+            new EzLocalizationManager.EzLocalisableString("候选卡片数", "Candidate card count");
+
+        public static readonly EzLocalizationManager.EzLocalisableString QUICK_ROTATION_CANDIDATE_COUNT_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "每轮抽卡界面展示的谱面数量（3–6）。",
+            "Number of beatmap cards shown each pick round (3–6).");
+
         public static readonly EzLocalizationManager.EzLocalisableString ACRYLIC_UI_ENABLED =
             new EzLocalizationManager.EzLocalisableString("毛玻璃 UI", "Acrylic UI");
 

--- a/osu.Game/EzOsuGame/Overlays/EzGameSection.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzGameSection.cs
@@ -24,6 +24,7 @@ namespace osu.Game.EzOsuGame.Overlays
             Children = new Drawable[]
             {
                 new EzUISettings(),
+                new EzQuickRotationSettings(),
                 new EzPetSettings(),
                 new EzGameSettings(),
                 new ServerSettings(),

--- a/osu.Game/EzOsuGame/Overlays/EzQuickRotationSettings.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzQuickRotationSettings.cs
@@ -1,0 +1,64 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Localisation;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Overlays.Settings;
+
+namespace osu.Game.EzOsuGame.Overlays
+{
+    public partial class EzQuickRotationSettings : SettingsSubsection
+    {
+        protected override LocalisableString Header => EzSettingsStrings.QUICK_ROTATION_SECTION_HEADER;
+
+        [BackgroundDependencyLoader]
+        private void load(Ez2ConfigManager ezConfig)
+        {
+            AddRange(new Drawable[]
+            {
+                new SettingsItemV2(new FormCheckBox
+                {
+                    Caption = EzSettingsStrings.QUICK_ROTATION_ENABLED,
+                    HintText = EzSettingsStrings.QUICK_ROTATION_ENABLED_TOOLTIP,
+                    Current = ezConfig.GetBindable<bool>(Ez2Setting.QuickRotationEnabled),
+                })
+                {
+                    Keywords = new[] { "quick", "rotation", "快速轮换", "抽卡", "card" }
+                },
+                new SettingsItemV2(new FormSliderBar<double>
+                {
+                    Caption = EzSettingsStrings.QUICK_ROTATION_DIFFICULTY_TOLERANCE,
+                    HintText = EzSettingsStrings.QUICK_ROTATION_DIFFICULTY_TOLERANCE_TOOLTIP,
+                    Current = ezConfig.GetBindable<double>(Ez2Setting.QuickRotationDifficultyTolerance),
+                    KeyboardStep = 0.1f,
+                })
+                {
+                    Keywords = new[] { "quick", "rotation", "tolerance", "difficulty", "容差" }
+                },
+                new SettingsItemV2(new FormCheckBox
+                {
+                    Caption = EzSettingsStrings.QUICK_ROTATION_CROSS_KEY_MODE,
+                    HintText = EzSettingsStrings.QUICK_ROTATION_CROSS_KEY_MODE_TOOLTIP,
+                    Current = ezConfig.GetBindable<bool>(Ez2Setting.QuickRotationCrossKeyMode),
+                })
+                {
+                    Keywords = new[] { "quick", "rotation", "mania", "key", "跨键" }
+                },
+                new SettingsItemV2(new FormSliderBar<int>
+                {
+                    Caption = EzSettingsStrings.QUICK_ROTATION_CANDIDATE_COUNT,
+                    HintText = EzSettingsStrings.QUICK_ROTATION_CANDIDATE_COUNT_TOOLTIP,
+                    Current = ezConfig.GetBindable<int>(Ez2Setting.QuickRotationCandidateCount),
+                    KeyboardStep = 1,
+                })
+                {
+                    Keywords = new[] { "quick", "rotation", "candidate", "card", "候选" }
+                },
+            });
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Screens/Play/EzFlowMode.cs
+++ b/osu.Game/EzOsuGame/Screens/Play/EzFlowMode.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Screens;
 using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Screens.Rotation;
 using osu.Game.Screens.Select;
 
 namespace osu.Game.EzOsuGame.Screens.Play
@@ -15,6 +16,9 @@ namespace osu.Game.EzOsuGame.Screens.Play
         public static bool ShouldSkipResults(IScreen from)
         {
             if (!IsEnabled)
+                return false;
+
+            if (EzQuickRotationCoordinator.Session.IsActive)
                 return false;
 
             for (var screen = from; screen != null; screen = screen.GetParentScreen())

--- a/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationApiBeatmapFactory.cs
+++ b/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationApiBeatmapFactory.cs
@@ -1,0 +1,74 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Game.Beatmaps;
+using osu.Game.EzOsuGame.Beatmaps;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Rulesets;
+
+namespace osu.Game.EzOsuGame.Screens.Rotation
+{
+    public static class EzQuickRotationApiBeatmapFactory
+    {
+        public static APIBeatmap Create(BeatmapInfo beatmap, RulesetInfo ruleset)
+        {
+            var beatmapSet = CreateBeatmapSet(beatmap);
+
+            var apiBeatmap = new APIBeatmap
+            {
+                OnlineID = beatmap.OnlineID,
+                OnlineBeatmapSetID = beatmap.BeatmapSet?.OnlineID ?? beatmapSet.OnlineID,
+                Status = beatmap.Status,
+                Checksum = beatmap.MD5Hash,
+                AuthorID = beatmap.Metadata.Author.OnlineID,
+                RulesetID = ruleset.OnlineID,
+                StarRating = resolveStarRating(beatmap, ruleset),
+                DifficultyName = beatmap.DifficultyName,
+                CircleSize = beatmap.Difficulty.CircleSize,
+                DrainRate = beatmap.Difficulty.DrainRate,
+                OverallDifficulty = beatmap.Difficulty.OverallDifficulty,
+                ApproachRate = beatmap.Difficulty.ApproachRate,
+                Length = beatmap.Length,
+                HitLength = beatmap.Length,
+                BPM = beatmap.BPM,
+                BeatmapSet = beatmapSet,
+            };
+
+            return apiBeatmap;
+        }
+
+        private static double resolveStarRating(BeatmapInfo beatmap, RulesetInfo ruleset)
+        {
+            if (EzQuickRotationDifficultyHelper.UsesXxyStarRating(ruleset))
+                return beatmap.GetPersistedXxyStarRating() ?? beatmap.StarRating;
+
+            return beatmap.StarRating;
+        }
+
+        private static APIBeatmapSet CreateBeatmapSet(BeatmapInfo beatmap)
+        {
+            var set = beatmap.BeatmapSet ?? throw new InvalidOperationException("Beatmap set must be populated.");
+
+            return new APIBeatmapSet
+            {
+                OnlineID = set.OnlineID,
+                Status = set.Status,
+                Title = beatmap.Metadata.Title,
+                TitleUnicode = beatmap.Metadata.TitleUnicode,
+                Artist = beatmap.Metadata.Artist,
+                ArtistUnicode = beatmap.Metadata.ArtistUnicode,
+                Author = new APIUser
+                {
+                    Username = beatmap.Metadata.Author.Username,
+                    Id = beatmap.Metadata.Author.OnlineID,
+                },
+                Source = beatmap.Metadata.Source,
+                Tags = beatmap.Metadata.Tags,
+                BPM = beatmap.BPM,
+            };
+        }
+
+        public static APIBeatmapSet? TryCreateBeatmapSet(BeatmapInfo beatmap) => beatmap.BeatmapSet == null ? null : CreateBeatmapSet(beatmap);
+    }
+}

--- a/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationCoordinator.cs
+++ b/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationCoordinator.cs
@@ -1,0 +1,31 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Screens;
+using osu.Game.EzOsuGame.Screens.Play;
+using osu.Game.Screens.Select;
+
+namespace osu.Game.EzOsuGame.Screens.Rotation
+{
+    public static class EzQuickRotationCoordinator
+    {
+        public static EzQuickRotationSession Session { get; } = new EzQuickRotationSession();
+
+        public static void NavigateAfterPlay(IScreen from)
+        {
+            if (!Session.IsActive)
+                return;
+
+            if (EzFlowMode.IsEnabled)
+                from.Push(new EzQuickRotationTransitionScreen());
+            else
+                from.Push(new EzQuickRotationPickScreen());
+        }
+
+        public static void EndSession(OsuGame? game)
+        {
+            Session.End();
+            game?.PerformFromScreen(_ => { }, new[] { typeof(SoloSongSelect) });
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationDifficultyHelper.cs
+++ b/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationDifficultyHelper.cs
@@ -1,0 +1,137 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using osu.Framework.Utils;
+using osu.Game.Beatmaps;
+using osu.Game.EzOsuGame.Analysis;
+using osu.Game.EzOsuGame.Mods.LAsMods;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Utils;
+
+namespace osu.Game.EzOsuGame.Screens.Rotation
+{
+    public static class EzQuickRotationDifficultyHelper
+    {
+        public const double MIN_SPEED = 0.4;
+        public const double MAX_SPEED = 3.0;
+
+        public static bool UsesXxyStarRating(RulesetInfo ruleset) => EzXxyStarRatingSupport.SupportsRuleset(ruleset);
+
+        public static double GetBaselineStarRating(BeatmapManager beatmapManager,
+                                                   BeatmapInfo beatmapInfo,
+                                                   RulesetInfo ruleset,
+                                                   IReadOnlyList<Mod> mods,
+                                                   CancellationToken cancellationToken = default) => measureDifficulty(beatmapManager, beatmapInfo, ruleset, mods, 1.0, cancellationToken);
+
+        public static double MeasureDifficultyAtSpeed(BeatmapManager beatmapManager,
+                                                      BeatmapInfo beatmapInfo,
+                                                      RulesetInfo ruleset,
+                                                      double speed,
+                                                      CancellationToken cancellationToken = default) =>
+            measureDifficulty(beatmapManager, beatmapInfo, ruleset, Array.Empty<Mod>(), speed, cancellationToken);
+
+        private static double measureDifficulty(BeatmapManager beatmapManager,
+                                                BeatmapInfo beatmapInfo,
+                                                RulesetInfo ruleset,
+                                                IReadOnlyList<Mod> mods,
+                                                double speed,
+                                                CancellationToken cancellationToken)
+        {
+            if (UsesXxyStarRating(ruleset))
+            {
+                var working = beatmapManager.GetWorkingBeatmap(beatmapInfo);
+                var playable = working.GetPlayableBeatmap(ruleset, mods, cancellationToken);
+
+                if (EzAnalysisProviderBridge.TryGetValue(ruleset, new EzAnalysisRequest(playable, speed), EzAnalysisFields.XXY_SR, cancellationToken, out double xxySr))
+                    return xxySr;
+            }
+
+            return measureOfficialStarRating(beatmapManager, beatmapInfo, ruleset, mods, speed, cancellationToken);
+        }
+
+        private static double measureOfficialStarRating(BeatmapManager beatmapManager,
+                                                        BeatmapInfo beatmapInfo,
+                                                        RulesetInfo ruleset,
+                                                        IReadOnlyList<Mod> mods,
+                                                        double speed,
+                                                        CancellationToken cancellationToken)
+        {
+            var working = beatmapManager.GetWorkingBeatmap(beatmapInfo);
+            var rulesetInstance = ruleset.CreateInstance();
+            var rateMods = createRateModsForMeasurement(rulesetInstance, speed, mods).ToArray();
+            return rulesetInstance.CreateDifficultyCalculator(working).Calculate(rateMods, cancellationToken).StarRating;
+        }
+
+        private static IEnumerable<Mod> createRateModsForMeasurement(Ruleset ruleset, double speed, IReadOnlyList<Mod> baseMods)
+        {
+            foreach (var mod in baseMods.Where(m => m is not ModRateAdjust and not ModNiceBPM))
+                yield return mod;
+
+            if (Precision.AlmostEquals(speed, 1.0))
+                yield break;
+
+            ModRateAdjust? rateMod = ruleset.CreateMod<ModHalfTime>()?.DeepClone() as ModHalfTime ?? (ModRateAdjust?)(ruleset.CreateMod<ModDoubleTime>()?.DeepClone() as ModDoubleTime);
+
+            if (rateMod == null)
+                yield break;
+
+            rateMod.SpeedChange.Value = Math.Clamp(speed, rateMod.SpeedChange.MinValue, rateMod.SpeedChange.MaxValue);
+            yield return rateMod;
+        }
+
+        public static bool IsManiaRuleset(RulesetInfo ruleset) => ruleset.ShortName == "mania";
+    }
+
+    public readonly record struct EzQuickRotationBalanceResult(double Speed, double BalancedDifficulty, bool WithinTolerance);
+
+    public static class EzQuickRotationDifficultyBalancer
+    {
+        public const int MAX_ITERATIONS = 8;
+
+        public static EzQuickRotationBalanceResult Balance(BeatmapManager beatmapManager,
+                                                           BeatmapInfo beatmapInfo,
+                                                           RulesetInfo ruleset,
+                                                           double baselineDifficulty,
+                                                           double tolerance,
+                                                           CancellationToken cancellationToken = default)
+        {
+            double accumulatedStep = 0;
+            double speed = 1.0;
+            double measured = EzQuickRotationDifficultyHelper.MeasureDifficultyAtSpeed(beatmapManager, beatmapInfo, ruleset, speed, cancellationToken);
+
+            for (int i = 0; i < MAX_ITERATIONS; i++)
+            {
+                if (Math.Abs(measured - baselineDifficulty) <= tolerance)
+                    return new EzQuickRotationBalanceResult(speed, measured, true);
+
+                double step = (measured - baselineDifficulty) / 10.0;
+                accumulatedStep += step;
+                speed = Math.Clamp(1.0 - accumulatedStep, EzQuickRotationDifficultyHelper.MIN_SPEED, EzQuickRotationDifficultyHelper.MAX_SPEED);
+                measured = EzQuickRotationDifficultyHelper.MeasureDifficultyAtSpeed(beatmapManager, beatmapInfo, ruleset, speed, cancellationToken);
+            }
+
+            return new EzQuickRotationBalanceResult(speed, measured, Math.Abs(measured - baselineDifficulty) <= tolerance);
+        }
+
+        public static ModNiceBPM CreateNiceBpmMod(RulesetInfo ruleset, double speed)
+        {
+            var mod = ruleset.CreateInstance().AllMods.OfType<ModNiceBPM>().FirstOrDefault()?.DeepClone() as ModNiceBPM ?? new ModNiceBPM();
+            double clampedSpeed = Math.Clamp(speed, EzQuickRotationDifficultyHelper.MIN_SPEED, EzQuickRotationDifficultyHelper.MAX_SPEED);
+            mod.InitialRate.Value = clampedSpeed;
+            mod.SpeedChange.Value = clampedSpeed;
+            return mod;
+        }
+
+        public static IReadOnlyList<Mod> MergeMods(IReadOnlyList<Mod> baseMods, ModNiceBPM niceBpm)
+        {
+            var merged = baseMods.Where(m => m is not ModRateAdjust and not ModNiceBPM).Select(m => m.DeepClone()).ToList();
+            merged.Add(niceBpm);
+            return ModUtils.CheckCompatibleSet(merged, out _) ? merged : new List<Mod> { niceBpm };
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationGameplayLauncher.cs
+++ b/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationGameplayLauncher.cs
@@ -1,0 +1,36 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Bindables;
+using osu.Framework.Screens;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Screens.Play;
+
+namespace osu.Game.EzOsuGame.Screens.Rotation
+{
+    public static class EzQuickRotationGameplayLauncher
+    {
+        public static void Start(IScreen host,
+                                 BeatmapManager beatmapManager,
+                                 Bindable<WorkingBeatmap> beatmap,
+                                 Bindable<RulesetInfo> ruleset,
+                                 Bindable<IReadOnlyList<Mod>> mods,
+                                 BeatmapInfo beatmapInfo,
+                                 RulesetInfo rulesetInfo,
+                                 IReadOnlyList<Mod> modList)
+        {
+            beatmap.Value = beatmapManager.GetWorkingBeatmap(beatmapInfo, true);
+
+            if (beatmap.IsDefault)
+                return;
+
+            ruleset.Value = rulesetInfo;
+            mods.Value = modList.Select(m => m.DeepClone()).ToArray();
+            host.Push(new EzQuickRotationPlayerLoader(() => new SoloPlayer()));
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationLocalCardCover.cs
+++ b/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationLocalCardCover.cs
@@ -1,0 +1,75 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Beatmaps;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.Screens.Rotation
+{
+    /// <summary>
+    /// Ranked-play card cover using the beatmap's on-disk background, falling back to the game default background.
+    /// </summary>
+    public partial class EzQuickRotationLocalCardCover : CompositeDrawable
+    {
+        private readonly BeatmapInfo beatmap;
+        private readonly ColourInfo gradientColour;
+
+        public EzQuickRotationLocalCardCover(BeatmapInfo beatmap, ColourInfo gradientColour)
+        {
+            this.beatmap = beatmap;
+            this.gradientColour = gradientColour;
+            RelativeSizeAxes = Axes.Both;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(BeatmapManager beatmaps)
+        {
+            InternalChildren =
+            [
+                new BufferedContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    GrayscaleStrength = 0.25f,
+                    Child = new EzQuickRotationLocalBeatmapBackgroundSprite(beatmap, beatmaps)
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        FillMode = FillMode.Fill,
+                        EdgeSmoothness = new Vector2(2),
+                    },
+                },
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = gradientColour,
+                },
+            ];
+        }
+
+        private partial class EzQuickRotationLocalBeatmapBackgroundSprite : Sprite
+        {
+            private readonly BeatmapInfo beatmapInfo;
+            private readonly BeatmapManager beatmaps;
+
+            public EzQuickRotationLocalBeatmapBackgroundSprite(BeatmapInfo beatmapInfo, BeatmapManager beatmaps)
+            {
+                this.beatmapInfo = beatmapInfo;
+                this.beatmaps = beatmaps;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                var working = beatmaps.GetWorkingBeatmap(beatmapInfo);
+                Texture = working.GetBackground() ?? beatmaps.DefaultBeatmap.GetBackground();
+            }
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationLocalRankedPlayCard.cs
+++ b/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationLocalRankedPlayCard.cs
@@ -1,0 +1,31 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
+using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay;
+using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card;
+
+namespace osu.Game.EzOsuGame.Screens.Rotation
+{
+    public sealed partial class EzQuickRotationLocalRankedPlayCard : RankedPlayCard
+    {
+        public BeatmapInfo SourceBeatmap { get; }
+
+        private readonly APIBeatmap apiBeatmap;
+
+        public EzQuickRotationLocalRankedPlayCard(BeatmapInfo beatmap, APIBeatmap apiBeatmap)
+            : base(new RankedPlayCardWithPlaylistItem(new RankedPlayCardItem { ID = beatmap.ID }))
+        {
+            SourceBeatmap = beatmap;
+            this.apiBeatmap = apiBeatmap;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            EzQuickRotationRankedPlayCardHelper.PresentLocalBeatmap(this, apiBeatmap, SourceBeatmap);
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationPickScreen.cs
+++ b/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationPickScreen.cs
@@ -1,0 +1,332 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
+using osu.Framework.Screens;
+using osu.Game.Audio;
+using osu.Game.Beatmaps;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Cursor;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Input.Bindings;
+using osu.Game.Screens.Footer;
+using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card;
+using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Hand;
+using osu.Game.Screens.Play;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.EzOsuGame.Screens.Rotation
+{
+    [Cached]
+    public partial class EzQuickRotationPickScreen : ScreenWithBeatmapBackground, IKeyBindingHandler<GlobalAction>, IPreviewTrackOwner
+    {
+        private static readonly Color4 header_plate_colour = Color4.Black.Opacity(0.65f);
+        private const float background_dim_alpha = 0.25f;
+        private const float header_corner_radius = 12f;
+
+        private PlayerHandOfCards playerHand = null!;
+        private EzQuickRotationWedgeArea wedgeArea = null!;
+        private Container emptyStateContainer = null!;
+
+        private readonly List<EzQuickRotationLocalRankedPlayCard> cards = new List<EzQuickRotationLocalRankedPlayCard>();
+
+        private Sample? cardAddSample;
+
+        [Cached]
+        private readonly CardDetailsOverlayContainer cardDetailsOverlay = new CardDetailsOverlayContainer();
+
+        [Cached]
+        private readonly SongPreviewParticleContainer particleContainer = new SongPreviewParticleContainer();
+
+        [Resolved]
+        private OsuGame? game { get; set; }
+
+        [Resolved]
+        private BeatmapManager beatmaps { get; set; } = null!;
+
+        [Resolved]
+        private PreviewTrackManager previewTrackManager { get; set; } = null!;
+
+        [BackgroundDependencyLoader]
+        private void load(AudioManager audio)
+        {
+            cardAddSample = audio.Samples.Get(@"Multiplayer/Matchmaking/Ranked/card-add-1");
+
+            var session = EzQuickRotationCoordinator.Session;
+            var initialCandidates = EzQuickRotationPoolBuilder.DrawCandidates(session.CachedPool, session.PlayedBeatmapIds, EzQuickRotationSession.CandidateCount);
+            var initialWedgeBeatmap = initialCandidates.Count > 0
+                ? beatmaps.GetWorkingBeatmap(initialCandidates[0])
+                : beatmaps.GetWorkingBeatmap(null);
+
+            InternalChildren = new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = Colour4.Black.Opacity(background_dim_alpha),
+                },
+                cardDetailsOverlay,
+                particleContainer,
+                new PopoverContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = new OsuContextMenuContainer
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Child = new Container
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Children = new[]
+                            {
+                                wedgeArea = new EzQuickRotationWedgeArea(initialWedgeBeatmap, session.Ruleset, session.BaseMods),
+                                createStageHeader(),
+                                new RoundedButton
+                                {
+                                    Text = EzQuickRotationStrings.PICK_END_SESSION,
+                                    Width = ScreenBackButton.BUTTON_WIDTH,
+                                    Anchor = Anchor.BottomLeft,
+                                    Origin = Anchor.BottomLeft,
+                                    Margin = new MarginPadding
+                                    {
+                                        Left = OsuGame.SCREEN_EDGE_MARGIN,
+                                        Bottom = OsuGame.SCREEN_EDGE_MARGIN + ShearedButton.DEFAULT_HEIGHT + 10,
+                                    },
+                                    Action = () => EzQuickRotationCoordinator.EndSession(game),
+                                },
+                                emptyStateContainer = new Container
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Alpha = 0,
+                                    Children = new Drawable[]
+                                    {
+                                        new OsuSpriteText
+                                        {
+                                            Text = EzQuickRotationStrings.POOL_EMPTY,
+                                            Font = OsuFont.TorusAlternate.With(size: 28, weight: FontWeight.SemiBold),
+                                            Anchor = Anchor.Centre,
+                                            Origin = Anchor.Centre,
+                                        },
+                                    },
+                                },
+                                playerHand = new PlayerHandOfCards
+                                {
+                                    Anchor = Anchor.BottomCentre,
+                                    Origin = Anchor.BottomCentre,
+                                    RelativeSizeAxes = Axes.Both,
+                                    Height = 0.55f,
+                                    SelectionMode = HandSelectionMode.Single,
+                                    PlayCardAction = onPlayButtonClicked,
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+
+            playerHand.SelectionChanged += onCardSelectionChanged;
+            loadCandidates(initialCandidates);
+        }
+
+        private Drawable createStageHeader()
+        {
+            var session = EzQuickRotationCoordinator.Session;
+
+            return new Container
+            {
+                AutoSizeAxes = Axes.Both,
+                Anchor = Anchor.CentreRight,
+                Origin = Anchor.CentreRight,
+                Margin = new MarginPadding { Right = 40 },
+                Masking = true,
+                CornerRadius = header_corner_radius,
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = header_plate_colour,
+                    },
+                    new FillFlowContainer
+                    {
+                        AutoSizeAxes = Axes.Both,
+                        Direction = FillDirection.Vertical,
+                        Padding = new MarginPadding { Horizontal = 28, Vertical = 18 },
+                        Spacing = new Vector2(0, 8),
+                        Children = new Drawable[]
+                        {
+                            new OsuSpriteText
+                            {
+                                Text = EzQuickRotationStrings.PICK_TITLE,
+                                Font = OsuFont.TorusAlternate.With(size: 34),
+                                Shadow = false,
+                                Anchor = Anchor.TopCentre,
+                                Origin = Anchor.TopCentre,
+                            },
+                            new OsuSpriteText
+                            {
+                                Text = EzQuickRotationStrings.PICK_CAPTION,
+                                Font = OsuFont.TorusAlternate.With(size: 22, weight: FontWeight.SemiBold),
+                                Anchor = Anchor.TopCentre,
+                                Origin = Anchor.TopCentre,
+                            },
+                            new OsuSpriteText
+                            {
+                                Text = EzQuickRotationStrings.PICK_BASELINE.Format(session.BaselineDifficulty),
+                                Font = OsuFont.TorusAlternate.With(size: 18),
+                                Alpha = 0.85f,
+                                Anchor = Anchor.TopCentre,
+                                Origin = Anchor.TopCentre,
+                            },
+                            new OsuSpriteText
+                            {
+                                Text = EzQuickRotationStrings.PICK_ENTER_RANDOM,
+                                Font = OsuFont.TorusAlternate.With(size: 16),
+                                Alpha = 0.7f,
+                                Anchor = Anchor.TopCentre,
+                                Origin = Anchor.TopCentre,
+                            },
+                        },
+                    },
+                },
+            };
+        }
+
+        private void loadCandidates(IReadOnlyList<BeatmapInfo> candidates)
+        {
+            var session = EzQuickRotationCoordinator.Session;
+
+            if (candidates.Count == 0)
+            {
+                emptyStateContainer.FadeIn(300);
+                playerHand.SelectionMode = HandSelectionMode.Disabled;
+                return;
+            }
+
+            const double stagger = 50;
+            double delay = 0;
+
+            updateWedgeForBeatmap(candidates[0]);
+
+            foreach (var beatmap in candidates)
+            {
+                var apiBeatmap = EzQuickRotationApiBeatmapFactory.Create(beatmap, session.Ruleset);
+                var card = new EzQuickRotationLocalRankedPlayCard(beatmap, apiBeatmap);
+                cards.Add(card);
+
+                double currentDelay = delay;
+
+                playerHand.AddCard(card, handCard =>
+                {
+                    handCard.Position = playerHand.BottomCardInsertPosition;
+                    handCard.DelayMovementOnEntering(currentDelay);
+                });
+
+                Scheduler.AddDelayed(() => SamplePlaybackHelper.PlayWithRandomPitch(cardAddSample), delay);
+                delay += stagger;
+            }
+
+            Scheduler.AddDelayed(() =>
+            {
+                if (playerHand.GetCardsInDisplayOrder().FirstOrDefault() is { } firstCard)
+                    firstCard.TriggerClick();
+            }, delay + 100);
+        }
+
+        private void onCardSelectionChanged()
+        {
+            var selectedCard = playerHand.Cards.FirstOrDefault(c => c.Selected)?.Card as EzQuickRotationLocalRankedPlayCard;
+
+            if (selectedCard == null)
+                return;
+
+            updateWedgeForBeatmap(selectedCard.SourceBeatmap);
+        }
+
+        private void updateWedgeForBeatmap(BeatmapInfo beatmap)
+        {
+            var session = EzQuickRotationCoordinator.Session;
+            var working = beatmaps.GetWorkingBeatmap(beatmap);
+            wedgeArea.UpdateSelection(working, session.Ruleset, session.BaseMods);
+        }
+
+        private void onPlayButtonClicked()
+        {
+            var selectedCard = playerHand.Cards.FirstOrDefault(c => c.Selected)?.Card as EzQuickRotationLocalRankedPlayCard;
+
+            if (selectedCard == null)
+                return;
+
+            playerHand.SelectionMode = HandSelectionMode.Disabled;
+            playerHand.PlayCardAction = null;
+            startBeatmap(selectedCard.SourceBeatmap);
+        }
+
+        private void startBeatmap(BeatmapInfo beatmap)
+        {
+            var session = EzQuickRotationCoordinator.Session;
+            var balance = EzQuickRotationDifficultyBalancer.Balance(beatmaps, beatmap, session.Ruleset, session.BaselineDifficulty,
+                EzQuickRotationSession.DifficultyTolerance);
+
+            var niceBpm = EzQuickRotationDifficultyBalancer.CreateNiceBpmMod(session.Ruleset, balance.Speed);
+            var mods = EzQuickRotationDifficultyBalancer.MergeMods(session.BaseMods, niceBpm);
+
+            session.MarkPlayed(beatmap);
+            EzQuickRotationGameplayLauncher.Start(this, beatmaps, Beatmap, Ruleset, Mods, beatmap, session.Ruleset, mods);
+        }
+
+        public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
+        {
+            if (e.Repeat)
+                return false;
+
+            switch (e.Action)
+            {
+                case GlobalAction.Select:
+                    if (cards.Count == 0)
+                        return true;
+
+                    var randomBeatmap = cards[Random.Shared.Next(cards.Count)].SourceBeatmap;
+                    startBeatmap(randomBeatmap);
+                    return true;
+
+                case GlobalAction.QuickExit:
+                    EzQuickRotationCoordinator.EndSession(game);
+                    return true;
+            }
+
+            return false;
+        }
+
+        public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
+        {
+        }
+
+        public override bool OnExiting(ScreenExitEvent e)
+        {
+            previewTrackManager.StopAnyPlaying(this);
+            return base.OnExiting(e);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            playerHand.SelectionChanged -= onCardSelectionChanged;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationPlayerLoader.cs
+++ b/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationPlayerLoader.cs
@@ -1,0 +1,18 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Game.Screens.Play;
+
+namespace osu.Game.EzOsuGame.Screens.Rotation
+{
+    public partial class EzQuickRotationPlayerLoader : PlayerLoader
+    {
+        public EzQuickRotationPlayerLoader(Func<Player> createPlayer)
+            : base(createPlayer)
+        {
+        }
+
+        public override bool ShowFooter => !QuickRestart;
+    }
+}

--- a/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationPoolBuilder.cs
+++ b/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationPoolBuilder.cs
@@ -1,0 +1,93 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Game.Beatmaps;
+using osu.Game.EzOsuGame.Beatmaps;
+using osu.Game.Screens.Select;
+
+namespace osu.Game.EzOsuGame.Screens.Rotation
+{
+    public static class EzQuickRotationPoolBuilder
+    {
+        public static EzQuickRotationPoolConstraints CreateConstraintsFromFilter(FilterCriteria criteria, BeatmapInfo firstBeatmap, bool crossKeyMode)
+        {
+            int? lockedKeyCount = null;
+
+            if (!crossKeyMode && criteria.Ruleset?.ShortName == "mania")
+                lockedKeyCount = (int)firstBeatmap.Difficulty.CircleSize;
+
+            HashSet<string>? collectionHashes = criteria.CollectionBeatmapMD5Hashes?.ToHashSet();
+
+            return new EzQuickRotationPoolConstraints(
+                criteria.UserStarDifficulty.Min,
+                collectionHashes,
+                criteria.Ruleset!,
+                lockedKeyCount,
+                crossKeyMode);
+        }
+
+        public static IReadOnlyList<BeatmapInfo> BuildPool(BeatmapManager beatmapManager, EzQuickRotationPoolConstraints constraints)
+        {
+            if (constraints.Ruleset == null)
+                return Array.Empty<BeatmapInfo>();
+
+            return beatmapManager.GetAllUsableBeatmapSets()
+                                 .SelectMany(set => set.Beatmaps)
+                                 .Where(b => !b.Hidden)
+                                 .Where(b => b.AllowGameplayWithRuleset(constraints.Ruleset, allowConversion: false))
+                                 .Where(b => matchesCollection(b, constraints.CollectionMd5Hashes))
+                                 .Where(b => matchesStarMin(b, constraints))
+                                 .Where(b => matchesKeyCount(b, constraints))
+                                 .Distinct()
+                                 .ToList();
+        }
+
+        public static IReadOnlyList<BeatmapInfo> DrawCandidates(IReadOnlyList<BeatmapInfo> pool, IReadOnlySet<Guid> playedBeatmapIds, int count, Random? random = null)
+        {
+            random ??= Random.Shared;
+
+            var available = pool.Where(b => !playedBeatmapIds.Contains(b.ID)).ToList();
+
+            if (available.Count == 0)
+                return Array.Empty<BeatmapInfo>();
+
+            if (available.Count <= count)
+                return available.OrderBy(_ => random.Next()).ToList();
+
+            return available.OrderBy(_ => random.Next()).Take(count).ToList();
+        }
+
+        private static bool matchesCollection(BeatmapInfo beatmap, HashSet<string>? collectionMd5Hashes) => collectionMd5Hashes?.Contains(beatmap.MD5Hash) ?? true;
+
+        private static bool matchesStarMin(BeatmapInfo beatmap, EzQuickRotationPoolConstraints constraints)
+        {
+            if (constraints.StarRatingMin is not double min)
+                return true;
+
+            double star = EzQuickRotationDifficultyHelper.UsesXxyStarRating(constraints.Ruleset)
+                ? beatmap.GetPersistedXxyStarRating() ?? beatmap.StarRating
+                : beatmap.StarRating;
+
+            return star >= min;
+        }
+
+        internal static bool matchesKeyCount(BeatmapInfo beatmap, EzQuickRotationPoolConstraints constraints)
+        {
+            if (constraints.Ruleset.ShortName != "mania")
+                return true;
+
+            int keyCount = (int)beatmap.Difficulty.CircleSize;
+
+            if (constraints.CrossKeyMode)
+                return keyCount >= EzQuickRotationPoolConstraints.CrossKeyMin && keyCount <= EzQuickRotationPoolConstraints.CrossKeyMax;
+
+            if (constraints.LockedKeyCount is int lockedKeyCount)
+                return keyCount == lockedKeyCount;
+
+            return true;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationPoolConstraints.cs
+++ b/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationPoolConstraints.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.Rulesets;
+
+namespace osu.Game.EzOsuGame.Screens.Rotation
+{
+    public sealed record EzQuickRotationPoolConstraints(
+        double? StarRatingMin,
+        HashSet<string>? CollectionMd5Hashes,
+        RulesetInfo Ruleset,
+        int? LockedKeyCount,
+        bool CrossKeyMode)
+    {
+        public const int CrossKeyMin = 4;
+
+        public const int CrossKeyMax = 10;
+    }
+}

--- a/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationRankedPlayCardHelper.cs
+++ b/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationRankedPlayCardHelper.cs
@@ -1,0 +1,28 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Reflection;
+using System.Threading.Tasks;
+using osu.Game.Beatmaps;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card;
+
+namespace osu.Game.EzOsuGame.Screens.Rotation
+{
+    internal static class EzQuickRotationRankedPlayCardHelper
+    {
+        private static readonly FieldInfo? songPreviewContainerField = typeof(RankedPlayCard).GetField("songPreviewContainer", BindingFlags.Instance | BindingFlags.NonPublic);
+        private static readonly FieldInfo? cardRevealedField = typeof(RankedPlayCard).GetField("cardRevealed", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        public static void PresentLocalBeatmap(RankedPlayCard card, APIBeatmap beatmap, BeatmapInfo localBeatmap)
+        {
+            card.SetContent(new RankedPlayCardContent(beatmap, localBeatmap));
+
+            if (songPreviewContainerField?.GetValue(card) is object previewContainer)
+                previewContainer.GetType().GetMethod("LoadPreview")?.Invoke(previewContainer, new object[] { beatmap });
+
+            if (cardRevealedField?.GetValue(card) is TaskCompletionSource revealed)
+                revealed.TrySetResult();
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationResults.cs
+++ b/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationResults.cs
@@ -1,0 +1,34 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Screens;
+using osu.Game.Graphics.UserInterfaceV2;
+
+namespace osu.Game.EzOsuGame.Screens.Rotation
+{
+    public static class EzQuickRotationResults
+    {
+        public static void TryAddContinueButton(FillFlowContainer buttons, IScreen screen)
+        {
+            if (!EzQuickRotationCoordinator.Session.IsActive)
+                return;
+
+            buttons.Insert(0, new RoundedButton
+            {
+                Text = EzQuickRotationStrings.CONTINUE_ROTATION,
+                Width = 300,
+                Action = () => screen.Push(new EzQuickRotationPickScreen()),
+            });
+        }
+
+        public static bool TryHandleSelect(IScreen screen)
+        {
+            if (!EzQuickRotationCoordinator.Session.IsActive)
+                return false;
+
+            screen.Push(new EzQuickRotationPickScreen());
+            return true;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationSession.cs
+++ b/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationSession.cs
@@ -1,0 +1,60 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Game.Beatmaps;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Screens.Select;
+
+namespace osu.Game.EzOsuGame.Screens.Rotation
+{
+    public sealed class EzQuickRotationSession
+    {
+        public bool IsActive { get; private set; }
+
+        public EzQuickRotationPoolConstraints PoolConstraints { get; private set; } = null!;
+
+        public IReadOnlyList<BeatmapInfo> CachedPool { get; private set; } = Array.Empty<BeatmapInfo>();
+
+        public HashSet<Guid> PlayedBeatmapIds { get; } = new HashSet<Guid>();
+
+        public double BaselineDifficulty { get; private set; }
+
+        public RulesetInfo Ruleset { get; private set; } = null!;
+
+        public IReadOnlyList<Mod> BaseMods { get; private set; } = Array.Empty<Mod>();
+
+        public void Begin(BeatmapManager beatmapManager,
+                          FilterCriteria filterCriteria,
+                          BeatmapInfo firstBeatmap,
+                          RulesetInfo ruleset,
+                          IReadOnlyList<Mod> baseMods,
+                          double baselineDifficulty)
+        {
+            bool crossKeyMode = GlobalConfigStore.EzConfig.Get<bool>(Ez2Setting.QuickRotationCrossKeyMode);
+
+            PoolConstraints = EzQuickRotationPoolBuilder.CreateConstraintsFromFilter(filterCriteria, firstBeatmap, crossKeyMode);
+            CachedPool = EzQuickRotationPoolBuilder.BuildPool(beatmapManager, PoolConstraints);
+            BaselineDifficulty = baselineDifficulty;
+            Ruleset = ruleset;
+            BaseMods = baseMods.Select(m => m.DeepClone()).ToArray();
+            PlayedBeatmapIds.Clear();
+            PlayedBeatmapIds.Add(firstBeatmap.ID);
+            IsActive = true;
+        }
+
+        public void MarkPlayed(BeatmapInfo beatmap) => PlayedBeatmapIds.Add(beatmap.ID);
+
+        public void End() => IsActive = false;
+
+        public static bool IsEnabled => GlobalConfigStore.EzConfig.Get<bool>(Ez2Setting.QuickRotationEnabled);
+
+        public static double DifficultyTolerance => GlobalConfigStore.EzConfig.Get<double>(Ez2Setting.QuickRotationDifficultyTolerance);
+
+        public static int CandidateCount => GlobalConfigStore.EzConfig.Get<int>(Ez2Setting.QuickRotationCandidateCount);
+    }
+}

--- a/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationSongSelectStub.cs
+++ b/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationSongSelectStub.cs
@@ -1,0 +1,54 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Bindables;
+using osu.Game.Beatmaps;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Scoring;
+using osu.Game.Screens;
+using osu.Game.Screens.Select;
+
+namespace osu.Game.EzOsuGame.Screens.Rotation
+{
+    /// <summary>
+    /// No-op <see cref="ISongSelect"/> for wedge components that only need search-link actions disabled.
+    /// </summary>
+    internal sealed class EzQuickRotationSongSelectStub : ISongSelect
+    {
+        public bool CanPresentScore => false;
+
+        public IBindable<BeatmapSetInfo?> ScopedBeatmapSet { get; } = new Bindable<BeatmapSetInfo?>();
+
+        public void Delete(BeatmapSetInfo beatmapBeatmapSetInfo)
+        {
+        }
+
+        public void RestoreAllHidden(BeatmapSetInfo beatmapSet)
+        {
+        }
+
+        public void ManageCollections()
+        {
+        }
+
+        public void PresentScore(ScoreInfo score, ScorePresentType presentType = ScorePresentType.Results)
+        {
+        }
+
+        public void AddToSearch(string query)
+        {
+        }
+
+        public IEnumerable<OsuMenuItem> GetForwardActions(BeatmapInfo beatmap) => Array.Empty<OsuMenuItem>();
+
+        public void ScopeToBeatmapSet(BeatmapSetInfo beatmapSet)
+        {
+        }
+
+        public void UnscopeBeatmapSet()
+        {
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationStrings.cs
+++ b/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationStrings.cs
@@ -1,0 +1,30 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.EzOsuGame.Localization;
+
+namespace osu.Game.EzOsuGame.Screens.Rotation
+{
+    public static class EzQuickRotationStrings
+    {
+        public static readonly EzLocalizationManager.EzLocalisableString TRANSITION_TITLE = new EzLocalizationManager.EzLocalisableString("即将进入快速轮换", "Entering Quick Rotation");
+
+        public static readonly EzLocalizationManager.EzLocalisableString TRANSITION_SKIP_HINT = new EzLocalizationManager.EzLocalisableString("点击或按跳过键继续", "Click or press skip to continue");
+
+        public static readonly EzLocalizationManager.EzLocalisableString PICK_TITLE = new EzLocalizationManager.EzLocalisableString("选择下一张谱面", "Pick the next beatmap");
+
+        public static readonly EzLocalizationManager.EzLocalisableString PICK_CAPTION = new EzLocalizationManager.EzLocalisableString("选择一张卡牌开始游玩", "Select a card to play!");
+
+        public static readonly EzLocalizationManager.EzLocalisableString PICK_BASELINE = new EzLocalizationManager.EzLocalisableString("基准难度: {0:0.00}", "Baseline: {0:0.00}");
+
+        public static readonly EzLocalizationManager.EzLocalisableString PICK_ENTER_RANDOM = new EzLocalizationManager.EzLocalisableString("按回车随机选择", "Press enter for a random pick");
+
+        public static readonly EzLocalizationManager.EzLocalisableString PICK_PLAY = new EzLocalizationManager.EzLocalisableString("开始", "Play");
+
+        public static readonly EzLocalizationManager.EzLocalisableString PICK_END_SESSION = new EzLocalizationManager.EzLocalisableString("结束轮换", "End rotation");
+
+        public static readonly EzLocalizationManager.EzLocalisableString POOL_EMPTY = new EzLocalizationManager.EzLocalisableString("候选池已用尽", "No more beatmaps in the pool");
+
+        public static readonly EzLocalizationManager.EzLocalisableString CONTINUE_ROTATION = new EzLocalizationManager.EzLocalisableString("继续快速轮换", "Continue Quick Rotation");
+    }
+}

--- a/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationTransitionScreen.cs
+++ b/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationTransitionScreen.cs
@@ -1,0 +1,123 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
+using osu.Framework.Screens;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Input.Bindings;
+using osu.Game.Screens.Play;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.Screens.Rotation
+{
+    public partial class EzQuickRotationTransitionScreen : ScreenWithBeatmapBackground, IKeyBindingHandler<GlobalAction>
+    {
+        private OsuSpriteText countdownText = null!;
+        private bool advanced;
+
+        [Resolved]
+        private OsuGame? game { get; set; }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            InternalChildren = new Drawable[]
+            {
+                new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = Colour4.Black.Opacity(0.6f),
+                        },
+                        new FillFlowContainer
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            AutoSizeAxes = Axes.Both,
+                            Direction = FillDirection.Vertical,
+                            Spacing = new Vector2(0, 12),
+                            Children = new Drawable[]
+                            {
+                                new OsuSpriteText
+                                {
+                                    Text = EzQuickRotationStrings.TRANSITION_TITLE,
+                                    Font = OsuFont.GetFont(size: 28, weight: FontWeight.Bold),
+                                },
+                                countdownText = new OsuSpriteText
+                                {
+                                    Font = OsuFont.GetFont(size: 48, weight: FontWeight.Bold),
+                                },
+                                new OsuSpriteText
+                                {
+                                    Text = EzQuickRotationStrings.TRANSITION_SKIP_HINT,
+                                    Font = OsuFont.GetFont(size: 18),
+                                    Alpha = 0.8f,
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            updateCountdown(3);
+            Scheduler.AddDelayed(() => updateCountdown(2), 1000);
+            Scheduler.AddDelayed(() => updateCountdown(1), 2000);
+            Scheduler.AddDelayed(advance, 3000);
+        }
+
+        private void updateCountdown(int value) => countdownText.Text = value.ToString();
+
+        private void advance()
+        {
+            if (advanced)
+                return;
+
+            advanced = true;
+            this.Push(new EzQuickRotationPickScreen());
+        }
+
+        protected override bool OnClick(ClickEvent e)
+        {
+            advance();
+            return true;
+        }
+
+        public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
+        {
+            if (e.Repeat)
+                return false;
+
+            switch (e.Action)
+            {
+                case GlobalAction.SkipCutscene:
+                case GlobalAction.Select:
+                    advance();
+                    return true;
+
+                case GlobalAction.QuickExit:
+                    EzQuickRotationCoordinator.EndSession(game);
+                    return true;
+            }
+
+            return false;
+        }
+
+        public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
+        {
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationWedgeArea.cs
+++ b/osu.Game/EzOsuGame/Screens/Rotation/EzQuickRotationWedgeArea.cs
@@ -1,0 +1,141 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Beatmaps;
+using osu.Game.Graphics.Containers;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Screens.Select;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.Screens.Rotation
+{
+    /// <summary>
+    /// Song-select style wedge stack (title + details) for the quick rotation pick screen.
+    /// </summary>
+    public partial class EzQuickRotationWedgeArea : CompositeDrawable
+    {
+        private readonly Bindable<WorkingBeatmap> working = new Bindable<WorkingBeatmap>();
+        private readonly Bindable<RulesetInfo> ruleset = new Bindable<RulesetInfo>();
+        private readonly Bindable<IReadOnlyList<Mod>> mods = new Bindable<IReadOnlyList<Mod>>(Array.Empty<Mod>());
+        private readonly Bindable<SongSelect.BeatmapSetLookupResult?> onlineLookupResult = new Bindable<SongSelect.BeatmapSetLookupResult?>(SongSelect.BeatmapSetLookupResult.Completed(null));
+
+        private BeatmapTitleWedge titleWedge = null!;
+        private BeatmapDetailsArea detailsArea = null!;
+        private FillFlowContainer wedgeFlow = null!;
+
+        public EzQuickRotationWedgeArea(WorkingBeatmap? initialWorking = null, RulesetInfo? initialRuleset = null, IReadOnlyList<Mod>? initialMods = null)
+        {
+            RelativeSizeAxes = Axes.Both;
+            Width = 0.6f;
+            Anchor = Anchor.TopLeft;
+            Origin = Anchor.TopLeft;
+            Masking = true;
+
+            if (initialWorking != null)
+                working.Value = initialWorking;
+
+            if (initialRuleset != null)
+                ruleset.Value = initialRuleset;
+
+            if (initialMods != null)
+                mods.Value = initialMods;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(BeatmapManager beatmapManager)
+        {
+            var session = EzQuickRotationCoordinator.Session;
+
+            working.Value ??= beatmapManager.GetWorkingBeatmap(null);
+            ruleset.Value ??= session.Ruleset;
+            mods.Value ??= session.BaseMods;
+
+            Padding = new MarginPadding
+            {
+                Top = 40,
+                Right = 20,
+            };
+
+            InternalChild = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Shear = OsuGame.SHEAR,
+                Padding = new MarginPadding
+                {
+                    Top = -SongSelect.CORNER_RADIUS_HIDE_OFFSET,
+                    Left = -SongSelect.CORNER_RADIUS_HIDE_OFFSET,
+                },
+                Child = wedgeFlow = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Direction = FillDirection.Vertical,
+                    Spacing = new Vector2(0, 4),
+                    Children = new Drawable[]
+                    {
+                        new ShearAligningWrapper(titleWedge = new BeatmapTitleWedge()),
+                        new ShearAligningWrapper(detailsArea = new BeatmapDetailsArea
+                        {
+                            RelativeSizeAxes = Axes.X,
+                        }),
+                    },
+                },
+            };
+        }
+
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+        {
+            var dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
+            dependencies.CacheAs((IBindable<WorkingBeatmap>)working);
+            dependencies.CacheAs((IBindable<RulesetInfo>)ruleset);
+            dependencies.CacheAs((IBindable<IReadOnlyList<Mod>>)mods);
+            dependencies.CacheAs((IBindable<SongSelect.BeatmapSetLookupResult?>)onlineLookupResult);
+            dependencies.CacheAs<ISongSelect>(new EzQuickRotationSongSelectStub());
+            return dependencies;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            updateDetailsHeight();
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+            updateDetailsHeight();
+        }
+
+        private void updateDetailsHeight()
+        {
+            float remaining = Math.Max(0, DrawHeight - titleWedge.DrawHeight - wedgeFlow.Spacing.Y);
+            if (Math.Abs(detailsArea.Height - remaining) > 0.5f)
+                detailsArea.Height = remaining;
+        }
+
+        public void UpdateSelection(WorkingBeatmap workingBeatmap,
+                                    RulesetInfo rulesetInfo,
+                                    IReadOnlyList<Mod> modList,
+                                    SongSelect.BeatmapSetLookupResult? lookupResult = null)
+        {
+            working.Value = workingBeatmap;
+            ruleset.Value = rulesetInfo;
+            mods.Value = modList;
+            onlineLookupResult.Value = lookupResult ?? SongSelect.BeatmapSetLookupResult.Completed(
+                EzQuickRotationApiBeatmapFactory.TryCreateBeatmapSet(workingBeatmap.BeatmapInfo));
+
+            if (!titleWedge.IsPresent)
+                titleWedge.Show();
+
+            if (!detailsArea.IsPresent)
+                detailsArea.Show();
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Screens/Rotation/RankedPlayCardContent.EzLocalCover.cs
+++ b/osu.Game/EzOsuGame/Screens/Rotation/RankedPlayCardContent.EzLocalCover.cs
@@ -1,0 +1,46 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Beatmaps;
+using osu.Game.EzOsuGame.Screens.Rotation;
+using osu.Game.Online.API.Requests.Responses;
+
+namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
+{
+    public partial class RankedPlayCardContent
+    {
+        private BeatmapInfo? ezLocalCoverBeatmap;
+
+        public RankedPlayCardContent(APIBeatmap beatmap, BeatmapInfo localCoverBeatmap)
+        {
+            Beatmap = beatmap;
+            ezLocalCoverBeatmap = localCoverBeatmap;
+            Size = RankedPlayCard.SIZE;
+        }
+
+        private Drawable createCardCover()
+        {
+            Drawable cover = ezLocalCoverBeatmap != null
+                ? new EzQuickRotationLocalCardCoverAdapter(ezLocalCoverBeatmap)
+                : new CardCover(Beatmap);
+
+            cover.RelativeSizeAxes = Axes.Both;
+            return cover;
+        }
+
+        private partial class EzQuickRotationLocalCardCoverAdapter(BeatmapInfo beatmap) : CompositeDrawable
+        {
+            [BackgroundDependencyLoader]
+            private void load(CardColours colours)
+            {
+                RelativeSizeAxes = Axes.Both;
+                InternalChild = new EzQuickRotationLocalCardCover(beatmap,
+                    ColourInfo.GradientVertical(colours.Background.Opacity(0.2f), colours.Background.Opacity(0.65f)));
+            }
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Screens/Select/EzSoloSongSelect.QuickRotation.cs
+++ b/osu.Game/EzOsuGame/Screens/Select/EzSoloSongSelect.QuickRotation.cs
@@ -1,0 +1,29 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Screens;
+using osu.Game.Beatmaps;
+using osu.Game.EzOsuGame.Screens.Rotation;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Screens.Select
+{
+    public partial class SoloSongSelect
+    {
+        private void tryBeginQuickRotation()
+        {
+            if (!EzQuickRotationSession.IsEnabled || EzQuickRotationCoordinator.Session.IsActive)
+                return;
+
+            var criteria = FilterControl.CreateCriteria();
+            var beatmapInfo = Beatmap.Value.BeatmapInfo;
+            double baseline = EzQuickRotationDifficultyHelper.GetBaselineStarRating(beatmaps, beatmapInfo, Ruleset.Value, Mods.Value);
+
+            EzQuickRotationCoordinator.Session.Begin(beatmaps, criteria, beatmapInfo, Ruleset.Value, Mods.Value, baseline);
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCardContent.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Card/RankedPlayCardContent.cs
@@ -58,10 +58,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card
                             FillMode = FillMode.Fit,
                             Children =
                             [
-                                new CardCover(Beatmap)
-                                {
-                                    RelativeSizeAxes = Axes.Both,
-                                },
+                                createCardCover(),
                                 new CardMetadata(Beatmap)
                                 {
                                     RelativeSizeAxes = Axes.Both,

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -32,6 +32,7 @@ using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.Performance;
 using osu.Game.EzOsuGame.Scoring;
 using osu.Game.EzOsuGame.Screens.Play;
+using osu.Game.EzOsuGame.Screens.Rotation;
 using osu.Game.Online.API;
 using osu.Game.Overlays;
 using osu.Game.Rulesets;
@@ -1135,6 +1136,14 @@ namespace osu.Game.Screens.Play
                 if (!this.IsCurrentScreen())
                     // This player instance may already be in the process of exiting.
                     return;
+
+                // [Ez] 快速轮换：会话进行中时进入抽卡/过渡界面。
+                if (EzQuickRotationCoordinator.Session.IsActive)
+                {
+                    EzOsuGame.Diagnostics.EzTimingTrace.Record("ResultsDelegate.QuickRotation", "Navigating to quick rotation flow");
+                    EzQuickRotationCoordinator.NavigateAfterPlay(this);
+                    return;
+                }
 
                 // [Ez] 心流：从选歌进入的单人游玩跳过结算，成绩已导入后直接回选歌。
                 if (EzFlowMode.ShouldSkipResults(this))

--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -26,6 +26,7 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
 using osu.Game.EzOsuGame.Statistics;
+using osu.Game.EzOsuGame.Screens.Rotation;
 using osu.Game.Localisation;
 using osu.Game.Online.Placeholders;
 using osu.Game.Overlays;
@@ -219,6 +220,8 @@ namespace osu.Game.Screens.Ranking
                 buttons.Add(new RetryButton { Width = 300 });
                 allowHotkeyRetry = true;
             }
+
+            EzQuickRotationResults.TryAddContinueButton(buttons, this);
 
             if (allowHotkeyRetry)
             {
@@ -585,6 +588,9 @@ namespace osu.Game.Screens.Ranking
                     break;
 
                 case GlobalAction.Select:
+                    if (EzQuickRotationResults.TryHandleSelect(this))
+                        return true;
+
                     if (SelectedScore.Value != null)
                         StatisticsPanel.ToggleVisibility();
                     return true;

--- a/osu.Game/Screens/Select/SoloSongSelect.cs
+++ b/osu.Game/Screens/Select/SoloSongSelect.cs
@@ -98,6 +98,8 @@ namespace osu.Game.Screens.Select
         {
             if (playerLoader != null) return;
 
+            tryBeginQuickRotation();
+
             modsAtGameplayStart = Mods.Value.Select(m => m.DeepClone()).ToArray();
 
             // Ctrl+Enter should start map with autoplay enabled.


### PR DESCRIPTION
## Summary

- 新增 Ez「快速轮换」：从选歌进入后连续随机抽卡选谱，支持心流组合 3 秒过渡、Nice BPM 难度平衡、收藏夹/星级下限/跨键（4–10K）图池过滤。
- 抽卡界面复用 Ranked Play 手牌与卡牌视觉，左上角接入选歌 Wedge 查看谱面详情，本地封面与独立背景暗化。
- 挂接 SoloSongSelect、Player、Results、EzFlowMode；含难度平衡与图池过滤单元测试。

## Test plan

- [x] 设置中开启快速轮换，从 Mania 选歌开局，确认进入过渡/抽卡界面
- [x] 跨键开：候选仅 4–10K；跨键关：锁定首轮键数
- [x] 切换卡牌时 Wedge 更新，左侧斜边不可见，背景有 0.2 暗化
- [x] 选卡开局、结算继续、结束轮换与 QuickExit 流程正常
- [x] `dotnet test osu.Game.Tests --filter FullyQualifiedName~EzOsuGame.Rotation`
