### PR TITLE
Align EZ2AC LN with arcade 16th tick combo

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/HitModeReplayFixtures.cs
+++ b/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/HitModeReplayFixtures.cs
@@ -95,6 +95,9 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
 
         public static (Score score, IBeatmap beatmap, GameplayEnvironment environment) CreateEz2AcHoldHeadPerfect()
         {
+            var environment = ReplayJudgeTestConfig.Create(EzEnumHitMode.EZ2AC, EzEnumHealthMode.Ez2Ac);
+            ReplayJudgeTestConfig.ApplyToGlobalConfig(environment);
+
             var ruleset = new ManiaRuleset();
             var beatmap = new TestBeatmap(ruleset.RulesetInfo)
             {
@@ -102,7 +105,7 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
                 {
                     new HoldNote { StartTime = 1000, Duration = 1000, Column = 0 },
                 },
-                ControlPointInfo = new ControlPointInfo(),
+                ControlPointInfo = createTiming120(),
             };
 
             foreach (var obj in beatmap.HitObjects)
@@ -113,13 +116,51 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
                 Frames = new List<ReplayFrame>
                 {
                     new ManiaReplayFrame(1000, ManiaAction.Key1),
-                    new ManiaReplayFrame(2000),
+                    // 持满到尾后仍按住；尾为 Ignore，无需精准松手
+                    new ManiaReplayFrame(2200),
                 },
             };
 
-            var environment = ReplayJudgeTestConfig.Create(EzEnumHitMode.EZ2AC, EzEnumHealthMode.Ez2Ac);
+            return (createScore(ruleset, replay), beatmap, environment);
+        }
 
+        /// <summary>
+        /// 头按住到尾，中途不松：应有 SliderTailHit tick，且 Statistics 基础档不含 tick。
+        /// </summary>
+        public static (Score score, IBeatmap beatmap, GameplayEnvironment environment) CreateEz2AcHoldThroughEnd()
+            => CreateEz2AcHoldHeadPerfect();
+
+        /// <summary>
+        /// 中途松手：tick 为 IgnoreMiss，无 ComboBreak；之后可再抓。
+        /// </summary>
+        public static (Score score, IBeatmap beatmap, GameplayEnvironment environment) CreateEz2AcHoldEarlyReleaseNoComboBreak()
+        {
+            var environment = ReplayJudgeTestConfig.Create(EzEnumHitMode.EZ2AC, EzEnumHealthMode.Ez2Ac);
             ReplayJudgeTestConfig.ApplyToGlobalConfig(environment);
+
+            var ruleset = new ManiaRuleset();
+            var beatmap = new TestBeatmap(ruleset.RulesetInfo)
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new HoldNote { StartTime = 1000, Duration = 2000, Column = 0 },
+                },
+                ControlPointInfo = createTiming120(),
+            };
+
+            foreach (var obj in beatmap.HitObjects)
+                obj.ApplyDefaults(beatmap.ControlPointInfo, beatmap.Difficulty);
+
+            var replay = new Replay
+            {
+                Frames = new List<ReplayFrame>
+                {
+                    new ManiaReplayFrame(1000, ManiaAction.Key1),
+                    new ManiaReplayFrame(1500),
+                    new ManiaReplayFrame(3200),
+                },
+            };
+
             return (createScore(ruleset, replay), beatmap, environment);
         }
 
@@ -389,12 +430,12 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
                 EzEnumHitMode.Malody_E or EzEnumHitMode.Malody_B => CreateMalodyHoldPerfect(hitMode),
                 EzEnumHitMode.EZ2AC => CreateEz2AcHoldHeadPerfect(),
                 EzEnumHitMode.O2Jam => CreateO2HoldPerfect(),
-                EzEnumHitMode.IIDX_HD or EzEnumHitMode.LR2_HD or EzEnumHitMode.Raja_NM => CreateBmsHoldPerfect(hitMode),
+                EzEnumHitMode.IIDX_HD or EzEnumHitMode.LR2_HD or EzEnumHitMode.Raja_NM => createBmsHoldPerfect(hitMode),
                 _ => CreateO2HoldPerfect(),
             };
         }
 
-        private static (Score score, IBeatmap beatmap, GameplayEnvironment environment) CreateBmsHoldPerfect(EzEnumHitMode hitMode)
+        private static (Score score, IBeatmap beatmap, GameplayEnvironment environment) createBmsHoldPerfect(EzEnumHitMode hitMode)
         {
             const double head = 1500;
             const double tail = 4000;
@@ -521,7 +562,7 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
         }
 
         /// <summary>
-        /// LN 头在 Great 窗口应经 SoftenLnJudge 升为 Perfect。
+        /// LN 头在 Great(Cool) 窗口应经 SoftenLnHeadJudge 升为 Kool。
         /// </summary>
         public static (Score score, IBeatmap beatmap, GameplayEnvironment environment) CreateEz2AcHoldHeadGreatSoftened()
         {
@@ -544,7 +585,7 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
                 {
                     new HoldNote { StartTime = head, Duration = tail - head, Column = 0 },
                 },
-                ControlPointInfo = new ControlPointInfo(),
+                ControlPointInfo = createTiming120(),
             };
 
             foreach (var obj in beatmap.HitObjects)

--- a/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/ManiaReplaySessionTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/EzMania/ReplayJudge/ManiaReplaySessionTest.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Game.Beatmaps;
@@ -344,6 +345,36 @@ namespace osu.Game.Rulesets.Mania.Tests.EzMania.ReplayJudge
             Assert.That(ManiaReplayParityHelper.AreJudgementsEquivalent(generatorEvents, sessionEvents), Is.True,
                 () => $"generator=[{ManiaReplayParityHelper.DescribeJudgements(generatorEvents)}] session=[{ManiaReplayParityHelper.DescribeJudgements(sessionEvents)}]");
             Assert.That(sessionEvents.Single(e => e.HitObject is HeadNote).Result, Is.EqualTo(Ez2AcHitModeJudgement.MapTo(Ez2AcJudge.Kool)));
+        }
+
+        [Test]
+        public void TestEz2AcHoldThroughEndTicksIncreaseComboWithoutBasicStats()
+        {
+            var (score, beatmap, environment) = HitModeReplayFixtures.CreateEz2AcHoldThroughEnd();
+            var hold = (HoldNote)beatmap.HitObjects[0];
+
+            Assert.That(hold.Ticks, Is.Not.Null.And.Not.Empty);
+
+            var resultScore = ManiaReplaySession.Run(score, beatmap, environment);
+            var events = resultScore.ScoreInfo.HitEvents;
+
+            Assert.That(events.Count(e => e.HitObject is HoldNoteTick && e.Result == HitResult.SliderTailHit), Is.EqualTo(hold.Ticks!.Count));
+            Assert.That(resultScore.ScoreInfo.Statistics.GetValueOrDefault(HitResult.Perfect), Is.EqualTo(1), "only head Kool should count as Perfect");
+            Assert.That(resultScore.ScoreInfo.Statistics.GetValueOrDefault(HitResult.SliderTailHit), Is.EqualTo(hold.Ticks.Count));
+            Assert.That(resultScore.ScoreInfo.Statistics.GetValueOrDefault(HitResult.ComboBreak), Is.EqualTo(0));
+            Assert.That(resultScore.ScoreInfo.MaxCombo, Is.GreaterThanOrEqualTo(1 + hold.Ticks.Count));
+        }
+
+        [Test]
+        public void TestEz2AcHoldEarlyReleaseDoesNotComboBreak()
+        {
+            var (score, beatmap, environment) = HitModeReplayFixtures.CreateEz2AcHoldEarlyReleaseNoComboBreak();
+            var resultScore = ManiaReplaySession.Run(score, beatmap, environment);
+            var events = resultScore.ScoreInfo.HitEvents;
+
+            Assert.That(resultScore.ScoreInfo.Statistics.GetValueOrDefault(HitResult.ComboBreak), Is.EqualTo(0));
+            Assert.That(events.Any(e => e.HitObject is HoldNoteTick && e.Result == HitResult.IgnoreMiss), Is.True);
+            Assert.That(events.Single(e => e.HitObject is HeadNote).Result, Is.EqualTo(HitResult.Perfect));
         }
 
         [Test]

--- a/osu.Game.Rulesets.Mania.Tests/TestSceneReplaySessionParity.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneReplaySessionParity.cs
@@ -223,21 +223,7 @@ namespace osu.Game.Rulesets.Mania.Tests
         [Test]
         public void TestEz2AcHoldDrawableMatchesSession()
         {
-            parityEnvironment = ReplayJudgeTestConfig.Create(EzEnumHitMode.EZ2AC, EzEnumHealthMode.Ez2Ac);
-
-            const double head = 1000;
-            const double tail = 2000;
-
-            runDrawableParityTest(
-                new List<ManiaHitObject>
-                {
-                    new HoldNote { StartTime = head, Duration = tail - head, Column = 0 },
-                },
-                new List<ReplayFrame>
-                {
-                    new ManiaReplayFrame(head, ManiaAction.Key1),
-                    new ManiaReplayFrame(tail),
-                });
+            runDrawableParityTestFromFixture(HitModeReplayFixtures.CreateEz2AcHoldThroughEnd());
         }
 
         // ==================== POLICY-PARITY: JudgePrecedence × 叠键 ====================
@@ -324,8 +310,7 @@ namespace osu.Game.Rulesets.Mania.Tests
         }
 
         /// <summary>
-        /// [Ez] 断连 LN（提早松手、尾判 miss）：用户报告 EZ2AC 下游戏结束统计比 Session 重算少若干判定，
-        /// 缺失数量与 ComboBreak 数一致。全量比较 Statistics（含 ComboBreak / Miss）。
+        /// [Ez] 中途松手 LN：EZ2AC 现为 tick IgnoreMiss（不断 combo），尾 Ignore；与 Session 全量 Statistics 对齐。
         /// </summary>
         [Test]
         public void TestFullScoreParity_Ez2AcBrokenHold()
@@ -344,14 +329,14 @@ namespace osu.Game.Rulesets.Mania.Tests
                 new List<ReplayFrame>
                 {
                     new ManiaReplayFrame(head, ManiaAction.Key1),
-                    new ManiaReplayFrame(1500), // 提早松手 → hold break，尾判 miss
+                    new ManiaReplayFrame(1500), // 提早松手 → tick IgnoreMiss，不断 combo
                     new ManiaReplayFrame(4000, ManiaAction.Key2),
                     new ManiaReplayFrame(4100),
                 });
         }
 
         /// <summary>
-        /// [Ez] 断连后重按到尾判：EZ2AC 断连 LN 的另一常见形态。
+        /// [Ez] 断连后重按：再抓后 tick 恢复涨 combo。
         /// </summary>
         [Test]
         public void TestFullScoreParity_Ez2AcBrokenHoldRepress()
@@ -372,7 +357,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                     new ManiaReplayFrame(head, ManiaAction.Key1),
                     new ManiaReplayFrame(1500), // 中途断连
                     new ManiaReplayFrame(2000, ManiaAction.Key1), // 重按
-                    new ManiaReplayFrame(tail), // 到尾判才松手
+                    new ManiaReplayFrame(tail + 200), // 持过尾再松
                     new ManiaReplayFrame(4000, ManiaAction.Key2),
                     new ManiaReplayFrame(4100),
                 });
@@ -406,7 +391,7 @@ namespace osu.Game.Rulesets.Mania.Tests
         }
 
         /// <summary>
-        /// [Ez] 持满 body 但在尾键窗外松手：曾导致 Tail HandledNoOp 永久循环、HasCompleted 无法达标。
+        /// [Ez] 持满过尾再松：尾为 IgnoreHit，不应再因晚松 Fail；与 Session 对齐并能正常收束。
         /// </summary>
         [Test]
         public void TestFullScoreParity_Ez2AcLateTailRelease()
@@ -425,7 +410,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 new List<ReplayFrame>
                 {
                     new ManiaReplayFrame(head, ManiaAction.Key1),
-                    new ManiaReplayFrame(3500), // 尾窗结束后松手
+                    new ManiaReplayFrame(3500), // 持过尾再松
                     new ManiaReplayFrame(5000, ManiaAction.Key2),
                     new ManiaReplayFrame(5100),
                 },
@@ -490,16 +475,20 @@ namespace osu.Game.Rulesets.Mania.Tests
 
             AddStep("load player", () =>
             {
-                Beatmap.Value = CreateWorkingBeatmap(new ManiaBeatmap(new StageDefinition(4))
+                var beatmap = new ManiaBeatmap(new StageDefinition(4))
                 {
                     HitObjects = hitObjects,
                     BeatmapInfo =
                     {
                         Ruleset = new ManiaRuleset().RulesetInfo,
                     },
-                });
+                };
 
-                Beatmap.Value.Beatmap.ControlPointInfo.Add(0, new EffectControlPoint { ScrollSpeed = 0.1f });
+                // 与 Session fixtures 一致：120 BPM，保证 EZ2AC LN 16 分 tick 网格对齐。
+                beatmap.ControlPointInfo.Add(0, new TimingControlPoint { BeatLength = 500 });
+                beatmap.ControlPointInfo.Add(0, new EffectControlPoint { ScrollSpeed = 0.1f });
+
+                Beatmap.Value = CreateWorkingBeatmap(beatmap);
 
                 replayScore = new Score { Replay = new Replay { Frames = frames } };
                 ReplayJudgeTestConfig.ApplyEmbeddedModes(replayScore, parityEnvironment);
@@ -533,16 +522,20 @@ namespace osu.Game.Rulesets.Mania.Tests
 
             AddStep("load player", () =>
             {
-                Beatmap.Value = CreateWorkingBeatmap(new ManiaBeatmap(new StageDefinition(4))
+                var beatmap = new ManiaBeatmap(new StageDefinition(4))
                 {
                     HitObjects = hitObjects,
                     BeatmapInfo =
                     {
                         Ruleset = new ManiaRuleset().RulesetInfo,
                     },
-                });
+                };
 
-                Beatmap.Value.Beatmap.ControlPointInfo.Add(0, new EffectControlPoint { ScrollSpeed = 0.1f });
+                // 与 Session fixtures 一致：120 BPM，保证 EZ2AC LN 16 分 tick 网格对齐。
+                beatmap.ControlPointInfo.Add(0, new TimingControlPoint { BeatLength = 500 });
+                beatmap.ControlPointInfo.Add(0, new EffectControlPoint { ScrollSpeed = 0.1f });
+
+                Beatmap.Value = CreateWorkingBeatmap(beatmap);
 
                 replayScore = new Score { Replay = new Replay { Frames = frames } };
                 ReplayJudgeTestConfig.ApplyEmbeddedModes(replayScore, parityEnvironment);

--- a/osu.Game.Rulesets.Mania/EzMania/Helper/HitModeHelper.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/Helper/HitModeHelper.cs
@@ -441,6 +441,12 @@ namespace osu.Game.Rulesets.Mania.EzMania.Helper
                 case HitResult.Good:
                     return 41;  // Good
 
+                // LN tick 只推 combo，不计 ACC/判定档分值
+                case HitResult.LargeTickHit:
+                case HitResult.LargeTickMiss:
+                case HitResult.SliderTailHit:
+                    return 0;
+
                 default:
                     return 0;
             }

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaEnvironmentJudgements.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaEnvironmentJudgements.cs
@@ -19,10 +19,20 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
     {
         public static Judgement CreateForTailNote(EzEnumHitMode hitMode)
         {
-            if (MalodyHitModeJudgement.IsMalodyMode(hitMode))
+            // Malody / EZ2AC：尾不单独计分（无松手窗），仅 Ignore 完结。
+            if (MalodyHitModeJudgement.IsMalodyMode(hitMode) || hitMode == EzEnumHitMode.EZ2AC)
                 return new MalodyTailJudgement();
 
             return new ManiaJudgement();
+        }
+
+        public static Judgement CreateForHoldNoteTick(EzEnumHitMode hitMode)
+        {
+            if (hitMode == EzEnumHitMode.EZ2AC)
+                return new HoldNoteTickJudgement();
+
+            // 其它模式：tick 仍存在于 nested 树中，Ignore 完结以免卡 AllJudged，且不计分。
+            return new IgnoreJudgement();
         }
 
         public static void ApplyToBeatmap(IBeatmap beatmap, EzEnumHitMode hitMode)
@@ -33,8 +43,16 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
 
         private static void applyRecursive(HitObject hitObject, EzEnumHitMode hitMode)
         {
-            if (hitObject is TailNote)
-                hitObject.SetJudgement(CreateForTailNote(hitMode));
+            switch (hitObject)
+            {
+                case TailNote:
+                    hitObject.SetJudgement(CreateForTailNote(hitMode));
+                    break;
+
+                case HoldNoteTick:
+                    hitObject.SetJudgement(CreateForHoldNoteTick(hitMode));
+                    break;
+            }
 
             foreach (var nested in hitObject.NestedHitObjects)
                 applyRecursive(nested, hitMode);

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaEzDrawableJudgement.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaEzDrawableJudgement.cs
@@ -31,6 +31,9 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
         private static readonly ConditionalWeakTable<DrawableHoldNote, O2HitModeJudgement.HoldBreakState> o2_hold_states =
             new ConditionalWeakTable<DrawableHoldNote, O2HitModeJudgement.HoldBreakState>();
 
+        private static readonly ConditionalWeakTable<DrawableHoldNote, Ez2AcHoldState> ez2ac_hold_states =
+            new ConditionalWeakTable<DrawableHoldNote, Ez2AcHoldState>();
+
         public static bool CanRouteToKPoor(DrawableNote note) => GetBmsState(note).CanRouteToKPoor;
 
         public static bool CanRouteToKPoor(DrawableHoldNoteTail tail) => GetBmsState(tail).CanRouteToKPoor;
@@ -98,6 +101,97 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
             return true;
         }
 
+        internal static bool TryEz2AcHoldOnReleased(DrawableHoldNote hold)
+        {
+            var round = getJudgementRound(hold);
+
+            if (round.Environment.ManiaHitMode != EzEnumHitMode.EZ2AC)
+                return false;
+
+            if (!hold.IsHolding.Value)
+                return false;
+
+            var state = GetEz2AcHoldState(hold);
+            state.OnRelease();
+            hold.Result.ReportHoldState(hold.Time.Current, false);
+
+            // 尾到达后才完结；中途松手可再抓，不判尾、不断 Body。
+            if (hold.Time.Current >= hold.Tail.HitObject.StartTime)
+            {
+                hold.Tail.UpdateResult();
+                if (!hold.Body.AllJudged)
+                    hold.Body.TriggerResult(true);
+            }
+
+            return true;
+        }
+
+        internal static bool TryEz2AcHoldCheckForResult(DrawableHoldNote hold, bool userTriggered, double timeOffset)
+        {
+            var round = getJudgementRound(hold);
+
+            if (round.Environment.ManiaHitMode != EzEnumHitMode.EZ2AC)
+                return false;
+
+            if (!hold.Tail.AllJudged)
+                return false;
+
+            hold.EzFinalizeEz2AcHoldFromTail();
+            return true;
+        }
+
+        internal static bool TryHoldTickCheckForResult(DrawableHoldNoteTick tick, bool userTriggered, double timeOffset)
+        {
+            if (userTriggered)
+                return true;
+
+            if (timeOffset < 0)
+                return true;
+
+            if (tick.HoldNote is not DrawableHoldNote hold)
+                return false;
+
+            var round = getJudgementRound(tick);
+
+            if (round.Environment.ManiaHitMode != EzEnumHitMode.EZ2AC)
+                return false;
+
+            var state = GetEz2AcHoldState(hold);
+            bool holding = hold.IsHolding.Value;
+            var result = Ez2AcHitModeJudgement.Instance.EvaluateTick(state, holding);
+            tick.EzApplyTickResult(result);
+            return true;
+        }
+
+        internal static Ez2AcHoldState GetEz2AcHoldState(DrawableHoldNote hold)
+            => ez2ac_hold_states.GetValue(hold, _ => new Ez2AcHoldState());
+
+        /// <summary>头判定应用后同步 EZ2AC LN 状态机。</summary>
+        internal static void NotifyEz2AcHeadJudged(DrawableHoldNote hold, HitResult headResult, bool wasHoldingBeforePress)
+        {
+            var round = getJudgementRound(hold);
+
+            if (round.Environment.ManiaHitMode != EzEnumHitMode.EZ2AC)
+                return;
+
+            var state = GetEz2AcHoldState(hold);
+            var judge = Ez2AcHitModeJudgement.FromHitResult(headResult);
+            state.OnHeadJudged(judge, preHeld: wasHoldingBeforePress);
+        }
+
+        internal static void NotifyEz2AcRepress(DrawableHoldNote hold)
+        {
+            var round = getJudgementRound(hold);
+
+            if (round.Environment.ManiaHitMode != EzEnumHitMode.EZ2AC)
+                return;
+
+            if (!hold.Head.AllJudged)
+                return;
+
+            GetEz2AcHoldState(hold).OnRepress();
+        }
+
         internal static bool TryHitModeCheckForResult(DrawableNote note, bool userTriggered, double timeOffset)
             => TryApplyEzNoteCheckForResult(note, userTriggered, timeOffset);
 
@@ -150,6 +244,9 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
                     else
                         drawable.EzApplyFinalResult(outcome.Result, round.Environment.ManiaHitMode);
 
+                    if (drawable is DrawableHoldNoteHead head && head.ParentHold is DrawableHoldNote hold)
+                        NotifyEz2AcHeadJudged(hold, outcome.Result, wasHoldingBeforePress: false);
+
                     break;
 
                 case ManiaNoteJudgementOutcomeKind.DispatchExtra:
@@ -190,6 +287,9 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
                 return false;
 
             if (TryMalodyHoldOnReleased(hold))
+                return true;
+
+            if (TryEz2AcHoldOnReleased(hold))
                 return true;
 
             hold.Tail.UpdateResult();

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaJudgementKernel.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaJudgementKernel.cs
@@ -264,39 +264,13 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
                 return HoldTailEvaluationResult.FromResult(O2HitModeJudgement.MapTo(judge));
             }
 
-            if (strategy is Ez2AcHitModeJudgement ez2Ac)
+            if (strategy is Ez2AcHitModeJudgement)
             {
-                if (!request.UserTriggered)
-                {
-                    if (request.TimeOffset < 0)
-                        return HoldTailEvaluationResult.HandledNoOp;
-
-                    if (!request.HitWindows.CanBeHit(request.TimeOffset))
-                        return HoldTailEvaluationResult.MinResult;
-
+                // EZ2AC：尾无松手窗。未到尾 → 不完结（可再抓）；到点后 IgnoreHit。
+                if (request.TimeOffset < 0)
                     return HoldTailEvaluationResult.HandledNoOp;
-                }
 
-                var tailJudge = ez2Ac.EvaluateTailJudge(new HoldTailEvaluationContext
-                {
-                    RawOffset = request.RawOffset,
-                    TimeOffsetForJudgement = request.TimeOffset,
-                    HitWindows = request.HitWindows,
-                    HeadHit = request.HeadHit,
-                    HoldBreak = ez2Ac.IsHoldBreak(request.RawOffset, request.HitWindows),
-                    HoldBroken = request.HoldBroken,
-                    WasHoldingBeforeRelease = request.WasHolding,
-                });
-
-                if (tailJudge == Ez2AcJudge.None)
-                {
-                    if (!request.HitWindows.CanBeHit(request.TimeOffset))
-                        return HoldTailEvaluationResult.MinResult;
-
-                    return HoldTailEvaluationResult.HandledNoOp;
-                }
-
-                return HoldTailEvaluationResult.FromResult(Ez2AcHitModeJudgement.MapTo(tailJudge));
+                return HoldTailEvaluationResult.FromResult(HitResult.IgnoreHit);
             }
 
             var genericResult = strategy.EvaluateTail(new HoldTailEvaluationContext

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaLaneController.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaLaneController.cs
@@ -156,6 +156,13 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
                 registerAutoMissDrawable(hold.Tail);
                 registerAutoMissDrawable(hold);
                 hold.Body.ColumnSchedulesAutoMiss = true;
+
+                foreach (var nested in hold.NestedHitObjects)
+                {
+                    if (nested is DrawableHoldNoteTick tick)
+                        tick.ColumnSchedulesAutoMiss = true;
+                }
+
                 return;
             }
 
@@ -199,6 +206,13 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
                 unregisterAutoMissDrawable(hold.Tail);
                 unregisterAutoMissDrawable(hold);
                 hold.Body.ColumnSchedulesAutoMiss = false;
+
+                foreach (var nested in hold.NestedHitObjects)
+                {
+                    if (nested is DrawableHoldNoteTick tick)
+                        tick.ColumnSchedulesAutoMiss = false;
+                }
+
                 return;
             }
 

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaReplaySession.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaReplaySession.cs
@@ -88,6 +88,12 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
             if (scoreProcessor is ManiaScoreProcessor maniaScoreProcessor)
                 maniaScoreProcessor.HitModeOverride = environment.ManiaHitMode;
 
+            var simulationEnvironment = createSimulationEnvironment(environment);
+
+            // 先 Align + 绑定 Judgement，再 ApplyBeatmap，避免 MaximumBaseScore 按官方尾 Perfect 虚高。
+            ManiaWindowBaker.Align(beatmap, simulationEnvironment);
+            ManiaEnvironmentJudgements.ApplyToBeatmap(beatmap, simulationEnvironment.ManiaHitMode);
+
             scoreProcessor.ApplyBeatmap(beatmap);
 
             if (score.ScoreInfo.IsLegacyScore)
@@ -101,10 +107,6 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
             double gameplayRate = ModUtils.CalculateRateWithMods(resolvedMods);
             recorder?.RecordInitial(scoreProcessor, gameplayRate);
 
-            var simulationEnvironment = createSimulationEnvironment(environment);
-
-            ManiaWindowBaker.Align(beatmap, simulationEnvironment);
-            ManiaEnvironmentJudgements.ApplyToBeatmap(beatmap, simulationEnvironment.ManiaHitMode);
             var targets = buildTargets(beatmap);
 
             var holdByHead = new Dictionary<HeadNote, HoldNote>();

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaReplaySessionSimulator.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/ManiaReplaySessionSimulator.cs
@@ -52,13 +52,67 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
 
             var headWasHit = new Dictionary<HeadNote, bool>();
             var keyHeldByColumn = new Dictionary<int, bool>();
+            var ez2AcHoldStates = new Dictionary<HoldNote, Ez2AcHoldState>();
+            var judgedTicks = new HashSet<HoldNoteTick>();
 
             foreach (var input in inputData.SortedEvents)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
                 bool wasHoldingBeforeEvent = keyHeldByColumn.TryGetValue(input.Column, out bool held) && held;
-                keyHeldByColumn[input.Column] = input.IsPress;
+
+                // Drawable：同帧先 Update tick 再（或交错）处理按键。
+                // 松手：先结算 <t 的持有 tick，再松，再结算 =t 为 Miss。
+                // 重按：先结算 <=t（仍为 Broken）为 Miss，再 Recover，避免 =t 被算进涨 combo。
+                applyEz2AcTicksUpTo(
+                    input.Time,
+                    environment,
+                    holdByHead,
+                    headWasHit,
+                    keyHeldByColumn,
+                    ez2AcHoldStates,
+                    judgedTicks,
+                    scoreProcessor,
+                    gameplayRate,
+                    timelineRecorder,
+                    endExclusive: true);
+
+                if (!input.IsPress)
+                {
+                    keyHeldByColumn[input.Column] = false;
+                    tryApplyEz2AcHoldRelease(input.Column, holdByHead, headWasHit, headByTail, releaseColumns, ez2AcHoldStates, environment);
+
+                    applyEz2AcTicksUpTo(
+                        input.Time,
+                        environment,
+                        holdByHead,
+                        headWasHit,
+                        keyHeldByColumn,
+                        ez2AcHoldStates,
+                        judgedTicks,
+                        scoreProcessor,
+                        gameplayRate,
+                        timelineRecorder,
+                        endExclusive: false);
+                }
+                else
+                {
+                    applyEz2AcTicksUpTo(
+                        input.Time,
+                        environment,
+                        holdByHead,
+                        headWasHit,
+                        keyHeldByColumn,
+                        ez2AcHoldStates,
+                        judgedTicks,
+                        scoreProcessor,
+                        gameplayRate,
+                        timelineRecorder,
+                        endExclusive: false);
+
+                    keyHeldByColumn[input.Column] = true;
+                    tryApplyEz2AcHoldRepress(input.Column, holdByHead, headWasHit, headByTail, releaseColumns, ez2AcHoldStates, environment);
+                }
 
                 var perColumnDict = input.IsPress ? pressColumns : releaseColumns;
                 if (!perColumnDict.TryGetValue(input.Column, out var laneStates))
@@ -103,7 +157,13 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
                 if (selected == null || selected.Judged)
                 {
                     if (!input.IsPress)
+                    {
+                        tryApplyEz2AcHoldRelease(input.Column, holdByHead, headWasHit, headByTail, releaseColumns, ez2AcHoldStates, environment);
                         tryApplyEarlyHoldBreakBody(laneStates, input.Time, wasHoldingBeforeEvent, environment, headByTail, holdByHead, headWasHit, scoreProcessor, gameplayRate, timelineRecorder);
+                    }
+                    else if (input.IsPress)
+                        tryApplyEz2AcHoldRepress(input.Column, holdByHead, headWasHit, headByTail, releaseColumns, ez2AcHoldStates, environment);
+
                     continue;
                 }
 
@@ -157,7 +217,11 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
                         {
                             // [parity] 本次松手未判定尾键 → 检查是否构成断连（Body ComboBreak）。
                             if (!input.IsPress)
+                            {
+                                tryApplyEz2AcHoldRelease(input.Column, holdByHead, headWasHit, headByTail, releaseColumns, ez2AcHoldStates, environment);
                                 tryApplyEarlyHoldBreakBody(laneStates, input.Time, wasHoldingBeforeEvent, environment, headByTail, holdByHead, headWasHit, scoreProcessor, gameplayRate, timelineRecorder);
+                            }
+
                             continue;
                         }
                     }
@@ -296,7 +360,204 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
                 }
 
                 if (target is HeadNote head)
+                {
                     headWasHit[head] = result.IsHit();
+
+                    if (environment.ManiaHitMode == EzEnumHitMode.EZ2AC
+                        && holdByHead.TryGetValue(head, out var judgedHold))
+                    {
+                        var state = getEz2AcState(ez2AcHoldStates, judgedHold);
+                        state.OnHeadJudged(Ez2AcHitModeJudgement.FromHitResult(result), preHeld: wasHoldingBeforeEvent);
+                    }
+                }
+            }
+
+            // 收尾：剩余 tick + EZ2AC 未判尾（持满不松）
+            double endTime = inputData.SortedEvents.Count > 0
+                ? inputData.SortedEvents[^1].Time + 1
+                : beatmap.HitObjects.LastOrDefault()?.GetEndTime() ?? 0;
+
+            applyEz2AcTicksUpTo(
+                endTime + 10_000,
+                environment,
+                holdByHead,
+                headWasHit,
+                keyHeldByColumn,
+                ez2AcHoldStates,
+                judgedTicks,
+                scoreProcessor,
+                gameplayRate,
+                timelineRecorder);
+
+            finalizeEz2AcOpenTails(
+                environment,
+                holdByHead,
+                headByTail,
+                releaseColumns,
+                headWasHit,
+                keyHeldByColumn,
+                scoreProcessor,
+                gameplayRate,
+                timelineRecorder,
+                endTime + 10_000);
+        }
+
+        private static Ez2AcHoldState getEz2AcState(Dictionary<HoldNote, Ez2AcHoldState> map, HoldNote hold)
+        {
+            if (!map.TryGetValue(hold, out var state))
+                map[hold] = state = new Ez2AcHoldState();
+
+            return state;
+        }
+
+        private static void tryApplyEz2AcHoldRelease(
+            int column,
+            Dictionary<HeadNote, HoldNote> holdByHead,
+            Dictionary<HeadNote, bool> headWasHit,
+            Dictionary<TailNote, HeadNote> headByTail,
+            Dictionary<int, List<LaneTargetState>> releaseColumns,
+            Dictionary<HoldNote, Ez2AcHoldState> ez2AcHoldStates,
+            IGameplayEnvironment environment)
+        {
+            if (environment.ManiaHitMode != EzEnumHitMode.EZ2AC)
+                return;
+
+            foreach (var (head, hold) in holdByHead)
+            {
+                if (hold.Column != column)
+                    continue;
+
+                if (!headWasHit.TryGetValue(head, out bool hit) || !hit)
+                    continue;
+
+                getEz2AcState(ez2AcHoldStates, hold).OnRelease();
+                return;
+            }
+        }
+
+        private static void tryApplyEz2AcHoldRepress(
+            int column,
+            Dictionary<HeadNote, HoldNote> holdByHead,
+            Dictionary<HeadNote, bool> headWasHit,
+            Dictionary<TailNote, HeadNote> headByTail,
+            Dictionary<int, List<LaneTargetState>> releaseColumns,
+            Dictionary<HoldNote, Ez2AcHoldState> ez2AcHoldStates,
+            IGameplayEnvironment environment)
+        {
+            if (environment.ManiaHitMode != EzEnumHitMode.EZ2AC)
+                return;
+
+            foreach (var (head, hold) in holdByHead)
+            {
+                if (hold.Column != column)
+                    continue;
+
+                if (!headWasHit.TryGetValue(head, out bool hit) || !hit)
+                    continue;
+
+                getEz2AcState(ez2AcHoldStates, hold).OnRepress();
+                return;
+            }
+        }
+
+        private static void applyEz2AcTicksUpTo(
+            double time,
+            IGameplayEnvironment environment,
+            Dictionary<HeadNote, HoldNote> holdByHead,
+            Dictionary<HeadNote, bool> headWasHit,
+            Dictionary<int, bool> keyHeldByColumn,
+            Dictionary<HoldNote, Ez2AcHoldState> ez2AcHoldStates,
+            HashSet<HoldNoteTick> judgedTicks,
+            ScoreProcessor scoreProcessor,
+            double gameplayRate,
+            ManiaReplayTimelineRecorder? timelineRecorder,
+            bool endExclusive = false)
+        {
+            if (environment.ManiaHitMode != EzEnumHitMode.EZ2AC)
+                return;
+
+            double cutoff = time + environment.OffsetPlusMania;
+
+            foreach (var hold in holdByHead.Values)
+            {
+                if (hold.Ticks == null)
+                    continue;
+
+                bool holding = keyHeldByColumn.TryGetValue(hold.Column, out bool held) && held;
+                var state = getEz2AcState(ez2AcHoldStates, hold);
+
+                foreach (var tick in hold.Ticks)
+                {
+                    if (judgedTicks.Contains(tick))
+                        continue;
+
+                    if (endExclusive ? tick.StartTime >= cutoff : tick.StartTime > cutoff)
+                        continue;
+
+                    // 涨 combo 由态机（是否已接上/未断开）+ 按住决定；不另查 head 档位。
+                    var result = Ez2AcHitModeJudgement.Instance.EvaluateTick(state, holding);
+                    judgedTicks.Add(tick);
+                    // 与 Drawable 到点结算对齐：事件时间取 tick.StartTime，TimeOffset≈0。
+                    ApplyAuxiliaryResult(
+                        scoreProcessor,
+                        tick,
+                        result,
+                        ComputeStoredTimeOffset(tick.StartTime, tick),
+                        tick.StartTime,
+                        gameplayRate,
+                        timelineRecorder);
+                }
+            }
+        }
+
+        private static void finalizeEz2AcOpenTails(
+            IGameplayEnvironment environment,
+            Dictionary<HeadNote, HoldNote> holdByHead,
+            Dictionary<TailNote, HeadNote> headByTail,
+            Dictionary<int, List<LaneTargetState>> releaseColumns,
+            Dictionary<HeadNote, bool> headWasHit,
+            Dictionary<int, bool> keyHeldByColumn,
+            ScoreProcessor scoreProcessor,
+            double gameplayRate,
+            ManiaReplayTimelineRecorder? timelineRecorder,
+            double eventTime)
+        {
+            if (environment.ManiaHitMode != EzEnumHitMode.EZ2AC)
+                return;
+
+            // Tail 绑 IgnoreHit 后不进 releaseColumns，直接扫 HoldNote。
+            foreach (var (head, hold) in holdByHead)
+            {
+                if (hold.Tail == null)
+                    continue;
+
+                // 已在常规路径判过尾则跳过（少见：尾若被重新纳入 targets）。
+                bool headHit = headWasHit.TryGetValue(head, out bool hit) && hit;
+
+                ApplyFinalResult(
+                    scoreProcessor,
+                    hold.Tail,
+                    HitResult.IgnoreHit,
+                    ComputeStoredTimeOffset(eventTime, hold.Tail),
+                    eventTime,
+                    gameplayRate,
+                    environment.ManiaHitMode,
+                    timelineRecorder);
+
+                if (hold.Body != null)
+                {
+                    ApplyAuxiliaryResult(scoreProcessor, hold.Body, HitResult.IgnoreHit,
+                        ComputeStoredTimeOffset(eventTime, hold.Body), eventTime, gameplayRate, timelineRecorder);
+                }
+
+                ApplyAuxiliaryResult(
+                    scoreProcessor,
+                    hold,
+                    headHit ? HitResult.IgnoreHit : HitResult.IgnoreMiss,
+                    ComputeStoredTimeOffset(eventTime, hold),
+                    eventTime,
+                    gameplayRate,
+                    timelineRecorder);
             }
         }
 
@@ -565,7 +826,8 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge
             if (!wasHoldingBeforeEvent)
                 return;
 
-            if (MalodyHitModeJudgement.IsMalodyMode(environment.ManiaHitMode))
+            if (MalodyHitModeJudgement.IsMalodyMode(environment.ManiaHitMode)
+                || environment.ManiaHitMode == EzEnumHitMode.EZ2AC)
                 return;
 
             foreach (var state in laneStates)

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/Mappings/Ez2AcHitModeJudgement.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/Mappings/Ez2AcHitModeJudgement.cs
@@ -10,6 +10,7 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge.Mappings
     /// <summary>
     /// EZ2AC 判定 — Mode 原生名 + MapTo；
     /// Session 与 Drawable 唯一源。
+    /// LN：头定品质 + 16 分 tick 只推 combo；尾 Ignore（无松手窗）。
     /// </summary>
     public enum Ez2AcJudge
     {
@@ -46,13 +47,11 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge.Mappings
         };
 
         /// <summary>
-        /// LN 尾判软化：因长条更难对准，将尾判结果放松一档。
+        /// LN 头软化（7th 2.0+）：仅 Cool→Kool；Good/Miss 不整档抬升。
         /// </summary>
-        public static Ez2AcJudge SoftenLnJudge(Ez2AcJudge judge) => judge switch
+        public static Ez2AcJudge SoftenLnHeadJudge(Ez2AcJudge judge) => judge switch
         {
             Ez2AcJudge.Cool => Ez2AcJudge.Kool,
-            Ez2AcJudge.Good => Ez2AcJudge.Cool,
-            Ez2AcJudge.Miss => Ez2AcJudge.Good,
             _ => judge,
         };
 
@@ -74,40 +73,43 @@ namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge.Mappings
                 return ManiaNoteJudgementOutcome.Ignore;
 
             if (isLnHead)
-                judge = SoftenLnJudge(judge);
+                judge = SoftenLnHeadJudge(judge);
 
             return ManiaNoteJudgementOutcome.ApplyResult(MapTo(judge));
         }
 
         public ManiaNoteJudgementOutcome EvaluateDrawablePress(double timeOffset, HitWindows hitWindows, bool isLnHead) => EvaluatePress(timeOffset, hitWindows, isLnHead);
 
-        public HitResult EvaluateTail(in HoldTailEvaluationContext context) => MapTo(EvaluateTailJudge(context));
+        /// <summary>LN 尾不计分，仅 Ignore 完结（对齐 Malody 尾角色）。</summary>
+        public HitResult EvaluateTail(in HoldTailEvaluationContext context) => HitResult.IgnoreHit;
 
-        public Ez2AcJudge EvaluateTailJudge(in HoldTailEvaluationContext context)
+        public Ez2AcJudge EvaluateTailJudge(in HoldTailEvaluationContext context) => Ez2AcJudge.None;
+
+        /// <summary>
+        /// Tick：按住且状态允许 → SliderTailHit（只推 combo）；否则 IgnoreMiss（不断 combo、不计档）。
+        /// </summary>
+        public HitResult EvaluateTick(Ez2AcHoldState state, bool isHolding)
         {
-            var judge = FromHitResult(context.HitWindows.ResultFor(context.TimeOffsetForJudgement));
+            if (isHolding && state.ShouldIncreaseCombo)
+                return HitResult.SliderTailHit;
 
-            if (judge == Ez2AcJudge.None)
-                return Ez2AcJudge.None;
-
-            judge = SoftenLnJudge(judge);
-
-            if (judge > Ez2AcJudge.Miss && (!context.HeadHit || context.HoldBreak || context.HoldBroken))
-                judge = Ez2AcJudge.Good;
-
-            return judge;
+            return HitResult.IgnoreMiss;
         }
 
         public bool CanBeginHoldAt(double time, TailNote tail) => LazerHoldJudgementReplica.Instance.CanBeginHoldAt(time, tail);
 
-        public bool IsHoldBreak(double rawOffset, HitWindows hitWindows) => LazerHoldJudgementReplica.Instance.IsHoldBreak(rawOffset, hitWindows);
+        public bool IsHoldBreak(double rawOffset, HitWindows hitWindows) => false;
 
         public HitResult RejudgeHitEvent(HitEvent hitEvent, HitWindows hitWindows)
         {
             if (hitEvent.HitObject is TailNote)
+                return HitResult.IgnoreHit;
+
+            if (hitEvent.HitObject is HoldNoteTick)
             {
-                var tailOutcome = EvaluatePress(hitEvent.TimeOffset, hitWindows);
-                return tailOutcome.Kind == ManiaNoteJudgementOutcomeKind.Apply ? tailOutcome.Result : HitResult.Miss;
+                return hitEvent.Result is HitResult.SliderTailHit or HitResult.IgnoreMiss
+                    ? hitEvent.Result
+                    : HitResult.IgnoreMiss;
             }
 
             var outcome = EvaluatePress(hitEvent.TimeOffset, hitWindows, hitEvent.HitObject is HeadNote);

--- a/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/Mappings/Ez2AcHoldState.cs
+++ b/osu.Game.Rulesets.Mania/EzMania/ReplayJudge/Mappings/Ez2AcHoldState.cs
@@ -1,0 +1,63 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Mania.EzMania.ReplayJudge.Mappings
+{
+    /// <summary>
+    /// EZ2AC LN 持有态：tick 只问「已接上且未中途断开」+ 按住与否；不区分头 Kool/Good 档。
+    /// </summary>
+    public enum Ez2AcHoldPhase
+    {
+        Idle,
+
+        /// <summary>已接上，按住时 tick 涨 combo。</summary>
+        Holding,
+
+        /// <summary>中途松手，再抓前 tick 不涨 combo。</summary>
+        Broken,
+
+        /// <summary>头 Fail / 从未接上，再抓前 tick 不涨 combo。</summary>
+        Missing,
+    }
+
+    public sealed class Ez2AcHoldState
+    {
+        public Ez2AcHoldPhase Phase { get; private set; } = Ez2AcHoldPhase.Idle;
+
+        public void Reset() => Phase = Ez2AcHoldPhase.Idle;
+
+        /// <summary>
+        /// 头判定落地后更新状态。<paramref name="preHeld"/> 为头到达时键已按下（预按）。
+        /// </summary>
+        public void OnHeadJudged(Ez2AcJudge judge, bool preHeld)
+        {
+            // 头档位只记在 Head 自身；此处只区分「接上」与「Fail 未接上」。
+            if (preHeld)
+            {
+                Phase = Ez2AcHoldPhase.Holding;
+                return;
+            }
+
+            Phase = judge switch
+            {
+                Ez2AcJudge.Fail or Ez2AcJudge.None => Ez2AcHoldPhase.Missing,
+                _ => Ez2AcHoldPhase.Holding,
+            };
+        }
+
+        public void OnRelease()
+        {
+            if (Phase == Ez2AcHoldPhase.Holding)
+                Phase = Ez2AcHoldPhase.Broken;
+        }
+
+        public void OnRepress()
+        {
+            if (Phase is Ez2AcHoldPhase.Broken or Ez2AcHoldPhase.Missing)
+                Phase = Ez2AcHoldPhase.Holding;
+        }
+
+        /// <summary>按住且处于可涨 combo 的相位时，tick 应 <see cref="osu.Game.Rulesets.Scoring.HitResult.SliderTailHit"/>。</summary>
+        public bool ShouldIncreaseCombo => Phase == Ez2AcHoldPhase.Holding;
+    }
+}

--- a/osu.Game.Rulesets.Mania/Judgements/HoldNoteTickJudgement.cs
+++ b/osu.Game.Rulesets.Mania/Judgements/HoldNoteTickJudgement.cs
@@ -1,0 +1,19 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Mania.Judgements
+{
+    /// <summary>
+    /// EZ2AC LN tick：成功用 <see cref="HitResult.SliderTailHit"/>（涨 combo、非 IsBasic、可与 IgnoreMiss 配对）；
+    /// 未按住用 <see cref="HitResult.IgnoreMiss"/>（完结物件、不断 combo、不计档）。
+    /// 不用 LargeTickHit/Miss：后者 Miss 会断 combo，且 IgnoreMiss 无法作为 LargeTick 的合法结果。
+    /// </summary>
+    public class HoldNoteTickJudgement : ManiaJudgement
+    {
+        public override HitResult MaxResult => HitResult.SliderTailHit;
+
+        public override HitResult MinResult => HitResult.IgnoreMiss;
+    }
+}

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -12,6 +12,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Audio;
+using osu.Game.EzOsuGame.Configuration;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mania.EzMania.ReplayJudge;
 using osu.Game.Rulesets.Mania.Judgements;
@@ -55,6 +56,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
         private Container<DrawableHoldNoteHead> headContainer;
         private Container<DrawableHoldNoteTail> tailContainer;
         private Container<DrawableHoldNoteBody> bodyContainer;
+        private Container<DrawableHoldNoteTick> tickContainer;
 
         private PausableSkinnableSound slidingSample;
 
@@ -105,6 +107,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                     }
                 },
                 bodyContainer = new Container<DrawableHoldNoteBody> { RelativeSizeAxes = Axes.Both },
+                tickContainer = new Container<DrawableHoldNoteTick> { RelativeSizeAxes = Axes.Both },
                 bodyPiece = new SkinnableDrawable(new ManiaSkinComponentLookup(ManiaSkinComponents.HoldNoteBody), _ => new DefaultBodyPiece
                 {
                     RelativeSizeAxes = Axes.Both,
@@ -158,6 +161,11 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                 case DrawableHoldNoteBody body:
                     bodyContainer.Child = body;
                     break;
+
+                case DrawableHoldNoteTick tick:
+                    // 不可见，但仍须挂入树以获得 Clock / ApplyResult 生命周期。
+                    tickContainer.Add(tick);
+                    break;
             }
         }
 
@@ -167,6 +175,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             headContainer.Clear(false);
             tailContainer.Clear(false);
             bodyContainer.Clear(false);
+            tickContainer.Clear(false);
         }
 
         protected override DrawableHitObject CreateNestedHitObject(HitObject hitObject)
@@ -181,6 +190,9 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
 
                 case HoldNoteBody body:
                     return new DrawableHoldNoteBody(body);
+
+                case HoldNoteTick tick:
+                    return new DrawableHoldNoteTick(tick);
             }
 
             return base.CreateNestedHitObject(hitObject);
@@ -225,6 +237,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             base.Update();
 
             ManiaEzDrawableJudgement.TryO2HoldUpdate(this);
+            judgePendingHoldTicks();
 
             if (Head.Judged && !Head.IsHit)
                 missingStartTime.Value ??= Head.Result.TimeAbsolute;
@@ -275,6 +288,21 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                 sizingContainer.Height = 1;
         }
 
+        private void judgePendingHoldTicks()
+        {
+            // Empty HitWindows 的 tick 不会进列级 auto-miss 队列，必须由父 Hold 到点结算（含非 EZ2AC 的 Ignore）。
+            var nested = NestedHitObjects;
+
+            for (int i = 0; i < nested.Count; i++)
+            {
+                if (nested[i] is not DrawableHoldNoteTick tick || tick.AllJudged || tick.HitObject == null)
+                    continue;
+
+                if (Time.Current >= tick.HitObject.StartTime)
+                    tick.UpdateTickResult();
+            }
+        }
+
         protected override JudgementResult CreateResult(Judgement judgement) => new HoldNoteJudgementResult(HitObject, judgement);
 
         public new HoldNoteJudgementResult Result => (HoldNoteJudgementResult)base.Result;
@@ -284,6 +312,9 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             if (UsesEzJudgement)
             {
                 if (ManiaEzDrawableJudgement.TryMalodyHoldCheckForResult(this, userTriggered, timeOffset))
+                    return;
+
+                if (ManiaEzDrawableJudgement.TryEz2AcHoldCheckForResult(this, userTriggered, timeOffset))
                     return;
 
                 if (ManiaEzDrawableJudgement.TryO2HoldCheckForResult(this, userTriggered, timeOffset))
@@ -343,9 +374,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             if (currentTime > Tail.HitObject.StartTime && !Tail.HitObject.HitWindows.CanBeHit(currentTime - Tail.HitObject.StartTime))
                 return false;
 
-            beginHoldAt(currentTime - Head.HitObject.StartTime);
-
-            return Head.UpdateResult();
+            return beginHoldAndJudgeHead(currentTime);
         }
 
         /// <summary>
@@ -362,9 +391,28 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             if (currentTime > Tail.HitObject.StartTime && !Tail.HitObject.HitWindows.CanBeHit(currentTime - Tail.HitObject.StartTime))
                 return false;
 
+            return beginHoldAndJudgeHead(currentTime);
+        }
+
+        private bool beginHoldAndJudgeHead(double currentTime)
+        {
+            bool preHeld = Result.IsHolding(currentTime);
+            bool headAlreadyJudged = Head.AllJudged;
+
             beginHoldAt(currentTime - Head.HitObject.StartTime);
 
-            return Head.UpdateResult();
+            if (headAlreadyJudged)
+            {
+                ManiaEzDrawableJudgement.NotifyEz2AcRepress(this);
+                return true;
+            }
+
+            bool judged = Head.UpdateResult();
+
+            if (Head.AllJudged)
+                ManiaEzDrawableJudgement.NotifyEz2AcHeadJudged(this, Head.Result.Type, preHeld);
+
+            return judged;
         }
 
         private void beginHoldAt(double timeOffset)
@@ -394,6 +442,9 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             if (ManiaEzDrawableJudgement.TryMalodyHoldOnReleased(this))
                 return;
 
+            if (ManiaEzDrawableJudgement.TryEz2AcHoldOnReleased(this))
+                return;
+
             if (isHolding.Value)
             {
                 Tail.UpdateResult();
@@ -408,7 +459,13 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             if (Tail.AllJudged)
                 Body.TriggerResult(Tail.IsHit);
             else if (isEarlyHoldRelease() || UsesEzJudgement)
+            {
+                // EZ2AC LN：中途松手由 tick IgnoreMiss 处理，Miss 不断 combo。
+                if (ManiaEzDrawableJudgement.GetJudgementRound(this).Environment.ManiaHitMode == EzEnumHitMode.EZ2AC)
+                    return;
+
                 Body.TriggerResult(false);
+            }
         }
 
         private bool isEarlyHoldRelease()
@@ -449,6 +506,18 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                 MissForcefully();
 
             EzTriggerBodyIfNeeded(Head.IsHit);
+            EzReportHoldReleased();
+        }
+
+        internal void EzFinalizeEz2AcHoldFromTail()
+        {
+            // 尾为 Ignore；父物件与 Body 以头是否命中收束，中途松不 ComboBreak。
+            if (Head.IsHit)
+                ApplyMaxResult();
+            else
+                MissForcefully();
+
+            EzTriggerBodyIfNeeded(true);
             EzReportHoldReleased();
         }
 

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTick.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTick.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using osu.Game.Rulesets.Mania.EzMania.ReplayJudge;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Mania.Objects.Drawables
+{
+    public partial class DrawableHoldNoteTick : DrawableManiaHitObject<HoldNoteTick>
+    {
+        public override bool DisplayResult => false;
+
+        protected internal DrawableHoldNote HoldNote => ParentHitObject as DrawableHoldNote;
+
+        public DrawableHoldNoteTick()
+            : this(null)
+        {
+        }
+
+        public DrawableHoldNoteTick(HoldNoteTick hitObject)
+            : base(hitObject)
+        {
+        }
+
+        public override void PlaySamples()
+        {
+            // LN tick 不播 note 音效。
+        }
+
+        protected override void CheckForResult(bool userTriggered, double timeOffset)
+        {
+            if (ManiaEzDrawableJudgement.TryHoldTickCheckForResult(this, userTriggered, timeOffset))
+                return;
+
+            // 非 EZ2AC：Ignore 判定，到点直接完结以免卡 AllJudged。
+            if (timeOffset >= 0)
+                ApplyMaxResult();
+        }
+
+        internal void EzApplyTickResult(HitResult result)
+            => ApplyResult(static (r, t) => r.Type = t, result);
+
+        internal void UpdateTickResult() => UpdateResult(false);
+    }
+}

--- a/osu.Game.Rulesets.Mania/Objects/HoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/HoldNote.cs
@@ -6,6 +6,9 @@
 using System.Collections.Generic;
 using System.Threading;
 using osu.Game.Audio;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.EzOsuGame.Configuration;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
@@ -65,6 +68,12 @@ namespace osu.Game.Rulesets.Mania.Objects
 
                 if (Tail != null)
                     Tail.Column = value;
+
+                if (Ticks != null)
+                {
+                    foreach (var tick in Ticks)
+                        tick.Column = value;
+                }
             }
         }
 
@@ -87,11 +96,28 @@ namespace osu.Game.Rulesets.Mania.Objects
         public HoldNoteBody Body { get; protected set; }
 
         /// <summary>
+        /// EZ2AC 风格 16 分 LN ticks（头格由 Head 承担，此处从下一格起）。
+        /// 非 EZ2AC 下判定会被绑成 Ignore。
+        /// </summary>
+        public List<HoldNoteTick> Ticks { get; private set; }
+
+        /// <summary>
         /// Whether sliding samples should be played when held.
         /// </summary>
         public bool PlaySlidingSamples { get; init; }
 
         public override double MaximumJudgementOffset => Tail.MaximumJudgementOffset;
+
+        /// <summary>头时刻拍长（ms），用于生成 16 分 tick。</summary>
+        private double beatLength = 500;
+
+        protected override void ApplyDefaultsToSelf(ControlPointInfo controlPointInfo, IBeatmapDifficultyInfo difficulty)
+        {
+            base.ApplyDefaultsToSelf(controlPointInfo, difficulty);
+
+            TimingControlPoint timingPoint = controlPointInfo.TimingPointAt(StartTime);
+            beatLength = timingPoint.BeatLength;
+        }
 
         protected override void CreateNestedHitObjects(CancellationToken cancellationToken)
         {
@@ -121,6 +147,62 @@ namespace osu.Game.Rulesets.Mania.Objects
                 Column = Column,
                 Duration = Duration
             });
+
+            Ticks = new List<HoldNoteTick>();
+
+            // 仅 EZ2AC HitMode 生成 16 分 tick；其它模式保持官方头尾松手语义。
+            if (isEz2AcHitMode())
+                createTicks(cancellationToken);
+        }
+
+        private static bool isEz2AcHitMode()
+        {
+            try
+            {
+                return GlobalConfigStore.EzConfig.Get<EzEnumHitMode>(Ez2Setting.ManiaHitMode) == EzEnumHitMode.EZ2AC;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private void createTicks(CancellationToken cancellationToken)
+        {
+            // 16 分音符间隔；头格由 Head 计判定+combo，tick 从下一格起只推 combo。
+            double interval = beatLength / 4;
+
+            if (interval <= 0 || double.IsNaN(interval) || double.IsInfinity(interval))
+                interval = 125;
+
+            double t = StartTime + interval;
+            const double end_epsilon = 0.5;
+
+            while (t < EndTime - end_epsilon)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var tick = new HoldNoteTick
+                {
+                    StartTime = t,
+                    Column = Column,
+                };
+                Ticks.Add(tick);
+                AddNested(tick);
+                t += interval;
+            }
+
+            // 短于一格的 LN：在尾前放一格，保证按住仍有 combo tick。
+            if (Ticks.Count == 0 && Duration > end_epsilon)
+            {
+                var tick = new HoldNoteTick
+                {
+                    StartTime = EndTime - end_epsilon,
+                    Column = Column,
+                };
+                Ticks.Add(tick);
+                AddNested(tick);
+            }
         }
 
         public override Judgement CreateJudgement() => new IgnoreJudgement();

--- a/osu.Game.Rulesets.Mania/Objects/HoldNoteTick.cs
+++ b/osu.Game.Rulesets.Mania/Objects/HoldNoteTick.cs
@@ -1,0 +1,19 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Mania.Objects
+{
+    /// <summary>
+    /// EZ2AC LN 16 分 tick：只推动 combo，不计入 Kool/Cool 等基础判定档。
+    /// 默认 Ignore；EZ2AC 由 <see cref="EzMania.ReplayJudge.ManiaEnvironmentJudgements"/> 绑成 HoldNoteTickJudgement。
+    /// </summary>
+    public class HoldNoteTick : ManiaHitObject
+    {
+        public override Judgement CreateJudgement() => new IgnoreJudgement();
+
+        protected override HitWindows CreateHitWindows() => HitWindows.Empty;
+    }
+}

--- a/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
+++ b/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
@@ -9,6 +9,7 @@ using osu.Game.EzOsuGame.Configuration;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mania.EzMania.Helper;
 using osu.Game.Rulesets.Mania.EzMania.Mods.CommunityMod;
+using osu.Game.Rulesets.Mania.EzMania.ReplayJudge;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Scoring;
@@ -41,6 +42,13 @@ namespace osu.Game.Rulesets.Mania.Scoring
         public override void ApplyEzGameplayEnvironment()
         {
             HitModeOverride ??= GlobalConfigStore.EzConfig.Get<EzEnumHitMode>(Ez2Setting.ManiaHitMode);
+        }
+
+        public override void ApplyBeatmap(IBeatmap beatmap)
+        {
+            // Tail/Tick 的 Ignore 系 Judgement 必须在全谱模拟前绑定，否则 EZ2AC/Malody 会把官方尾 Perfect 计入 MaximumBaseScore。
+            ManiaEnvironmentJudgements.ApplyToBeatmap(beatmap, hitMode);
+            base.ApplyBeatmap(beatmap);
         }
 
         public ManiaScoreProcessor()

--- a/osu.Game.Rulesets.Mania/UI/Column.cs
+++ b/osu.Game.Rulesets.Mania/UI/Column.cs
@@ -242,6 +242,7 @@ namespace osu.Game.Rulesets.Mania.UI
             RegisterPool<HeadNote, DrawableHoldNoteHead>(10, 50);
             RegisterPool<TailNote, DrawableHoldNoteTail>(10, 50);
             RegisterPool<HoldNoteBody, DrawableHoldNoteBody>(10, 50);
+            RegisterPool<HoldNoteTick, DrawableHoldNoteTick>(50, 200);
 
             if (rulesetConfig != null)
                 touchOverlay = rulesetConfig.GetBindable<bool>(ManiaRulesetSetting.TouchOverlay);


### PR DESCRIPTION
## Summary
- EZ2AC HitMode LN uses 16th-note ticks for combo only (no basic judgement inflation, no tail release Fail).
- Hold state simplified to Holding/Broken/Missing; Miss does not break combo, Fail does.
- Session/Drawable parity covered for hold-through, early release, and repress.

## Test plan
- [x] `dotnet test osu.Game.Rulesets.Mania.Tests --filter FullyQualifiedName~TestSceneReplaySessionParity|FullyQualifiedName~ManiaReplaySessionTest.TestEz2Ac`
- [ ] In-game EZ2AC: hold LN to end without release — combo rises, no Fail/hitsound at tail
- [ ] Early release then repress — combo continues after re-grab; Statistics basic tiers unchanged by ticks