### PR TITLE
外部规则集 OnlineID 映射与管理器

### DIFF
--- a/osu.Game.Tests/EzOsuGame/ExternalRulesets/EzExternalRulesetIdResolverTest.cs
+++ b/osu.Game.Tests/EzOsuGame/ExternalRulesets/EzExternalRulesetIdResolverTest.cs
@@ -1,0 +1,76 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.EzOsuGame.ExternalRulesets;
+
+namespace osu.Game.Tests.EzOsuGame.ExternalRulesets
+{
+    [TestFixture]
+    public class EzExternalRulesetIdResolverTest
+    {
+        [Test]
+        public void TestExplicitIdConflictRemapsLaterRuleset()
+        {
+            var inputs = new List<ExternalRulesetMappingInput>
+            {
+                new ExternalRulesetMappingInput("first", 5, true, 5, 0, 0),
+                new ExternalRulesetMappingInput("second", 5, true, 5, 1, 1),
+            };
+
+            var outputs = EzExternalRulesetIdResolver.Resolve(inputs, new HashSet<int> { 0, 1, 2, 3 });
+
+            Assert.That(outputs[0].ResolvedOnlineId, Is.EqualTo(5));
+            Assert.That(outputs[0].WasRemapped, Is.False);
+            Assert.That(outputs[1].ResolvedOnlineId, Is.EqualTo(4));
+            Assert.That(outputs[1].WasRemapped, Is.True);
+        }
+
+        [Test]
+        public void TestUndefinedIdRulesetsStayUntouched()
+        {
+            var inputs = new List<ExternalRulesetMappingInput>
+            {
+                new ExternalRulesetMappingInput("a", -1, true, null, int.MaxValue, 0),
+                new ExternalRulesetMappingInput("b", -1, true, null, int.MaxValue, 1),
+            };
+
+            var outputs = EzExternalRulesetIdResolver.Resolve(inputs, new HashSet<int> { 0, 1, 2, 3 });
+
+            Assert.That(outputs.All(o => o.ResolvedOnlineId == -1));
+            Assert.That(outputs.All(o => !o.ParticipatesInMapping));
+            Assert.That(outputs.All(o => !o.WasRemapped));
+        }
+
+        [Test]
+        public void TestUndefinedIdDoesNotConflictWithExplicitId()
+        {
+            var inputs = new List<ExternalRulesetMappingInput>
+            {
+                new ExternalRulesetMappingInput("undefined", -1, true, null, int.MaxValue, 0),
+                new ExternalRulesetMappingInput("explicit", 5, true, 5, 0, 1),
+            };
+
+            var outputs = EzExternalRulesetIdResolver.Resolve(inputs, new HashSet<int> { 0, 1, 2, 3 });
+
+            Assert.That(outputs.Single(o => o.ShortName == "undefined").ResolvedOnlineId, Is.EqualTo(-1));
+            Assert.That(outputs.Single(o => o.ShortName == "explicit").ResolvedOnlineId, Is.EqualTo(5));
+        }
+
+        [Test]
+        public void TestDisabledRulesetSkipped()
+        {
+            var inputs = new List<ExternalRulesetMappingInput>
+            {
+                new ExternalRulesetMappingInput("disabled", 5, false, 5, 0, 0),
+            };
+
+            var outputs = EzExternalRulesetIdResolver.Resolve(inputs, new HashSet<int> { 0, 1, 2, 3 });
+
+            Assert.That(outputs[0].Enabled, Is.False);
+            Assert.That(outputs[0].ParticipatesInMapping, Is.False);
+        }
+    }
+}

--- a/osu.Game.Tests/EzOsuGame/ExternalRulesets/EzRulesetMappingConfigTest.cs
+++ b/osu.Game.Tests/EzOsuGame/ExternalRulesets/EzRulesetMappingConfigTest.cs
@@ -1,0 +1,60 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.IO;
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.EzOsuGame.ExternalRulesets;
+
+namespace osu.Game.Tests.EzOsuGame.ExternalRulesets
+{
+    [TestFixture]
+    public class EzRulesetMappingConfigTest
+    {
+        [Test]
+        public void TestSaveWritesHeaderAndExplicitOnlyDefaults()
+        {
+            using var host = new TemporaryNativeStorage("ez-ruleset-mapping-test");
+            var storage = host.GetStorageForDirectory(".");
+
+            var config = new EzRulesetMappingConfig();
+            config.EnsureDefaults(new[]
+            {
+                new DiscoveredExternalRuleset("no-id", "No ID Ruleset", -1),
+                new DiscoveredExternalRuleset("diva", "DIVA", 4),
+            });
+
+            config.Save(storage);
+
+            string text = File.ReadAllText(storage.GetFullPath(EzRulesetMappingConfig.FILENAME));
+
+            Assert.That(text, Does.Contain(EzRulesetMappingConfig.HEADER_LINE1));
+            Assert.That(text, Does.Contain(EzRulesetMappingConfig.HEADER_LINE2));
+            Assert.That(text, Does.Contain("[no-id]"));
+            Assert.That(text, Does.Contain("[diva]"));
+            Assert.That(text, Does.Contain("OnlineID=4"));
+            Assert.That(text, Does.Not.Contain("[no-id]\r\nEnabled=1\r\nOnlineID="));
+        }
+
+        [Test]
+        public void TestLoadRoundTrip()
+        {
+            using var host = new TemporaryNativeStorage("ez-ruleset-mapping-roundtrip");
+            var storage = host.GetStorageForDirectory(".");
+
+            var original = new EzRulesetMappingConfig();
+            var diva = original.GetOrAdd("diva");
+            diva.Enabled = true;
+            diva.OnlineID = 7;
+            diva.Order = 2;
+            original.Save(storage);
+
+            var loaded = EzRulesetMappingConfig.Load(storage);
+            var entry = loaded.GetOrAdd("diva");
+
+            Assert.That(entry.Enabled, Is.True);
+            Assert.That(entry.OnlineID, Is.EqualTo(7));
+            Assert.That(entry.Order, Is.EqualTo(2));
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/ExternalRulesets/EzExternalRulesetIdResolver.cs
+++ b/osu.Game/EzOsuGame/ExternalRulesets/EzExternalRulesetIdResolver.cs
@@ -1,0 +1,85 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace osu.Game.EzOsuGame.ExternalRulesets
+{
+    public readonly record struct ExternalRulesetMappingInput(
+        string ShortName,
+        int InstanceOnlineId,
+        bool Enabled,
+        int? IniOnlineId,
+        int IniOrder,
+        int DiscoveryIndex);
+
+    public readonly record struct ExternalRulesetMappingOutput(
+        string ShortName,
+        int ResolvedOnlineId,
+        bool Enabled,
+        bool WasRemapped,
+        bool ParticipatesInMapping);
+
+    public static class EzExternalRulesetIdResolver
+    {
+        public static List<ExternalRulesetMappingOutput> Resolve(
+            IReadOnlyList<ExternalRulesetMappingInput> inputs,
+            HashSet<int> usedOfficialAndMappedIds)
+        {
+            var results = new List<ExternalRulesetMappingOutput>();
+            var used = new HashSet<int>(usedOfficialAndMappedIds);
+
+            var ordered = inputs
+                          .OrderBy(i => i.IniOrder)
+                          .ThenBy(i => i.DiscoveryIndex)
+                          .ToList();
+
+            foreach (var input in ordered)
+            {
+                if (!input.Enabled)
+                {
+                    results.Add(new ExternalRulesetMappingOutput(input.ShortName, input.InstanceOnlineId, false, false, false));
+                    continue;
+                }
+
+                bool hasExplicitIniId = input.IniOnlineId is int iniId && iniId >= EzExternalRulesetMapping.EXPLICIT_ONLINE_ID_MINIMUM;
+                bool hasExplicitInstanceId = EzExternalRulesetMapping.HasExplicitOnlineId(input.InstanceOnlineId);
+
+                if (!hasExplicitIniId && !hasExplicitInstanceId)
+                {
+                    results.Add(new ExternalRulesetMappingOutput(input.ShortName, input.InstanceOnlineId, true, false, false));
+                    continue;
+                }
+
+                int candidate = hasExplicitIniId
+                    ? input.IniOnlineId!.Value
+                    : input.InstanceOnlineId;
+
+                bool wasRemapped = false;
+
+                if (used.Contains(candidate))
+                {
+                    candidate = nextFreeId(used);
+                    wasRemapped = true;
+                }
+
+                used.Add(candidate);
+
+                results.Add(new ExternalRulesetMappingOutput(input.ShortName, candidate, true, wasRemapped, true));
+            }
+
+            return results;
+        }
+
+        private static int nextFreeId(HashSet<int> used)
+        {
+            int candidate = EzExternalRulesetMapping.EXPLICIT_ONLINE_ID_MINIMUM;
+
+            while (used.Contains(candidate))
+                candidate++;
+
+            return candidate;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/ExternalRulesets/EzExternalRulesetMapping.cs
+++ b/osu.Game/EzOsuGame/ExternalRulesets/EzExternalRulesetMapping.cs
@@ -1,0 +1,24 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets;
+
+namespace osu.Game.EzOsuGame.ExternalRulesets
+{
+    /// <summary>
+    /// Helpers for third-party rulesets in <c>rulesets/</c> that optionally declare an explicit <see cref="RulesetInfo.OnlineID"/>.
+    /// </summary>
+    public static class EzExternalRulesetMapping
+    {
+        public const int EXPLICIT_ONLINE_ID_MINIMUM = 4;
+
+        public static bool HasExplicitOnlineId(Ruleset instance)
+            => instance is not ILegacyRuleset && instance.RulesetInfo.OnlineID >= EXPLICIT_ONLINE_ID_MINIMUM;
+
+        public static bool HasExplicitOnlineId(int instanceOnlineId)
+            => instanceOnlineId >= EXPLICIT_ONLINE_ID_MINIMUM;
+
+        public static bool IsOfficialOnlineId(int onlineId)
+            => onlineId >= 0 && onlineId <= ILegacyRuleset.MAX_LEGACY_RULESET_ID;
+    }
+}

--- a/osu.Game/EzOsuGame/ExternalRulesets/EzExternalRulesetScanner.cs
+++ b/osu.Game/EzOsuGame/ExternalRulesets/EzExternalRulesetScanner.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.Rulesets;
+
+namespace osu.Game.EzOsuGame.ExternalRulesets
+{
+    public static class EzExternalRulesetScanner
+    {
+        private const string ruleset_library_prefix = @"osu.Game.Rulesets";
+
+        public static List<DiscoveredExternalRuleset> Scan(Storage storage)
+        {
+            var results = new List<DiscoveredExternalRuleset>();
+            var rulesetStorage = storage.GetStorageForDirectory(@"rulesets");
+
+            foreach (string file in rulesetStorage.GetFiles(@".", @$"{ruleset_library_prefix}.*.dll").Where(f => !f.Contains(@"Tests")))
+            {
+                try
+                {
+                    string fullPath = rulesetStorage.GetFullPath(file);
+                    var assembly = Assembly.LoadFrom(fullPath);
+                    Type rulesetType = assembly.GetTypes().First(t => t.IsPublic && t.IsSubclassOf(typeof(Ruleset)));
+                    var instance = (Ruleset)Activator.CreateInstance(rulesetType)!;
+
+                    results.Add(new DiscoveredExternalRuleset(instance.ShortName, instance.RulesetInfo.Name, instance.RulesetInfo.OnlineID));
+                }
+                catch (Exception ex)
+                {
+                    Logger.Log($"Failed to inspect external ruleset '{Path.GetFileName(file)}': {ex.Message}", Ez2ConfigManager.LOGGER_NAME);
+                }
+            }
+
+            return results
+                   .OrderBy(r => r.ShortName, StringComparer.Ordinal)
+                   .ToList();
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/ExternalRulesets/EzRealmRulesetStore.cs
+++ b/osu.Game/EzOsuGame/ExternalRulesets/EzRealmRulesetStore.cs
@@ -1,0 +1,127 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using osu.Game.Database;
+using osu.Game.EzOsuGame.Configuration;
+using osu.Game.Rulesets;
+using Realms;
+
+namespace osu.Game.EzOsuGame.ExternalRulesets
+{
+    public class EzRealmRulesetStore : RealmRulesetStore
+    {
+        private EzRulesetMappingConfig? mappingConfig;
+        private readonly HashSet<string> disabledByConfig = new HashSet<string>(StringComparer.Ordinal);
+        private readonly HashSet<string> mappedExplicitShortNames = new HashSet<string>(StringComparer.Ordinal);
+
+        public EzRealmRulesetStore(RealmAccess realmAccess, Storage? storage = null)
+            : base(realmAccess, storage)
+        {
+            ArgumentNullException.ThrowIfNull(storage);
+        }
+
+        protected override void OnBeforeRulesetValidation(Realm realm, IQueryable<RulesetInfo> rulesets, List<Ruleset> instances)
+        {
+            // GameStorage is set in RulesetStore's ctor before PrepareDetachedRulesets runs.
+            var storage = GameStorage ?? throw new InvalidOperationException($"{nameof(GameStorage)} is required for external ruleset mapping.");
+
+            mappingConfig = EzRulesetMappingConfig.Load(storage);
+
+            var userInstances = instances
+                                .Where(i => IsUserRulesetAssembly(i.GetType().Assembly))
+                                .ToList();
+
+            mappingConfig.EnsureDefaults(userInstances.Select(i =>
+                new DiscoveredExternalRuleset(i.ShortName, i.RulesetInfo.Name, i.RulesetInfo.OnlineID)));
+
+            var usedIds = new HashSet<int> { 0, 1, 2, 3 };
+
+            var inputs = new List<ExternalRulesetMappingInput>();
+
+            for (int i = 0; i < userInstances.Count; i++)
+            {
+                var instance = userInstances[i];
+                var entry = mappingConfig.GetOrAdd(instance.ShortName);
+
+                inputs.Add(new ExternalRulesetMappingInput(
+                    instance.ShortName,
+                    instance.RulesetInfo.OnlineID,
+                    entry.Enabled,
+                    entry.OnlineID,
+                    entry.Order ?? int.MaxValue,
+                    i));
+            }
+
+            var outputs = EzExternalRulesetIdResolver.Resolve(inputs, usedIds);
+
+            disabledByConfig.Clear();
+            mappedExplicitShortNames.Clear();
+
+            bool configChanged = false;
+
+            foreach (var output in outputs)
+            {
+                var entry = mappingConfig.GetOrAdd(output.ShortName);
+
+                if (!output.Enabled)
+                {
+                    disabledByConfig.Add(output.ShortName);
+                    continue;
+                }
+
+                var realmEntry = rulesets.FirstOrDefault(r => r.ShortName == output.ShortName);
+
+                if (realmEntry == null)
+                    continue;
+
+                if (output.ParticipatesInMapping)
+                {
+                    mappedExplicitShortNames.Add(output.ShortName);
+
+                    if (realmEntry.OnlineID != output.ResolvedOnlineId)
+                        realmEntry.OnlineID = output.ResolvedOnlineId;
+
+                    if (entry.OnlineID != output.ResolvedOnlineId)
+                    {
+                        entry.OnlineID = output.ResolvedOnlineId;
+                        configChanged = true;
+                    }
+
+                    if (output.WasRemapped)
+                    {
+                        Logger.Log(
+                            $"External ruleset '{output.ShortName}' OnlineID conflict resolved: mapped to {output.ResolvedOnlineId}. See EzRulesetMapping.ini.",
+                            Ez2ConfigManager.LOGGER_NAME,
+                            LogLevel.Important);
+                        configChanged = true;
+                    }
+                }
+            }
+
+            if (configChanged)
+                mappingConfig.Save(storage);
+        }
+
+        protected override bool ShouldDisableRuleset(RulesetInfo ruleset)
+            => disabledByConfig.Contains(ruleset.ShortName);
+
+        protected override bool ShouldAllowOnlineIdMismatch(RulesetInfo ruleset, Ruleset instance, int instanceOnlineId)
+            => IsUserRulesetAssembly(instance.GetType().Assembly) && mappedExplicitShortNames.Contains(ruleset.ShortName);
+
+        protected override bool ShouldSkipDuplicateOnlineIdCheck(RulesetInfo ruleset, int onlineId, IQueryable<RulesetInfo> allRulesets)
+        {
+            if (mappedExplicitShortNames.Contains(ruleset.ShortName))
+                return true;
+
+            if (onlineId < EzExternalRulesetMapping.EXPLICIT_ONLINE_ID_MINIMUM)
+                return true;
+
+            return false;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/ExternalRulesets/EzRulesetMappingConfig.cs
+++ b/osu.Game/EzOsuGame/ExternalRulesets/EzRulesetMappingConfig.cs
@@ -1,0 +1,147 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using osu.Framework.Platform;
+
+namespace osu.Game.EzOsuGame.ExternalRulesets
+{
+    public sealed class EzRulesetMappingEntry
+    {
+        public bool Enabled { get; set; } = true;
+
+        public int? OnlineID { get; set; }
+
+        public int? Order { get; set; }
+    }
+
+    public readonly record struct DiscoveredExternalRuleset(string ShortName, string Name, int InstanceOnlineId);
+
+    public sealed class EzRulesetMappingConfig
+    {
+        public const string FILENAME = "EzRulesetMapping.ini";
+
+        public const string HEADER_LINE1 = "# OnlineID must avoid 0~3 (official modes). Use -1 or >= 4. Restart required.";
+        public const string HEADER_LINE2 = "# Only rulesets with explicit OnlineID (>=4) need OnlineID/Order entries.";
+
+        public Dictionary<string, EzRulesetMappingEntry> Entries { get; } = new Dictionary<string, EzRulesetMappingEntry>(StringComparer.Ordinal);
+
+        public static EzRulesetMappingConfig Load(Storage storage)
+        {
+            var config = new EzRulesetMappingConfig();
+
+            using var stream = storage.GetStream(FILENAME);
+
+            if (stream == null)
+                return config;
+
+            string? currentSection = null;
+
+            using var reader = new StreamReader(stream);
+
+            while (reader.ReadLine() is { } line)
+            {
+                line = line.Trim();
+
+                if (line.Length == 0 || line.StartsWith('#'))
+                    continue;
+
+                if (line.StartsWith('[') && line.EndsWith(']'))
+                {
+                    currentSection = line.Substring(1, line.Length - 2).Trim();
+                    config.Entries.TryAdd(currentSection, new EzRulesetMappingEntry());
+                    continue;
+                }
+
+                int equalsIndex = line.IndexOf('=');
+
+                if (equalsIndex < 0 || currentSection == null)
+                    continue;
+
+                string key = line.Substring(0, equalsIndex).Trim();
+                string value = line.Substring(equalsIndex + 1).Trim();
+                var entry = config.Entries[currentSection];
+
+                switch (key)
+                {
+                    case "Enabled":
+                        if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int enabled))
+                            entry.Enabled = enabled != 0;
+                        break;
+
+                    case "OnlineID":
+                        if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int onlineId))
+                            entry.OnlineID = onlineId;
+                        break;
+
+                    case "Order":
+                        if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int order))
+                            entry.Order = order;
+                        break;
+                }
+            }
+
+            return config;
+        }
+
+        public void Save(Storage storage)
+        {
+            using var stream = storage.GetStream(FILENAME, FileAccess.Write, FileMode.Create);
+            using var writer = new StreamWriter(stream, Encoding.UTF8);
+
+            writer.WriteLine(HEADER_LINE1);
+            writer.WriteLine(HEADER_LINE2);
+            writer.WriteLine();
+
+            var orderedSections = Entries
+                                  .OrderBy(kv => kv.Value.Order ?? int.MaxValue)
+                                  .ThenBy(kv => kv.Key, StringComparer.Ordinal);
+
+            foreach (var (shortName, entry) in orderedSections)
+            {
+                writer.WriteLine($"[{shortName}]");
+                writer.WriteLine($"Enabled={(entry.Enabled ? 1 : 0)}");
+
+                if (entry.OnlineID.HasValue)
+                    writer.WriteLine($"OnlineID={entry.OnlineID.Value}");
+
+                if (entry.Order.HasValue)
+                    writer.WriteLine($"Order={entry.Order.Value}");
+
+                writer.WriteLine();
+            }
+        }
+
+        public EzRulesetMappingEntry GetOrAdd(string shortName)
+        {
+            if (!Entries.TryGetValue(shortName, out var entry))
+            {
+                entry = new EzRulesetMappingEntry();
+                Entries[shortName] = entry;
+            }
+
+            return entry;
+        }
+
+        public void EnsureDefaults(IEnumerable<DiscoveredExternalRuleset> discovered)
+        {
+            int nextOrder = Entries.Values.Where(e => e.Order.HasValue).Select(e => e.Order!.Value).DefaultIfEmpty(-1).Max() + 1;
+
+            foreach (var ruleset in discovered)
+            {
+                var entry = GetOrAdd(ruleset.ShortName);
+
+                if (EzExternalRulesetMapping.HasExplicitOnlineId(ruleset.InstanceOnlineId))
+                {
+                    entry.OnlineID ??= ruleset.InstanceOnlineId;
+                    entry.Order ??= nextOrder++;
+                }
+            }
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
@@ -1059,6 +1059,36 @@ namespace osu.Game.EzOsuGame.Localization
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ONLINE_PULL_FAILED =
             new EzLocalizationManager.EzLocalisableString("线上成绩下载失败。", "Failed to download online scores.");
 
+        public static readonly EzLocalizationManager.EzLocalisableString EXTERNAL_RULESET_MANAGER =
+            new EzLocalizationManager.EzLocalisableString("外部规则集管理器", "External Ruleset Manager");
+
+        public static readonly EzLocalizationManager.EzLocalisableString EXTERNAL_RULESET_MANAGER_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "管理 rulesets/ 目录下的第三方规则集：启用/禁用加载，以及显式 OnlineID（≥4）的排序与映射。修改后需重启游戏。",
+            "Manage third-party rulesets in rulesets/: enable/disable loading and order explicit OnlineIDs (>=4). Restart required after saving.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString EXTERNAL_RULESET_MANAGER_HEADER =
+            new EzLocalizationManager.EzLocalisableString("外部规则集管理", "External Ruleset Management");
+
+        public static readonly EzLocalizationManager.EzLocalisableString EXTERNAL_RULESET_MANAGER_BODY = new EzLocalizationManager.EzLocalisableString(
+            "仅影响 rulesets/ 目录中的用户 DLL。未定义 OnlineID（-1）的规则集不会被分配新 ID。",
+            "Only affects user DLLs in rulesets/. Rulesets without an explicit OnlineID (-1) are not assigned new IDs.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString EXTERNAL_RULESET_MANAGER_SAVE =
+            new EzLocalizationManager.EzLocalisableString("保存", "Save");
+
+        public static readonly EzLocalizationManager.EzLocalisableString EXTERNAL_RULESET_MANAGER_SAVED =
+            new EzLocalizationManager.EzLocalisableString("外部规则集配置已保存，请重启游戏后生效。", "External ruleset config saved. Restart the game to apply.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString EXTERNAL_RULESET_MANAGER_RESTART_HINT = new EzLocalizationManager.EzLocalisableString(
+            "保存后请重启游戏使配置生效。",
+            "Restart the game after saving to apply changes.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString EXTERNAL_RULESET_NO_DEFINED_ID =
+            new EzLocalizationManager.EzLocalisableString("未定义 ID", "No ID defined");
+
+        public static readonly EzLocalizationManager.EzLocalisableString EXTERNAL_RULESET_ENABLED =
+            new EzLocalizationManager.EzLocalisableString("启用", "Enabled");
+
         #endregion
     }
 }

--- a/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
@@ -1099,6 +1099,13 @@ namespace osu.Game.EzOsuGame.Localization
         public static readonly EzLocalizationManager.EzLocalisableString EXTERNAL_RULESET_ENABLED =
             new EzLocalizationManager.EzLocalisableString("启用", "Enabled");
 
+        public static readonly EzLocalizationManager.EzLocalisableString EXTERNAL_RULESET_ID_LABEL =
+            new EzLocalizationManager.EzLocalisableString("ID", "ID");
+
+        public static readonly EzLocalizationManager.EzLocalisableString EXTERNAL_RULESET_INVALID_ONLINE_ID = new EzLocalizationManager.EzLocalisableString(
+            "OnlineID 必须为 -1 或 ≥4（不能使用 0~3）。",
+            "OnlineID must be -1 or ≥4 (0~3 are reserved).");
+
         #endregion
     }
 }

--- a/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettingsStrings.cs
@@ -1083,6 +1083,16 @@ namespace osu.Game.EzOsuGame.Localization
             "保存后请重启游戏使配置生效。",
             "Restart the game after saving to apply changes.");
 
+        public static readonly EzLocalizationManager.EzLocalisableString EXTERNAL_RULESET_MANAGER_EMPTY = new EzLocalizationManager.EzLocalisableString(
+            "rulesets/ 目录下暂无外部规则集 DLL。\n请将 osu.Game.Rulesets.*.dll 放入该目录后重新打开本窗口。",
+            "No external ruleset DLLs in rulesets/.\nPlace osu.Game.Rulesets.*.dll there, then reopen this window.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString EXTERNAL_RULESET_MANAGER_OPEN_FOLDER =
+            new EzLocalizationManager.EzLocalisableString("打开 rulesets 文件夹", "Open rulesets folder");
+
+        public static readonly EzLocalizationManager.EzLocalisableString EXTERNAL_RULESET_MANAGER_OPEN_FOLDER_FAILED =
+            new EzLocalizationManager.EzLocalisableString("无法打开 rulesets 文件夹。", "Could not open the rulesets folder.");
+
         public static readonly EzLocalizationManager.EzLocalisableString EXTERNAL_RULESET_NO_DEFINED_ID =
             new EzLocalizationManager.EzLocalisableString("未定义 ID", "No ID defined");
 

--- a/osu.Game/EzOsuGame/Overlays/EzExperimentalSettings.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzExperimentalSettings.cs
@@ -34,7 +34,8 @@ namespace osu.Game.EzOsuGame.Overlays
                           INotificationOverlay? notifications,
                           EzLocalProfileService? localProfileService,
                           EzLocalProfileOnlinePullService? onlinePullService,
-                          RulesetStore? rulesetStore)
+                          RulesetStore? rulesetStore,
+                          EzExternalRulesetManagerDialog? externalRulesetManager)
         {
             EzDataRebuildSettingsSection.AddTo(this, backgroundDataStoreProcessor, analysisWarmupProcessor, dialogOverlay, notifications);
 
@@ -59,7 +60,7 @@ namespace osu.Game.EzOsuGame.Overlays
                 Text = EzSettingsStrings.EXTERNAL_RULESET_MANAGER,
                 TooltipText = EzSettingsStrings.EXTERNAL_RULESET_MANAGER_TOOLTIP,
                 Keywords = new[] { "ruleset", "external", "mapping", "onlineid", "第三方", "规则集", "映射", "外部" },
-                Action = () => requestExternalRulesetManager(dialogOverlay, notifications),
+                Action = () => externalRulesetManager?.ShowManager(),
             });
 
             AddRange(new Drawable[]
@@ -256,12 +257,6 @@ namespace osu.Game.EzOsuGame.Overlays
             notification.Progress = 1f;
             notification.CompletionText = EzSettingsStrings.LOCAL_PROFILE_COMPUTE_DONE;
             notification.State = ProgressNotificationState.Completed;
-        }
-
-        private void requestExternalRulesetManager(IDialogOverlay? dialogOverlay, INotificationOverlay? notifications)
-        {
-            dialogOverlay?.Push(new EzExternalRulesetManagerDialog(() =>
-                notifications?.Post(new SimpleNotification { Text = EzSettingsStrings.EXTERNAL_RULESET_MANAGER_SAVED })));
         }
 
         private void requestOnlinePull(

--- a/osu.Game/EzOsuGame/Overlays/EzExperimentalSettings.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzExperimentalSettings.cs
@@ -54,6 +54,14 @@ namespace osu.Game.EzOsuGame.Overlays
                 Action = () => requestOnlinePull(onlinePullService, localProfileService, rulesetStore, dialogOverlay, notifications),
             });
 
+            Add(new SettingsButtonV2
+            {
+                Text = EzSettingsStrings.EXTERNAL_RULESET_MANAGER,
+                TooltipText = EzSettingsStrings.EXTERNAL_RULESET_MANAGER_TOOLTIP,
+                Keywords = new[] { "ruleset", "external", "mapping", "onlineid", "第三方", "规则集", "映射", "外部" },
+                Action = () => requestExternalRulesetManager(dialogOverlay, notifications),
+            });
+
             AddRange(new Drawable[]
             {
                 new SettingsItemV2(new FormCheckBox
@@ -183,7 +191,7 @@ namespace osu.Game.EzOsuGame.Overlays
             var progress = new DirectLocalProfileComputeProgress(notification);
 
             localProfileService.ComputeAsync(selected, replaceIncludedUsernames, progress, notification.CancellationToken)
-                              .ContinueWith(t => finishComputeNotification(t, localProfileService, notification, notifications));
+                               .ContinueWith(t => finishComputeNotification(t, localProfileService, notification, notifications));
         }
 
         /// <summary>
@@ -248,6 +256,12 @@ namespace osu.Game.EzOsuGame.Overlays
             notification.Progress = 1f;
             notification.CompletionText = EzSettingsStrings.LOCAL_PROFILE_COMPUTE_DONE;
             notification.State = ProgressNotificationState.Completed;
+        }
+
+        private void requestExternalRulesetManager(IDialogOverlay? dialogOverlay, INotificationOverlay? notifications)
+        {
+            dialogOverlay?.Push(new EzExternalRulesetManagerDialog(() =>
+                notifications?.Post(new SimpleNotification { Text = EzSettingsStrings.EXTERNAL_RULESET_MANAGER_SAVED })));
         }
 
         private void requestOnlinePull(

--- a/osu.Game/EzOsuGame/Overlays/EzExternalRulesetManagerDialog.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzExternalRulesetManagerDialog.cs
@@ -329,7 +329,7 @@ namespace osu.Game.EzOsuGame.Overlays
 
         private Drawable createRowDrawable(ManagerRow row)
         {
-            // Row shell: left label + right controls (not FillFlow left/right mix).
+            // Row shell: left label + right controls (Container left/right; FillFlow children share CentreLeft).
             var controlsFlow = new FillFlowContainer
             {
                 AutoSizeAxes = Axes.Both,
@@ -345,10 +345,31 @@ namespace osu.Game.EzOsuGame.Overlays
                 {
                     Anchor = Anchor.CentreLeft,
                     Origin = Anchor.CentreLeft,
-                    Text = $"ID {row.OnlineId}",
-                    Font = OsuFont.Default.With(weight: FontWeight.Bold),
+                    Text = EzSettingsStrings.EXTERNAL_RULESET_ID_LABEL,
+                    Font = OsuFont.Default.With(size: 14, weight: FontWeight.Bold),
                 });
 
+                var idBox = new OsuNumberBox
+                {
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    Width = 72,
+                    Height = 30,
+                    Text = row.OnlineId?.ToString() ?? string.Empty,
+                    PlaceholderText = "≥4",
+                };
+
+                row.IdBox = idBox;
+
+                idBox.OnCommit += (sender, _) =>
+                {
+                    if (int.TryParse(sender.Text, out int parsed) && isAllowedOnlineId(parsed))
+                        row.OnlineId = parsed;
+                    else
+                        sender.Text = row.OnlineId?.ToString() ?? string.Empty;
+                };
+
+                controlsFlow.Add(idBox);
                 controlsFlow.Add(createMoveButton(FontAwesome.Solid.ArrowUp, () => moveExplicitRow(row, -1)));
                 controlsFlow.Add(createMoveButton(FontAwesome.Solid.ArrowDown, () => moveExplicitRow(row, 1)));
             }
@@ -460,6 +481,23 @@ namespace osu.Game.EzOsuGame.Overlays
 
         private void save()
         {
+            GetContainingFocusManager()?.ChangeFocus(null);
+
+            foreach (var row in rows.Where(r => r.HasExplicitId))
+            {
+                if (row.IdBox != null && int.TryParse(row.IdBox.Text, out int typed) && isAllowedOnlineId(typed))
+                    row.OnlineId = typed;
+
+                if (row.OnlineId is not int id || !isAllowedOnlineId(id))
+                {
+                    notifications?.Post(new SimpleErrorNotification
+                    {
+                        Text = EzSettingsStrings.EXTERNAL_RULESET_INVALID_ONLINE_ID,
+                    });
+                    return;
+                }
+            }
+
             var config = EzRulesetMappingConfig.Load(storage);
 
             int explicitOrder = 0;
@@ -486,13 +524,17 @@ namespace osu.Game.EzOsuGame.Overlays
             Hide();
         }
 
+        private static bool isAllowedOnlineId(int onlineId)
+            => onlineId == -1 || onlineId >= EzExternalRulesetMapping.EXPLICIT_ONLINE_ID_MINIMUM;
+
         private sealed class ManagerRow
         {
             public DiscoveredExternalRuleset Ruleset { get; }
             public BindableBool Enabled { get; }
             public bool HasExplicitId { get; }
-            public int? OnlineId { get; }
+            public int? OnlineId { get; set; }
             public int Order { get; set; }
+            public OsuNumberBox? IdBox { get; set; }
 
             public ManagerRow(DiscoveredExternalRuleset ruleset, BindableBool enabled, bool hasExplicitId, int? onlineId, int order)
             {

--- a/osu.Game/EzOsuGame/Overlays/EzExternalRulesetManagerDialog.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzExternalRulesetManagerDialog.cs
@@ -1,0 +1,289 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Platform;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.EzOsuGame.ExternalRulesets;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays.Dialog;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.Overlays
+{
+    public partial class EzExternalRulesetManagerDialog : PopupDialog
+    {
+        private const float content_width = 520;
+        private const float row_height = 40;
+
+        private readonly List<ManagerRow> rows = new List<ManagerRow>();
+        private FillFlowContainer rowFlow = null!;
+        private OsuColour colours = null!;
+
+        [Resolved]
+        private Storage storage { get; set; } = null!;
+
+        public EzExternalRulesetManagerDialog(Action onSaved)
+        {
+            Icon = FontAwesome.Solid.PuzzlePiece;
+            HeaderText = EzSettingsStrings.EXTERNAL_RULESET_MANAGER_HEADER;
+            BodyText = EzSettingsStrings.EXTERNAL_RULESET_MANAGER_BODY;
+
+            Buttons = new PopupDialogButton[]
+            {
+                new PopupDialogOkButton
+                {
+                    Text = EzSettingsStrings.EXTERNAL_RULESET_MANAGER_SAVE,
+                    Action = () => save(onSaved),
+                },
+                new PopupDialogCancelButton
+                {
+                    Text = EzSettingsStrings.CANCEL_BUTTON,
+                },
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour loadedColours)
+        {
+            colours = loadedColours;
+            var discovered = EzExternalRulesetScanner.Scan(storage);
+            var config = EzRulesetMappingConfig.Load(storage);
+            config.EnsureDefaults(discovered);
+
+            foreach (var ruleset in discovered)
+            {
+                var entry = config.GetOrAdd(ruleset.ShortName);
+                bool hasExplicitId = EzExternalRulesetMapping.HasExplicitOnlineId(ruleset.InstanceOnlineId)
+                                     || entry.OnlineID is int iniId && iniId >= EzExternalRulesetMapping.EXPLICIT_ONLINE_ID_MINIMUM;
+
+                rows.Add(new ManagerRow(
+                    ruleset,
+                    new BindableBool(entry.Enabled),
+                    hasExplicitId,
+                    hasExplicitId ? entry.OnlineID ?? ruleset.InstanceOnlineId : null,
+                    entry.Order ?? int.MaxValue));
+            }
+
+            rows.Sort((a, b) =>
+            {
+                if (a.HasExplicitId != b.HasExplicitId)
+                    return a.HasExplicitId ? -1 : 1;
+
+                int orderCompare = a.Order.CompareTo(b.Order);
+
+                if (orderCompare != 0)
+                    return orderCompare;
+
+                return string.Compare(a.Ruleset.ShortName, b.Ruleset.ShortName, StringComparison.Ordinal);
+            });
+
+            normaliseExplicitOrder();
+
+            rowFlow = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(0, 6),
+            };
+
+            rebuildRowFlow();
+
+            MainContent.Child = new FillFlowContainer
+            {
+                Margin = new MarginPadding { Top = 12 },
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Width = content_width,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(8),
+                Children = new Drawable[]
+                {
+                    new Container
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Height = Math.Min(280, Math.Max(row_height, rows.Count * (row_height + 6))),
+                        Child = new OsuScrollContainer
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Child = rowFlow,
+                        },
+                    },
+                    new OsuSpriteText
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Text = EzSettingsStrings.EXTERNAL_RULESET_MANAGER_RESTART_HINT,
+                        Font = OsuFont.Default.With(size: 14),
+                        Colour = colours.Yellow,
+                    },
+                },
+            };
+        }
+
+        private void rebuildRowFlow()
+        {
+            rowFlow.Clear();
+
+            foreach (var row in rows)
+                rowFlow.Add(createRowDrawable(row));
+        }
+
+        private Drawable createRowDrawable(ManagerRow row)
+        {
+            var controlsFlow = new FillFlowContainer
+            {
+                AutoSizeAxes = Axes.Both,
+                Direction = FillDirection.Horizontal,
+                Spacing = new Vector2(8),
+                Anchor = Anchor.CentreRight,
+                Origin = Anchor.CentreRight,
+            };
+
+            if (row.HasExplicitId)
+            {
+                controlsFlow.Add(new OsuSpriteText
+                {
+                    Text = $"ID {row.OnlineId}",
+                    Font = OsuFont.Default.With(weight: FontWeight.Bold),
+                });
+
+                controlsFlow.Add(createMoveButton(FontAwesome.Solid.ArrowUp, () => moveExplicitRow(row, -1)));
+                controlsFlow.Add(createMoveButton(FontAwesome.Solid.ArrowDown, () => moveExplicitRow(row, 1)));
+            }
+            else
+            {
+                controlsFlow.Add(new OsuSpriteText
+                {
+                    Text = EzSettingsStrings.EXTERNAL_RULESET_NO_DEFINED_ID,
+                    Font = OsuFont.Default.With(size: 14),
+                    Colour = colours.Gray5,
+                });
+            }
+
+            controlsFlow.Add(new OsuCheckbox
+            {
+                LabelText = EzSettingsStrings.EXTERNAL_RULESET_ENABLED,
+                Current = { BindTarget = row.Enabled },
+            });
+
+            return new Container
+            {
+                RelativeSizeAxes = Axes.X,
+                Height = row_height,
+                Children = new Drawable[]
+                {
+                    new OsuSpriteText
+                    {
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Text = $"{row.Ruleset.Name} ({row.Ruleset.ShortName})",
+                        Font = OsuFont.Default.With(size: 16, weight: FontWeight.Medium),
+                    },
+                    controlsFlow,
+                },
+            };
+        }
+
+        private IconButton createMoveButton(IconUsage icon, Action action)
+        {
+            return new IconButton
+            {
+                Icon = icon,
+                Scale = new Vector2(0.75f),
+                Action = action,
+            };
+        }
+
+        private void moveExplicitRow(ManagerRow row, int delta)
+        {
+            var explicitRows = rows.Where(r => r.HasExplicitId).ToList();
+            int index = explicitRows.IndexOf(row);
+
+            if (index < 0)
+                return;
+
+            int newIndex = index + delta;
+
+            if (newIndex < 0 || newIndex >= explicitRows.Count)
+                return;
+
+            var other = explicitRows[newIndex];
+            (row.Order, other.Order) = (other.Order, row.Order);
+
+            rows.Sort((a, b) =>
+            {
+                if (a.HasExplicitId != b.HasExplicitId)
+                    return a.HasExplicitId ? -1 : 1;
+
+                return a.Order.CompareTo(b.Order);
+            });
+
+            rebuildRowFlow();
+        }
+
+        private void normaliseExplicitOrder()
+        {
+            int order = 0;
+
+            foreach (var row in rows.Where(r => r.HasExplicitId))
+                row.Order = order++;
+        }
+
+        private void save(Action onSaved)
+        {
+            var config = EzRulesetMappingConfig.Load(storage);
+
+            int explicitOrder = 0;
+
+            foreach (var row in rows)
+            {
+                var entry = config.GetOrAdd(row.Ruleset.ShortName);
+                entry.Enabled = row.Enabled.Value;
+
+                if (row.HasExplicitId)
+                {
+                    entry.Order = explicitOrder++;
+                    entry.OnlineID = row.OnlineId;
+                }
+                else
+                {
+                    entry.Order = null;
+                    entry.OnlineID = null;
+                }
+            }
+
+            config.Save(storage);
+            onSaved();
+        }
+
+        private sealed class ManagerRow
+        {
+            public DiscoveredExternalRuleset Ruleset { get; }
+            public BindableBool Enabled { get; }
+            public bool HasExplicitId { get; }
+            public int? OnlineId { get; }
+            public int Order { get; set; }
+
+            public ManagerRow(DiscoveredExternalRuleset ruleset, BindableBool enabled, bool hasExplicitId, int? onlineId, int order)
+            {
+                Ruleset = ruleset;
+                Enabled = enabled;
+                HasExplicitId = hasExplicitId;
+                OnlineId = onlineId;
+                Order = order;
+            }
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Overlays/EzExternalRulesetManagerDialog.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzExternalRulesetManagerDialog.cs
@@ -3,60 +3,285 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Platform;
-using osu.Game.EzOsuGame.Localization;
 using osu.Game.EzOsuGame.ExternalRulesets;
+using osu.Game.EzOsuGame.Localization;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
-using osu.Game.Overlays.Dialog;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Notifications;
 using osuTK;
 
 namespace osu.Game.EzOsuGame.Overlays
 {
-    public partial class EzExternalRulesetManagerDialog : PopupDialog
+    public partial class EzExternalRulesetManagerDialog : OsuFocusedOverlayContainer
     {
-        private const float content_width = 520;
-        private const float row_height = 40;
+        private const float row_height = 44;
+        private const double enter_duration = 500;
+        private const double exit_duration = 200;
+
+        protected override string PopInSampleName => @"UI/overlay-big-pop-in";
+        protected override string PopOutSampleName => @"UI/overlay-big-pop-out";
 
         private readonly List<ManagerRow> rows = new List<ManagerRow>();
+
         private FillFlowContainer rowFlow = null!;
+        private OsuSpriteText emptyHint = null!;
         private OsuColour colours = null!;
 
         [Resolved]
         private Storage storage { get; set; } = null!;
 
-        public EzExternalRulesetManagerDialog(Action onSaved)
-        {
-            Icon = FontAwesome.Solid.PuzzlePiece;
-            HeaderText = EzSettingsStrings.EXTERNAL_RULESET_MANAGER_HEADER;
-            BodyText = EzSettingsStrings.EXTERNAL_RULESET_MANAGER_BODY;
+        [Resolved(CanBeNull = true)]
+        private INotificationOverlay? notifications { get; set; }
 
-            Buttons = new PopupDialogButton[]
-            {
-                new PopupDialogOkButton
-                {
-                    Text = EzSettingsStrings.EXTERNAL_RULESET_MANAGER_SAVE,
-                    Action = () => save(onSaved),
-                },
-                new PopupDialogCancelButton
-                {
-                    Text = EzSettingsStrings.CANCEL_BUTTON,
-                },
-            };
+        public EzExternalRulesetManagerDialog()
+        {
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+
+            RelativeSizeAxes = Axes.Both;
+            Size = new Vector2(0.55f, 0.72f);
+
+            Masking = true;
+            CornerRadius = 10;
+        }
+
+        public void ShowManager()
+        {
+            if (IsLoaded)
+                refreshEntries();
+
+            Show();
         }
 
         [BackgroundDependencyLoader]
         private void load(OsuColour loadedColours)
         {
             colours = loadedColours;
+
+            Children = new Drawable[]
+            {
+                new Box
+                {
+                    Colour = colours.GreySeaFoamDark,
+                    RelativeSizeAxes = Axes.Both,
+                },
+                new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = new GridContainer
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        RowDimensions = new[]
+                        {
+                            new Dimension(GridSizeMode.AutoSize),
+                            new Dimension(),
+                            new Dimension(GridSizeMode.AutoSize),
+                        },
+                        Content = new[]
+                        {
+                            new Drawable[]
+                            {
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    Children = new Drawable[]
+                                    {
+                                        new FillFlowContainer
+                                        {
+                                            RelativeSizeAxes = Axes.X,
+                                            AutoSizeAxes = Axes.Y,
+                                            Direction = FillDirection.Vertical,
+                                            Padding = new MarginPadding { Vertical = 12, Horizontal = 20 },
+                                            Spacing = new Vector2(0, 4),
+                                            Children = new Drawable[]
+                                            {
+                                                new OsuSpriteText
+                                                {
+                                                    Anchor = Anchor.TopCentre,
+                                                    Origin = Anchor.TopCentre,
+                                                    Text = EzSettingsStrings.EXTERNAL_RULESET_MANAGER_HEADER,
+                                                    Font = OsuFont.GetFont(size: 28),
+                                                },
+                                                new OsuSpriteText
+                                                {
+                                                    Anchor = Anchor.TopCentre,
+                                                    Origin = Anchor.TopCentre,
+                                                    Text = EzSettingsStrings.EXTERNAL_RULESET_MANAGER_BODY,
+                                                    Font = OsuFont.Default.With(size: 14),
+                                                    Colour = colours.Yellow,
+                                                },
+                                            },
+                                        },
+                                        new IconButton
+                                        {
+                                            Anchor = Anchor.TopRight,
+                                            Origin = Anchor.TopRight,
+                                            Icon = FontAwesome.Solid.Times,
+                                            Colour = colours.GreySeaFoamDarker,
+                                            Scale = new Vector2(0.8f),
+                                            Margin = new MarginPadding { Top = 10, Right = 10 },
+                                            Action = Hide,
+                                        },
+                                    },
+                                },
+                            },
+                            new Drawable[]
+                            {
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Padding = new MarginPadding { Horizontal = 12 },
+                                    Masking = true,
+                                    CornerRadius = 10,
+                                    Children = new Drawable[]
+                                    {
+                                        new Box
+                                        {
+                                            RelativeSizeAxes = Axes.Both,
+                                            Colour = colours.GreySeaFoamDarker,
+                                        },
+                                        new Container
+                                        {
+                                            RelativeSizeAxes = Axes.Both,
+                                            Padding = new MarginPadding(10),
+                                            Children = new Drawable[]
+                                            {
+                                                emptyHint = new OsuSpriteText
+                                                {
+                                                    Anchor = Anchor.Centre,
+                                                    Origin = Anchor.Centre,
+                                                    Text = EzSettingsStrings.EXTERNAL_RULESET_MANAGER_EMPTY,
+                                                    Font = OsuFont.Default.With(size: 16),
+                                                    Colour = colours.Gray5,
+                                                    Alpha = 0,
+                                                },
+                                                new OsuScrollContainer
+                                                {
+                                                    RelativeSizeAxes = Axes.Both,
+                                                    Child = rowFlow = new FillFlowContainer
+                                                    {
+                                                        RelativeSizeAxes = Axes.X,
+                                                        AutoSizeAxes = Axes.Y,
+                                                        Direction = FillDirection.Vertical,
+                                                        Spacing = new Vector2(0, 8),
+                                                    },
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                            new Drawable[]
+                            {
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    Padding = new MarginPadding(12),
+                                    Child = new FillFlowContainer
+                                    {
+                                        RelativeSizeAxes = Axes.X,
+                                        AutoSizeAxes = Axes.Y,
+                                        Direction = FillDirection.Vertical,
+                                        Spacing = new Vector2(0, 8),
+                                        Children = new Drawable[]
+                                        {
+                                            new OsuSpriteText
+                                            {
+                                                RelativeSizeAxes = Axes.X,
+                                                Text = EzSettingsStrings.EXTERNAL_RULESET_MANAGER_RESTART_HINT,
+                                                Font = OsuFont.Default.With(size: 13),
+                                                Colour = colours.Yellow,
+                                            },
+                                            new GridContainer
+                                            {
+                                                RelativeSizeAxes = Axes.X,
+                                                AutoSizeAxes = Axes.Y,
+                                                RowDimensions = new[]
+                                                {
+                                                    new Dimension(GridSizeMode.AutoSize),
+                                                },
+                                                ColumnDimensions = new[]
+                                                {
+                                                    new Dimension(),
+                                                    new Dimension(),
+                                                    new Dimension(),
+                                                },
+                                                Content = new[]
+                                                {
+                                                    new Drawable[]
+                                                    {
+                                                        new RoundedButton
+                                                        {
+                                                            RelativeSizeAxes = Axes.X,
+                                                            Height = 40,
+                                                            Text = EzSettingsStrings.EXTERNAL_RULESET_MANAGER_OPEN_FOLDER,
+                                                            Action = openRulesetsFolder,
+                                                        },
+                                                        new RoundedButton
+                                                        {
+                                                            RelativeSizeAxes = Axes.X,
+                                                            Height = 40,
+                                                            Text = EzSettingsStrings.EXTERNAL_RULESET_MANAGER_SAVE,
+                                                            Action = save,
+                                                        },
+                                                        new RoundedButton
+                                                        {
+                                                            RelativeSizeAxes = Axes.X,
+                                                            Height = 40,
+                                                            Text = EzSettingsStrings.CANCEL_BUTTON,
+                                                            Action = Hide,
+                                                        },
+                                                    },
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            refreshEntries();
+        }
+
+        protected override void PopIn()
+        {
+            refreshEntries();
+            this.FadeIn(enter_duration, Easing.OutQuint);
+            this.ScaleTo(1, enter_duration, Easing.OutQuint);
+        }
+
+        protected override void PopOut()
+        {
+            this.FadeOut(exit_duration, Easing.OutQuint);
+            this.ScaleTo(0.95f, exit_duration, Easing.OutQuint);
+        }
+
+        private void refreshEntries()
+        {
+            rows.Clear();
+
             var discovered = EzExternalRulesetScanner.Scan(storage);
             var config = EzRulesetMappingConfig.Load(storage);
             config.EnsureDefaults(discovered);
@@ -89,47 +314,7 @@ namespace osu.Game.EzOsuGame.Overlays
             });
 
             normaliseExplicitOrder();
-
-            rowFlow = new FillFlowContainer
-            {
-                RelativeSizeAxes = Axes.X,
-                AutoSizeAxes = Axes.Y,
-                Direction = FillDirection.Vertical,
-                Spacing = new Vector2(0, 6),
-            };
-
             rebuildRowFlow();
-
-            MainContent.Child = new FillFlowContainer
-            {
-                Margin = new MarginPadding { Top = 12 },
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Width = content_width,
-                AutoSizeAxes = Axes.Y,
-                Direction = FillDirection.Vertical,
-                Spacing = new Vector2(8),
-                Children = new Drawable[]
-                {
-                    new Container
-                    {
-                        RelativeSizeAxes = Axes.X,
-                        Height = Math.Min(280, Math.Max(row_height, rows.Count * (row_height + 6))),
-                        Child = new OsuScrollContainer
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            Child = rowFlow,
-                        },
-                    },
-                    new OsuSpriteText
-                    {
-                        RelativeSizeAxes = Axes.X,
-                        Text = EzSettingsStrings.EXTERNAL_RULESET_MANAGER_RESTART_HINT,
-                        Font = OsuFont.Default.With(size: 14),
-                        Colour = colours.Yellow,
-                    },
-                },
-            };
         }
 
         private void rebuildRowFlow()
@@ -138,10 +323,13 @@ namespace osu.Game.EzOsuGame.Overlays
 
             foreach (var row in rows)
                 rowFlow.Add(createRowDrawable(row));
+
+            emptyHint.Alpha = rows.Count == 0 ? 1 : 0;
         }
 
         private Drawable createRowDrawable(ManagerRow row)
         {
+            // Row shell: left label + right controls (not FillFlow left/right mix).
             var controlsFlow = new FillFlowContainer
             {
                 AutoSizeAxes = Axes.Both,
@@ -155,6 +343,8 @@ namespace osu.Game.EzOsuGame.Overlays
             {
                 controlsFlow.Add(new OsuSpriteText
                 {
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
                     Text = $"ID {row.OnlineId}",
                     Font = OsuFont.Default.With(weight: FontWeight.Bold),
                 });
@@ -166,6 +356,8 @@ namespace osu.Game.EzOsuGame.Overlays
             {
                 controlsFlow.Add(new OsuSpriteText
                 {
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
                     Text = EzSettingsStrings.EXTERNAL_RULESET_NO_DEFINED_ID,
                     Font = OsuFont.Default.With(size: 14),
                     Colour = colours.Gray5,
@@ -174,6 +366,8 @@ namespace osu.Game.EzOsuGame.Overlays
 
             controlsFlow.Add(new OsuCheckbox
             {
+                Anchor = Anchor.CentreLeft,
+                Origin = Anchor.CentreLeft,
                 LabelText = EzSettingsStrings.EXTERNAL_RULESET_ENABLED,
                 Current = { BindTarget = row.Enabled },
             });
@@ -200,6 +394,8 @@ namespace osu.Game.EzOsuGame.Overlays
         {
             return new IconButton
             {
+                Anchor = Anchor.CentreLeft,
+                Origin = Anchor.CentreLeft,
                 Icon = icon,
                 Scale = new Vector2(0.75f),
                 Action = action,
@@ -241,7 +437,28 @@ namespace osu.Game.EzOsuGame.Overlays
                 row.Order = order++;
         }
 
-        private void save(Action onSaved)
+        private void openRulesetsFolder()
+        {
+            string path = storage.GetStorageForDirectory(@"rulesets").GetFullPath(@".");
+
+            try
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = path,
+                    UseShellExecute = true,
+                });
+            }
+            catch (Exception)
+            {
+                notifications?.Post(new SimpleErrorNotification
+                {
+                    Text = EzSettingsStrings.EXTERNAL_RULESET_MANAGER_OPEN_FOLDER_FAILED,
+                });
+            }
+        }
+
+        private void save()
         {
             var config = EzRulesetMappingConfig.Load(storage);
 
@@ -265,7 +482,8 @@ namespace osu.Game.EzOsuGame.Overlays
             }
 
             config.Save(storage);
-            onSaved();
+            notifications?.Post(new SimpleNotification { Text = EzSettingsStrings.EXTERNAL_RULESET_MANAGER_SAVED });
+            Hide();
         }
 
         private sealed class ManagerRow

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1289,6 +1289,7 @@ namespace osu.Game
             loadComponentSingleFile(FirstRunOverlay = new FirstRunSetupOverlay(), footerBasedOverlayContent.Add, true);
             loadComponentSingleFile(new ManageCollectionsDialog(), overlayContent.Add, true);
             loadComponentSingleFile(new EzManageSongsBranchesDialog(), overlayContent.Add, true);
+            loadComponentSingleFile(new EzExternalRulesetManagerDialog(), overlayContent.Add, true);
             loadComponentSingleFile(new EzFontSettingsOverlay(), topMostOverlayContent.Add, true);
             loadComponentSingleFile(beatmapListing = new BeatmapListingOverlay(), overlayContent.Add, true);
             loadComponentSingleFile(dashboard = new DashboardOverlay(), overlayContent.Add, true);

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -54,6 +54,7 @@ using osu.Game.EzOsuGame.Input;
 using osu.Game.EzOsuGame.LocalProfile;
 using osu.Game.EzOsuGame.Online;
 using osu.Game.EzOsuGame.Scoring;
+using osu.Game.EzOsuGame.ExternalRulesets;
 using osu.Game.Localisation;
 using osu.Game.Online;
 using osu.Game.Online.API;
@@ -347,7 +348,7 @@ namespace osu.Game
 
             dependencies.Cache(realm = new RealmAccess(Storage, CLIENT_DATABASE_FILENAME, Host.UpdateThread));
 
-            dependencies.CacheAs<RulesetStore>(RulesetStore = new RealmRulesetStore(realm, Storage));
+            dependencies.CacheAs<RulesetStore>(RulesetStore = new EzRealmRulesetStore(realm, Storage));
             dependencies.CacheAs<IRulesetStore>(RulesetStore);
 
             Decoder.RegisterDependencies(RulesetStore);

--- a/osu.Game/Rulesets/RealmRulesetStore.cs
+++ b/osu.Game/Rulesets/RealmRulesetStore.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using Realms;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
@@ -25,11 +26,11 @@ namespace osu.Game.Rulesets
             : base(storage)
         {
             this.realmAccess = realmAccess;
-            prepareDetachedRulesets();
+            PrepareDetachedRulesets();
             informUserAboutBrokenRulesets();
         }
 
-        private void prepareDetachedRulesets()
+        protected virtual void PrepareDetachedRulesets()
         {
             realmAccess.Write(realm =>
             {
@@ -67,6 +68,8 @@ namespace osu.Game.Rulesets
                     }
                 }
 
+                OnBeforeRulesetValidation(realm, rulesets, instances);
+
                 List<RulesetInfo> detachedRulesets = new List<RulesetInfo>();
 
                 // perform a consistency check and detach final rulesets from realm for cross-thread runtime usage.
@@ -74,6 +77,12 @@ namespace osu.Game.Rulesets
                 {
                     try
                     {
+                        if (ShouldDisableRuleset(r))
+                        {
+                            r.Available = false;
+                            continue;
+                        }
+
                         var resolvedType = Type.GetType(r.InstantiationInfo);
 
                         if (resolvedType == null)
@@ -93,10 +102,12 @@ namespace osu.Game.Rulesets
                                 $"Ruleset API version is too old (was {instance.RulesetAPIVersionSupported}, expected {Ruleset.CURRENT_RULESET_API_VERSION})");
                         }
 
-                        if (r.OnlineID != instanceInfo.OnlineID)
+                        if (!ShouldAllowOnlineIdMismatch(r, instance, instanceInfo.OnlineID) && r.OnlineID != instanceInfo.OnlineID)
                             throw new InvalidOperationException($@"Online ID mismatch for ruleset {r.ShortName}: database has {r.OnlineID}, constructed instance has {instanceInfo.OnlineID}");
 
-                        if (r.OnlineID > 0 && rulesets.Any(otherRuleset => otherRuleset.ShortName != r.ShortName && otherRuleset.OnlineID == r.OnlineID))
+                        if (!ShouldSkipDuplicateOnlineIdCheck(r, r.OnlineID, rulesets)
+                            && r.OnlineID > 0
+                            && rulesets.Any(otherRuleset => otherRuleset.ShortName != r.ShortName && otherRuleset.OnlineID == r.OnlineID))
                             throw new InvalidOperationException($@"Ruleset {r.ShortName} shares online ID {r.OnlineID} with another ruleset");
 
                         // If a ruleset isn't up-to-date with the API, it could cause a crash at an arbitrary point of execution.
@@ -122,6 +133,16 @@ namespace osu.Game.Rulesets
                 availableRulesets.AddRange(detachedRulesets.Order());
             });
         }
+
+        protected virtual void OnBeforeRulesetValidation(Realm realm, IQueryable<RulesetInfo> rulesets, List<Ruleset> instances)
+        {
+        }
+
+        protected virtual bool ShouldDisableRuleset(RulesetInfo ruleset) => false;
+
+        protected virtual bool ShouldAllowOnlineIdMismatch(RulesetInfo ruleset, Ruleset instance, int instanceOnlineId) => false;
+
+        protected virtual bool ShouldSkipDuplicateOnlineIdCheck(RulesetInfo ruleset, int onlineId, IQueryable<RulesetInfo> allRulesets) => false;
 
         private bool checkRulesetUpToDate(Ruleset instance)
         {

--- a/osu.Game/Rulesets/RulesetStore.cs
+++ b/osu.Game/Rulesets/RulesetStore.cs
@@ -19,6 +19,13 @@ namespace osu.Game.Rulesets
 
         protected readonly Dictionary<Assembly, Type> LoadedAssemblies = new Dictionary<Assembly, Type>();
         protected readonly HashSet<Assembly> UserRulesetAssemblies = new HashSet<Assembly>();
+
+        /// <summary>
+        /// Game configuration root storage (same level as <c>client.realm</c>), if provided.
+        /// Available during the base constructor — before derived fields are assigned.
+        /// </summary>
+        protected readonly Storage? GameStorage;
+
         protected readonly Storage? RulesetStorage;
 
         /// <summary>
@@ -28,6 +35,8 @@ namespace osu.Game.Rulesets
 
         protected RulesetStore(Storage? storage = null)
         {
+            GameStorage = storage;
+
             // On android in release configuration assemblies are loaded from the apk directly into memory.
             // We cannot read assemblies from cwd, so should check loaded assemblies instead.
             loadFromAppDomain();
@@ -61,6 +70,8 @@ namespace osu.Game.Rulesets
         /// <param name="shortName">The ruleset's short name.</param>
         /// <returns>A ruleset, if available, else null.</returns>
         public RulesetInfo? GetRuleset(string shortName) => AvailableRulesets.FirstOrDefault(r => r.ShortName == shortName);
+
+        public bool IsUserRulesetAssembly(Assembly assembly) => UserRulesetAssemblies.Contains(assembly);
 
         private Assembly? resolveRulesetDependencyAssembly(object? sender, ResolveEventArgs args)
         {


### PR DESCRIPTION
## Summary
- 启动时对 `rulesets/` 用户 DLL 做 OnlineID 冲突消解：仅处理显式 ID（≥4），未定义（-1）不动；冲突时后加载者 remap 到空闲 ≥4，并写入 `EzRulesetMapping.ini`（与 client.realm 同级）。
- 实验性功能增加「外部规则集管理器」面板：启用/禁用、编辑 OnlineID、排序；保存后需重启生效。
- `EzRealmRulesetStore` 接管规则集加载；`RealmRulesetStore` 仅增加可覆写钩子。

## Test plan
- [x] Debug 启动无 NRE；配置目录生成/读取 `EzRulesetMapping.ini`
- [ ] 放入两个显式同 OnlineID 的外部 DLL，启动后后加载者被 remap，ini 有记录
- [ ] 未定义 ID（-1）的外部规则集保持 -1，管理器显示「未定义 ID」
- [ ] 管理器可改启用开关与 OnlineID（非法 0~3 拒绝保存），保存提示重启
- [ ] 重启后禁用项不出现在 AvailableRulesets；改过的 ID 生效