### PR TITLE
Add local profile Track UI for mania SSR skills

### DIFF
--- a/osu.Game.Tests/Visual/EzOsuGame/TestSceneEzLocalProfileOverlay.cs
+++ b/osu.Game.Tests/Visual/EzOsuGame/TestSceneEzLocalProfileOverlay.cs
@@ -12,6 +12,7 @@ using osu.Game.Database;
 using osu.Game.EzOsuGame.Analysis;
 using osu.Game.EzOsuGame.LocalProfile;
 using osu.Game.EzOsuGame.Scoring;
+using osu.Game.EzOsuGame.Skills;
 using osu.Game.Scoring;
 
 namespace osu.Game.Tests.Visual.EzOsuGame
@@ -60,6 +61,7 @@ namespace osu.Game.Tests.Visual.EzOsuGame
                 CachedDependencies = new (Type, object)[]
                 {
                     (typeof(EzLocalProfileService), profileService),
+                    (typeof(EzSkillProvider), new EzSkillProvider(new EzSkillStore(realm))),
                 },
                 Child = overlay,
             };

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileAggregator.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileAggregator.cs
@@ -64,6 +64,41 @@ namespace osu.Game.EzOsuGame.LocalProfile
         }
 
         /// <summary>
+        /// Detached mania scores for SSR skill aggregation, keyed by normalised username.
+        /// </summary>
+        public Dictionary<string, List<ScoreInfo>> CollectDetachedManiaScores(IReadOnlyCollection<string> usernames)
+        {
+            var includeSet = new HashSet<string>(usernames.Select(normaliseUsername), StringComparer.Ordinal);
+            var byUser = new Dictionary<string, List<ScoreInfo>>(StringComparer.Ordinal);
+
+            realm.Run(r =>
+            {
+                if (includeSet.Count == 0)
+                    return;
+
+                foreach (var score in queryValidScores(r))
+                {
+                    if (score.Ruleset.OnlineID != EzLocalProfileConstants.MANIA_RULESET_ID)
+                        continue;
+
+                    string username = normaliseUsername(score.RealmUser.Username);
+                    if (!includeSet.Contains(username))
+                        continue;
+
+                    if (score.BeatmapInfo == null)
+                        continue;
+
+                    if (!byUser.TryGetValue(username, out var list))
+                        byUser[username] = list = new List<ScoreInfo>();
+
+                    list.Add(score.DeepClone());
+                }
+            });
+
+            return byUser;
+        }
+
+        /// <summary>
         /// Aggregate only the given usernames, returning one result slice per username (all scores counted).
         /// Does not merge online contributions — that happens when rebuilding display totals.
         /// </summary>

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileAnalysisSystem.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileAnalysisSystem.cs
@@ -1,0 +1,14 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    /// <summary>
+    /// Local profile analysis surface under mania: Ez archive stats vs Track (MinaCalc SSR skills).
+    /// </summary>
+    public enum EzLocalProfileAnalysisSystem
+    {
+        Ez = 0,
+        Track = 1,
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileAnalysisSystemSelector.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileAnalysisSystemSelector.cs
@@ -1,0 +1,21 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.Overlays;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    /// <summary>
+    /// Ez / Track switch shown under the mania ruleset selector.
+    /// </summary>
+    public partial class EzLocalProfileAnalysisSystemSelector : OverlaySortTabControl<EzLocalProfileAnalysisSystem>
+    {
+        public EzLocalProfileAnalysisSystemSelector()
+        {
+            Title = EzSettingsProfile.LOCAL_PROFILE_ANALYSIS_SYSTEM;
+            // OsuTabControl already adds all enum values automatically.
+            Current.Value = EzLocalProfileAnalysisSystem.Ez;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOverlay.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOverlay.cs
@@ -26,10 +26,13 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
         private readonly Bindable<RulesetInfo> ruleset = new Bindable<RulesetInfo>();
         private readonly Bindable<string> selectedPlayer = new Bindable<string>(EzLocalProfileConstants.ALL_PLAYERS);
+        private readonly Bindable<EzLocalProfileAnalysisSystem> analysisSystem = new Bindable<EzLocalProfileAnalysisSystem>(EzLocalProfileAnalysisSystem.Ez);
 
         private FillFlowContainer contentFlow = null!;
         private Container emptyStateContainer = null!;
+        private Container analysisSystemRow = null!;
         private OverlayRulesetSelector rulesetSelector = null!;
+        private EzLocalProfileAnalysisSystemSelector analysisSystemSelector = null!;
         private OsuDropdown<string> playerDropdown = null!;
 
         [Resolved]
@@ -97,18 +100,42 @@ namespace osu.Game.EzOsuGame.LocalProfile
                                             RelativeSizeAxes = Axes.Both,
                                             Colour = ColourProvider.Background5,
                                         },
-                                        new Container
+                                        new FillFlowContainer
                                         {
                                             RelativeSizeAxes = Axes.X,
                                             AutoSizeAxes = Axes.Y,
-                                            Padding = new MarginPadding
+                                            Direction = FillDirection.Vertical,
+                                            Children = new Drawable[]
                                             {
-                                                Horizontal = HORIZONTAL_PADDING,
-                                                Vertical = 10
-                                            },
-                                            Child = rulesetSelector = new OverlayRulesetSelector
-                                            {
-                                                Current = { BindTarget = ruleset }
+                                                new Container
+                                                {
+                                                    RelativeSizeAxes = Axes.X,
+                                                    AutoSizeAxes = Axes.Y,
+                                                    Padding = new MarginPadding
+                                                    {
+                                                        Horizontal = HORIZONTAL_PADDING,
+                                                        Vertical = 10
+                                                    },
+                                                    Child = rulesetSelector = new OverlayRulesetSelector
+                                                    {
+                                                        Current = { BindTarget = ruleset }
+                                                    }
+                                                },
+                                                analysisSystemRow = new Container
+                                                {
+                                                    RelativeSizeAxes = Axes.X,
+                                                    AutoSizeAxes = Axes.Y,
+                                                    Padding = new MarginPadding
+                                                    {
+                                                        Horizontal = HORIZONTAL_PADDING,
+                                                        Bottom = 10
+                                                    },
+                                                    Alpha = 0,
+                                                    Child = analysisSystemSelector = new EzLocalProfileAnalysisSystemSelector
+                                                    {
+                                                        Current = { BindTarget = analysisSystem }
+                                                    }
+                                                }
                                             }
                                         }
                                     }
@@ -214,8 +241,13 @@ namespace osu.Game.EzOsuGame.LocalProfile
             base.LoadComplete();
 
             ruleset.Value = rulesets.GetRuleset(0) ?? rulesets.AvailableRulesets.First();
-            ruleset.BindValueChanged(_ => Schedule(refreshContent), true);
+            ruleset.BindValueChanged(_ => Schedule(() =>
+            {
+                updateAnalysisSystemVisibility();
+                refreshContent();
+            }), true);
             selectedPlayer.BindValueChanged(_ => Schedule(refreshContent));
+            analysisSystem.BindValueChanged(_ => Schedule(refreshContent));
 
             profileService.Snapshot.BindValueChanged(s => Schedule(() =>
             {
@@ -225,6 +257,16 @@ namespace osu.Game.EzOsuGame.LocalProfile
             }), true);
 
             API.LocalUser.BindValueChanged(u => Schedule(() => Header.UpdateUsername(u.NewValue.Username)), true);
+            updateAnalysisSystemVisibility();
+        }
+
+        private void updateAnalysisSystemVisibility()
+        {
+            bool mania = (ruleset.Value?.OnlineID ?? -1) == EzLocalProfileConstants.MANIA_RULESET_ID;
+            analysisSystemRow.Alpha = mania ? 1 : 0;
+
+            if (!mania && analysisSystem.Value != EzLocalProfileAnalysisSystem.Ez)
+                analysisSystem.Value = EzLocalProfileAnalysisSystem.Ez;
         }
 
         protected override void PopIn()
@@ -269,14 +311,41 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
             int rulesetId = ruleset.Value?.OnlineID ?? 0;
             var rulesetStats = snapshot.RulesetStats.FirstOrDefault(s => s.RulesetId == rulesetId);
+            bool trackMode = rulesetId == EzLocalProfileConstants.MANIA_RULESET_ID
+                             && analysisSystem.Value == EzLocalProfileAnalysisSystem.Track;
 
             contentFlow.Add(new EzLocalProfileSection(
                 EzSettingsProfile.LOCAL_PROFILE_SECTION_CAREER,
                 new EzLocalProfileCareerBody(rulesetStats, snapshot.GradeCounts.Where(g => g.RulesetId == rulesetId))));
 
-            contentFlow.Add(new EzLocalProfileSection(
-                EzSettingsProfile.LOCAL_PROFILE_SECTION_MODE_DATA,
-                new EzLocalProfileModeDataBody(snapshot, rulesetId)));
+            if (trackMode)
+            {
+                Drawable trackBody;
+
+                if (string.Equals(selectedPlayer.Value, EzLocalProfileConstants.ALL_PLAYERS, StringComparison.Ordinal))
+                {
+                    trackBody = new OsuSpriteText
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Text = EzSettingsProfile.LOCAL_PROFILE_TRACK_NEEDS_PLAYER,
+                        Font = OsuFont.GetFont(size: 14),
+                    };
+                }
+                else
+                {
+                    trackBody = new EzLocalProfileTrackSkillsBody(selectedPlayer.Value);
+                }
+
+                contentFlow.Add(new EzLocalProfileSection(
+                    EzSettingsProfile.LOCAL_PROFILE_SECTION_TRACK_SKILLS,
+                    trackBody));
+            }
+            else
+            {
+                contentFlow.Add(new EzLocalProfileSection(
+                    EzSettingsProfile.LOCAL_PROFILE_SECTION_MODE_DATA,
+                    new EzLocalProfileModeDataBody(snapshot, rulesetId)));
+            }
 
             refreshDrillContent(snapshot, rulesetId);
         }

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileRoundedBar.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileRoundedBar.cs
@@ -16,10 +16,12 @@ namespace osu.Game.EzOsuGame.LocalProfile
     public partial class EzLocalProfileRoundedBar : Container
     {
         private readonly float fillRatio;
+        private readonly Colour4? fillColour;
 
-        public EzLocalProfileRoundedBar(float fillRatio)
+        public EzLocalProfileRoundedBar(float fillRatio, Colour4? fillColour = null)
         {
             this.fillRatio = float.IsFinite(fillRatio) ? Math.Clamp(fillRatio, 0f, 1f) : 0;
+            this.fillColour = fillColour;
             RelativeSizeAxes = Axes.Both;
             Masking = true;
             CornerRadius = 6;
@@ -39,7 +41,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 {
                     RelativeSizeAxes = Axes.Both,
                     Width = fillRatio,
-                    Colour = colours.Highlight1,
+                    Colour = fillColour ?? colours.Highlight1,
                 }
             };
         }

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileService.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileService.cs
@@ -14,6 +14,7 @@ using osu.Game.Database;
 using osu.Game.EzOsuGame.Analysis;
 using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.Scoring;
+using osu.Game.EzOsuGame.Skills;
 using osu.Game.Scoring;
 
 namespace osu.Game.EzOsuGame.LocalProfile
@@ -25,6 +26,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
     {
         private readonly EzLocalProfileStore store;
         private readonly EzLocalProfileAggregator aggregator;
+        private readonly EzPlayerSsrAggregator? ssrAggregator;
         private readonly Lock computeLock = new Lock();
         private CancellationTokenSource? computeCts;
 
@@ -38,10 +40,12 @@ namespace osu.Game.EzOsuGame.LocalProfile
             EzAnalysisPersistentStore analysisStore,
             BeatmapManager beatmapManager,
             ScoreManager scoreManager,
-            IEzReplaySession replaySession)
+            IEzReplaySession replaySession,
+            EzPlayerSsrAggregator? ssrAggregator = null)
         {
             store = new EzLocalProfileStore(storage);
             aggregator = new EzLocalProfileAggregator(realm, analysisStore, beatmapManager, scoreManager, replaySession);
+            this.ssrAggregator = ssrAggregator;
             Snapshot.Value = store.LoadSnapshot();
         }
 
@@ -104,6 +108,9 @@ namespace osu.Game.EzOsuGame.LocalProfile
                         var online = store.LoadOnlineScoreContributions();
                         var localOnlineIds = aggregator.CollectLocalOnlineScoreIds();
                         store.ApplyUsernamePartitions(byUser, replaceOtherUsernames, online, localOnlineIds);
+
+                        if (ssrAggregator != null && selected.Count > 0)
+                            writePlayerSsr(selected, token);
                     }
                     catch (OperationCanceledException)
                     {
@@ -119,6 +126,33 @@ namespace osu.Game.EzOsuGame.LocalProfile
                         IsComputing.Value = false;
                     }
                 }, token);
+            }
+        }
+
+        private void writePlayerSsr(IReadOnlyList<string> usernames, CancellationToken token)
+        {
+            try
+            {
+                var maniaScores = aggregator.CollectDetachedManiaScores(usernames);
+
+                foreach ((string username, List<ScoreInfo> scores) in maniaScores)
+                {
+                    token.ThrowIfCancellationRequested();
+
+                    if (scores.Count == 0)
+                        continue;
+
+                    ssrAggregator!.ComputeAndStore(username, scores);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // Profile archive already saved; SSR is best-effort for Track mode.
+                Logger.Error(ex, "[EzLocalProfile] Failed to compute player SSR skills after profile save.", Ez2ConfigManager.LOGGER_NAME);
             }
         }
 

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileTrackSkillsBody.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileTrackSkillsBody.cs
@@ -1,0 +1,242 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Globalization;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Events;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.EzOsuGame.Skills;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    /// <summary>
+    /// Track-mode skills body: key-count chips + SSR skill bars from Realm.
+    /// </summary>
+    public partial class EzLocalProfileTrackSkillsBody : FillFlowContainer
+    {
+        private readonly string username;
+
+        private readonly BindableInt selectedKeyCount = new BindableInt();
+        private FillFlowContainer keyChipFlow = null!;
+        private FillFlowContainer skillBarsFlow = null!;
+        private OsuSpriteText emptyHint = null!;
+
+        [Resolved]
+        private EzSkillProvider skillProvider { get; set; } = null!;
+
+        public EzLocalProfileTrackSkillsBody(string username)
+        {
+            this.username = username;
+
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            Direction = FillDirection.Vertical;
+            Spacing = new Vector2(0, 14);
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Children = new Drawable[]
+            {
+                keyChipFlow = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Full,
+                    Spacing = new Vector2(8),
+                },
+                emptyHint = new OsuSpriteText
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Font = OsuFont.GetFont(size: 14),
+                    Alpha = 0,
+                },
+                skillBarsFlow = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Vertical,
+                    Spacing = new Vector2(0, 8),
+                },
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            selectedKeyCount.BindValueChanged(_ => refreshSkillBars(), false);
+            rebuild();
+        }
+
+        private void rebuild()
+        {
+            keyChipFlow.Clear();
+            skillBarsFlow.Clear();
+
+            var keyCounts = skillProvider.GetPlayerSsrKeyCounts(username);
+
+            if (keyCounts.Count == 0)
+            {
+                emptyHint.Text = EzSettingsProfile.LOCAL_PROFILE_TRACK_EMPTY;
+                emptyHint.Show();
+                return;
+            }
+
+            emptyHint.Hide();
+
+            foreach (int key in keyCounts)
+            {
+                keyChipFlow.Add(new KeyChip(key, selectedKeyCount)
+                {
+                    Anchor = Anchor.TopLeft,
+                    Origin = Anchor.TopLeft,
+                });
+            }
+
+            if (!keyCounts.Contains(selectedKeyCount.Value))
+                selectedKeyCount.Value = keyCounts[0];
+            else
+                refreshSkillBars();
+        }
+
+        private void refreshSkillBars()
+        {
+            skillBarsFlow.Clear();
+
+            int keyCount = selectedKeyCount.Value;
+            if (keyCount <= 0)
+                return;
+
+            var skills = skillProvider.GetPlayerSsr(username, keyCount);
+            var definitions = skillProvider.Registry.GetSystem(EzSkillSystems.PLAYER_SSR)?.Skills
+                              ?? Array.Empty<EzSkillDefinition>();
+
+            double max = skills.Values.DefaultIfEmpty(0).Max();
+            if (max <= 0)
+                max = 1;
+
+            foreach (var def in definitions)
+            {
+                skills.TryGetValue(def.SkillId, out double value);
+                float ratio = (float)(value / max);
+                skillBarsFlow.Add(new SkillBarRow(def.DisplayName, value, ratio, Colour4.FromHex(def.AccentHex)));
+            }
+        }
+
+        private partial class KeyChip : OsuClickableContainer
+        {
+            private readonly int keyCount;
+            private readonly BindableInt selected;
+            private Box background = null!;
+            private OsuSpriteText label = null!;
+
+            public KeyChip(int keyCount, BindableInt selected)
+            {
+                this.keyCount = keyCount;
+                this.selected = selected;
+
+                AutoSizeAxes = Axes.Both;
+                Masking = true;
+                CornerRadius = 8;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colours)
+            {
+                Children = new Drawable[]
+                {
+                    background = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = colours.Background5,
+                    },
+                    new Container
+                    {
+                        AutoSizeAxes = Axes.Both,
+                        Padding = new MarginPadding { Horizontal = 12, Vertical = 8 },
+                        Child = label = new OsuSpriteText
+                        {
+                            Text = $"{keyCount}K",
+                            Font = OsuFont.GetFont(size: 13, weight: FontWeight.Bold),
+                        }
+                    }
+                };
+
+                Action = () => selected.Value = keyCount;
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+                selected.BindValueChanged(_ => updateVisual(), true);
+            }
+
+            protected override bool OnHover(HoverEvent e)
+            {
+                updateVisual();
+                return base.OnHover(e);
+            }
+
+            protected override void OnHoverLost(HoverLostEvent e)
+            {
+                updateVisual();
+                base.OnHoverLost(e);
+            }
+
+            private void updateVisual()
+            {
+                bool active = selected.Value == keyCount;
+                label.Font = label.Font.With(weight: active ? FontWeight.Bold : FontWeight.SemiBold);
+                background.FadeTo(active || IsHovered ? 1f : 0.7f, 80);
+            }
+        }
+
+        private partial class SkillBarRow : Container
+        {
+            public SkillBarRow(string displayName, double value, float ratio, Colour4 accent)
+            {
+                RelativeSizeAxes = Axes.X;
+                Height = 22;
+                Padding = new MarginPadding { Horizontal = 4 };
+
+                Children = new Drawable[]
+                {
+                    new OsuSpriteText
+                    {
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Text = displayName,
+                        Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
+                        Width = 96,
+                    },
+                    new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Padding = new MarginPadding { Left = 104, Right = 56 },
+                        Child = new EzLocalProfileRoundedBar(ratio, accent),
+                    },
+                    new OsuSpriteText
+                    {
+                        Anchor = Anchor.CentreRight,
+                        Origin = Anchor.CentreRight,
+                        Text = value.ToString("0.00", CultureInfo.InvariantCulture),
+                        Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
+                    },
+                };
+            }
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Localization/EzSettings.Profile.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettings.Profile.cs
@@ -107,6 +107,22 @@ namespace osu.Game.EzOsuGame.Localization
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SECTION_MODE_DATA =
             new EzLocalizationManager.EzLocalisableString("各模式统计", "Stats by mode");
 
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_ANALYSIS_SYSTEM =
+            new EzLocalizationManager.EzLocalisableString("分析系统", "Analysis");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SECTION_TRACK_SKILLS =
+            new EzLocalizationManager.EzLocalisableString("Track 技能", "Track Skills");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_TRACK_EMPTY =
+            new EzLocalizationManager.EzLocalisableString(
+                "暂无 Track 技能。请到设置重新计算本地个人成绩（需该玩家名下的 Mania 成绩）。",
+                "No Track skills yet. Recompute Local Profile Stats in Settings (requires mania scores for this player).");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_TRACK_NEEDS_PLAYER =
+            new EzLocalizationManager.EzLocalisableString(
+                "Track 技能按玩家名计算。请在上方选择具体玩家（不要选 All）。",
+                "Track skills are per player. Select a specific player above (not All).");
+
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_XXY_PLAY_DISTRIBUTION =
             new EzLocalizationManager.EzLocalisableString("xxy 星级分布", "Plays by xxy SR");
 

--- a/osu.Game/EzOsuGame/Skills/EzSkillProvider.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSkillProvider.cs
@@ -29,6 +29,9 @@ namespace osu.Game.EzOsuGame.Skills
         public IReadOnlyDictionary<string, double> GetPlayerSsr(string username, int keyCount)
             => store.GetPlayerSkills(username, keyCount, EzSkillSystems.PLAYER_SSR);
 
+        public IReadOnlyList<int> GetPlayerSsrKeyCounts(string username)
+            => store.GetPlayerSsrKeyCounts(username);
+
         public IReadOnlyList<EzPlayerSkillHistoryPoint> GetPlayerSkillHistory(string username, int keyCount, string skillId, int maxPoints = 64)
             => store.GetPlayerSkillHistory(username, keyCount, skillId, maxPoints);
 

--- a/osu.Game/EzOsuGame/Skills/EzSkillStore.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSkillStore.cs
@@ -106,6 +106,24 @@ namespace osu.Game.EzOsuGame.Skills
             });
         }
 
+        public IReadOnlyList<int> GetPlayerSsrKeyCounts(string username, int? algorithmVersion = null)
+        {
+            int version = algorithmVersion ?? EzManiaSkillAlgorithm.VERSION;
+
+            return realmAccess.Run(r =>
+            {
+                return r.All<EzPlayerSkillValue>()
+                        .Where(v => v.Username == username
+                                    && v.SystemId == EzSkillSystems.PLAYER_SSR
+                                    && v.AlgorithmVersion == version)
+                        .AsEnumerable()
+                        .Select(v => v.KeyCount)
+                        .Distinct()
+                        .OrderBy(k => k)
+                        .ToList();
+            });
+        }
+
         public void WritePlayerSsr(
             string username,
             int keyCount,
@@ -191,7 +209,7 @@ namespace osu.Game.EzOsuGame.Skills
             {
                 var row = r.All<EzDanEstimate>()
                            .FirstOrDefault(v => v.Username == username && v.KeyCount == keyCount && v.Side == side);
-                return row == null ? null : row.Detach();
+                return row?.Detach();
             });
         }
 

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -411,16 +411,18 @@ namespace osu.Game
             dependencies.Cache(ezAnalysisCache = new EzAnalysisCache());
             ReplaySession = new EzReplaySessionRouter(RulesetStore.AvailableRulesets);
             dependencies.CacheAs<IEzReplaySession>(ReplaySession);
-            dependencies.Cache(new EzLocalProfileService(Storage, realm, ezAnalysisPersistentStore, BeatmapManager, ScoreManager, ReplaySession));
-            dependencies.Cache(new EzLocalProfileOnlinePullService(API, ScoreManager, BeatmapManager, realm, Storage));
 
             var skillRegistry = new EzSkillRegistry();
             var skillStore = new EzSkillStore(realm);
+            var playerSsrAggregator = new EzPlayerSsrAggregator(BeatmapManager, skillStore);
             dependencies.Cache(skillRegistry);
             dependencies.Cache(skillStore);
             dependencies.Cache(new EzSkillProvider(skillStore, skillRegistry));
             dependencies.Cache(new EzBeatmapMsdComputer(BeatmapManager, skillStore));
-            dependencies.Cache(new EzPlayerSsrAggregator(BeatmapManager, skillStore));
+            dependencies.Cache(playerSsrAggregator);
+
+            dependencies.Cache(new EzLocalProfileService(Storage, realm, ezAnalysisPersistentStore, BeatmapManager, ScoreManager, ReplaySession, playerSsrAggregator));
+            dependencies.Cache(new EzLocalProfileOnlinePullService(API, ScoreManager, BeatmapManager, realm, Storage));
 
             if (Ez2ConfigManager.Get<bool>(Ez2Setting.EzScoreRaceServiceEnabled))
             {


### PR DESCRIPTION
## Summary
- **Depends on #96 — merge #96 first**, then retarget/merge this PR (stacked on `feature/mania-skills-realm-ez8`).
- After local profile compute, persist player SSR via `EzPlayerSsrAggregator` (no Realm schema bump).
- Mania-only Ez/Track analysis switch: Track shows key-mode chips + SSR skill bars from `EzSkillProvider`; score drill stays.

## Test plan
- [ ] Confirm diff does **not** change `EZ_REALM_SCHEMA_VERSION`
- [ ] Merge #96 first; then merge this branch (or retarget base to `master` after #96 lands)
- [ ] Open Local Profile → mania → switch Ez / Track
- [ ] With player = All on Track: see “select a player” hint
- [ ] After recompute with mania scores for one player: Track shows 4K/7K/… chips and skill bars
- [ ] Non-mania rulesets hide the analysis switch and keep Mode Data

Made with [Cursor](https://cursor.com)