### PR TITLE
Add mania skill Realm foundation (Ez schema v8)

### DIFF
--- a/osu.Game.Tests/EzOsuGame/Skills/EzMinaCalcFacadeTest.cs
+++ b/osu.Game.Tests/EzOsuGame/Skills/EzMinaCalcFacadeTest.cs
@@ -1,0 +1,145 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.EzOsuGame.Skills;
+using MinaCalc;
+
+namespace osu.Game.Tests.EzOsuGame.Skills
+{
+    [TestFixture]
+    public class EzMinaCalcFacadeTest
+    {
+        [Test]
+        public void Msd_is_stable_and_goal_insensitive()
+        {
+            var notes = createStreamNotes();
+
+            using var calc = new EzMinaCalcFacade();
+            var a = calc.CalculateMsd(notes, 1f);
+            var b = calc.CalculateMsd(notes, 1f);
+
+            Assert.That(a.Overall, Is.GreaterThan(0));
+            Assert.That(a.Overall, Is.EqualTo(b.Overall).Within(1e-4));
+            Assert.That(a.Stream, Is.GreaterThan(0));
+        }
+
+        [Test]
+        public void Ssr_increases_with_higher_goal()
+        {
+            var notes = createStreamNotes();
+
+            using var calc = new EzMinaCalcFacade();
+            var low = calc.CalculateSsr(notes, 1f, 0.93f);
+            var high = calc.CalculateSsr(notes, 1f, 0.99f);
+
+            Assert.That(high.Overall, Is.GreaterThan(low.Overall));
+        }
+
+        [Test]
+        public void Msd_and_ssr_are_distinct_modes()
+        {
+            var notes = createStreamNotes();
+
+            using var calc = new EzMinaCalcFacade();
+            var msd = calc.CalculateMsd(notes, 1f);
+            var ssr = calc.CalculateSsr(notes, 1f, 0.93f);
+
+            // Same notes: modes must not produce identical vectors (proves we did not call one path for both).
+            Assert.That(Math.Abs(msd.Overall - ssr.Overall), Is.GreaterThan(0.01));
+        }
+
+        [Test]
+        public void Engine_version_is_positive()
+        {
+            Assert.That(EzMinaCalcFacade.EngineVersion, Is.GreaterThan(0));
+        }
+
+        private static MinaCalcNote[] createStreamNotes()
+        {
+            var notes = new MinaCalcNote[32];
+
+            for (int i = 0; i < notes.Length; i++)
+            {
+                notes[i] = new MinaCalcNote
+                {
+                    Notes = 1u << (i % 4),
+                    RowTime = i * 0.1f,
+                };
+            }
+
+            return notes;
+        }
+    }
+
+    [TestFixture]
+    public class EzSsrAggregatorTest
+    {
+        [Test]
+        public void Aggregate_empty_returns_zero()
+        {
+            Assert.That(EzSsrAggregator.Aggregate(Array.Empty<double>()), Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Aggregate_single_value_near_input()
+        {
+            double rating = EzSsrAggregator.Aggregate(new[] { 20.0 });
+            Assert.That(rating, Is.GreaterThan(10));
+            Assert.That(rating, Is.LessThan(25));
+            // Etterna AggregateSSRs with a single sample sits slightly below the raw SSR after scaler/rounding.
+            Assert.That(rating, Is.EqualTo(20 * 1.04).Within(6));
+        }
+
+        [Test]
+        public void Aggregate_vectors_fills_each_axis()
+        {
+            var plays = new[]
+            {
+                new EzSkillsetVector(10, 9, 8, 7, 6, 5, 4, 3),
+                new EzSkillsetVector(12, 11, 10, 9, 8, 7, 6, 5),
+            };
+
+            var result = EzSsrAggregator.AggregateVectors(plays);
+            Assert.That(result.Overall, Is.GreaterThan(0));
+            Assert.That(result.Stream, Is.GreaterThan(0));
+            Assert.That(result.Technical, Is.GreaterThan(0));
+        }
+    }
+
+    [TestFixture]
+    public class EzSkillRegistryTest
+    {
+        [Test]
+        public void Default_systems_keep_msd_ssr_and_dan_separate()
+        {
+            var registry = new EzSkillRegistry();
+
+            Assert.That(registry.GetSystem(EzSkillSystems.BEATMAP_MSD), Is.Not.Null);
+            Assert.That(registry.GetSystem(EzSkillSystems.PLAYER_SSR), Is.Not.Null);
+            Assert.That(registry.GetSystem(EzSkillSystems.DAN), Is.Not.Null);
+
+            Assert.That(registry.AllSkills.Any(s => s.SkillId.StartsWith($"{EzSkillSystems.BEATMAP_MSD}.", StringComparison.Ordinal)));
+            Assert.That(registry.AllSkills.Any(s => s.SkillId.StartsWith($"{EzSkillSystems.PLAYER_SSR}.", StringComparison.Ordinal)));
+            Assert.That(registry.AllSkills.Any(s => s.SkillId.StartsWith($"{EzSkillSystems.DAN}.", StringComparison.Ordinal)));
+
+            // No skill id is shared across systems.
+            var ids = registry.AllSkills.Select(s => s.SkillId).ToList();
+            Assert.That(ids.Distinct().Count(), Is.EqualTo(ids.Count));
+        }
+    }
+
+    [TestFixture]
+    public class EzMinaNoteConverterTest
+    {
+        [Test]
+        public void Convert_empty_beatmap_returns_empty()
+        {
+            var beatmap = new Beatmap();
+            Assert.That(EzMinaNoteConverter.Convert(beatmap), Is.Empty);
+        }
+    }
+}

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -113,15 +113,17 @@ namespace osu.Game.Database
         /// Ez2Lazer schema revision. Bump when adding Ez-persisted fields; do not change <see cref="schema_version"/> for Ez-only work.
         ///
         /// Ez2Lazer-only revisions are tracked separately via <see cref="EZ_REALM_SCHEMA_VERSION"/>.
-        /// The on-disk Realm schema version is <see cref="EzFileSchemaVersion"/> (schema_version * 1000 + EZ_REALM_SCHEMA_VERSION, currently 52007).
+        /// The on-disk Realm schema version is <see cref="EzFileSchemaVersion"/> (schema_version * 1000 + EZ_REALM_SCHEMA_VERSION, currently 52008).
         /// Ez v1: Add ScoreInfo.ManiaHitMode and ManiaHealthMode.
         /// Ez v2: Add BeatmapInfo.HasVideo and HasStoryboard.
         /// Ez v3: Add BeatmapInfo.XxyStarRating.
         /// Ez v4: Add BeatmapInfo.PerformancePoints.
         /// Ez v5: Change BeatmapInfo.HasVideo/HasStoryboard to nullable (null = unknown).
         /// Ez v6: Add RulesetInfo.LastAppliedXxySrVersion.
+        /// Ez v7: Normalize BeatmapSetInfo external hosting paths.
+        /// Ez v8: Add EzBeatmapSkillValue / EzPlayerSkillValue / EzDanEstimate; RulesetInfo.LastAppliedManiaSkillVersion.
         /// </summary>
-        public const int EZ_REALM_SCHEMA_VERSION = 7;
+        public const int EZ_REALM_SCHEMA_VERSION = 8;
 
         public static int EzFileSchemaVersion => schema_version * 1000 + EZ_REALM_SCHEMA_VERSION;
 
@@ -1561,6 +1563,13 @@ namespace osu.Game.Database
                         if (set.HostingKind == BeatmapSetHostingKind.External && !string.IsNullOrWhiteSpace(set.ExternalContentRoot))
                             set.ExternalContentRoot = Path.GetFullPath(set.ExternalContentRoot);
                     }
+
+                    break;
+
+                case 8:
+                    // New skill RealmObjects start empty. Mark mania skill algorithm as unset on rulesets.
+                    foreach (var ruleset in migration.NewRealm.All<RulesetInfo>())
+                        ruleset.LastAppliedManiaSkillVersion = 0;
 
                     break;
             }

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -121,7 +121,8 @@ namespace osu.Game.Database
         /// Ez v5: Change BeatmapInfo.HasVideo/HasStoryboard to nullable (null = unknown).
         /// Ez v6: Add RulesetInfo.LastAppliedXxySrVersion.
         /// Ez v7: Normalize BeatmapSetInfo external hosting paths.
-        /// Ez v8: Add EzBeatmapSkillValue / EzPlayerSkillValue / EzDanEstimate; RulesetInfo.LastAppliedManiaSkillVersion.
+        /// Ez v8: Add mania skill RealmObjects (EzBeatmapSkillValue, EzPlayerSkillValue, EzDanEstimate,
+        /// EzPlayerSkillHistoryPoint) with extended dan/provisional fields; RulesetInfo.LastAppliedManiaSkillVersion.
         /// </summary>
         public const int EZ_REALM_SCHEMA_VERSION = 8;
 
@@ -1567,7 +1568,8 @@ namespace osu.Game.Database
                     break;
 
                 case 8:
-                    // New skill RealmObjects start empty. Mark mania skill algorithm as unset on rulesets.
+                    // Skill tables are new and start empty. Mark mania skill algorithm as unset on rulesets.
+                    // Extended columns (Provisional/Stale, dan course fields, history points, BeatmapId) use defaults.
                     foreach (var ruleset in migration.NewRealm.All<RulesetInfo>())
                         ruleset.LastAppliedManiaSkillVersion = 0;
 

--- a/osu.Game/EzOsuGame/Skills/BeatmapMsdSkillSystem.cs
+++ b/osu.Game/EzOsuGame/Skills/BeatmapMsdSkillSystem.cs
@@ -1,0 +1,60 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    /// <summary>
+    /// Chart-side MinaCalc MSD axes. Each axis is an independent skill (not one blob).
+    /// </summary>
+    public sealed class BeatmapMsdSkillSystem : IEzSkillSystem
+    {
+        public string SystemId => EzSkillSystems.BEATMAP_MSD;
+
+        public IReadOnlyList<EzSkillDefinition> Skills { get; } = createSkills();
+
+        private static IReadOnlyList<EzSkillDefinition> createSkills()
+        {
+            var list = new List<EzSkillDefinition>(EzSkillIds.MINA_SKILLSETS.Length);
+
+            foreach (string axis in EzSkillIds.MINA_SKILLSETS)
+            {
+                list.Add(new EzSkillDefinition(
+                    EzSkillSystems.BEATMAP_MSD,
+                    EzSkillIds.Msd(axis),
+                    axisDisplay(axis),
+                    EzSkillScope.Beatmap,
+                    accent(axis)));
+            }
+
+            return list;
+        }
+
+        private static string axisDisplay(string axis) => axis switch
+        {
+            EzSkillIds.OVERALL => "Overall",
+            EzSkillIds.STREAM => "Stream",
+            EzSkillIds.JUMPSTREAM => "Jumpstream",
+            EzSkillIds.HANDSTREAM => "Handstream",
+            EzSkillIds.STAMINA => "Stamina",
+            EzSkillIds.JACK_SPEED => "Jackspeed",
+            EzSkillIds.CHORDJACK => "Chordjack",
+            EzSkillIds.TECHNICAL => "Technical",
+            _ => axis,
+        };
+
+        private static string accent(string axis) => axis switch
+        {
+            EzSkillIds.OVERALL => "#c9cfdd",
+            EzSkillIds.STREAM => "#8f6bd8",
+            EzSkillIds.JUMPSTREAM => "#6f87d8",
+            EzSkillIds.HANDSTREAM => "#b06bc0",
+            EzSkillIds.STAMINA => "#ad6b5d",
+            EzSkillIds.JACK_SPEED => "#c66f84",
+            EzSkillIds.CHORDJACK => "#c59a5c",
+            EzSkillIds.TECHNICAL => "#83a86f",
+            _ => "#8f6bd8",
+        };
+    }
+}

--- a/osu.Game/EzOsuGame/Skills/DanSkillSystem.cs
+++ b/osu.Game/EzOsuGame/Skills/DanSkillSystem.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    /// <summary>
+    /// Independent dan estimate system (LeoBlack / course clears). Stub skills only until estimator is ported.
+    /// Must not be mixed into MSD/SSR aggregation.
+    /// </summary>
+    public sealed class DanSkillSystem : IEzSkillSystem
+    {
+        public const string SIDE_RC = "rc";
+        public const string SIDE_LN = "ln";
+
+        private static readonly int[] tracked_key_counts = { 4, 5, 6, 7, 8, 9 };
+
+        public string SystemId => EzSkillSystems.DAN;
+
+        public IReadOnlyList<EzSkillDefinition> Skills { get; } = createSkills();
+
+        private static IReadOnlyList<EzSkillDefinition> createSkills()
+        {
+            var list = new List<EzSkillDefinition>();
+
+            foreach (int keys in tracked_key_counts)
+            {
+                list.Add(new EzSkillDefinition(
+                    EzSkillSystems.DAN,
+                    EzSkillIds.Dan(keys, SIDE_RC),
+                    $"{keys}K Regular dan",
+                    EzSkillScope.Player,
+                    "#ec6a9c"));
+
+                list.Add(new EzSkillDefinition(
+                    EzSkillSystems.DAN,
+                    EzSkillIds.Dan(keys, SIDE_LN),
+                    $"{keys}K LN dan",
+                    EzSkillScope.Player,
+                    "#f07474"));
+            }
+
+            return list;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Skills/EzBeatmapMsdComputer.cs
+++ b/osu.Game/EzOsuGame/Skills/EzBeatmapMsdComputer.cs
@@ -1,0 +1,61 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Game.Beatmaps;
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    /// <summary>
+    /// Computes NoMod 1.0x MSD axes for a beatmap and writes each axis as an independent Realm skill.
+    /// </summary>
+    public sealed class EzBeatmapMsdComputer
+    {
+        private readonly BeatmapManager beatmapManager;
+        private readonly EzSkillStore skillStore;
+
+        public EzBeatmapMsdComputer(BeatmapManager beatmapManager, EzSkillStore skillStore)
+        {
+            this.beatmapManager = beatmapManager;
+            this.skillStore = skillStore;
+        }
+
+        /// <summary>
+        /// Returns existing MSD skills when present and current; otherwise computes and persists.
+        /// </summary>
+        public IReadOnlyDictionary<string, double>? TryGetOrCompute(BeatmapInfo beatmapInfo)
+        {
+            ArgumentNullException.ThrowIfNull(beatmapInfo);
+
+            if (beatmapInfo.Ruleset.OnlineID != 3)
+                return null;
+
+            var existing = skillStore.GetBeatmapSkills(beatmapInfo.Hash, EzSkillSystems.BEATMAP_MSD);
+            if (existing.Count >= EzSkillIds.MINA_SKILLSETS.Length)
+                return existing;
+
+            return ComputeAndStore(beatmapInfo);
+        }
+
+        public IReadOnlyDictionary<string, double>? ComputeAndStore(BeatmapInfo beatmapInfo)
+        {
+            ArgumentNullException.ThrowIfNull(beatmapInfo);
+
+            if (beatmapInfo.Ruleset.OnlineID != 3)
+                return null;
+
+            var working = beatmapManager.GetWorkingBeatmap(beatmapInfo);
+            var playable = working.GetPlayableBeatmap(beatmapInfo.Ruleset);
+
+            using var calc = new EzMinaCalcFacade();
+            var vector = calc.CalculateMsd(playable);
+
+            if (vector.Overall <= 0 && vector.Stream <= 0)
+                return null;
+
+            skillStore.WriteBeatmapMsd(beatmapInfo.Hash, vector);
+            return skillStore.GetBeatmapSkills(beatmapInfo.Hash, EzSkillSystems.BEATMAP_MSD);
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Skills/EzBeatmapMsdComputer.cs
+++ b/osu.Game/EzOsuGame/Skills/EzBeatmapMsdComputer.cs
@@ -54,7 +54,7 @@ namespace osu.Game.EzOsuGame.Skills
             if (vector.Overall <= 0 && vector.Stream <= 0)
                 return null;
 
-            skillStore.WriteBeatmapMsd(beatmapInfo.Hash, vector);
+            skillStore.WriteBeatmapMsd(beatmapInfo.Hash, vector, beatmapInfo.ID);
             return skillStore.GetBeatmapSkills(beatmapInfo.Hash, EzSkillSystems.BEATMAP_MSD);
         }
     }

--- a/osu.Game/EzOsuGame/Skills/EzBeatmapSkillValue.cs
+++ b/osu.Game/EzOsuGame/Skills/EzBeatmapSkillValue.cs
@@ -1,0 +1,33 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using Realms;
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    /// <summary>
+    /// Persisted independent skill value for a beatmap (e.g. msd.stream).
+    /// </summary>
+    [MapTo("EzBeatmapSkillValue")]
+    public class EzBeatmapSkillValue : RealmObject
+    {
+        [PrimaryKey]
+        public Guid ID { get; set; } = Guid.NewGuid();
+
+        [Indexed]
+        public string BeatmapHash { get; set; } = string.Empty;
+
+        [Indexed]
+        public string SystemId { get; set; } = string.Empty;
+
+        [Indexed]
+        public string SkillId { get; set; } = string.Empty;
+
+        public double Value { get; set; }
+
+        public int AlgorithmVersion { get; set; }
+
+        public DateTimeOffset ComputedAt { get; set; }
+    }
+}

--- a/osu.Game/EzOsuGame/Skills/EzBeatmapSkillValue.cs
+++ b/osu.Game/EzOsuGame/Skills/EzBeatmapSkillValue.cs
@@ -7,7 +7,7 @@ using Realms;
 namespace osu.Game.EzOsuGame.Skills
 {
     /// <summary>
-    /// Persisted independent skill value for a beatmap (e.g. msd.stream).
+    /// Persisted independent skill value for a beatmap (e.g. beatmap_msd.stream).
     /// </summary>
     [MapTo("EzBeatmapSkillValue")]
     public class EzBeatmapSkillValue : RealmObject
@@ -17,6 +17,10 @@ namespace osu.Game.EzOsuGame.Skills
 
         [Indexed]
         public string BeatmapHash { get; set; } = string.Empty;
+
+        /// <summary>Optional <see cref="Beatmaps.BeatmapInfo.ID"/> for maintenance when hash changes.</summary>
+        [Indexed]
+        public Guid BeatmapId { get; set; } = Guid.Empty;
 
         [Indexed]
         public string SystemId { get; set; } = string.Empty;

--- a/osu.Game/EzOsuGame/Skills/EzDanEstimate.cs
+++ b/osu.Game/EzOsuGame/Skills/EzDanEstimate.cs
@@ -1,0 +1,38 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using Realms;
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    /// <summary>
+    /// Independent dan estimate row (not an MSD/SSR skillset). Stub until LeoBlack port.
+    /// </summary>
+    [MapTo("EzDanEstimate")]
+    public class EzDanEstimate : RealmObject
+    {
+        [PrimaryKey]
+        public Guid ID { get; set; } = Guid.NewGuid();
+
+        [Indexed]
+        public string Username { get; set; } = string.Empty;
+
+        [Indexed]
+        public int KeyCount { get; set; }
+
+        /// <summary><see cref="DanSkillSystem.SIDE_RC"/> or <see cref="DanSkillSystem.SIDE_LN"/>.</summary>
+        [Indexed]
+        public string Side { get; set; } = DanSkillSystem.SIDE_RC;
+
+        public double RawDan { get; set; } = -1;
+
+        public string Label { get; set; } = string.Empty;
+
+        public int Clears { get; set; }
+
+        public int AlgorithmVersion { get; set; }
+
+        public DateTimeOffset ComputedAt { get; set; }
+    }
+}

--- a/osu.Game/EzOsuGame/Skills/EzDanEstimate.cs
+++ b/osu.Game/EzOsuGame/Skills/EzDanEstimate.cs
@@ -7,7 +7,7 @@ using Realms;
 namespace osu.Game.EzOsuGame.Skills
 {
     /// <summary>
-    /// Independent dan estimate row (not an MSD/SSR skillset). Stub until LeoBlack port.
+    /// Independent dan estimate row (not an MSD/SSR skillset). Extended columns reserved for LeoBlack; evidence lists stay SQLite.
     /// </summary>
     [MapTo("EzDanEstimate")]
     public class EzDanEstimate : RealmObject
@@ -30,6 +30,20 @@ namespace osu.Game.EzOsuGame.Skills
         public string Label { get; set; } = string.Empty;
 
         public int Clears { get; set; }
+
+        /// <summary>Estimate sits past the published ladder ceiling.</summary>
+        public bool BeyondTable { get; set; }
+
+        public string CourseName { get; set; } = string.Empty;
+
+        /// <summary>Course clear accuracy; -1 when unset.</summary>
+        public double CourseAccuracy { get; set; } = -1;
+
+        /// <summary>Weighted clears counted toward the estimate window; -1 unset.</summary>
+        public int ClearWindowHave { get; set; } = -1;
+
+        /// <summary>Clears needed to fill the averaging window; -1 unset.</summary>
+        public int ClearWindowNeed { get; set; } = -1;
 
         public int AlgorithmVersion { get; set; }
 

--- a/osu.Game/EzOsuGame/Skills/EzMinaCalcFacade.cs
+++ b/osu.Game/EzOsuGame/Skills/EzMinaCalcFacade.cs
@@ -1,0 +1,58 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using MinaCalc;
+using osu.Game.Beatmaps;
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    /// <summary>
+    /// Thread-affine wrapper around <see cref="Calculator"/>.
+    /// MinaCalc 0.4.2: last bool is MSD when false, SSR (goal-sensitive) when true.
+    /// </summary>
+    public sealed class EzMinaCalcFacade : IDisposable
+    {
+        private readonly Calculator calculator = new Calculator();
+        private bool disposed;
+
+        public static int EngineVersion => Calculator.Version;
+
+        /// <summary>Chart difficulty (MSD). Goal is ignored by the engine in this mode.</summary>
+        public EzSkillsetVector CalculateMsd(MinaCalcNote[] notes, float rate = 1f)
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+            if (notes.Length == 0)
+                return default;
+
+            // MinaCalc 0.4.2: final bool false = MSD (goal ignored), true = SSR (goal-sensitive).
+            return EzSkillsetVector.FromMina(calculator.CalculateAtRate(notes, rate, 0.93f, false));
+        }
+
+        /// <summary>Score-relative skill rating (SSR) at the given Wife/accuracy goal.</summary>
+        public EzSkillsetVector CalculateSsr(MinaCalcNote[] notes, float rate, float goal)
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+            if (notes.Length == 0)
+                return default;
+
+            goal = Math.Clamp(goal, 0.8f, 0.9975f);
+            return EzSkillsetVector.FromMina(calculator.CalculateAtRate(notes, rate, goal, true));
+        }
+
+        public EzSkillsetVector CalculateMsd(IBeatmap beatmap, float rate = 1f)
+            => CalculateMsd(EzMinaNoteConverter.Convert(beatmap), rate);
+
+        public EzSkillsetVector CalculateSsr(IBeatmap beatmap, float rate, float goal)
+            => CalculateSsr(EzMinaNoteConverter.Convert(beatmap), rate, goal);
+
+        public void Dispose()
+        {
+            if (disposed)
+                return;
+
+            disposed = true;
+            calculator.Dispose();
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Skills/EzMinaNoteConverter.cs
+++ b/osu.Game/EzOsuGame/Skills/EzMinaNoteConverter.cs
@@ -1,0 +1,75 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MinaCalc;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    /// <summary>
+    /// Converts a playable mania <see cref="IBeatmap"/> into MinaCalc note rows
+    /// (column bitmask + absolute time in seconds). Hold notes contribute their head only
+    /// (lnTailTaps = false), matching mania-hub default.
+    /// </summary>
+    public static class EzMinaNoteConverter
+    {
+        /// <summary>
+        /// Builds MinaCalc rows. Returns empty when there are no column objects.
+        /// </summary>
+        public static MinaCalcNote[] Convert(IBeatmap beatmap)
+        {
+            ArgumentNullException.ThrowIfNull(beatmap);
+
+            // Group by start time (ms → seconds row). Same-time chords share one bitmask.
+            var byTime = new SortedDictionary<double, uint>();
+
+            foreach (HitObject obj in beatmap.HitObjects)
+            {
+                if (obj is not IHasColumn columnObj)
+                    continue;
+
+                int column = columnObj.Column;
+                if (column < 0 || column >= 32)
+                    continue;
+
+                double timeSec = obj.StartTime / 1000.0;
+                // Snap near-equal times so floating chord members stay one row.
+                double key = Math.Round(timeSec, 6);
+
+                byTime.TryGetValue(key, out uint mask);
+                byTime[key] = mask | (1u << column);
+            }
+
+            if (byTime.Count == 0)
+                return Array.Empty<MinaCalcNote>();
+
+            return byTime.Select(kvp => new MinaCalcNote
+            {
+                Notes = kvp.Value,
+                RowTime = (float)kvp.Key,
+            }).ToArray();
+        }
+
+        public static int ResolveKeyCount(IBeatmap beatmap)
+        {
+            int fromCs = (int)Math.Round(beatmap.Difficulty.CircleSize);
+            if (fromCs is >= 1 and <= 18)
+                return fromCs;
+
+            int maxColumn = -1;
+
+            foreach (HitObject obj in beatmap.HitObjects)
+            {
+                if (obj is IHasColumn columnObj)
+                    maxColumn = Math.Max(maxColumn, columnObj.Column);
+            }
+
+            return maxColumn >= 0 ? maxColumn + 1 : 4;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Skills/EzPlayerSkillHistoryPoint.cs
+++ b/osu.Game/EzOsuGame/Skills/EzPlayerSkillHistoryPoint.cs
@@ -7,10 +7,10 @@ using Realms;
 namespace osu.Game.EzOsuGame.Skills
 {
     /// <summary>
-    /// Persisted independent player skill value for one keymode (e.g. player_ssr.stream @ 7K).
+    /// One point on a player's per-skillset history curve (Skills history UI).
     /// </summary>
-    [MapTo("EzPlayerSkillValue")]
-    public class EzPlayerSkillValue : RealmObject
+    [MapTo("EzPlayerSkillHistoryPoint")]
+    public class EzPlayerSkillHistoryPoint : RealmObject
     {
         [PrimaryKey]
         public Guid ID { get; set; } = Guid.NewGuid();
@@ -22,23 +22,13 @@ namespace osu.Game.EzOsuGame.Skills
         public int KeyCount { get; set; }
 
         [Indexed]
-        public string SystemId { get; set; } = string.Empty;
-
-        [Indexed]
         public string SkillId { get; set; } = string.Empty;
 
         public double Value { get; set; }
 
-        public int AnalyzedPlays { get; set; }
-
-        /// <summary>Thin evidence: rating shrunk toward population median (hub provisional chip).</summary>
-        public bool Provisional { get; set; }
-
-        /// <summary>Stored snapshot may be mid-recompute (hub stale chip).</summary>
-        public bool Stale { get; set; }
+        [Indexed]
+        public DateTimeOffset RecordedAt { get; set; }
 
         public int AlgorithmVersion { get; set; }
-
-        public DateTimeOffset ComputedAt { get; set; }
     }
 }

--- a/osu.Game/EzOsuGame/Skills/EzPlayerSkillValue.cs
+++ b/osu.Game/EzOsuGame/Skills/EzPlayerSkillValue.cs
@@ -1,0 +1,38 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using Realms;
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    /// <summary>
+    /// Persisted independent player skill value for one keymode (e.g. ssr.stream @ 7K).
+    /// </summary>
+    [MapTo("EzPlayerSkillValue")]
+    public class EzPlayerSkillValue : RealmObject
+    {
+        [PrimaryKey]
+        public Guid ID { get; set; } = Guid.NewGuid();
+
+        [Indexed]
+        public string Username { get; set; } = string.Empty;
+
+        [Indexed]
+        public int KeyCount { get; set; }
+
+        [Indexed]
+        public string SystemId { get; set; } = string.Empty;
+
+        [Indexed]
+        public string SkillId { get; set; } = string.Empty;
+
+        public double Value { get; set; }
+
+        public int AnalyzedPlays { get; set; }
+
+        public int AlgorithmVersion { get; set; }
+
+        public DateTimeOffset ComputedAt { get; set; }
+    }
+}

--- a/osu.Game/EzOsuGame/Skills/EzPlayerSsrAggregator.cs
+++ b/osu.Game/EzOsuGame/Skills/EzPlayerSsrAggregator.cs
@@ -1,0 +1,103 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Scoring;
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    /// <summary>
+    /// Aggregates per-play SSR vectors into independent player skills (Etterna AggregateSSRs).
+    /// Accuracy→goal is a simplified mapping for foundation; Wife estimate can be refined later.
+    /// </summary>
+    public sealed class EzPlayerSsrAggregator
+    {
+        private readonly BeatmapManager beatmapManager;
+        private readonly EzSkillStore skillStore;
+
+        public EzPlayerSsrAggregator(BeatmapManager beatmapManager, EzSkillStore skillStore)
+        {
+            this.beatmapManager = beatmapManager;
+            this.skillStore = skillStore;
+        }
+
+        public void ComputeAndStore(string username, IEnumerable<ScoreInfo> scores)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(username);
+
+            var byKey = new Dictionary<int, List<EzSkillsetVector>>();
+
+            using var calc = new EzMinaCalcFacade();
+
+            foreach (var score in scores)
+            {
+                if (score.Ruleset.OnlineID != 3)
+                    continue;
+
+                if (string.IsNullOrWhiteSpace(score.BeatmapHash))
+                    continue;
+
+                var beatmapInfo = score.BeatmapInfo ?? beatmapManager.QueryBeatmap(b => b.Hash == score.BeatmapHash);
+                if (beatmapInfo == null)
+                    continue;
+
+                var working = beatmapManager.GetWorkingBeatmap(beatmapInfo);
+                var playable = working.GetPlayableBeatmap(score.Ruleset, score.Mods);
+                int keyCount = EzMinaNoteConverter.ResolveKeyCount(playable);
+                float rate = resolveRate(score.Mods);
+                float goal = accuracyToGoal(score.Accuracy);
+
+                if (goal <= 0.8f)
+                    continue;
+
+                var notes = EzMinaNoteConverter.Convert(playable);
+                if (notes.Length == 0)
+                    continue;
+
+                var vector = calc.CalculateSsr(notes, rate, goal);
+                if (vector.Overall <= 0)
+                    continue;
+
+                if (!byKey.TryGetValue(keyCount, out var list))
+                    byKey[keyCount] = list = new List<EzSkillsetVector>();
+
+                list.Add(vector);
+            }
+
+            foreach ((int keyCount, List<EzSkillsetVector> plays) in byKey)
+            {
+                var aggregated = EzSsrAggregator.AggregateVectors(plays);
+                skillStore.WritePlayerSsr(username, keyCount, aggregated, plays.Count);
+            }
+        }
+
+        private static float resolveRate(IEnumerable<Mod> mods)
+        {
+            double rate = 1;
+
+            foreach (var mod in mods)
+            {
+                if (mod is ModRateAdjust rateAdjust)
+                    rate *= rateAdjust.SpeedChange.Value;
+            }
+
+            return (float)Math.Clamp(rate, 0.5, 2.0);
+        }
+
+        /// <summary>
+        /// Maps display accuracy to MinaCalc SSR goal. Foundation: clamp accuracy into [0.8, 0.9975].
+        /// </summary>
+        public static float AccuracyToGoal(double accuracy) => accuracyToGoal(accuracy);
+
+        private static float accuracyToGoal(double accuracy)
+        {
+            if (!double.IsFinite(accuracy) || accuracy <= 0)
+                return 0.8f;
+
+            return (float)Math.Clamp(accuracy, 0.8, 0.9975);
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Skills/EzSkillBoundary.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSkillBoundary.cs
@@ -12,6 +12,7 @@ namespace osu.Game.EzOsuGame.Skills
     /// <item>xxy radar skill-ification is explicitly deferred.</item>
     /// </list>
     /// Reference clone: sibling repo <c>Ez2Lazer/mania-hub</c>.
+    /// Ez Realm v8 (single bump) holds skill rows, dan estimate columns, and history points.
     /// </summary>
     public static class EzSkillBoundary
     {

--- a/osu.Game/EzOsuGame/Skills/EzSkillBoundary.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSkillBoundary.cs
@@ -1,0 +1,19 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    /// <summary>
+    /// Boundary notes (aligned with mania-hub / mania-tracker):
+    /// <list type="bullet">
+    /// <item><see cref="EzSkillSystems.BEATMAP_MSD"/> — chart difficulty axes from MinaCalc MSD. Not player skill.</item>
+    /// <item><see cref="EzSkillSystems.PLAYER_SSR"/> — player skill axes from score-goal SSR + AggregateSSRs. Profile Skills radar source.</item>
+    /// <item><see cref="EzSkillSystems.DAN"/> — independent dan estimates (LeoBlack). Stub only in this foundation.</item>
+    /// <item>xxy radar skill-ification is explicitly deferred.</item>
+    /// </list>
+    /// Reference clone: sibling repo <c>Ez2Lazer/mania-hub</c>.
+    /// </summary>
+    public static class EzSkillBoundary
+    {
+    }
+}

--- a/osu.Game/EzOsuGame/Skills/EzSkillDefinition.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSkillDefinition.cs
@@ -1,0 +1,18 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    public enum EzSkillScope
+    {
+        Beatmap = 0,
+        Player = 1,
+    }
+
+    public readonly record struct EzSkillDefinition(
+        string SystemId,
+        string SkillId,
+        string DisplayName,
+        EzSkillScope Scope,
+        string AccentHex);
+}

--- a/osu.Game/EzOsuGame/Skills/EzSkillIds.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSkillIds.cs
@@ -1,0 +1,54 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    /// <summary>
+    /// Stable string IDs for skill systems and individual skills.
+    /// MSD = chart difficulty axes; SSR = player skill axes; Dan is a separate system.
+    /// </summary>
+    public static class EzSkillSystems
+    {
+        public const string BEATMAP_MSD = "beatmap_msd";
+        public const string PLAYER_SSR = "player_ssr";
+        public const string DAN = "dan";
+    }
+
+    public static class EzSkillIds
+    {
+        public const string OVERALL = "overall";
+        public const string STREAM = "stream";
+        public const string JUMPSTREAM = "jumpstream";
+        public const string HANDSTREAM = "handstream";
+        public const string STAMINA = "stamina";
+        public const string JACK_SPEED = "jack_speed";
+        public const string CHORDJACK = "chordjack";
+        public const string TECHNICAL = "technical";
+
+        /// <summary>MinaCalc / Etterna skillset axes (Overall included as its own skill).</summary>
+        public static readonly string[] MINA_SKILLSETS =
+        {
+            OVERALL,
+            STREAM,
+            JUMPSTREAM,
+            HANDSTREAM,
+            STAMINA,
+            JACK_SPEED,
+            CHORDJACK,
+            TECHNICAL,
+        };
+
+        public static string Msd(string axis) => $"{EzSkillSystems.BEATMAP_MSD}.{axis}";
+        public static string Ssr(string axis) => $"{EzSkillSystems.PLAYER_SSR}.{axis}";
+
+        public static string Dan(int keyCount, string side) => $"{EzSkillSystems.DAN}.{keyCount}k.{side}";
+    }
+
+    /// <summary>
+    /// Bump when MinaCalc note conversion or aggregation semantics change; invalidates stored values.
+    /// </summary>
+    public static class EzManiaSkillAlgorithm
+    {
+        public const int VERSION = 1;
+    }
+}

--- a/osu.Game/EzOsuGame/Skills/EzSkillProvider.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSkillProvider.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    /// <summary>
+    /// Unified read API for consumers (song select, local profile Track, …).
+    /// </summary>
+    public sealed class EzSkillProvider
+    {
+        private readonly EzSkillStore store;
+
+        public EzSkillProvider(EzSkillStore store, EzSkillRegistry? registry = null)
+        {
+            this.store = store;
+            Registry = registry ?? new EzSkillRegistry();
+        }
+
+        public EzSkillRegistry Registry { get; }
+
+        public IReadOnlyDictionary<string, double> GetBeatmapMsd(string beatmapHash)
+            => store.GetBeatmapSkills(beatmapHash, EzSkillSystems.BEATMAP_MSD);
+
+        public bool TryGetBeatmapMsdSkill(string beatmapHash, string axisId, out double value)
+            => store.TryGetBeatmapSkill(beatmapHash, EzSkillIds.Msd(axisId), out value);
+
+        public IReadOnlyDictionary<string, double> GetPlayerSsr(string username, int keyCount)
+            => store.GetPlayerSkills(username, keyCount, EzSkillSystems.PLAYER_SSR);
+
+        public EzDanEstimate? GetDan(string username, int keyCount, string side)
+            => store.GetDanEstimate(username, keyCount, side);
+    }
+}

--- a/osu.Game/EzOsuGame/Skills/EzSkillProvider.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSkillProvider.cs
@@ -29,6 +29,9 @@ namespace osu.Game.EzOsuGame.Skills
         public IReadOnlyDictionary<string, double> GetPlayerSsr(string username, int keyCount)
             => store.GetPlayerSkills(username, keyCount, EzSkillSystems.PLAYER_SSR);
 
+        public IReadOnlyList<EzPlayerSkillHistoryPoint> GetPlayerSkillHistory(string username, int keyCount, string skillId, int maxPoints = 64)
+            => store.GetPlayerSkillHistory(username, keyCount, skillId, maxPoints);
+
         public EzDanEstimate? GetDan(string username, int keyCount, string side)
             => store.GetDanEstimate(username, keyCount, side);
     }

--- a/osu.Game/EzOsuGame/Skills/EzSkillRegistry.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSkillRegistry.cs
@@ -1,0 +1,41 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    public sealed class EzSkillRegistry
+    {
+        private readonly Dictionary<string, IEzSkillSystem> systems = new Dictionary<string, IEzSkillSystem>(StringComparer.Ordinal);
+
+        public EzSkillRegistry(IEnumerable<IEzSkillSystem>? systems = null)
+        {
+            foreach (var system in systems ?? CreateDefaultSystems())
+                Register(system);
+        }
+
+        public void Register(IEzSkillSystem system)
+        {
+            ArgumentNullException.ThrowIfNull(system);
+            systems[system.SystemId] = system;
+        }
+
+        public IEzSkillSystem? GetSystem(string systemId)
+            => systems.GetValueOrDefault(systemId);
+
+        public IReadOnlyList<IEzSkillSystem> Systems => systems.Values.ToList();
+
+        public IEnumerable<EzSkillDefinition> AllSkills
+            => systems.Values.SelectMany(s => s.Skills);
+
+        public static IEnumerable<IEzSkillSystem> CreateDefaultSystems()
+        {
+            yield return new BeatmapMsdSkillSystem();
+            yield return new PlayerSsrSkillSystem();
+            yield return new DanSkillSystem();
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Skills/EzSkillStore.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSkillStore.cs
@@ -60,7 +60,7 @@ namespace osu.Game.EzOsuGame.Skills
             return true;
         }
 
-        public void WriteBeatmapMsd(string beatmapHash, EzSkillsetVector vector, DateTimeOffset? computedAt = null)
+        public void WriteBeatmapMsd(string beatmapHash, EzSkillsetVector vector, Guid beatmapId = default, DateTimeOffset? computedAt = null)
         {
             DateTimeOffset at = computedAt ?? DateTimeOffset.UtcNow;
             int version = EzManiaSkillAlgorithm.VERSION;
@@ -79,6 +79,7 @@ namespace osu.Game.EzOsuGame.Skills
                     r.Add(new EzBeatmapSkillValue
                     {
                         BeatmapHash = beatmapHash,
+                        BeatmapId = beatmapId,
                         SystemId = EzSkillSystems.BEATMAP_MSD,
                         SkillId = EzSkillIds.Msd(axis),
                         Value = value,
@@ -105,7 +106,15 @@ namespace osu.Game.EzOsuGame.Skills
             });
         }
 
-        public void WritePlayerSsr(string username, int keyCount, EzSkillsetVector vector, int analyzedPlays, DateTimeOffset? computedAt = null)
+        public void WritePlayerSsr(
+            string username,
+            int keyCount,
+            EzSkillsetVector vector,
+            int analyzedPlays,
+            bool provisional = false,
+            bool stale = false,
+            DateTimeOffset? computedAt = null,
+            bool appendHistory = true)
         {
             DateTimeOffset at = computedAt ?? DateTimeOffset.UtcNow;
             int version = EzManiaSkillAlgorithm.VERSION;
@@ -123,18 +132,56 @@ namespace osu.Game.EzOsuGame.Skills
 
                 foreach ((string axis, double value) in vector.Enumerate())
                 {
+                    string skillId = EzSkillIds.Ssr(axis);
+
                     r.Add(new EzPlayerSkillValue
                     {
                         Username = username,
                         KeyCount = keyCount,
                         SystemId = EzSkillSystems.PLAYER_SSR,
-                        SkillId = EzSkillIds.Ssr(axis),
+                        SkillId = skillId,
                         Value = value,
                         AnalyzedPlays = analyzedPlays,
+                        Provisional = provisional,
+                        Stale = stale,
                         AlgorithmVersion = version,
                         ComputedAt = at,
                     });
+
+                    if (appendHistory && value > 0)
+                    {
+                        r.Add(new EzPlayerSkillHistoryPoint
+                        {
+                            Username = username,
+                            KeyCount = keyCount,
+                            SkillId = skillId,
+                            Value = value,
+                            RecordedAt = at,
+                            AlgorithmVersion = version,
+                        });
+                    }
                 }
+            });
+        }
+
+        public IReadOnlyList<EzPlayerSkillHistoryPoint> GetPlayerSkillHistory(
+            string username,
+            int keyCount,
+            string skillId,
+            int maxPoints = 64)
+        {
+            return realmAccess.Run(r =>
+            {
+                return r.All<EzPlayerSkillHistoryPoint>()
+                        .Where(v => v.Username == username
+                                    && v.KeyCount == keyCount
+                                    && v.SkillId == skillId)
+                        .ToList()
+                        .OrderByDescending(v => v.RecordedAt)
+                        .Take(maxPoints)
+                        .Select(v => v.Detach())
+                        .Reverse()
+                        .ToList();
             });
         }
 
@@ -144,7 +191,41 @@ namespace osu.Game.EzOsuGame.Skills
             {
                 var row = r.All<EzDanEstimate>()
                            .FirstOrDefault(v => v.Username == username && v.KeyCount == keyCount && v.Side == side);
-                return row?.Detach();
+                return row == null ? null : row.Detach();
+            });
+        }
+
+        public void WriteDanEstimate(EzDanEstimate estimate)
+        {
+            ArgumentNullException.ThrowIfNull(estimate);
+
+            realmAccess.Write(r =>
+            {
+                var existing = r.All<EzDanEstimate>()
+                                .Where(v => v.Username == estimate.Username
+                                            && v.KeyCount == estimate.KeyCount
+                                            && v.Side == estimate.Side)
+                                .ToList();
+
+                foreach (var row in existing)
+                    r.Remove(row);
+
+                r.Add(new EzDanEstimate
+                {
+                    Username = estimate.Username,
+                    KeyCount = estimate.KeyCount,
+                    Side = estimate.Side,
+                    RawDan = estimate.RawDan,
+                    Label = estimate.Label,
+                    Clears = estimate.Clears,
+                    BeyondTable = estimate.BeyondTable,
+                    CourseName = estimate.CourseName,
+                    CourseAccuracy = estimate.CourseAccuracy,
+                    ClearWindowHave = estimate.ClearWindowHave,
+                    ClearWindowNeed = estimate.ClearWindowNeed,
+                    AlgorithmVersion = estimate.AlgorithmVersion != 0 ? estimate.AlgorithmVersion : EzManiaSkillAlgorithm.VERSION,
+                    ComputedAt = estimate.ComputedAt == default ? DateTimeOffset.UtcNow : estimate.ComputedAt,
+                });
             });
         }
     }

--- a/osu.Game/EzOsuGame/Skills/EzSkillStore.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSkillStore.cs
@@ -1,0 +1,151 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Game.Database;
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    /// <summary>
+    /// Read/write helpers for skill Realm objects. Does not open the game for the caller.
+    /// </summary>
+    public sealed class EzSkillStore
+    {
+        private readonly RealmAccess realmAccess;
+
+        public EzSkillStore(RealmAccess realmAccess)
+        {
+            this.realmAccess = realmAccess;
+        }
+
+        public IReadOnlyDictionary<string, double> GetBeatmapSkills(string beatmapHash, string systemId, int? algorithmVersion = null)
+        {
+            int version = algorithmVersion ?? EzManiaSkillAlgorithm.VERSION;
+
+            return realmAccess.Run(r =>
+            {
+                var rows = r.All<EzBeatmapSkillValue>()
+                            .Where(v => v.BeatmapHash == beatmapHash
+                                        && v.SystemId == systemId
+                                        && v.AlgorithmVersion == version);
+
+                return rows.ToDictionary(v => v.SkillId, v => v.Value, StringComparer.Ordinal);
+            });
+        }
+
+        public bool TryGetBeatmapSkill(string beatmapHash, string skillId, out double value, int? algorithmVersion = null)
+        {
+            int version = algorithmVersion ?? EzManiaSkillAlgorithm.VERSION;
+            double found = double.NaN;
+
+            realmAccess.Run(r =>
+            {
+                var row = r.All<EzBeatmapSkillValue>()
+                           .FirstOrDefault(v => v.BeatmapHash == beatmapHash
+                                                && v.SkillId == skillId
+                                                && v.AlgorithmVersion == version);
+                if (row != null)
+                    found = row.Value;
+            });
+
+            if (double.IsNaN(found))
+            {
+                value = 0;
+                return false;
+            }
+
+            value = found;
+            return true;
+        }
+
+        public void WriteBeatmapMsd(string beatmapHash, EzSkillsetVector vector, DateTimeOffset? computedAt = null)
+        {
+            DateTimeOffset at = computedAt ?? DateTimeOffset.UtcNow;
+            int version = EzManiaSkillAlgorithm.VERSION;
+
+            realmAccess.Write(r =>
+            {
+                var existing = r.All<EzBeatmapSkillValue>()
+                                .Where(v => v.BeatmapHash == beatmapHash && v.SystemId == EzSkillSystems.BEATMAP_MSD)
+                                .ToList();
+
+                foreach (var row in existing)
+                    r.Remove(row);
+
+                foreach ((string axis, double value) in vector.Enumerate())
+                {
+                    r.Add(new EzBeatmapSkillValue
+                    {
+                        BeatmapHash = beatmapHash,
+                        SystemId = EzSkillSystems.BEATMAP_MSD,
+                        SkillId = EzSkillIds.Msd(axis),
+                        Value = value,
+                        AlgorithmVersion = version,
+                        ComputedAt = at,
+                    });
+                }
+            });
+        }
+
+        public IReadOnlyDictionary<string, double> GetPlayerSkills(string username, int keyCount, string systemId, int? algorithmVersion = null)
+        {
+            int version = algorithmVersion ?? EzManiaSkillAlgorithm.VERSION;
+
+            return realmAccess.Run(r =>
+            {
+                var rows = r.All<EzPlayerSkillValue>()
+                            .Where(v => v.Username == username
+                                        && v.KeyCount == keyCount
+                                        && v.SystemId == systemId
+                                        && v.AlgorithmVersion == version);
+
+                return rows.ToDictionary(v => v.SkillId, v => v.Value, StringComparer.Ordinal);
+            });
+        }
+
+        public void WritePlayerSsr(string username, int keyCount, EzSkillsetVector vector, int analyzedPlays, DateTimeOffset? computedAt = null)
+        {
+            DateTimeOffset at = computedAt ?? DateTimeOffset.UtcNow;
+            int version = EzManiaSkillAlgorithm.VERSION;
+
+            realmAccess.Write(r =>
+            {
+                var existing = r.All<EzPlayerSkillValue>()
+                                .Where(v => v.Username == username
+                                            && v.KeyCount == keyCount
+                                            && v.SystemId == EzSkillSystems.PLAYER_SSR)
+                                .ToList();
+
+                foreach (var row in existing)
+                    r.Remove(row);
+
+                foreach ((string axis, double value) in vector.Enumerate())
+                {
+                    r.Add(new EzPlayerSkillValue
+                    {
+                        Username = username,
+                        KeyCount = keyCount,
+                        SystemId = EzSkillSystems.PLAYER_SSR,
+                        SkillId = EzSkillIds.Ssr(axis),
+                        Value = value,
+                        AnalyzedPlays = analyzedPlays,
+                        AlgorithmVersion = version,
+                        ComputedAt = at,
+                    });
+                }
+            });
+        }
+
+        public EzDanEstimate? GetDanEstimate(string username, int keyCount, string side)
+        {
+            return realmAccess.Run(r =>
+            {
+                var row = r.All<EzDanEstimate>()
+                           .FirstOrDefault(v => v.Username == username && v.KeyCount == keyCount && v.Side == side);
+                return row?.Detach();
+            });
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Skills/EzSkillsetVector.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSkillsetVector.cs
@@ -1,0 +1,44 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using MinaCalc;
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    /// <summary>
+    /// One MinaCalc skillset vector (MSD or SSR). Each axis maps to an independent skill id.
+    /// </summary>
+    public readonly record struct EzSkillsetVector(
+        double Overall,
+        double Stream,
+        double Jumpstream,
+        double Handstream,
+        double Stamina,
+        double JackSpeed,
+        double Chordjack,
+        double Technical)
+    {
+        public static EzSkillsetVector FromMina(MinaCalcScores scores) => new EzSkillsetVector(scores.Overall, scores.Stream, scores.Jumpstream, scores.Handstream, scores.Stamina, scores.JackSpeed,
+            scores.Chordjack, scores.Technical);
+
+        public double Get(string skillId) => skillId switch
+        {
+            EzSkillIds.OVERALL => Overall,
+            EzSkillIds.STREAM => Stream,
+            EzSkillIds.JUMPSTREAM => Jumpstream,
+            EzSkillIds.HANDSTREAM => Handstream,
+            EzSkillIds.STAMINA => Stamina,
+            EzSkillIds.JACK_SPEED => JackSpeed,
+            EzSkillIds.CHORDJACK => Chordjack,
+            EzSkillIds.TECHNICAL => Technical,
+            _ => 0,
+        };
+
+        public IEnumerable<(string AxisId, double Value)> Enumerate()
+        {
+            foreach (string id in EzSkillIds.MINA_SKILLSETS)
+                yield return (id, Get(id));
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Skills/EzSsrAggregator.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSsrAggregator.cs
@@ -1,0 +1,76 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    /// <summary>
+    /// Etterna ScoreManager::AggregateSSRs port (mania-hub player-skills.ts aggregateSsrs).
+    /// </summary>
+    public static class EzSsrAggregator
+    {
+        private const double aggregate_rating_scaler = 1.04;
+
+        public static double Aggregate(IEnumerable<double> values)
+        {
+            double[] ssrs = values.Where(v => double.IsFinite(v) && v > 0).ToArray();
+            if (ssrs.Length == 0)
+                return 0;
+
+            double rating = 0;
+            double res = 10.24;
+
+            for (int iter = 1; iter <= 11; iter++)
+            {
+                double sum;
+
+                do
+                {
+                    rating += res;
+                    sum = 0;
+
+                    foreach (double ssr in ssrs)
+                        sum += Math.Max(0, 2 / (1 - erf(0.1 * (ssr - rating))) - 2);
+                }
+                while (Math.Pow(2, rating * 0.1) < sum);
+
+                if (iter == 11)
+                    break;
+
+                rating -= res;
+                res /= 2;
+            }
+
+            return Math.Round(rating * aggregate_rating_scaler * 100) / 100;
+        }
+
+        public static EzSkillsetVector AggregateVectors(IReadOnlyList<EzSkillsetVector> plays)
+        {
+            if (plays.Count == 0)
+                return default;
+
+            return new EzSkillsetVector(
+                Aggregate(plays.Select(p => p.Overall)),
+                Aggregate(plays.Select(p => p.Stream)),
+                Aggregate(plays.Select(p => p.Jumpstream)),
+                Aggregate(plays.Select(p => p.Handstream)),
+                Aggregate(plays.Select(p => p.Stamina)),
+                Aggregate(plays.Select(p => p.JackSpeed)),
+                Aggregate(plays.Select(p => p.Chordjack)),
+                Aggregate(plays.Select(p => p.Technical)));
+        }
+
+        /// <summary>Abramowitz &amp; Stegun 7.1.26.</summary>
+        private static double erf(double x)
+        {
+            int sign = x < 0 ? -1 : 1;
+            double ax = Math.Abs(x);
+            double t = 1 / (1 + 0.3275911 * ax);
+            double poly = ((((1.061405429 * t - 1.453152027) * t + 1.421413741) * t - 0.284496736) * t + 0.254829592) * t;
+            return sign * (1 - poly * Math.Exp(-ax * ax));
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Skills/IEzSkillSystem.cs
+++ b/osu.Game/EzOsuGame/Skills/IEzSkillSystem.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    /// <summary>
+    /// Pluggable skill family (MSD chart axes, SSR player axes, Dan, later xxy, …).
+    /// </summary>
+    public interface IEzSkillSystem
+    {
+        string SystemId { get; }
+
+        IReadOnlyList<EzSkillDefinition> Skills { get; }
+    }
+}

--- a/osu.Game/EzOsuGame/Skills/PlayerSsrSkillSystem.cs
+++ b/osu.Game/EzOsuGame/Skills/PlayerSsrSkillSystem.cs
@@ -1,0 +1,61 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    /// <summary>
+    /// Player-side SSR skill axes (aggregated from score-goal MinaCalc runs).
+    /// Independent from beatmap MSD — same axis names, different system namespace.
+    /// </summary>
+    public sealed class PlayerSsrSkillSystem : IEzSkillSystem
+    {
+        public string SystemId => EzSkillSystems.PLAYER_SSR;
+
+        public IReadOnlyList<EzSkillDefinition> Skills { get; } = createSkills();
+
+        private static IReadOnlyList<EzSkillDefinition> createSkills()
+        {
+            var list = new List<EzSkillDefinition>(EzSkillIds.MINA_SKILLSETS.Length);
+
+            foreach (string axis in EzSkillIds.MINA_SKILLSETS)
+            {
+                list.Add(new EzSkillDefinition(
+                    EzSkillSystems.PLAYER_SSR,
+                    EzSkillIds.Ssr(axis),
+                    axisDisplay(axis),
+                    EzSkillScope.Player,
+                    accent(axis)));
+            }
+
+            return list;
+        }
+
+        private static string axisDisplay(string axis) => axis switch
+        {
+            EzSkillIds.OVERALL => "Overall",
+            EzSkillIds.STREAM => "Stream",
+            EzSkillIds.JUMPSTREAM => "Jumpstream",
+            EzSkillIds.HANDSTREAM => "Handstream",
+            EzSkillIds.STAMINA => "Stamina",
+            EzSkillIds.JACK_SPEED => "Jackspeed",
+            EzSkillIds.CHORDJACK => "Chordjack",
+            EzSkillIds.TECHNICAL => "Technical",
+            _ => axis,
+        };
+
+        private static string accent(string axis) => axis switch
+        {
+            EzSkillIds.OVERALL => "#c9cfdd",
+            EzSkillIds.STREAM => "#8f6bd8",
+            EzSkillIds.JUMPSTREAM => "#6f87d8",
+            EzSkillIds.HANDSTREAM => "#b06bc0",
+            EzSkillIds.STAMINA => "#ad6b5d",
+            EzSkillIds.JACK_SPEED => "#c66f84",
+            EzSkillIds.CHORDJACK => "#c59a5c",
+            EzSkillIds.TECHNICAL => "#83a86f",
+            _ => "#8f6bd8",
+        };
+    }
+}

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -54,6 +54,7 @@ using osu.Game.EzOsuGame.Input;
 using osu.Game.EzOsuGame.LocalProfile;
 using osu.Game.EzOsuGame.Online;
 using osu.Game.EzOsuGame.Scoring;
+using osu.Game.EzOsuGame.Skills;
 using osu.Game.EzOsuGame.ExternalRulesets;
 using osu.Game.Localisation;
 using osu.Game.Online;
@@ -412,6 +413,14 @@ namespace osu.Game
             dependencies.CacheAs<IEzReplaySession>(ReplaySession);
             dependencies.Cache(new EzLocalProfileService(Storage, realm, ezAnalysisPersistentStore, BeatmapManager, ScoreManager, ReplaySession));
             dependencies.Cache(new EzLocalProfileOnlinePullService(API, ScoreManager, BeatmapManager, realm, Storage));
+
+            var skillRegistry = new EzSkillRegistry();
+            var skillStore = new EzSkillStore(realm);
+            dependencies.Cache(skillRegistry);
+            dependencies.Cache(skillStore);
+            dependencies.Cache(new EzSkillProvider(skillStore, skillRegistry));
+            dependencies.Cache(new EzBeatmapMsdComputer(BeatmapManager, skillStore));
+            dependencies.Cache(new EzPlayerSsrAggregator(BeatmapManager, skillStore));
 
             if (Ez2ConfigManager.Get<bool>(Ez2Setting.EzScoreRaceServiceEnabled))
             {

--- a/osu.Game/Rulesets/RulesetInfo.cs
+++ b/osu.Game/Rulesets/RulesetInfo.cs
@@ -32,6 +32,12 @@ namespace osu.Game.Rulesets
         /// </summary>
         public int LastAppliedXxySrVersion { get; set; }
 
+        /// <summary>
+        /// Ez2Lazer: last applied mania skill algorithm version (<see cref="EzOsuGame.Skills.EzManiaSkillAlgorithm.VERSION"/>).
+        /// Used to invalidate <see cref="EzOsuGame.Skills.EzBeatmapSkillValue"/> / player SSR rows.
+        /// </summary>
+        public int LastAppliedManiaSkillVersion { get; set; }
+
         public RulesetInfo(string shortName, string name, string instantiationInfo, int onlineID)
         {
             ShortName = shortName;

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -37,6 +37,7 @@
     <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
     <PackageReference Include="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />
+    <PackageReference Include="MinaCalc" Version="0.4.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="ppy.LocalisationAnalyser" Version="2026.611.0">
       <PrivateAssets>all</PrivateAssets>
@@ -71,9 +72,7 @@
     <ProjectReference Include="$(Ez2LazerResourcesProjectPath)" />
   </ItemGroup>
   <Target Name="ValidateEz2LazerSiblingProjects" BeforeTargets="BeforeBuild">
-    <Error Condition="'$(UseEz2LazerLocalFrameworkProject)' == 'true' and !Exists('$(Ez2LazerFrameworkProjectPath)')"
-           Text="Missing sibling directory osu-framework. Please clone https://github.com/SK-la/osu-framework into $(MSBuildThisFileDirectory)..\..\osu-framework, or disable UseEz2LazerLocalFrameworkProject to rely on NuGet." />
-    <Error Condition="'$(UseEz2LazerLocalResourcesProject)' == 'true' and !Exists('$(Ez2LazerResourcesProjectPath)')"
-           Text="Missing sibling directory osu-resources. Please clone https://github.com/SK-la/osu-resources into $(MSBuildThisFileDirectory)..\..\osu-resources, or disable UseEz2LazerLocalResourcesProject to rely on NuGet." />
+    <Error Condition="'$(UseEz2LazerLocalFrameworkProject)' == 'true' and !Exists('$(Ez2LazerFrameworkProjectPath)')" Text="Missing sibling directory osu-framework. Please clone https://github.com/SK-la/osu-framework into $(MSBuildThisFileDirectory)..\..\osu-framework, or disable UseEz2LazerLocalFrameworkProject to rely on NuGet." />
+    <Error Condition="'$(UseEz2LazerLocalResourcesProject)' == 'true' and !Exists('$(Ez2LazerResourcesProjectPath)')" Text="Missing sibling directory osu-resources. Please clone https://github.com/SK-la/osu-resources into $(MSBuildThisFileDirectory)..\..\osu-resources, or disable UseEz2LazerLocalResourcesProject to rely on NuGet." />
   </Target>
 </Project>


### PR DESCRIPTION
## Summary
- Add MinaCalc-backed mania skill systems (`beatmap_msd` / `player_ssr` / `dan` stub) with independent per-axis skill IDs.
- Persist skills in Realm as part of a **single** Ez schema bump **7→8** (no v9): skill value rows, history points, extended dan columns, provisional/stale flags.
- Expose `EzSkillStore` / `EzSkillProvider` for later Track UI and song select (UI not in this PR).

## Test plan
- [ ] `dotnet build` osu.Game
- [ ] `dotnet test --filter FullyQualifiedName~EzOsuGame.Skills`
- [ ] Confirm `EZ_REALM_SCHEMA_VERSION` is **8** only (no further bump in this PR)
- [ ] Do not run client against a real user `client.realm` unless intentionally validating migration from Ez 7


Made with [Cursor](https://cursor.com)