### PR TITLE
启动预载：Intro 内并行、首页让路、立即进选歌

### DIFF
--- a/osu.Game.Tests/Database/BackgroundDataStoreStartupDelayTest.cs
+++ b/osu.Game.Tests/Database/BackgroundDataStoreStartupDelayTest.cs
@@ -4,6 +4,7 @@
 using System;
 using NUnit.Framework;
 using osu.Game.Database;
+using osu.Game.EzOsuGame.Startup;
 
 namespace osu.Game.Tests.Database
 {
@@ -11,10 +12,10 @@ namespace osu.Game.Tests.Database
     public partial class BackgroundDataStoreStartupDelayTest
     {
         [Test]
-        public void ProductionStartupBackfillDelayIsFiveSeconds()
+        public void ProductionStartupBackfillDelayUsesEzStartupTuningDefault()
         {
             var probe = new ProbeBackgroundDataStoreProcessor();
-            Assert.That(probe.ExposedStartupBackfillDelay, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(probe.ExposedStartupBackfillDelay, Is.EqualTo(TimeSpan.FromSeconds(EzStartupTuning.BdspStartupBackfillDelaySeconds)));
         }
 
         private partial class ProbeBackgroundDataStoreProcessor : BackgroundDataStoreProcessor

--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Database
                 return;
 
             IsStartupProcessingFinished = true;
-            EzStartupTrace.Log("BDSP startup processing marked finished");
+            EzStartupTrace.Log("BDSP finished");
             StartupProcessingFinished?.Invoke();
         }
 
@@ -376,19 +376,15 @@ namespace osu.Game.Database
 
             localMetadataSource = new LocalCachedBeatmapMetadataSource(storage);
 
-            EzStartupTrace.Log($"BDSP.LoadComplete scheduling processing thread (StartupBackfillDelay={StartupBackfillDelay.TotalSeconds}s)");
-
             ProcessingTask = Task.Factory.StartNew(() =>
             {
                 try
                 {
                     Logger.Log("Beginning background data store processing..");
-                    EzStartupTrace.Log("BDSP processing thread started, entering StartupBackfillDelay sleep");
 
                     // Let SongSelect settle before Invalidate storms from Ez/official backfill
                     // (users see a 3–5s FPS cliff when unlimited carousel Replaces land in one burst).
                     Thread.Sleep(StartupBackfillDelay);
-                    EzStartupTrace.Log("BDSP StartupBackfillDelay sleep finished");
                     sleepIfRequired();
 
                     clearOutdatedStarRatings();
@@ -399,9 +395,7 @@ namespace osu.Game.Database
                     {
                         try
                         {
-                            EzStartupTrace.Log("BDSP Ez Realm metadata backfill started");
                             runEzRealmMetadataBackfill();
-                            EzStartupTrace.Log("BDSP Ez Realm metadata backfill finished");
                         }
                         finally
                         {
@@ -411,7 +405,6 @@ namespace osu.Game.Database
                     else
                     {
                         Logger.Log("Skipping startup Ez Realm metadata backfill because another backfill is already running.");
-                        EzStartupTrace.Log("BDSP Ez Realm metadata backfill skipped (already running)");
                     }
 
                     populateMissingStarRatings();
@@ -443,7 +436,6 @@ namespace osu.Game.Database
                 }
 
                 Logger.Log("Finished background data store processing!");
-                EzStartupTrace.Log("BDSP processing thread finished");
                 Scheduler.Add(markStartupProcessingFinished);
             });
         }

--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -23,6 +23,7 @@ using osu.Game.EzOsuGame.Analysis;
 using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.Database;
 using osu.Game.EzOsuGame.Scoring;
+using osu.Game.EzOsuGame.Startup;
 using osu.Game.Extensions;
 using osu.Game.Online.API;
 using osu.Game.Overlays;
@@ -42,6 +43,26 @@ namespace osu.Game.Database
     public partial class BackgroundDataStoreProcessor : Component
     {
         protected Task ProcessingTask { get; private set; } = null!;
+
+        /// <summary>
+        /// Whether the initial startup processing pass has completed (success, failure, or skipped).
+        /// </summary>
+        public bool IsStartupProcessingFinished { get; private set; }
+
+        /// <summary>
+        /// Fired on the update thread once when <see cref="IsStartupProcessingFinished"/> becomes true.
+        /// </summary>
+        public event Action? StartupProcessingFinished;
+
+        private void markStartupProcessingFinished()
+        {
+            if (IsStartupProcessingFinished)
+                return;
+
+            IsStartupProcessingFinished = true;
+            EzStartupTrace.Log("BDSP startup processing marked finished");
+            StartupProcessingFinished?.Invoke();
+        }
 
         [Resolved]
         private RulesetStore rulesetStore { get; set; } = null!;
@@ -101,9 +122,22 @@ namespace osu.Game.Database
 
         /// <summary>
         /// 进主循环前等待，避免选歌刚出现就遭遇 Ez/官方 backfill 的 Invalidate/Replace 风暴。
-        /// 测试覆写为 <see cref="TimeSpan.Zero"/>。
+        /// 默认 0（<see cref="EzStartupTuning.BdspStartupBackfillDelaySeconds"/>）以便在 intro 期间消化 Realm 写入。
+        /// 测试覆写为 <see cref="TimeSpan.Zero"/>；开发期可增大该值做 A/B 对比。
         /// </summary>
-        protected virtual TimeSpan StartupBackfillDelay => TimeSpan.FromSeconds(2);
+        protected virtual TimeSpan StartupBackfillDelay => TimeSpan.FromSeconds(EzStartupTuning.BdspStartupBackfillDelaySeconds);
+
+        /// <summary>
+        /// Whether Ez Realm metadata backfill is currently running (startup or manual queue).
+        /// </summary>
+        public bool IsEzRealmMetadataBackfillRunning
+        {
+            get
+            {
+                lock (ezRealmMetadataBackfillLock)
+                    return ezRealmMetadataBackfillQueued;
+            }
+        }
 
         /// <summary>
         /// Queue Ez Realm metadata backfill (Tag / XxySR / PP) on a background thread.
@@ -335,19 +369,26 @@ namespace osu.Game.Database
             base.LoadComplete();
 
             if (SkipProcessing)
+            {
+                markStartupProcessingFinished();
                 return;
+            }
 
             localMetadataSource = new LocalCachedBeatmapMetadataSource(storage);
+
+            EzStartupTrace.Log($"BDSP.LoadComplete scheduling processing thread (StartupBackfillDelay={StartupBackfillDelay.TotalSeconds}s)");
 
             ProcessingTask = Task.Factory.StartNew(() =>
             {
                 try
                 {
                     Logger.Log("Beginning background data store processing..");
+                    EzStartupTrace.Log("BDSP processing thread started, entering StartupBackfillDelay sleep");
 
                     // Let SongSelect settle before Invalidate storms from Ez/official backfill
                     // (users see a 3–5s FPS cliff when unlimited carousel Replaces land in one burst).
                     Thread.Sleep(StartupBackfillDelay);
+                    EzStartupTrace.Log("BDSP StartupBackfillDelay sleep finished");
                     sleepIfRequired();
 
                     clearOutdatedStarRatings();
@@ -358,7 +399,9 @@ namespace osu.Game.Database
                     {
                         try
                         {
+                            EzStartupTrace.Log("BDSP Ez Realm metadata backfill started");
                             runEzRealmMetadataBackfill();
+                            EzStartupTrace.Log("BDSP Ez Realm metadata backfill finished");
                         }
                         finally
                         {
@@ -368,6 +411,7 @@ namespace osu.Game.Database
                     else
                     {
                         Logger.Log("Skipping startup Ez Realm metadata backfill because another backfill is already running.");
+                        EzStartupTrace.Log("BDSP Ez Realm metadata backfill skipped (already running)");
                     }
 
                     populateMissingStarRatings();
@@ -399,6 +443,8 @@ namespace osu.Game.Database
                 }
 
                 Logger.Log("Finished background data store processing!");
+                EzStartupTrace.Log("BDSP processing thread finished");
+                Scheduler.Add(markStartupProcessingFinished);
             });
         }
 

--- a/osu.Game/EzOsuGame/Analysis/EzAnalysisWarmupProcessor.cs
+++ b/osu.Game/EzOsuGame/Analysis/EzAnalysisWarmupProcessor.cs
@@ -14,6 +14,7 @@ using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Startup;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Performance;
@@ -52,6 +53,9 @@ namespace osu.Game.EzOsuGame.Analysis
         [Resolved]
         private IHighPerformanceSessionManager? highPerformanceSessionManager { get; set; }
 
+        [Resolved(CanBeNull = true)]
+        private BackgroundDataStoreProcessor? backgroundDataStoreProcessor { get; set; }
+
         private IBindable<bool> sqliteEnabledBindable = null!;
         private bool sqliteEnabled;
         private bool backgroundWorkersStarted;
@@ -83,6 +87,8 @@ namespace osu.Game.EzOsuGame.Analysis
 
         private volatile bool pendingScanCompleted;
 
+        private Action? onBdspFinishedForSqliteWarmup;
+
         protected override void LoadComplete()
         {
             base.LoadComplete();
@@ -110,12 +116,43 @@ namespace osu.Game.EzOsuGame.Analysis
                 ensureBackgroundWorkersStarted();
                 pendingScanCompleted = true;
                 Schedule(() => queueSelectedBeatmapRecomputeIfRequired(currentBeatmap.Value));
-                tryQueueAutomaticSqliteUpgradeWarmup();
+                scheduleSqliteWarmupAfterBdsp();
                 return;
             }
 
             pendingScanCompleted = false;
             cancelPendingBeatmapProcessing();
+            unsubscribeBdspForSqliteWarmup();
+        }
+
+        private void scheduleSqliteWarmupAfterBdsp()
+        {
+            if (!sqliteEnabled)
+                return;
+
+            if (backgroundDataStoreProcessor == null || backgroundDataStoreProcessor.IsStartupProcessingFinished)
+            {
+                EzStartupTrace.Log("SQLite auto warmup scheduling (BDSP already finished or unavailable)");
+                tryQueueAutomaticSqliteUpgradeWarmup();
+                return;
+            }
+
+            EzStartupTrace.Log("SQLite auto warmup waiting for BDSP startup processing");
+            onBdspFinishedForSqliteWarmup ??= onBdspStartupProcessingFinishedForSqliteWarmup;
+            backgroundDataStoreProcessor.StartupProcessingFinished += onBdspFinishedForSqliteWarmup;
+        }
+
+        private void onBdspStartupProcessingFinishedForSqliteWarmup()
+        {
+            unsubscribeBdspForSqliteWarmup();
+            EzStartupTrace.Log("SQLite auto warmup scheduling (BDSP finished)");
+            tryQueueAutomaticSqliteUpgradeWarmup();
+        }
+
+        private void unsubscribeBdspForSqliteWarmup()
+        {
+            if (backgroundDataStoreProcessor != null && onBdspFinishedForSqliteWarmup != null)
+                backgroundDataStoreProcessor.StartupProcessingFinished -= onBdspFinishedForSqliteWarmup;
         }
 
         private void ensureBackgroundWorkersStarted()
@@ -142,18 +179,24 @@ namespace osu.Game.EzOsuGame.Analysis
         private void tryQueueAutomaticSqliteUpgradeWarmup()
         {
             if (!sqliteEnabled || !analysisDatabase.ShouldRunAutomaticSqliteWarmup())
+            {
+                EzStartupTrace.Log($"SQLite auto warmup skipped (sqliteEnabled={sqliteEnabled})");
                 return;
+            }
 
+            EzStartupTrace.Log("SQLite auto warmup queued");
             Task.Factory.StartNew(() =>
             {
                 try
                 {
+                    EzStartupTrace.Log("SQLite auto warmup started");
                     Logger.Log("Automatic SQLite upgrade warmup started.", Ez2ConfigManager.LOGGER_NAME, LogLevel.Important);
 
                     analysisDatabase.EnsureInitialised();
                     executeSqliteMainRebuild(forceAll: false);
                     executeSqliteSongsBranchesRebuild(forceAll: false);
 
+                    EzStartupTrace.Log("SQLite auto warmup finished");
                     Logger.Log("Automatic SQLite upgrade warmup finished.", Ez2ConfigManager.LOGGER_NAME, LogLevel.Important);
                 }
                 catch (Exception e)
@@ -789,6 +832,8 @@ namespace osu.Game.EzOsuGame.Analysis
         {
             if (isDisposing)
             {
+                unsubscribeBdspForSqliteWarmup();
+
                 startupWarmupCancellationSource.Cancel();
                 selectedBeatmapRecomputeCancellationSource.Cancel();
                 pendingBeatmapRecomputeCancellationSource.Cancel();

--- a/osu.Game/EzOsuGame/Analysis/EzAnalysisWarmupProcessor.cs
+++ b/osu.Game/EzOsuGame/Analysis/EzAnalysisWarmupProcessor.cs
@@ -14,7 +14,6 @@ using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.EzOsuGame.Configuration;
-using osu.Game.EzOsuGame.Startup;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Performance;
@@ -132,12 +131,10 @@ namespace osu.Game.EzOsuGame.Analysis
 
             if (backgroundDataStoreProcessor == null || backgroundDataStoreProcessor.IsStartupProcessingFinished)
             {
-                EzStartupTrace.Log("SQLite auto warmup scheduling (BDSP already finished or unavailable)");
                 tryQueueAutomaticSqliteUpgradeWarmup();
                 return;
             }
 
-            EzStartupTrace.Log("SQLite auto warmup waiting for BDSP startup processing");
             onBdspFinishedForSqliteWarmup ??= onBdspStartupProcessingFinishedForSqliteWarmup;
             backgroundDataStoreProcessor.StartupProcessingFinished += onBdspFinishedForSqliteWarmup;
         }
@@ -145,7 +142,6 @@ namespace osu.Game.EzOsuGame.Analysis
         private void onBdspStartupProcessingFinishedForSqliteWarmup()
         {
             unsubscribeBdspForSqliteWarmup();
-            EzStartupTrace.Log("SQLite auto warmup scheduling (BDSP finished)");
             tryQueueAutomaticSqliteUpgradeWarmup();
         }
 
@@ -179,24 +175,18 @@ namespace osu.Game.EzOsuGame.Analysis
         private void tryQueueAutomaticSqliteUpgradeWarmup()
         {
             if (!sqliteEnabled || !analysisDatabase.ShouldRunAutomaticSqliteWarmup())
-            {
-                EzStartupTrace.Log($"SQLite auto warmup skipped (sqliteEnabled={sqliteEnabled})");
                 return;
-            }
 
-            EzStartupTrace.Log("SQLite auto warmup queued");
             Task.Factory.StartNew(() =>
             {
                 try
                 {
-                    EzStartupTrace.Log("SQLite auto warmup started");
                     Logger.Log("Automatic SQLite upgrade warmup started.", Ez2ConfigManager.LOGGER_NAME, LogLevel.Important);
 
                     analysisDatabase.EnsureInitialised();
                     executeSqliteMainRebuild(forceAll: false);
                     executeSqliteSongsBranchesRebuild(forceAll: false);
 
-                    EzStartupTrace.Log("SQLite auto warmup finished");
                     Logger.Log("Automatic SQLite upgrade warmup finished.", Ez2ConfigManager.LOGGER_NAME, LogLevel.Important);
                 }
                 catch (Exception e)

--- a/osu.Game/EzOsuGame/Startup/EzSongSelectEnterTrace.cs
+++ b/osu.Game/EzOsuGame/Startup/EzSongSelectEnterTrace.cs
@@ -4,20 +4,35 @@
 namespace osu.Game.EzOsuGame.Startup
 {
     /// <summary>
-    /// No-op placeholder until debug enter-path tracing is wired in a later commit.
+    /// Debug-only MainMenu Play → SongSelect push → carousel ready metrics.
     /// </summary>
-    internal static class EzSongSelectEnterTrace
+    public static class EzSongSelectEnterTrace
     {
+        private static double? playPressedAt;
+        private static double? songSelectEnteringAt;
+
         public static void RecordPlayPressed(bool preloadHit)
         {
+            playPressedAt = EzStartupTrace.ElapsedMilliseconds;
+            EzStartupTrace.Log($"EnterPath PlayPressed preloadHit={preloadHit}");
         }
 
         public static void RecordSongSelectEntering()
         {
+            songSelectEnteringAt = EzStartupTrace.ElapsedMilliseconds;
+            double? pushFromPlay = songSelectEnteringAt - playPressedAt;
+            EzStartupTrace.Log($"EnterPath SongSelect.OnEntering pushFromPlay={pushFromPlay}ms");
         }
 
         public static void RecordCarouselReady()
         {
+            double now = EzStartupTrace.ElapsedMilliseconds;
+            double? fromPlay = now - playPressedAt;
+            double? fromEnter = now - songSelectEnteringAt;
+            EzStartupTrace.Log($"EnterPath CarouselItemsPresented fromPlay={fromPlay}ms fromEnter={fromEnter}ms");
+
+            playPressedAt = null;
+            songSelectEnteringAt = null;
         }
     }
 }

--- a/osu.Game/EzOsuGame/Startup/EzSongSelectEnterTrace.cs
+++ b/osu.Game/EzOsuGame/Startup/EzSongSelectEnterTrace.cs
@@ -1,0 +1,23 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.EzOsuGame.Startup
+{
+    /// <summary>
+    /// No-op placeholder until debug enter-path tracing is wired in a later commit.
+    /// </summary>
+    internal static class EzSongSelectEnterTrace
+    {
+        public static void RecordPlayPressed(bool preloadHit)
+        {
+        }
+
+        public static void RecordSongSelectEntering()
+        {
+        }
+
+        public static void RecordCarouselReady()
+        {
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Startup/EzStartupContentPreloader.cs
+++ b/osu.Game/EzOsuGame/Startup/EzStartupContentPreloader.cs
@@ -23,7 +23,8 @@ namespace osu.Game.EzOsuGame.Startup
 
         private bool lightStarted;
         private bool detachWarmupScheduled;
-        private bool detachWarmupFinished;
+
+        // private bool detachWarmupFinished;
 
         public EzStartupContentPreloader()
         {
@@ -41,13 +42,9 @@ namespace osu.Game.EzOsuGame.Startup
         public void ScheduleSettingsPreload()
         {
             if (lightStarted)
-            {
-                EzStartupTrace.Log("Preloader.ScheduleSettingsPreload skipped (already started)");
                 return;
-            }
 
             lightStarted = true;
-            EzStartupTrace.Log("Preloader.ScheduleSettingsPreload");
             tryScheduleSettingsPreload();
         }
 
@@ -59,7 +56,6 @@ namespace osu.Game.EzOsuGame.Startup
                 return;
             }
 
-            EzStartupTrace.Log("Preloader calling Settings.BeginLoadingSections");
             settings.BeginLoadingSections();
         }
 
@@ -69,7 +65,6 @@ namespace osu.Game.EzOsuGame.Startup
                 return;
 
             detachWarmupScheduled = true;
-            EzStartupTrace.Log("Preloader.ScheduleDetachWarmup started (background thread)");
 
             var store = beatmapStore;
             Task.Run(() =>
@@ -77,25 +72,16 @@ namespace osu.Game.EzOsuGame.Startup
                 try
                 {
                     store.GetBeatmapSets(CancellationToken.None);
-                    detachWarmupFinished = true;
-                    EzStartupTrace.Log("Preloader.ScheduleDetachWarmup finished");
+                    // detachWarmupFinished = true;
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
-                    EzStartupTrace.Log($"Preloader.ScheduleDetachWarmup failed: {e.Message}");
                 }
             });
         }
 
         public void LogStatus(string context)
         {
-            bool settingsLoaded = settings?.AreSectionsLoaded ?? false;
-            bool settingsDisplayReady = settings?.AreSectionsReadyForDisplay ?? false;
-
-            EzStartupTrace.Log(
-                $"Preloader[{context}] settingsRequested={lightStarted} settingsLoaded={settingsLoaded} settingsDisplayReady={settingsDisplayReady} " +
-                $"detachScheduled={detachWarmupScheduled} detachFinished={detachWarmupFinished}");
-            settings?.LogPreloadStatus(context);
         }
 
         public bool AreSettingsLoaded => settings?.AreSectionsLoaded ?? false;

--- a/osu.Game/EzOsuGame/Startup/EzStartupContentPreloader.cs
+++ b/osu.Game/EzOsuGame/Startup/EzStartupContentPreloader.cs
@@ -1,0 +1,105 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Database;
+using osu.Game.Overlays;
+
+namespace osu.Game.EzOsuGame.Startup
+{
+    /// <summary>
+    /// Preloads settings sections and song select during startup.
+    /// Dependencies are injected via <see cref="Configure"/> to avoid fragile DI ordering during startup.
+    /// Scheduling is driven by <see cref="EzStartupWorkCoordinator"/>.
+    /// </summary>
+    public partial class EzStartupContentPreloader : CompositeDrawable, IEzStartupContentPreloader
+    {
+        private SettingsOverlay? settings;
+        private BeatmapStore? beatmapStore;
+
+        private bool lightStarted;
+        private bool detachWarmupScheduled;
+        private bool detachWarmupFinished;
+
+        public EzStartupContentPreloader()
+        {
+            RelativeSizeAxes = Axes.Both;
+        }
+
+        public void Configure(SettingsOverlay settings, BeatmapStore beatmapStore, ISongSelectScreenFactory songSelectScreenFactory)
+        {
+            this.settings = settings;
+            this.beatmapStore = beatmapStore;
+        }
+
+        public void BeginLight() => ScheduleSettingsPreload();
+
+        public void ScheduleSettingsPreload()
+        {
+            if (lightStarted)
+            {
+                EzStartupTrace.Log("Preloader.ScheduleSettingsPreload skipped (already started)");
+                return;
+            }
+
+            lightStarted = true;
+            EzStartupTrace.Log("Preloader.ScheduleSettingsPreload");
+            tryScheduleSettingsPreload();
+        }
+
+        private void tryScheduleSettingsPreload()
+        {
+            if (settings == null || !settings.IsLoaded)
+            {
+                Scheduler.Add(tryScheduleSettingsPreload);
+                return;
+            }
+
+            EzStartupTrace.Log("Preloader calling Settings.BeginLoadingSections");
+            settings.BeginLoadingSections();
+        }
+
+        public void ScheduleDetachWarmup()
+        {
+            if (detachWarmupScheduled || beatmapStore == null)
+                return;
+
+            detachWarmupScheduled = true;
+            EzStartupTrace.Log("Preloader.ScheduleDetachWarmup started (background thread)");
+
+            var store = beatmapStore;
+            Task.Run(() =>
+            {
+                try
+                {
+                    store.GetBeatmapSets(CancellationToken.None);
+                    detachWarmupFinished = true;
+                    EzStartupTrace.Log("Preloader.ScheduleDetachWarmup finished");
+                }
+                catch (Exception e)
+                {
+                    EzStartupTrace.Log($"Preloader.ScheduleDetachWarmup failed: {e.Message}");
+                }
+            });
+        }
+
+        public void LogStatus(string context)
+        {
+            bool settingsLoaded = settings?.AreSectionsLoaded ?? false;
+            bool settingsDisplayReady = settings?.AreSectionsReadyForDisplay ?? false;
+
+            EzStartupTrace.Log(
+                $"Preloader[{context}] settingsRequested={lightStarted} settingsLoaded={settingsLoaded} settingsDisplayReady={settingsDisplayReady} " +
+                $"detachScheduled={detachWarmupScheduled} detachFinished={detachWarmupFinished}");
+            settings?.LogPreloadStatus(context);
+        }
+
+        public bool AreSettingsLoaded => settings?.AreSectionsLoaded ?? false;
+
+        public bool AreSettingsReadyForDisplay => settings?.AreSectionsReadyForDisplay ?? false;
+    }
+}

--- a/osu.Game/EzOsuGame/Startup/EzStartupPreloadTiming.cs
+++ b/osu.Game/EzOsuGame/Startup/EzStartupPreloadTiming.cs
@@ -1,0 +1,32 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.EzOsuGame.Startup
+{
+    /// <summary>
+    /// Controls when Ez startup preload work is scheduled relative to Intro / MainMenu.
+    /// Change <see cref="EzStartupTuning.PreloadTiming"/> to A/B test.
+    /// </summary>
+    public enum EzStartupPreloadTiming
+    {
+        /// <summary>
+        /// Settings at PrepareMenuLoad; song select +800ms; detach after main menu settles / BDSP Ez backfill.
+        /// </summary>
+        PipelineDefault,
+
+        /// <summary>
+        /// Settings and song select at PrepareMenuLoad; detach deferred.
+        /// </summary>
+        PipelineEarlySongSelect,
+
+        /// <summary>
+        /// Settings at PrepareMenuLoad; song select at LoadMenu; detach deferred.
+        /// </summary>
+        PipelineLateSongSelect,
+
+        /// <summary>
+        /// All preload work at PrepareMenuLoad (legacy; may stack with BDSP).
+        /// </summary>
+        ImmediateAll,
+    }
+}

--- a/osu.Game/EzOsuGame/Startup/EzStartupTrace.cs
+++ b/osu.Game/EzOsuGame/Startup/EzStartupTrace.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.EzOsuGame.Startup
+{
+    /// <summary>
+    /// No-op placeholder until debug timeline logging is wired in a later commit.
+    /// </summary>
+    internal static class EzStartupTrace
+    {
+        public static long ElapsedMilliseconds => 0;
+
+        public static void Log(string message)
+        {
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Startup/EzStartupTrace.cs
+++ b/osu.Game/EzOsuGame/Startup/EzStartupTrace.cs
@@ -1,17 +1,25 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Diagnostics;
+using osu.Framework.Logging;
+
 namespace osu.Game.EzOsuGame.Startup
 {
     /// <summary>
-    /// No-op placeholder until debug timeline logging is wired in a later commit.
+    /// Debug-only startup metrics. Search runtime logs for <c>[EzStartupTrace]</c>.
+    /// Each line is prefixed with <c>+elapsed ms</c> from process start.
+    /// Kept events: BDSP finished, settings async preload duration, main menu frame cost, EnterPath timings.
     /// </summary>
-    internal static class EzStartupTrace
+    public static class EzStartupTrace
     {
-        public static long ElapsedMilliseconds => 0;
+        private static readonly Stopwatch stopwatch = Stopwatch.StartNew();
+
+        public static long ElapsedMilliseconds => stopwatch.ElapsedMilliseconds;
 
         public static void Log(string message)
         {
+            Logger.Log($"[EzStartupTrace] +{stopwatch.ElapsedMilliseconds}ms {message}", LoggingTarget.Runtime, LogLevel.Debug);
         }
     }
 }

--- a/osu.Game/EzOsuGame/Startup/EzStartupTuning.cs
+++ b/osu.Game/EzOsuGame/Startup/EzStartupTuning.cs
@@ -1,0 +1,37 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.EzOsuGame.Startup
+{
+    /// <summary>
+    /// Developer knobs for startup pipeline A/B testing. Not persisted to config.
+    /// </summary>
+    public static class EzStartupTuning
+    {
+        /// <summary>
+        /// Preload scheduling strategy. Default: <see cref="EzStartupPreloadTiming.PipelineDefault"/>.
+        /// </summary>
+        public static EzStartupPreloadTiming PreloadTiming { get; set; } = EzStartupPreloadTiming.PipelineDefault;
+
+        /// <summary>
+        /// BDSP <c>StartupBackfillDelay</c> in seconds. Default 0 — run Realm backfill during intro so carousel Replace storms finish before song select.
+        /// Increase for A/B testing (e.g. 2 vs 5) if bulk backfill should defer past early main menu.
+        /// </summary>
+        public static int BdspStartupBackfillDelaySeconds { get; set; } = 0;
+
+        /// <summary>
+        /// If BDSP startup processing has not finished by this many ms after main menu entry, song select preload starts anyway.
+        /// </summary>
+        public static double SongSelectPreloadFallbackDelayMs { get; set; } = 30_000;
+
+        /// <summary>
+        /// After MainMenu becomes visible, defer resuming song-select preload until UI settle (logo/button fade) completes.
+        /// </summary>
+        public static double MainMenuUiSettleBeforeHeavyWorkMs { get; set; } = 600;
+
+        /// <summary>
+        /// First carousel filter after entering song select from main menu; staggers with screen fade-in.
+        /// </summary>
+        public static double SongSelectEnterFilterDelayMs { get; set; } = 400;
+    }
+}

--- a/osu.Game/EzOsuGame/Startup/EzStartupWorkCoordinator.cs
+++ b/osu.Game/EzOsuGame/Startup/EzStartupWorkCoordinator.cs
@@ -1,0 +1,260 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Threading;
+using osu.Game.Database;
+
+namespace osu.Game.EzOsuGame.Startup
+{
+    /// <summary>
+    /// Inserts Ez preload tasks into gaps in the official startup timeline without reordering OsuGame component load.
+    /// </summary>
+    public partial class EzStartupWorkCoordinator : CompositeDrawable, IEzStartupWorkCoordinator
+    {
+        /// <summary>
+        /// Brief buffer after BDSP startup processing before song select preload begins.
+        /// </summary>
+        private const double bdsp_finished_song_select_buffer_ms = 500;
+
+        private const double late_song_select_delay_ms = 1000;
+
+        /// <summary>
+        /// Defer detach until after song-select preload window; avoids stacking with BDSP Ez backfill.
+        /// </summary>
+        private const double main_menu_detach_delay_ms = 7000;
+
+        private const double bdsp_poll_interval_ms = 500;
+
+        private const double bdsp_availability_poll_interval_ms = 100;
+
+        private IEzStartupContentPreloader preloader = null!;
+        private IEzStartupSongSelectPreloadHost? songSelectHost;
+        private bool detachWarmupScheduled;
+        private bool songSelectScheduleRegistered;
+        private bool songSelectPreloadStarted;
+        private bool mainMenuEntered;
+        private ScheduledDelegate? songSelectFallbackDelegate;
+
+        [Resolved(CanBeNull = true)]
+        private BackgroundDataStoreProcessor? backgroundDataStoreProcessor { get; set; }
+
+        public EzStartupWorkCoordinator()
+        {
+            RelativeSizeAxes = Axes.Both;
+        }
+
+        public void Configure(IEzStartupContentPreloader preloader)
+        {
+            this.preloader = preloader;
+        }
+
+        public void OnPrepareMenuLoad()
+        {
+            EzStartupTrace.Log($"Coordinator.OnPrepareMenuLoad timing={EzStartupTuning.PreloadTiming} bdspDelay={EzStartupTuning.BdspStartupBackfillDelaySeconds}s");
+
+            switch (EzStartupTuning.PreloadTiming)
+            {
+                case EzStartupPreloadTiming.PipelineDefault:
+                    // Settings preload is started from OsuGame.loadStartupContentPreloader.
+                    break;
+
+                case EzStartupPreloadTiming.PipelineEarlySongSelect:
+                    preloader.BeginLight();
+                    break;
+
+                case EzStartupPreloadTiming.PipelineLateSongSelect:
+                    preloader.BeginLight();
+                    break;
+
+                case EzStartupPreloadTiming.ImmediateAll:
+                    preloader.BeginLight();
+                    preloader.ScheduleDetachWarmup();
+                    break;
+            }
+        }
+
+        public void OnLoadMenu()
+        {
+            songSelectHost?.LogSongSelectPreloadStatus("Intro.LoadMenu");
+            preloader.LogStatus("Intro.LoadMenu");
+            EzStartupTrace.Log("Coordinator.OnLoadMenu (Intro Push MainMenu imminent)");
+
+            tryStartSongSelectPreloadAfterBdsp("LoadMenu");
+        }
+
+        public void OnMainMenuOffscreenReady(IEzStartupSongSelectPreloadHost songSelectHost)
+        {
+            this.songSelectHost = songSelectHost;
+
+            EzStartupTrace.Log(
+                $"Coordinator.OnMainMenuOffscreenReady timing={EzStartupTuning.PreloadTiming} bdspFinished={backgroundDataStoreProcessor?.IsStartupProcessingFinished}");
+
+            songSelectHost.LogSongSelectPreloadStatus("OnMainMenuOffscreenReady");
+            registerSongSelectPreloadSchedule();
+        }
+
+        public void OnMainMenuEntered(IEzStartupSongSelectPreloadHost songSelectHost)
+        {
+            this.songSelectHost = songSelectHost;
+            mainMenuEntered = true;
+
+            EzStartupTrace.Log(
+                $"Coordinator.OnMainMenuEntered timing={EzStartupTuning.PreloadTiming} bdspFinished={backgroundDataStoreProcessor?.IsStartupProcessingFinished} " +
+                $"bdspEzBackfillRunning={backgroundDataStoreProcessor?.IsEzRealmMetadataBackfillRunning} songSelectPreloadStarted={songSelectPreloadStarted}");
+            preloader.LogStatus("OnMainMenuEntered");
+            songSelectHost.LogSongSelectPreloadStatus("OnMainMenuEntered");
+
+            // Fallback if offscreen MainMenu load finished after Push.
+            if (!songSelectScheduleRegistered)
+                registerSongSelectPreloadSchedule();
+
+            switch (EzStartupTuning.PreloadTiming)
+            {
+                case EzStartupPreloadTiming.PipelineDefault:
+                case EzStartupPreloadTiming.PipelineEarlySongSelect:
+                case EzStartupPreloadTiming.PipelineLateSongSelect:
+                case EzStartupPreloadTiming.ImmediateAll:
+                    scheduleDetachWarmupWhenSafe(main_menu_detach_delay_ms);
+                    break;
+            }
+        }
+
+        private void registerSongSelectPreloadSchedule()
+        {
+            if (songSelectScheduleRegistered)
+                return;
+
+            songSelectScheduleRegistered = true;
+
+            switch (EzStartupTuning.PreloadTiming)
+            {
+                case EzStartupPreloadTiming.PipelineDefault:
+                    scheduleSongSelectPreloadWhenBdspFinished();
+                    break;
+
+                case EzStartupPreloadTiming.PipelineEarlySongSelect:
+                case EzStartupPreloadTiming.ImmediateAll:
+                    startSongSelectPreload("offscreen-ready");
+                    break;
+
+                case EzStartupPreloadTiming.PipelineLateSongSelect:
+                    EzStartupTrace.Log($"Coordinator scheduling late song select preload in {late_song_select_delay_ms}ms");
+                    Scheduler.AddDelayed(() => startSongSelectPreload("offscreen-late"), late_song_select_delay_ms);
+                    break;
+            }
+        }
+
+        private void scheduleSongSelectPreloadWhenBdspFinished()
+        {
+            if (backgroundDataStoreProcessor == null)
+            {
+                EzStartupTrace.Log($"Coordinator BDSP not ready yet; retry in {bdsp_availability_poll_interval_ms}ms");
+                Scheduler.AddDelayed(scheduleSongSelectPreloadWhenBdspFinished, bdsp_availability_poll_interval_ms);
+                ensureSongSelectFallbackScheduled();
+                return;
+            }
+
+            if (backgroundDataStoreProcessor.IsStartupProcessingFinished)
+            {
+                EzStartupTrace.Log($"Coordinator BDSP already finished; song select preload in {bdsp_finished_song_select_buffer_ms}ms");
+                Scheduler.AddDelayed(() => startSongSelectPreload("BDSP-already-finished"), bdsp_finished_song_select_buffer_ms);
+                return;
+            }
+
+            backgroundDataStoreProcessor.StartupProcessingFinished += onBdspStartupProcessingFinished;
+            EzStartupTrace.Log($"Coordinator waiting for BDSP startup processing (fallback in {EzStartupTuning.SongSelectPreloadFallbackDelayMs}ms)");
+            ensureSongSelectFallbackScheduled();
+        }
+
+        private void tryStartSongSelectPreloadAfterBdsp(string reason)
+        {
+            if (songSelectPreloadStarted || !songSelectScheduleRegistered || backgroundDataStoreProcessor == null)
+                return;
+
+            if (!backgroundDataStoreProcessor.IsStartupProcessingFinished)
+                return;
+
+            EzStartupTrace.Log($"Coordinator {reason}: BDSP finished before preload started; scheduling song select preload");
+            songSelectFallbackDelegate?.Cancel();
+            songSelectFallbackDelegate = null;
+            backgroundDataStoreProcessor.StartupProcessingFinished -= onBdspStartupProcessingFinished;
+            Scheduler.AddDelayed(() => startSongSelectPreload($"{reason}-BDSP-already-finished"), bdsp_finished_song_select_buffer_ms);
+        }
+
+        private void ensureSongSelectFallbackScheduled()
+        {
+            if (songSelectFallbackDelegate != null)
+                return;
+
+            songSelectFallbackDelegate = Scheduler.AddDelayed(() => startSongSelectPreload("fallback-timeout"), EzStartupTuning.SongSelectPreloadFallbackDelayMs);
+        }
+
+        private void onBdspStartupProcessingFinished()
+        {
+            EzStartupTrace.Log(
+                $"Coordinator BDSP finished → next: songSelect (+{bdsp_finished_song_select_buffer_ms}ms), detach (main menu +{main_menu_detach_delay_ms}ms if not started)");
+            Scheduler.AddDelayed(() => startSongSelectPreload("BDSP-finished"), bdsp_finished_song_select_buffer_ms);
+        }
+
+        private void startSongSelectPreload(string reason)
+        {
+            if (songSelectPreloadStarted)
+                return;
+
+            songSelectPreloadStarted = true;
+            songSelectFallbackDelegate?.Cancel();
+            songSelectFallbackDelegate = null;
+
+            if (backgroundDataStoreProcessor != null)
+                backgroundDataStoreProcessor.StartupProcessingFinished -= onBdspStartupProcessingFinished;
+
+            if (songSelectHost == null)
+            {
+                EzStartupTrace.Log($"Coordinator song select preload skipped ({reason}, no host)");
+                return;
+            }
+
+            EzStartupTrace.Log($"Coordinator starting song select preload ({reason}) mainMenuEntered={mainMenuEntered}");
+
+            if (mainMenuEntered)
+                songSelectHost.ScheduleSongSelectPreloadAfterUiSettle();
+            else
+                songSelectHost.ScheduleSongSelectPreload();
+        }
+
+        private void scheduleDetachWarmupWhenSafe(double delayMs)
+        {
+            if (detachWarmupScheduled)
+                return;
+
+            detachWarmupScheduled = true;
+            EzStartupTrace.Log($"Coordinator scheduling detach warmup check in {delayMs}ms");
+
+            Scheduler.AddDelayed(() =>
+            {
+                if (backgroundDataStoreProcessor?.IsEzRealmMetadataBackfillRunning == true)
+                {
+                    EzStartupTrace.Log("Coordinator detach warmup deferred (BDSP Ez backfill still running)");
+                    detachWarmupScheduled = false;
+                    scheduleDetachWarmupWhenSafe(bdsp_poll_interval_ms);
+                    return;
+                }
+
+                EzStartupTrace.Log("Coordinator starting detach warmup");
+                preloader.ScheduleDetachWarmup();
+            }, delayMs);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (backgroundDataStoreProcessor != null)
+                backgroundDataStoreProcessor.StartupProcessingFinished -= onBdspStartupProcessingFinished;
+
+            songSelectFallbackDelegate?.Cancel();
+            base.Dispose(isDisposing);
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Startup/EzStartupWorkCoordinator.cs
+++ b/osu.Game/EzOsuGame/Startup/EzStartupWorkCoordinator.cs
@@ -53,8 +53,6 @@ namespace osu.Game.EzOsuGame.Startup
 
         public void OnPrepareMenuLoad()
         {
-            EzStartupTrace.Log($"Coordinator.OnPrepareMenuLoad timing={EzStartupTuning.PreloadTiming} bdspDelay={EzStartupTuning.BdspStartupBackfillDelaySeconds}s");
-
             switch (EzStartupTuning.PreloadTiming)
             {
                 case EzStartupPreloadTiming.PipelineDefault:
@@ -78,21 +76,12 @@ namespace osu.Game.EzOsuGame.Startup
 
         public void OnLoadMenu()
         {
-            songSelectHost?.LogSongSelectPreloadStatus("Intro.LoadMenu");
-            preloader.LogStatus("Intro.LoadMenu");
-            EzStartupTrace.Log("Coordinator.OnLoadMenu (Intro Push MainMenu imminent)");
-
             tryStartSongSelectPreloadAfterBdsp("LoadMenu");
         }
 
         public void OnMainMenuOffscreenReady(IEzStartupSongSelectPreloadHost songSelectHost)
         {
             this.songSelectHost = songSelectHost;
-
-            EzStartupTrace.Log(
-                $"Coordinator.OnMainMenuOffscreenReady timing={EzStartupTuning.PreloadTiming} bdspFinished={backgroundDataStoreProcessor?.IsStartupProcessingFinished}");
-
-            songSelectHost.LogSongSelectPreloadStatus("OnMainMenuOffscreenReady");
             registerSongSelectPreloadSchedule();
         }
 
@@ -100,12 +89,6 @@ namespace osu.Game.EzOsuGame.Startup
         {
             this.songSelectHost = songSelectHost;
             mainMenuEntered = true;
-
-            EzStartupTrace.Log(
-                $"Coordinator.OnMainMenuEntered timing={EzStartupTuning.PreloadTiming} bdspFinished={backgroundDataStoreProcessor?.IsStartupProcessingFinished} " +
-                $"bdspEzBackfillRunning={backgroundDataStoreProcessor?.IsEzRealmMetadataBackfillRunning} songSelectPreloadStarted={songSelectPreloadStarted}");
-            preloader.LogStatus("OnMainMenuEntered");
-            songSelectHost.LogSongSelectPreloadStatus("OnMainMenuEntered");
 
             // Fallback if offscreen MainMenu load finished after Push.
             if (!songSelectScheduleRegistered)
@@ -141,7 +124,6 @@ namespace osu.Game.EzOsuGame.Startup
                     break;
 
                 case EzStartupPreloadTiming.PipelineLateSongSelect:
-                    EzStartupTrace.Log($"Coordinator scheduling late song select preload in {late_song_select_delay_ms}ms");
                     Scheduler.AddDelayed(() => startSongSelectPreload("offscreen-late"), late_song_select_delay_ms);
                     break;
             }
@@ -151,7 +133,6 @@ namespace osu.Game.EzOsuGame.Startup
         {
             if (backgroundDataStoreProcessor == null)
             {
-                EzStartupTrace.Log($"Coordinator BDSP not ready yet; retry in {bdsp_availability_poll_interval_ms}ms");
                 Scheduler.AddDelayed(scheduleSongSelectPreloadWhenBdspFinished, bdsp_availability_poll_interval_ms);
                 ensureSongSelectFallbackScheduled();
                 return;
@@ -159,13 +140,11 @@ namespace osu.Game.EzOsuGame.Startup
 
             if (backgroundDataStoreProcessor.IsStartupProcessingFinished)
             {
-                EzStartupTrace.Log($"Coordinator BDSP already finished; song select preload in {bdsp_finished_song_select_buffer_ms}ms");
                 Scheduler.AddDelayed(() => startSongSelectPreload("BDSP-already-finished"), bdsp_finished_song_select_buffer_ms);
                 return;
             }
 
             backgroundDataStoreProcessor.StartupProcessingFinished += onBdspStartupProcessingFinished;
-            EzStartupTrace.Log($"Coordinator waiting for BDSP startup processing (fallback in {EzStartupTuning.SongSelectPreloadFallbackDelayMs}ms)");
             ensureSongSelectFallbackScheduled();
         }
 
@@ -177,7 +156,6 @@ namespace osu.Game.EzOsuGame.Startup
             if (!backgroundDataStoreProcessor.IsStartupProcessingFinished)
                 return;
 
-            EzStartupTrace.Log($"Coordinator {reason}: BDSP finished before preload started; scheduling song select preload");
             songSelectFallbackDelegate?.Cancel();
             songSelectFallbackDelegate = null;
             backgroundDataStoreProcessor.StartupProcessingFinished -= onBdspStartupProcessingFinished;
@@ -194,8 +172,6 @@ namespace osu.Game.EzOsuGame.Startup
 
         private void onBdspStartupProcessingFinished()
         {
-            EzStartupTrace.Log(
-                $"Coordinator BDSP finished → next: songSelect (+{bdsp_finished_song_select_buffer_ms}ms), detach (main menu +{main_menu_detach_delay_ms}ms if not started)");
             Scheduler.AddDelayed(() => startSongSelectPreload("BDSP-finished"), bdsp_finished_song_select_buffer_ms);
         }
 
@@ -212,12 +188,7 @@ namespace osu.Game.EzOsuGame.Startup
                 backgroundDataStoreProcessor.StartupProcessingFinished -= onBdspStartupProcessingFinished;
 
             if (songSelectHost == null)
-            {
-                EzStartupTrace.Log($"Coordinator song select preload skipped ({reason}, no host)");
                 return;
-            }
-
-            EzStartupTrace.Log($"Coordinator starting song select preload ({reason}) mainMenuEntered={mainMenuEntered}");
 
             if (mainMenuEntered)
                 songSelectHost.ScheduleSongSelectPreloadAfterUiSettle();
@@ -231,19 +202,16 @@ namespace osu.Game.EzOsuGame.Startup
                 return;
 
             detachWarmupScheduled = true;
-            EzStartupTrace.Log($"Coordinator scheduling detach warmup check in {delayMs}ms");
 
             Scheduler.AddDelayed(() =>
             {
                 if (backgroundDataStoreProcessor?.IsEzRealmMetadataBackfillRunning == true)
                 {
-                    EzStartupTrace.Log("Coordinator detach warmup deferred (BDSP Ez backfill still running)");
                     detachWarmupScheduled = false;
                     scheduleDetachWarmupWhenSafe(bdsp_poll_interval_ms);
                     return;
                 }
 
-                EzStartupTrace.Log("Coordinator starting detach warmup");
                 preloader.ScheduleDetachWarmup();
             }, delayMs);
         }

--- a/osu.Game/EzOsuGame/Startup/IEzStartupContentPreloader.cs
+++ b/osu.Game/EzOsuGame/Startup/IEzStartupContentPreloader.cs
@@ -1,0 +1,38 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.EzOsuGame.Startup
+{
+    public interface IEzStartupContentPreloader
+    {
+        /// <summary>
+        /// Begin preloading settings sections (lightweight).
+        /// </summary>
+        void BeginLight();
+
+        /// <summary>
+        /// Wait until the settings overlay is loaded, then start section preload. Call once from OsuGame after overlay chain is submitted.
+        /// </summary>
+        void ScheduleSettingsPreload();
+
+        /// <summary>
+        /// Warm the detached beatmap store on a background thread. Avoid running during BDSP Ez backfill.
+        /// </summary>
+        void ScheduleDetachWarmup();
+
+        /// <summary>
+        /// Emit a snapshot of preload state to the startup trace log.
+        /// </summary>
+        void LogStatus(string context);
+
+        /// <summary>
+        /// Whether settings section async construction has finished (mount may still be pending until PopIn).
+        /// </summary>
+        bool AreSettingsLoaded { get; }
+
+        /// <summary>
+        /// Whether settings sections are mounted and the sidebar is ready (first visible open complete).
+        /// </summary>
+        bool AreSettingsReadyForDisplay { get; }
+    }
+}

--- a/osu.Game/EzOsuGame/Startup/IEzStartupSongSelectPreloadHost.cs
+++ b/osu.Game/EzOsuGame/Startup/IEzStartupSongSelectPreloadHost.cs
@@ -1,0 +1,24 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Screens.Select;
+
+namespace osu.Game.EzOsuGame.Startup
+{
+    /// <summary>
+    /// Host for preloading <see cref="SoloSongSelect"/> under a screen that shares the OsuScreenStack dependency context.
+    /// </summary>
+    public interface IEzStartupSongSelectPreloadHost
+    {
+        void ScheduleSongSelectPreload();
+
+        /// <summary>
+        /// Resume song-select preload after main menu UI settle window.
+        /// </summary>
+        void ScheduleSongSelectPreloadAfterUiSettle();
+
+        bool TryConsumePreloadedSongSelect(out SoloSongSelect? screen);
+
+        void LogSongSelectPreloadStatus(string context);
+    }
+}

--- a/osu.Game/EzOsuGame/Startup/IEzStartupWorkCoordinator.cs
+++ b/osu.Game/EzOsuGame/Startup/IEzStartupWorkCoordinator.cs
@@ -1,0 +1,22 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.EzOsuGame.Startup
+{
+    /// <summary>
+    /// Schedules Ez startup preload work around official Intro / MainMenu / BDSP timing.
+    /// </summary>
+    public interface IEzStartupWorkCoordinator
+    {
+        void OnPrepareMenuLoad();
+
+        void OnLoadMenu();
+
+        /// <summary>
+        /// MainMenu finished offscreen load during intro.
+        /// </summary>
+        void OnMainMenuOffscreenReady(IEzStartupSongSelectPreloadHost songSelectHost);
+
+        void OnMainMenuEntered(IEzStartupSongSelectPreloadHost songSelectHost);
+    }
+}

--- a/osu.Game/EzOsuGame/Startup/ISongSelectScreenFactory.cs
+++ b/osu.Game/EzOsuGame/Startup/ISongSelectScreenFactory.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Screens.Select;
+
+namespace osu.Game.EzOsuGame.Startup
+{
+    public interface ISongSelectScreenFactory
+    {
+        SoloSongSelect Create();
+    }
+}

--- a/osu.Game/OsuGame.EzStartup.cs
+++ b/osu.Game/OsuGame.EzStartup.cs
@@ -10,9 +10,6 @@ namespace osu.Game
 {
     public partial class OsuGame
     {
-        private IEzStartupContentPreloader startupContentPreloader = null!;
-        private IEzStartupWorkCoordinator startupWorkCoordinator = null!;
-
         /// <summary>
         /// Creates a song select screen. Overridable for tests and preloading.
         /// </summary>
@@ -25,11 +22,9 @@ namespace osu.Game
 
             var preloader = new EzStartupContentPreloader();
             preloader.Configure(Settings, detachedBeatmapStore, factory);
-            startupContentPreloader = preloader;
 
             var coordinator = new EzStartupWorkCoordinator();
             coordinator.Configure(preloader);
-            startupWorkCoordinator = coordinator;
 
             loadComponentSingleFile(coordinator, Add, true);
             dependencies.CacheAs<IEzStartupWorkCoordinator>(coordinator);
@@ -37,9 +32,6 @@ namespace osu.Game
             loadComponentSingleFile(preloader, Add, true);
             dependencies.CacheAs<IEzStartupContentPreloader>(preloader);
 
-            EzStartupTrace.Log("OsuGame startup preloader registered");
-            // Settings overlay is queued earlier in the constructor; start section preload here (after the chain is submitted)
-            // so it does not compete with dozens of overlays still loading — see EzStartupTrace timeline.
             preloader.ScheduleSettingsPreload();
         }
 

--- a/osu.Game/OsuGame.EzStartup.cs
+++ b/osu.Game/OsuGame.EzStartup.cs
@@ -1,0 +1,61 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.EzOsuGame.Startup;
+using osu.Game.Screens;
+using osu.Game.Screens.Menu;
+using osu.Game.Screens.Select;
+
+namespace osu.Game
+{
+    public partial class OsuGame
+    {
+        private IEzStartupContentPreloader startupContentPreloader = null!;
+        private IEzStartupWorkCoordinator startupWorkCoordinator = null!;
+
+        /// <summary>
+        /// Creates a song select screen. Overridable for tests and preloading.
+        /// </summary>
+        protected virtual SoloSongSelect CreateSongSelectScreen() => new SoloSongSelect();
+
+        private void loadStartupContentPreloader()
+        {
+            var factory = new SongSelectScreenFactory(this);
+            dependencies.CacheAs<ISongSelectScreenFactory>(factory);
+
+            var preloader = new EzStartupContentPreloader();
+            preloader.Configure(Settings, detachedBeatmapStore, factory);
+            startupContentPreloader = preloader;
+
+            var coordinator = new EzStartupWorkCoordinator();
+            coordinator.Configure(preloader);
+            startupWorkCoordinator = coordinator;
+
+            loadComponentSingleFile(coordinator, Add, true);
+            dependencies.CacheAs<IEzStartupWorkCoordinator>(coordinator);
+
+            loadComponentSingleFile(preloader, Add, true);
+            dependencies.CacheAs<IEzStartupContentPreloader>(preloader);
+
+            EzStartupTrace.Log("OsuGame startup preloader registered");
+            // Settings overlay is queued earlier in the constructor; start section preload here (after the chain is submitted)
+            // so it does not compete with dozens of overlays still loading — see EzStartupTrace timeline.
+            preloader.ScheduleSettingsPreload();
+        }
+
+        private void onScreenExitedForStartupPreload(IOsuScreen? lastScreen, IOsuScreen? newScreen)
+        {
+            if (lastScreen is SoloSongSelect && newScreen is MainMenu mainMenu)
+                mainMenu.ScheduleSongSelectPreloadAfterUiSettle();
+        }
+
+        private partial class SongSelectScreenFactory : ISongSelectScreenFactory
+        {
+            private readonly OsuGame game;
+
+            public SongSelectScreenFactory(OsuGame game) => this.game = game;
+
+            public SoloSongSelect Create() => game.CreateSongSelectScreen();
+        }
+    }
+}

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -40,10 +40,10 @@ using osu.Game.Collections;
 using osu.Game.Configuration;
 using osu.Game.Database;
 using osu.Game.EzOsuGame.Acrylic;
-using osu.Game.EzOsuGame.Configuration;
-using osu.Game.EzOsuGame.Edit;
 using osu.Game.EzOsuGame.Analysis;
 using osu.Game.EzOsuGame.Background.Pixiv;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Edit;
 using osu.Game.EzOsuGame.Layout;
 using osu.Game.EzOsuGame.LocalProfile;
 using osu.Game.EzOsuGame.Overlays;
@@ -1358,6 +1358,8 @@ namespace osu.Game
 
             loadComponentSingleFile(new PixivAutoDownloadProcessor(), Add, true);
 
+            loadStartupContentPreloader();
+
             Add(externalLinkOpener = new ExternalLinkOpener());
             Add(new MusicKeyBindingHandler());
             Add(new OnlineStatusNotifier(() => ScreenStack.CurrentScreen));
@@ -1965,6 +1967,7 @@ namespace osu.Game
         private void screenExited(IScreen lastScreen, IScreen newScreen)
         {
             ScreenChanged((OsuScreen)lastScreen, (OsuScreen)newScreen);
+            onScreenExitedForStartupPreload((OsuScreen)lastScreen, (OsuScreen)newScreen);
 
             if (newScreen == null)
                 Exit();

--- a/osu.Game/Overlays/Settings/Sections/Input/BindingSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/BindingSettings.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Graphics;
@@ -15,7 +16,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
         public override IEnumerable<LocalisableString> FilterTerms => base.FilterTerms.Concat(new LocalisableString[] { @"keybindings", @"controls", @"keyboard", @"keys", @"buttons" });
 
-        public BindingSettings(KeyBindingPanel keyConfig)
+        public BindingSettings(Action openKeyConfig)
         {
             Children = new Drawable[]
             {
@@ -23,7 +24,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 {
                     Text = BindingSettingsStrings.Configure,
                     TooltipText = BindingSettingsStrings.ChangeBindingsButton,
-                    Action = keyConfig.ToggleVisibility,
+                    Action = openKeyConfig,
                     Height = 60
                 },
             };

--- a/osu.Game/Overlays/Settings/Sections/InputSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/InputSection.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
@@ -14,7 +15,7 @@ namespace osu.Game.Overlays.Settings.Sections
 {
     public partial class InputSection : SettingsSection
     {
-        private readonly KeyBindingPanel keyConfig;
+        private readonly Action openKeyConfig;
 
         public override LocalisableString Header => InputSettingsStrings.InputSectionHeader;
 
@@ -23,9 +24,9 @@ namespace osu.Game.Overlays.Settings.Sections
             Icon = OsuIcon.Input
         };
 
-        public InputSection(KeyBindingPanel keyConfig)
+        public InputSection(Action openKeyConfig)
         {
-            this.keyConfig = keyConfig;
+            this.openKeyConfig = openKeyConfig;
         }
 
         [BackgroundDependencyLoader]
@@ -33,7 +34,7 @@ namespace osu.Game.Overlays.Settings.Sections
         {
             Children = new Drawable[]
             {
-                new BindingSettings(keyConfig),
+                new BindingSettings(openKeyConfig),
             };
 
             foreach (var handler in host.AvailableInputHandlers)

--- a/osu.Game/Overlays/SettingsOverlay.cs
+++ b/osu.Game/Overlays/SettingsOverlay.cs
@@ -12,7 +12,6 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Framework.Testing;
 using osu.Game.EzOsuGame.Overlays;
-using osu.Game.EzOsuGame.Startup;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Localisation;
@@ -51,7 +50,6 @@ namespace osu.Game.Overlays
         protected override void LoadComplete()
         {
             base.LoadComplete();
-            EzStartupTrace.Log("SettingsOverlay.LoadComplete → BeginLoadingSections");
             BeginLoadingSections();
         }
 

--- a/osu.Game/Overlays/SettingsOverlay.cs
+++ b/osu.Game/Overlays/SettingsOverlay.cs
@@ -12,6 +12,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Framework.Testing;
 using osu.Game.EzOsuGame.Overlays;
+using osu.Game.EzOsuGame.Startup;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Localisation;
@@ -47,6 +48,13 @@ namespace osu.Game.Overlays
         {
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            EzStartupTrace.Log("SettingsOverlay.LoadComplete → BeginLoadingSections");
+            BeginLoadingSections();
+        }
+
         public override bool AcceptsFocus => lastOpenedSubPanel == null || lastOpenedSubPanel.State.Value == Visibility.Hidden;
 
         public void ShowAtControl<T>() where T : Drawable
@@ -68,15 +76,20 @@ namespace osu.Game.Overlays
 
         protected override float ExpandedPosition => lastOpenedSubPanel?.State.Value == Visibility.Visible ? -PANEL_WIDTH : base.ExpandedPosition;
 
+        private KeyBindingPanel keyBindingPanel = null!;
+        private bool keyBindingPanelAdded;
+
         [BackgroundDependencyLoader]
         private void load(RulesetStore rulesets)
         {
+            keyBindingPanel = createSubPanel(new KeyBindingPanel());
+
             var sections = new List<SettingsSection>
             {
                 // This list should be kept in sync with ScreenBehaviour.
                 new GeneralSection(),
                 new SkinSection(),
-                new InputSection(createSubPanel(new KeyBindingPanel())),
+                new InputSection(openKeyBindingPanel),
                 new UserInterfaceSection(),
                 new GameplaySection(),
                 new EzGameSection()
@@ -114,7 +127,27 @@ namespace osu.Game.Overlays
                 AddSection(s);
 
             foreach (var s in subPanels)
+            {
+                if (ReferenceEquals(s, keyBindingPanel))
+                    continue;
+
                 ContentContainer.Add(s);
+            }
+        }
+
+        private void openKeyBindingPanel()
+        {
+            ensureKeyBindingPanelAdded();
+            keyBindingPanel.Show();
+        }
+
+        private void ensureKeyBindingPanelAdded()
+        {
+            if (keyBindingPanelAdded)
+                return;
+
+            keyBindingPanelAdded = true;
+            ContentContainer.Add(keyBindingPanel);
         }
 
         private T createSubPanel<T>(T subPanel)

--- a/osu.Game/Overlays/SettingsPanel.cs
+++ b/osu.Game/Overlays/SettingsPanel.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using osuTK;
@@ -18,8 +19,11 @@ using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
+using osu.Framework.Platform;
+using osu.Framework.Threading;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.EzOsuGame.Startup;
 using osu.Game.Overlays.Settings;
 using osuTK.Graphics;
 
@@ -68,8 +72,33 @@ namespace osu.Game.Overlays
         private readonly List<SettingsSection> loadableSections = new List<SettingsSection>();
 
         private Task sectionsLoadingTask;
+        private List<SettingsSection> loadedSections;
+        private bool sectionsLoaded;
+        private bool sectionsDisplayReady;
+        private bool sectionsAsyncCallbackInvoked;
+        private bool sectionsMountInProgress;
+        private int sectionsMountedCount;
+        private Stopwatch sectionsLoadStopwatch;
+        private long? sectionsPreloadDurationMs;
+        private bool loadHeartbeatActive;
+        private double lastPopInTime;
+
+        /// <summary>
+        /// Whether settings sections have finished async construction (tree mount is deferred until PopIn).
+        /// </summary>
+        public bool AreSectionsLoaded => sectionsLoaded;
+
+        /// <summary>
+        /// Whether settings sections and sidebar buttons are mounted and ready to show without further loading.
+        /// </summary>
+        public bool AreSectionsReadyForDisplay => sectionsDisplayReady;
 
         public IBindable<SettingsSection> CurrentSection = new Bindable<SettingsSection>();
+
+        [Resolved]
+        private GameHost gameHost { get; set; } = null!;
+
+        private Scheduler preloadScheduler => gameHost.UpdateThread.Scheduler;
 
         [Cached]
         private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Purple);
@@ -100,10 +129,7 @@ namespace osu.Game.Overlays
                         Colour = colourProvider.Background4,
                         Alpha = 1,
                     },
-                    loading = new LoadingLayer
-                    {
-                        State = { Value = Visibility.Visible }
-                    }
+                    loading = new LoadingLayer()
                 }
             };
 
@@ -169,6 +195,13 @@ namespace osu.Game.Overlays
 
         protected override void PopIn()
         {
+            logPreloadStatus("PopIn");
+
+            lastPopInTime = Time.Current;
+
+            if (!sectionsDisplayReady)
+                loading.Show();
+
             ContentContainer.MoveToX(ExpandedPosition, TRANSITION_LENGTH, Easing.OutQuint);
 
             SectionsContainer.FadeEdgeEffectTo(WaveContainer.SHADOW_OPACITY, WaveContainer.APPEAR_DURATION, Easing.Out);
@@ -177,13 +210,44 @@ namespace osu.Game.Overlays
             // this is done as there is still a brief stutter during load completion which is more visible if the transition is in progress.
             // the eventual goal would be to remove the need for this by splitting up load into smaller work pieces, or fixing the remaining
             // load complete overheads.
-            Scheduler.AddDelayed(loadSections, TRANSITION_LENGTH / 3);
+            // Preloaded sections wait for the full PopIn transition; cold load uses the official 200ms offset.
+            Scheduler.AddDelayed(loadSections, getPopInLoadSectionsDelay());
 
             Sidebar?.MoveToX(0, TRANSITION_LENGTH, Easing.OutQuint);
             this.FadeTo(1, TRANSITION_LENGTH / 2, Easing.OutQuint);
 
             SearchTextBox.TakeFocus();
             SearchTextBox.HoldFocus = true;
+        }
+
+        private double getPopInLoadSectionsDelay()
+        {
+            if (sectionsDisplayReady)
+                return 0;
+
+            // Async CPU preload is done; defer tree mount until the slide/fade finishes.
+            if (sectionsLoaded)
+                return TRANSITION_LENGTH;
+
+            return TRANSITION_LENGTH / 3;
+        }
+
+        private double getRemainingPopInAnimationDelay()
+        {
+            if (sectionsDisplayReady)
+                return 0;
+
+            return Math.Max(0, TRANSITION_LENGTH - (Time.Current - lastPopInTime));
+        }
+
+        private void scheduleAfterPopInAnimation(Action action)
+        {
+            double delay = getRemainingPopInAnimationDelay();
+
+            if (delay > 0)
+                Scheduler.AddDelayed(action, delay);
+            else
+                Scheduler.Add(action);
         }
 
         protected virtual float ExpandedPosition => 0;
@@ -220,23 +284,173 @@ namespace osu.Game.Overlays
 
         private const double fade_in_duration = 500;
 
+        private const int sections_add_batch_size = 3;
+
+        private const double preload_heartbeat_interval_ms = 3000;
+
+        /// <summary>
+        /// Starts loading settings sections before the panel is shown.
+        /// Safe to call multiple times; only the first call has an effect.
+        /// </summary>
+        public void BeginLoadingSections()
+        {
+            EzStartupTrace.Log("Settings.BeginLoadingSections called");
+            loadSections();
+        }
+
+        /// <summary>
+        /// Emit a snapshot of section preload progress to the startup trace log.
+        /// </summary>
+        public void LogPreloadStatus(string context) => logPreloadStatus(context);
+
+        private void logPreloadStatus(string context)
+        {
+            string timing = sectionsPreloadDurationMs.HasValue
+                ? $"preloadDuration={sectionsPreloadDurationMs}ms"
+                : $"preloadElapsed={sectionsLoadStopwatch?.ElapsedMilliseconds ?? 0}ms";
+            string taskStatus = sectionsLoadingTask?.Status.ToString() ?? "none";
+            bool workerDone = sectionsLoadingTask?.IsCompleted ?? false;
+
+            EzStartupTrace.Log(
+                $"Settings[{context}] loaded={sectionsLoaded} displayReady={sectionsDisplayReady} " +
+                $"workerDone={workerDone} callbackInvoked={sectionsAsyncCallbackInvoked} " +
+                $"mounted={SectionsContainer.Count}/{loadableSections.Count} taskStatus={taskStatus} {timing} visible={State.Value == Visibility.Visible}");
+        }
+
         private void loadSections()
         {
-            if (sectionsLoadingTask != null)
+            if (sectionsDisplayReady)
+            {
+                EzStartupTrace.Log("Settings.loadSections skipped (already complete)");
                 return;
+            }
+
+            if (!sectionsLoaded)
+            {
+                if (sectionsLoadingTask != null)
+                {
+                    EzStartupTrace.Log("Settings.loadSections skipped (async in progress)");
+                    return;
+                }
+
+                beginAsyncSectionLoad();
+                return;
+            }
+
+            scheduleMountLoadedSections();
+        }
+
+        private void beginAsyncSectionLoad()
+        {
+            sectionsLoadStopwatch = Stopwatch.StartNew();
+            EzStartupTrace.Log($"Settings.loadSections started ({loadableSections.Count} sections)");
+            startLoadHeartbeat();
 
             sectionsLoadingTask = LoadComponentsAsync(loadableSections, sections =>
             {
-                SectionsContainer.AddRange(sections);
-                SectionsContainer.Footer.FadeInFromZero(fade_in_duration, Easing.OutQuint);
-                SectionsContainer.SearchContainer.FadeInFromZero(fade_in_duration, Easing.OutQuint);
+                sectionsAsyncCallbackInvoked = true;
+                loadedSections = sections.ToList();
+                sectionsLoaded = true;
 
-                loading.Hide();
+                if (State.Value != Visibility.Visible)
+                {
+                    sectionsPreloadDurationMs = sectionsLoadStopwatch.ElapsedMilliseconds;
+                    sectionsLoadStopwatch.Stop();
+                    loadHeartbeatActive = false;
+                    EzStartupTrace.Log($"Settings async preload complete after {sectionsPreloadDurationMs}ms (mount deferred until PopIn)");
+                    return;
+                }
 
-                SearchTextBox.Current.BindValueChanged(term => SectionsContainer.SearchTerm = term.NewValue, true);
+                EzStartupTrace.Log($"Settings sections worker finished after {sectionsLoadStopwatch.ElapsedMilliseconds}ms, scheduling mount after PopIn animation");
+                scheduleAfterPopInAnimation(scheduleMountLoadedSections);
+            }, scheduler: preloadScheduler);
+        }
 
-                loadSidebarButtons();
-            });
+        private void scheduleMountLoadedSections()
+        {
+            if (sectionsDisplayReady || loadedSections == null)
+                return;
+
+            int startIndex = SectionsContainer.Count;
+
+            if (startIndex >= loadedSections.Count)
+                return;
+
+            if (sectionsMountInProgress)
+            {
+                EzStartupTrace.Log("Settings.mount skipped (already in progress)");
+                return;
+            }
+
+            sectionsMountInProgress = true;
+            EzStartupTrace.Log($"Settings mounting preloaded sections from index {startIndex}");
+            Scheduler.Add(() => addSectionsInBatches(loadedSections, startIndex));
+        }
+
+        private void startLoadHeartbeat()
+        {
+            if (loadHeartbeatActive)
+                return;
+
+            loadHeartbeatActive = true;
+            scheduleLoadHeartbeat();
+        }
+
+        private void scheduleLoadHeartbeat()
+        {
+            preloadScheduler.AddDelayed(() =>
+            {
+                if (sectionsDisplayReady || (sectionsLoaded && State.Value != Visibility.Visible))
+                {
+                    loadHeartbeatActive = false;
+                    return;
+                }
+
+                logPreloadStatus("heartbeat");
+
+                if (sectionsLoadingTask != null)
+                    scheduleLoadHeartbeat();
+                else
+                    loadHeartbeatActive = false;
+            }, preload_heartbeat_interval_ms);
+        }
+
+        private void addSectionsInBatches(IReadOnlyList<SettingsSection> sections, int startIndex)
+        {
+            if (State.Value != Visibility.Visible)
+            {
+                sectionsMountInProgress = false;
+                return;
+            }
+
+            int endIndex = Math.Min(startIndex + sections_add_batch_size, sections.Count);
+
+            for (int i = startIndex; i < endIndex; i++)
+                SectionsContainer.Add(sections[i]);
+
+            sectionsMountedCount = endIndex;
+
+            if (endIndex < sections.Count)
+            {
+                Scheduler.Add(() => addSectionsInBatches(sections, endIndex));
+                return;
+            }
+
+            sectionsMountInProgress = false;
+            EzStartupTrace.Log($"Settings sections mount complete after {sectionsLoadStopwatch.ElapsedMilliseconds}ms");
+            finishSectionsDisplay();
+        }
+
+        private void finishSectionsDisplay()
+        {
+            SectionsContainer.Footer.FadeInFromZero(fade_in_duration, Easing.OutQuint);
+            SectionsContainer.SearchContainer.FadeInFromZero(fade_in_duration, Easing.OutQuint);
+
+            loading.Hide();
+
+            SearchTextBox.Current.BindValueChanged(term => SectionsContainer.SearchTerm = term.NewValue, true);
+
+            loadSidebarButtons();
         }
 
         private void loadSidebarButtons()
@@ -269,7 +483,13 @@ namespace osu.Game.Overlays
                     if (selectedSidebarButton != null)
                         selectedSidebarButton.Selected = true;
                 }, true);
-            });
+
+                sectionsDisplayReady = true;
+                loadHeartbeatActive = false;
+                sectionsPreloadDurationMs = sectionsLoadStopwatch.ElapsedMilliseconds;
+                sectionsLoadStopwatch.Stop();
+                EzStartupTrace.Log($"Settings display ready after {sectionsPreloadDurationMs}ms (sidebar mounted)");
+            }, scheduler: preloadScheduler);
         }
 
         private IEnumerable<SidebarIconButton> createSidebarButtons()
@@ -312,6 +532,7 @@ namespace osu.Game.Overlays
                     AutoSizeAxes = Axes.Y,
                     RelativeSizeAxes = Axes.X,
                     Direction = FillDirection.Vertical,
+                    Alpha = 0,
                 };
 
             [BackgroundDependencyLoader]

--- a/osu.Game/Overlays/SettingsPanel.cs
+++ b/osu.Game/Overlays/SettingsPanel.cs
@@ -73,11 +73,7 @@ namespace osu.Game.Overlays
 
         private Task sectionsLoadingTask;
         private List<SettingsSection> loadedSections;
-        private bool sectionsLoaded;
-        private bool sectionsDisplayReady;
-        private bool sectionsAsyncCallbackInvoked;
         private bool sectionsMountInProgress;
-        private int sectionsMountedCount;
         private Stopwatch sectionsLoadStopwatch;
         private long? sectionsPreloadDurationMs;
         private bool loadHeartbeatActive;
@@ -86,12 +82,12 @@ namespace osu.Game.Overlays
         /// <summary>
         /// Whether settings sections have finished async construction (tree mount is deferred until PopIn).
         /// </summary>
-        public bool AreSectionsLoaded => sectionsLoaded;
+        public bool AreSectionsLoaded { get; private set; }
 
         /// <summary>
         /// Whether settings sections and sidebar buttons are mounted and ready to show without further loading.
         /// </summary>
-        public bool AreSectionsReadyForDisplay => sectionsDisplayReady;
+        public bool AreSectionsReadyForDisplay { get; private set; }
 
         public IBindable<SettingsSection> CurrentSection = new Bindable<SettingsSection>();
 
@@ -195,11 +191,9 @@ namespace osu.Game.Overlays
 
         protected override void PopIn()
         {
-            logPreloadStatus("PopIn");
-
             lastPopInTime = Time.Current;
 
-            if (!sectionsDisplayReady)
+            if (!AreSectionsReadyForDisplay)
                 loading.Show();
 
             ContentContainer.MoveToX(ExpandedPosition, TRANSITION_LENGTH, Easing.OutQuint);
@@ -222,11 +216,11 @@ namespace osu.Game.Overlays
 
         private double getPopInLoadSectionsDelay()
         {
-            if (sectionsDisplayReady)
+            if (AreSectionsReadyForDisplay)
                 return 0;
 
             // Async CPU preload is done; defer tree mount until the slide/fade finishes.
-            if (sectionsLoaded)
+            if (AreSectionsLoaded)
                 return TRANSITION_LENGTH;
 
             return TRANSITION_LENGTH / 3;
@@ -234,7 +228,7 @@ namespace osu.Game.Overlays
 
         private double getRemainingPopInAnimationDelay()
         {
-            if (sectionsDisplayReady)
+            if (AreSectionsReadyForDisplay)
                 return 0;
 
             return Math.Max(0, TRANSITION_LENGTH - (Time.Current - lastPopInTime));
@@ -294,44 +288,25 @@ namespace osu.Game.Overlays
         /// </summary>
         public void BeginLoadingSections()
         {
-            EzStartupTrace.Log("Settings.BeginLoadingSections called");
             loadSections();
         }
 
         /// <summary>
         /// Emit a snapshot of section preload progress to the startup trace log.
         /// </summary>
-        public void LogPreloadStatus(string context) => logPreloadStatus(context);
-
-        private void logPreloadStatus(string context)
+        public void LogPreloadStatus(string context)
         {
-            string timing = sectionsPreloadDurationMs.HasValue
-                ? $"preloadDuration={sectionsPreloadDurationMs}ms"
-                : $"preloadElapsed={sectionsLoadStopwatch?.ElapsedMilliseconds ?? 0}ms";
-            string taskStatus = sectionsLoadingTask?.Status.ToString() ?? "none";
-            bool workerDone = sectionsLoadingTask?.IsCompleted ?? false;
-
-            EzStartupTrace.Log(
-                $"Settings[{context}] loaded={sectionsLoaded} displayReady={sectionsDisplayReady} " +
-                $"workerDone={workerDone} callbackInvoked={sectionsAsyncCallbackInvoked} " +
-                $"mounted={SectionsContainer.Count}/{loadableSections.Count} taskStatus={taskStatus} {timing} visible={State.Value == Visibility.Visible}");
         }
 
         private void loadSections()
         {
-            if (sectionsDisplayReady)
-            {
-                EzStartupTrace.Log("Settings.loadSections skipped (already complete)");
+            if (AreSectionsReadyForDisplay)
                 return;
-            }
 
-            if (!sectionsLoaded)
+            if (!AreSectionsLoaded)
             {
                 if (sectionsLoadingTask != null)
-                {
-                    EzStartupTrace.Log("Settings.loadSections skipped (async in progress)");
                     return;
-                }
 
                 beginAsyncSectionLoad();
                 return;
@@ -343,32 +318,29 @@ namespace osu.Game.Overlays
         private void beginAsyncSectionLoad()
         {
             sectionsLoadStopwatch = Stopwatch.StartNew();
-            EzStartupTrace.Log($"Settings.loadSections started ({loadableSections.Count} sections)");
             startLoadHeartbeat();
 
             sectionsLoadingTask = LoadComponentsAsync(loadableSections, sections =>
             {
-                sectionsAsyncCallbackInvoked = true;
                 loadedSections = sections.ToList();
-                sectionsLoaded = true;
+                AreSectionsLoaded = true;
 
                 if (State.Value != Visibility.Visible)
                 {
                     sectionsPreloadDurationMs = sectionsLoadStopwatch.ElapsedMilliseconds;
                     sectionsLoadStopwatch.Stop();
                     loadHeartbeatActive = false;
-                    EzStartupTrace.Log($"Settings async preload complete after {sectionsPreloadDurationMs}ms (mount deferred until PopIn)");
+                    EzStartupTrace.Log($"Settings.asyncPreload complete {sectionsPreloadDurationMs}ms (mount deferred)");
                     return;
                 }
 
-                EzStartupTrace.Log($"Settings sections worker finished after {sectionsLoadStopwatch.ElapsedMilliseconds}ms, scheduling mount after PopIn animation");
                 scheduleAfterPopInAnimation(scheduleMountLoadedSections);
             }, scheduler: preloadScheduler);
         }
 
         private void scheduleMountLoadedSections()
         {
-            if (sectionsDisplayReady || loadedSections == null)
+            if (AreSectionsReadyForDisplay || loadedSections == null)
                 return;
 
             int startIndex = SectionsContainer.Count;
@@ -377,13 +349,9 @@ namespace osu.Game.Overlays
                 return;
 
             if (sectionsMountInProgress)
-            {
-                EzStartupTrace.Log("Settings.mount skipped (already in progress)");
                 return;
-            }
 
             sectionsMountInProgress = true;
-            EzStartupTrace.Log($"Settings mounting preloaded sections from index {startIndex}");
             Scheduler.Add(() => addSectionsInBatches(loadedSections, startIndex));
         }
 
@@ -400,13 +368,11 @@ namespace osu.Game.Overlays
         {
             preloadScheduler.AddDelayed(() =>
             {
-                if (sectionsDisplayReady || (sectionsLoaded && State.Value != Visibility.Visible))
+                if (AreSectionsReadyForDisplay || (AreSectionsLoaded && State.Value != Visibility.Visible))
                 {
                     loadHeartbeatActive = false;
                     return;
                 }
-
-                logPreloadStatus("heartbeat");
 
                 if (sectionsLoadingTask != null)
                     scheduleLoadHeartbeat();
@@ -428,8 +394,6 @@ namespace osu.Game.Overlays
             for (int i = startIndex; i < endIndex; i++)
                 SectionsContainer.Add(sections[i]);
 
-            sectionsMountedCount = endIndex;
-
             if (endIndex < sections.Count)
             {
                 Scheduler.Add(() => addSectionsInBatches(sections, endIndex));
@@ -437,7 +401,6 @@ namespace osu.Game.Overlays
             }
 
             sectionsMountInProgress = false;
-            EzStartupTrace.Log($"Settings sections mount complete after {sectionsLoadStopwatch.ElapsedMilliseconds}ms");
             finishSectionsDisplay();
         }
 
@@ -484,11 +447,10 @@ namespace osu.Game.Overlays
                         selectedSidebarButton.Selected = true;
                 }, true);
 
-                sectionsDisplayReady = true;
+                AreSectionsReadyForDisplay = true;
                 loadHeartbeatActive = false;
                 sectionsPreloadDurationMs = sectionsLoadStopwatch.ElapsedMilliseconds;
                 sectionsLoadStopwatch.Stop();
-                EzStartupTrace.Log($"Settings display ready after {sectionsPreloadDurationMs}ms (sidebar mounted)");
             }, scheduler: preloadScheduler);
         }
 

--- a/osu.Game/Screens/Menu/IntroScreen.cs
+++ b/osu.Game/Screens/Menu/IntroScreen.cs
@@ -369,8 +369,6 @@ namespace osu.Game.Screens.Menu
             if (nextScreen != null)
                 return;
 
-            EzStartupTrace.Log("Intro.PrepareMenuLoad");
-
             nextScreen = createNextScreen?.Invoke();
 
             if (nextScreen != null)
@@ -389,8 +387,6 @@ namespace osu.Game.Screens.Menu
         {
             if (DidLoadMenu)
                 return;
-
-            EzStartupTrace.Log("Intro.LoadMenu (Push MainMenu)");
 
             startupWorkCoordinator?.OnLoadMenu();
 

--- a/osu.Game/Screens/Menu/IntroScreen.cs
+++ b/osu.Game/Screens/Menu/IntroScreen.cs
@@ -20,6 +20,7 @@ using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Database;
+using osu.Game.EzOsuGame.Startup;
 using osu.Game.Extensions;
 using osu.Game.Localisation;
 using osu.Game.Online.API;
@@ -103,6 +104,9 @@ namespace osu.Game.Screens.Menu
         {
             this.createNextScreen = createNextScreen;
         }
+
+        [Resolved(CanBeNull = true)]
+        private IEzStartupWorkCoordinator startupWorkCoordinator { get; set; }
 
         [Resolved]
         private BeatmapManager beatmaps { get; set; }
@@ -333,7 +337,9 @@ namespace osu.Game.Screens.Menu
                 // an exception is running ruleset tests, where the osu! ruleset may not be present (causing importing the intro to fail).
                 if (initialBeatmap != null)
                     beatmap.Value = initialBeatmap;
-                Track = beatmap.Value.Track;
+
+                if (beatmap.Value != null)
+                    Track = beatmap.Value.Track;
 
                 // ensure the track starts at maximum volume
                 musicController.CurrentTrack.FinishTransforms();
@@ -363,16 +369,30 @@ namespace osu.Game.Screens.Menu
             if (nextScreen != null)
                 return;
 
+            EzStartupTrace.Log("Intro.PrepareMenuLoad");
+
             nextScreen = createNextScreen?.Invoke();
 
             if (nextScreen != null)
-                LoadComponentAsync(nextScreen);
+            {
+                LoadComponentAsync(nextScreen, loaded =>
+                {
+                    if (loaded is MainMenu mainMenu)
+                        startupWorkCoordinator?.OnMainMenuOffscreenReady(mainMenu);
+                });
+            }
+
+            startupWorkCoordinator?.OnPrepareMenuLoad();
         }
 
         protected void LoadMenu()
         {
             if (DidLoadMenu)
                 return;
+
+            EzStartupTrace.Log("Intro.LoadMenu (Push MainMenu)");
+
+            startupWorkCoordinator?.OnLoadMenu();
 
             beatmap.Return();
 

--- a/osu.Game/Screens/Menu/MainMenu.EzStartup.cs
+++ b/osu.Game/Screens/Menu/MainMenu.EzStartup.cs
@@ -1,0 +1,113 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Threading;
+using osu.Game.EzOsuGame.Startup;
+using osu.Game.Screens.Select;
+
+namespace osu.Game.Screens.Menu
+{
+    public partial class MainMenu : IEzStartupSongSelectPreloadHost
+    {
+        private SoloSongSelect? preloadedSongSelect;
+        private bool songSelectPreloadScheduled;
+        private bool songSelectConsumed = true;
+        private double? mainMenuEnteredAt;
+        private ScheduledDelegate? songSelectUiSettleDelegate;
+
+        [Resolved(CanBeNull = true)]
+        private ISongSelectScreenFactory? songSelectScreenFactory { get; set; }
+
+        public void ScheduleSongSelectPreload()
+        {
+            if (songSelectPreloadScheduled || songSelectScreenFactory == null)
+                return;
+
+            songSelectUiSettleDelegate?.Cancel();
+            songSelectUiSettleDelegate = null;
+
+            songSelectPreloadScheduled = true;
+            songSelectConsumed = false;
+
+            preloadedSongSelect?.Expire();
+            preloadedSongSelect = null;
+
+            EzStartupTrace.Log("MainMenu.ScheduleSongSelectPreload started");
+            var screen = songSelectScreenFactory.Create();
+
+            LoadComponentAsync(screen, loaded =>
+            {
+                songSelectPreloadScheduled = false;
+                preloadedSongSelect = loaded;
+
+                EzStartupTrace.Log(
+                    $"MainMenu.ScheduleSongSelectPreload finished LoadState={loaded.LoadState} preloadReady={isSongSelectPreloadReady(loaded)}");
+            });
+        }
+
+        public void ScheduleSongSelectPreloadAfterUiSettle()
+        {
+            if (songSelectPreloadScheduled || songSelectScreenFactory == null)
+                return;
+
+            songSelectUiSettleDelegate?.Cancel();
+
+            if (!mainMenuEnteredAt.HasValue)
+            {
+                ScheduleSongSelectPreload();
+                return;
+            }
+
+            double elapsed = Clock.CurrentTime - mainMenuEnteredAt.Value;
+            double delay = Math.Max(0, EzStartupTuning.MainMenuUiSettleBeforeHeavyWorkMs - elapsed);
+
+            if (delay <= 0)
+            {
+                ScheduleSongSelectPreload();
+                return;
+            }
+
+            EzStartupTrace.Log($"MainMenu.ScheduleSongSelectPreloadAfterUiSettle delay={delay:0}ms");
+            songSelectUiSettleDelegate = Scheduler.AddDelayed(ScheduleSongSelectPreload, delay);
+        }
+
+        internal void NotifyMainMenuEnteredForStartup()
+        {
+            mainMenuEnteredAt = Clock.CurrentTime;
+        }
+
+        public bool TryConsumePreloadedSongSelect(out SoloSongSelect? screen)
+        {
+            LogSongSelectPreloadStatus("TryConsumePreloadedSongSelect");
+
+            if (preloadedSongSelect != null && !songSelectConsumed && isSongSelectPreloadReady(preloadedSongSelect))
+            {
+                screen = preloadedSongSelect;
+                songSelectConsumed = true;
+                preloadedSongSelect = null;
+                EzStartupTrace.Log($"MainMenu.TryConsumePreloadedSongSelect hit (LoadState={screen.LoadState})");
+                return true;
+            }
+
+            screen = null;
+            EzStartupTrace.Log(
+                $"MainMenu.TryConsumePreloadedSongSelect miss (preloaded={preloadedSongSelect != null}, consumed={songSelectConsumed}, loadState={preloadedSongSelect?.LoadState})");
+            return false;
+        }
+
+        public void LogSongSelectPreloadStatus(string context)
+        {
+            bool preloadReady = preloadedSongSelect != null && isSongSelectPreloadReady(preloadedSongSelect);
+
+            EzStartupTrace.Log(
+                $"MainMenu[{context}] songSelectScheduled={songSelectPreloadScheduled} songSelectPreloaded={preloadedSongSelect != null} " +
+                $"songSelectPreloadReady={preloadReady} songSelectLoadState={preloadedSongSelect?.LoadState} songSelectConsumed={songSelectConsumed}");
+        }
+
+        private static bool isSongSelectPreloadReady(SoloSongSelect screen)
+            => screen.LoadState >= LoadState.Ready;
+    }
+}

--- a/osu.Game/Screens/Menu/MainMenu.EzStartup.cs
+++ b/osu.Game/Screens/Menu/MainMenu.EzStartup.cs
@@ -35,16 +35,12 @@ namespace osu.Game.Screens.Menu
             preloadedSongSelect?.Expire();
             preloadedSongSelect = null;
 
-            EzStartupTrace.Log("MainMenu.ScheduleSongSelectPreload started");
             var screen = songSelectScreenFactory.Create();
 
             LoadComponentAsync(screen, loaded =>
             {
                 songSelectPreloadScheduled = false;
                 preloadedSongSelect = loaded;
-
-                EzStartupTrace.Log(
-                    $"MainMenu.ScheduleSongSelectPreload finished LoadState={loaded.LoadState} preloadReady={isSongSelectPreloadReady(loaded)}");
             });
         }
 
@@ -70,7 +66,6 @@ namespace osu.Game.Screens.Menu
                 return;
             }
 
-            EzStartupTrace.Log($"MainMenu.ScheduleSongSelectPreloadAfterUiSettle delay={delay:0}ms");
             songSelectUiSettleDelegate = Scheduler.AddDelayed(ScheduleSongSelectPreload, delay);
         }
 
@@ -81,30 +76,20 @@ namespace osu.Game.Screens.Menu
 
         public bool TryConsumePreloadedSongSelect(out SoloSongSelect? screen)
         {
-            LogSongSelectPreloadStatus("TryConsumePreloadedSongSelect");
-
             if (preloadedSongSelect != null && !songSelectConsumed && isSongSelectPreloadReady(preloadedSongSelect))
             {
                 screen = preloadedSongSelect;
                 songSelectConsumed = true;
                 preloadedSongSelect = null;
-                EzStartupTrace.Log($"MainMenu.TryConsumePreloadedSongSelect hit (LoadState={screen.LoadState})");
                 return true;
             }
 
             screen = null;
-            EzStartupTrace.Log(
-                $"MainMenu.TryConsumePreloadedSongSelect miss (preloaded={preloadedSongSelect != null}, consumed={songSelectConsumed}, loadState={preloadedSongSelect?.LoadState})");
             return false;
         }
 
         public void LogSongSelectPreloadStatus(string context)
         {
-            bool preloadReady = preloadedSongSelect != null && isSongSelectPreloadReady(preloadedSongSelect);
-
-            EzStartupTrace.Log(
-                $"MainMenu[{context}] songSelectScheduled={songSelectPreloadScheduled} songSelectPreloaded={preloadedSongSelect != null} " +
-                $"songSelectPreloadReady={preloadReady} songSelectLoadState={preloadedSongSelect?.LoadState} songSelectConsumed={songSelectConsumed}");
         }
 
         private static bool isSongSelectPreloadReady(SoloSongSelect screen)

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -41,6 +41,7 @@ using osu.Game.Screens.Edit;
 using osu.Game.Screens.OnlinePlay.DailyChallenge;
 using osu.Game.Screens.OnlinePlay.Multiplayer;
 using osu.Game.Screens.OnlinePlay.Playlists;
+using osu.Game.EzOsuGame.Startup;
 using osu.Game.Screens.Select;
 using osu.Game.Seasonal;
 using osuTK;
@@ -114,6 +115,12 @@ namespace osu.Game.Screens.Menu
         private SupporterDisplay supporterDisplay;
 
         private Sample reappearSampleSwoosh;
+
+        [Resolved(CanBeNull = true)]
+        private IEzStartupWorkCoordinator startupWorkCoordinator { get; set; }
+
+        [Resolved(CanBeNull = true)]
+        private IEzStartupContentPreloader startupContentPreloader { get; set; }
 
         [Resolved(canBeNull: true)]
         private SkinEditorOverlay skinEditor { get; set; }
@@ -267,8 +274,18 @@ namespace osu.Game.Screens.Menu
 
         public override void OnEntering(ScreenTransitionEvent e)
         {
+            double enterBegin = Clock.CurrentTime;
+            EzStartupTrace.Log("MainMenu.OnEntering begin");
+
             base.OnEntering(e);
+
+            NotifyMainMenuEnteredForStartup();
+            EzStartupTrace.Log("MainMenu.OnEntering");
+            startupWorkCoordinator?.OnMainMenuEntered(this);
             Buttons.FadeInFromZero(500);
+
+            Scheduler.Add(() =>
+                EzStartupTrace.Log($"MainMenu.OnEntering end frameCost={(Clock.CurrentTime - enterBegin):0}ms"));
 
             if (e.Last is IntroScreen && musicController.TrackLoaded)
             {
@@ -498,7 +515,20 @@ namespace osu.Game.Screens.Menu
         {
         }
 
-        private void loadSongSelect() => this.Push(new SoloSongSelect());
+        private void loadSongSelect()
+        {
+            EzStartupTrace.Log("MainMenu.loadSongSelect");
+            startupContentPreloader?.LogStatus("MainMenu.loadSongSelect");
+            LogSongSelectPreloadStatus("MainMenu.loadSongSelect");
+
+            bool preloadHit = TryConsumePreloadedSongSelect(out var screen);
+            EzSongSelectEnterTrace.RecordPlayPressed(preloadHit);
+
+            if (preloadHit)
+                this.Push(screen!);
+            else
+                this.Push(new SoloSongSelect());
+        }
 
         private void loadQuickPlay() => this.Push(new OnlinePlay.Matchmaking.Intro.ScreenIntro(MatchmakingPoolType.QuickPlay));
 

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -275,17 +275,15 @@ namespace osu.Game.Screens.Menu
         public override void OnEntering(ScreenTransitionEvent e)
         {
             double enterBegin = Clock.CurrentTime;
-            EzStartupTrace.Log("MainMenu.OnEntering begin");
 
             base.OnEntering(e);
 
             NotifyMainMenuEnteredForStartup();
-            EzStartupTrace.Log("MainMenu.OnEntering");
             startupWorkCoordinator?.OnMainMenuEntered(this);
             Buttons.FadeInFromZero(500);
 
             Scheduler.Add(() =>
-                EzStartupTrace.Log($"MainMenu.OnEntering end frameCost={(Clock.CurrentTime - enterBegin):0}ms"));
+                EzStartupTrace.Log($"MainMenu.OnEntering frameCost={(Clock.CurrentTime - enterBegin):0}ms"));
 
             if (e.Last is IntroScreen && musicController.TrackLoaded)
             {
@@ -517,9 +515,7 @@ namespace osu.Game.Screens.Menu
 
         private void loadSongSelect()
         {
-            EzStartupTrace.Log("MainMenu.loadSongSelect");
             startupContentPreloader?.LogStatus("MainMenu.loadSongSelect");
-            LogSongSelectPreloadStatus("MainMenu.loadSongSelect");
 
             bool preloadHit = TryConsumePreloadedSongSelect(out var screen);
             EzSongSelectEnterTrace.RecordPlayPressed(preloadHit);

--- a/osu.Game/Screens/Select/SongSelect.EzStartup.cs
+++ b/osu.Game/Screens/Select/SongSelect.EzStartup.cs
@@ -1,0 +1,37 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Screens;
+using osu.Game.EzOsuGame.Startup;
+using osu.Game.Screens.Menu;
+
+namespace osu.Game.Screens.Select
+{
+    public abstract partial class SongSelect
+    {
+        private bool ezDeferInitialCarouselFilter;
+
+        partial void onEzSongSelectEntering(ScreenTransitionEvent e)
+        {
+            if (e.Last is MainMenu)
+            {
+                ezDeferInitialCarouselFilter = true;
+                EzSongSelectEnterTrace.RecordSongSelectEntering();
+            }
+        }
+
+        private partial double? onEzGetFilterScheduleDelay(bool isFirstFilter, bool isSelectionValid)
+        {
+            if (ezDeferInitialCarouselFilter && isFirstFilter)
+            {
+                ezDeferInitialCarouselFilter = false;
+                EzStartupTrace.Log($"SongSelect deferring initial carousel filter by {EzStartupTuning.SongSelectEnterFilterDelayMs}ms");
+                return EzStartupTuning.SongSelectEnterFilterDelayMs;
+            }
+
+            return null;
+        }
+
+        partial void onEzCarouselItemsPresented() => EzSongSelectEnterTrace.RecordCarouselReady();
+    }
+}

--- a/osu.Game/Screens/Select/SongSelect.EzStartup.cs
+++ b/osu.Game/Screens/Select/SongSelect.EzStartup.cs
@@ -20,12 +20,11 @@ namespace osu.Game.Screens.Select
             }
         }
 
-        private partial double? onEzGetFilterScheduleDelay(bool isFirstFilter, bool isSelectionValid)
+        private partial double? onEzGetFilterScheduleDelay(bool isFirstFilter)
         {
             if (ezDeferInitialCarouselFilter && isFirstFilter)
             {
                 ezDeferInitialCarouselFilter = false;
-                EzStartupTrace.Log($"SongSelect deferring initial carousel filter by {EzStartupTuning.SongSelectEnterFilterDelayMs}ms");
                 return EzStartupTuning.SongSelectEnterFilterDelayMs;
             }
 

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -751,6 +751,7 @@ namespace osu.Game.Screens.Select
 
         public override void OnEntering(ScreenTransitionEvent e)
         {
+            onEzSongSelectEntering(e);
             base.OnEntering(e);
 
             this.FadeIn();
@@ -1066,8 +1067,26 @@ namespace osu.Game.Screens.Select
             // Criteria change may have included a ruleset change which made the current selection invalid.
             bool isSelectionValid = checkBeatmapValidForSelection(Beatmap.Value.BeatmapInfo);
 
-            filterDebounce = Scheduler.AddDelayed(() => carousel.Filter(criteria, !isSelectionValid), isFirstFilter || !isSelectionValid ? 0 : filter_delay);
+            filterDebounce = Scheduler.AddDelayed(() => carousel.Filter(criteria, !isSelectionValid), GetFilterScheduleDelay(isFirstFilter, isSelectionValid));
         }
+
+        /// <summary>
+        /// Delay before applying carousel filter. Overridable for startup enter-path staggering.
+        /// </summary>
+        protected virtual double GetFilterScheduleDelay(bool isFirstFilter, bool isSelectionValid)
+        {
+            double? ezDelay = onEzGetFilterScheduleDelay(isFirstFilter, isSelectionValid);
+            if (ezDelay.HasValue)
+                return ezDelay.Value;
+
+            return isFirstFilter || !isSelectionValid ? 0 : filter_delay;
+        }
+
+        partial void onEzSongSelectEntering(ScreenTransitionEvent e);
+
+        private partial double? onEzGetFilterScheduleDelay(bool isFirstFilter, bool isSelectionValid);
+
+        partial void onEzCarouselItemsPresented();
 
         private void newItemsPresented(IEnumerable<CarouselItem> carouselItems)
         {
@@ -1075,6 +1094,7 @@ namespace osu.Game.Screens.Select
                 return;
 
             CarouselItemsPresented = true;
+            onEzCarouselItemsPresented();
 
             updateNoResultsPlaceholder();
 

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -1075,7 +1075,7 @@ namespace osu.Game.Screens.Select
         /// </summary>
         protected virtual double GetFilterScheduleDelay(bool isFirstFilter, bool isSelectionValid)
         {
-            double? ezDelay = onEzGetFilterScheduleDelay(isFirstFilter, isSelectionValid);
+            double? ezDelay = onEzGetFilterScheduleDelay(isFirstFilter);
             if (ezDelay.HasValue)
                 return ezDelay.Value;
 
@@ -1084,7 +1084,7 @@ namespace osu.Game.Screens.Select
 
         partial void onEzSongSelectEntering(ScreenTransitionEvent e);
 
-        private partial double? onEzGetFilterScheduleDelay(bool isFirstFilter, bool isSelectionValid);
+        private partial double? onEzGetFilterScheduleDelay(bool isFirstFilter);
 
         partial void onEzCarouselItemsPresented();
 


### PR DESCRIPTION
## Summary

- 注册 Ez 启动预载协调器：BDSP 在 Intro 期立即运行（可配置 backfill delay），SQLite 自动 warmup 等 BDSP 完成后再触发。
- 设置面板 CPU 预载：启动期离屏 \LoadComponentsAsync\，PopIn 动画结束后再分批挂树；\SearchContainer\ 初始隐藏避免挂载完成时闪烁。
- 选歌预载：MainMenu 离屏建树，Intro offscreen ready 后在 BDSP 完成后启动；首页可见后 UI settle 窗口内再续跑，避免与 OnEntering 抢帧。
- 进选歌路径：从首页进入时首次 carousel filter 错峰，降低 Push 后 Filter 与过渡叠帧。
- 调试日志（独立提交）：\[EzStartupTrace]\ 使用 \LogLevel.Debug\，不推送到游戏内通知；仅保留 BDSP 完成、预载 hit/miss、EnterPath 等关键里程碑。

## Test plan

- [ ] 冷启动 → MainMenu：OnEntering 动画顺滑，无明显首屏卡顿
- [ ] 立即点 Play：日志 \preloadHit=true\（或 trace 说明 intro 时间不足）
- [ ] 打开设置：加载前有转圈，组件淡入无底层闪屏/二次转圈
- [ ] 运行时日志搜 \[EzStartupTrace]\ 仅在 Debug 级别出现，游戏内无通知推送


Made with [Cursor](https://cursor.com)