### PR TITLE
Fix drill score list: dedupe per beatmap (best PP) and show real play…

### DIFF
--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileScoreDetailPanels.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileScoreDetailPanels.cs
@@ -459,7 +459,10 @@ namespace osu.Game.EzOsuGame.LocalProfile
             beatmapCard.Update(row);
             var displayData = EzLocalProfileScoreDisplayData.From(row, EzLocalProfileDrillMods.Resolve(row, rulesets));
             scoreRow.Update(displayData);
-            keysRow.UpdateRow(row, displayData);
+
+            // 「成绩数」= 该谱面（BeatmapId）在全部成绩中的游玩次数。
+            int playCount = allScores.Count(s => s.BeatmapId == row.BeatmapId);
+            keysRow.UpdateRow(row, displayData, playCount);
             beatmapPerformance.Update(row, allScores);
         }
     }

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileScoreDrill.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileScoreDrill.cs
@@ -61,6 +61,28 @@ namespace osu.Game.EzOsuGame.LocalProfile
             return results;
         }
 
+        /// <summary>
+        /// 每张谱面（BeatmapId）只保留最高 PP 的一条，用于成绩记录列表展示。
+        /// 输入假定已按 PP 降序；对无序输入先按 PP 降序排列。
+        /// </summary>
+        public static List<EzLocalProfileDrillScoreRow> BestPerBeatmap(IEnumerable<EzLocalProfileDrillScoreRow> scores)
+        {
+            var ordered = scores.OrderByDescending(s => s.PpResolved).ToList();
+            var seen = new HashSet<Guid>();
+
+            var result = new List<EzLocalProfileDrillScoreRow>();
+
+            foreach (var row in ordered)
+            {
+                if (!seen.Add(row.BeatmapId))
+                    continue;
+
+                result.Add(row);
+            }
+
+            return result;
+        }
+
         private static bool matchesSearch(EzLocalProfileDrillScoreRow row, string term)
         {
             if (double.TryParse(term, NumberStyles.Float, CultureInfo.InvariantCulture, out double ppTarget)
@@ -191,12 +213,16 @@ namespace osu.Game.EzOsuGame.LocalProfile
         private void applyFilter()
         {
             var filtered = EzLocalProfileScoreDrillQuery.Filter(allScores, searchQuery.Value);
-            bool hasMatches = filtered.Count > 0;
+
+            // 成绩记录列表按谱面去重（每谱面最高 PP 一条）；详情列仍用全量 allScores 聚合 max/min/avg。
+            var bestPerBeatmap = EzLocalProfileScoreDrillQuery.BestPerBeatmap(filtered);
+
+            bool hasMatches = bestPerBeatmap.Count > 0;
 
             noMatchesText.Alpha = hasMatches ? 0 : 1;
             resultsGrid.Alpha = hasMatches ? 1 : 0;
 
-            selector.SetScores(filtered);
+            selector.SetScores(bestPerBeatmap);
         }
     }
 

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileScoreKeysRow.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileScoreKeysRow.cs
@@ -23,7 +23,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
             Spacing = new Vector2(8);
         }
 
-        public void UpdateRow(EzLocalProfileDrillScoreRow? row, EzLocalProfileScoreDisplayData? data = null)
+        public void UpdateRow(EzLocalProfileDrillScoreRow? row, EzLocalProfileScoreDisplayData? data = null, int? playCount = null)
         {
             Clear();
 
@@ -52,7 +52,9 @@ namespace osu.Game.EzOsuGame.LocalProfile
             Add(createChip(EzSettingsProfile.LOCAL_PROFILE_TOTAL_KEYS, row.TotalKeys.ToString("N0", CultureInfo.InvariantCulture)));
             Add(createChip(EzSettingsProfile.LOCAL_PROFILE_AVG_KPS, avgKps));
             Add(createChip(EzSettingsProfile.LOCAL_PROFILE_MAX_KPS, maxKps));
-            Add(createChip(EzSettingsProfile.LOCAL_PROFILE_SCORE_COUNT, "1"));
+
+            if (playCount is int count && count > 0)
+                Add(createChip(EzSettingsProfile.LOCAL_PROFILE_SCORE_COUNT, count.ToString("N0")));
         }
 
         private static Drawable createChip(LocalisableString title, string value)


### PR DESCRIPTION
… count

- BestPerBeatmap keeps the highest-PP row per BeatmapId for the score-record selector list.
- ScoreKeysRow shows the real number of plays for that beatmap instead of a hardcoded 1.
- Score detail column still aggregates PP/ACC/Offset max/min/avg over the full set of plays.