### PR TITLE
Add Track Profile Insights for local mania score stats

### DIFF
--- a/osu.Game.Tests/EzOsuGame/LocalProfile/EzLocalProfileInsightsCalculatorTest.cs
+++ b/osu.Game.Tests/EzOsuGame/LocalProfile/EzLocalProfileInsightsCalculatorTest.cs
@@ -1,0 +1,91 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Game.EzOsuGame.LocalProfile;
+using osu.Game.Scoring;
+
+namespace osu.Game.Tests.EzOsuGame.LocalProfile
+{
+    [TestFixture]
+    public class EzLocalProfileInsightsCalculatorTest
+    {
+        [Test]
+        public void WeightedMedianUsesDecayWeights()
+        {
+            double? median = EzLocalProfileInsightsCalculator.GetWeightedMedian(new List<(double, double)>
+            {
+                (100, 1),
+                (200, 0.05),
+            });
+
+            Assert.That(median, Is.EqualTo(100).Within(0.001));
+        }
+
+        [Test]
+        public void CalculateBuildsKeySplitAndPpRange()
+        {
+            var plays = new List<EzLocalProfileInsightPlay>
+            {
+                play(4, 500, "DT", bpm: 180, daysAgo: 1),
+                play(4, 400, "DT", bpm: 170, daysAgo: 10),
+                play(7, 300, "", bpm: 150, daysAgo: 5),
+                play(7, 200, "HT", bpm: 140, daysAgo: 20, convert: true),
+            };
+
+            var insights = EzLocalProfileInsightsCalculator.Calculate(plays);
+
+            Assert.That(insights.SampleSize, Is.EqualTo(4));
+            Assert.That(insights.KeySplit[0].KeyCount, Is.EqualTo(4));
+            Assert.That(insights.KeySplit[0].Count, Is.EqualTo(2));
+            Assert.That(insights.MostUsedMod!.Label, Is.EqualTo("DT"));
+            Assert.That(insights.PpRange!.Top, Is.EqualTo(500));
+            Assert.That(insights.PpRange.Bottom, Is.EqualTo(200));
+            Assert.That(insights.KeyPpConverts, Is.EqualTo(1));
+            Assert.That(insights.KeyPp.Count, Is.EqualTo(2)); // 4K + 7K native; convert excluded from 7K key pp
+            Assert.That(insights.NewestTopPlay!.Pp, Is.EqualTo(500));
+            Assert.That(insights.OldestTopPlay!.Pp, Is.EqualTo(200));
+        }
+
+        private static EzLocalProfileInsightPlay play(
+            int keyCount,
+            double pp,
+            string mod,
+            double bpm,
+            int daysAgo,
+            bool convert = false)
+        {
+            var row = new EzLocalProfileDrillScoreRow
+            {
+                ScoreId = Guid.NewGuid(),
+                RulesetId = EzLocalProfileConstants.MANIA_RULESET_ID,
+                Rank = ScoreRank.S,
+                PpResolved = pp,
+                Title = $"Map {pp}",
+                Artist = "Artist",
+                DifficultyName = $"{keyCount}K",
+                Date = DateTimeOffset.UtcNow.AddDays(-daysAgo),
+            };
+
+            return new EzLocalProfileInsightPlay
+            {
+                Row = row,
+                Pp = pp,
+                KeyCount = keyCount,
+                BeatmapOnlineId = (int)pp,
+                IsConvert = convert,
+                Bpm = bpm,
+                Rate = 1,
+                ModAcronyms = string.IsNullOrEmpty(mod) ? Array.Empty<string>() : new[] { mod },
+                Date = row.Date,
+                Title = row.Title,
+                Artist = row.Artist,
+                DifficultyName = row.DifficultyName,
+                StarRating = 5,
+                Rank = "S",
+            };
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileInsightModels.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileInsightModels.cs
@@ -1,0 +1,71 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    /// <summary>
+    /// One mania play in the Insights top-PP window (aligned with mania-hub InsightScoreSnapshot inputs).
+    /// </summary>
+    public sealed class EzLocalProfileInsightPlay
+    {
+        public required EzLocalProfileDrillScoreRow Row { get; init; }
+        public double Pp { get; init; }
+        public int KeyCount { get; init; }
+        public int BeatmapOnlineId { get; init; }
+        public bool IsConvert { get; init; }
+        public double Bpm { get; init; }
+        public double Rate { get; init; } = 1;
+        public IReadOnlyList<string> ModAcronyms { get; init; } = Array.Empty<string>();
+        public DateTimeOffset Date { get; init; }
+        public string Title { get; init; } = string.Empty;
+        public string Artist { get; init; } = string.Empty;
+        public string DifficultyName { get; init; } = string.Empty;
+        public double StarRating { get; init; }
+        public string Rank { get; init; } = string.Empty;
+    }
+
+    public sealed record EzLocalProfileKeySplit(int KeyCount, int Count);
+
+    public sealed record EzLocalProfileKeyPpBucket(int KeyCount, double WeightedPp, int Count, double MissingBound);
+
+    public sealed record EzLocalProfileCountEntry(string Label, int Count, int Total);
+
+    public sealed record EzLocalProfileBpmRange(
+        double Min,
+        double Max,
+        EzLocalProfileInsightPlay MinPlay,
+        EzLocalProfileInsightPlay MaxPlay);
+
+    public sealed record EzLocalProfileBpmByKey(int KeyCount, double Median, int Count);
+
+    public sealed record EzLocalProfilePpRange(double Top, double Bottom);
+
+    public sealed record EzLocalProfilePpDistributionBucket(int? Min, int? Max, int Count, int Total);
+
+    public sealed record EzLocalProfilePpCumulativeRow(int Threshold, int Count, int Total);
+
+    /// <summary>
+    /// Local Profile Track Insights result (mania-hub Profile Insights subset).
+    /// </summary>
+    public sealed class EzLocalProfileInsights
+    {
+        public int SampleSize { get; init; }
+        public IReadOnlyList<EzLocalProfileKeySplit> KeySplit { get; init; } = Array.Empty<EzLocalProfileKeySplit>();
+        public IReadOnlyList<EzLocalProfileKeyPpBucket> KeyPp { get; init; } = Array.Empty<EzLocalProfileKeyPpBucket>();
+        public int KeyPpConverts { get; init; }
+        public double KeyPpCutoff { get; init; }
+        public EzLocalProfileCountEntry? MostUsedMod { get; init; }
+        public IReadOnlyList<EzLocalProfileCountEntry> ModBreakdown { get; init; } = Array.Empty<EzLocalProfileCountEntry>();
+        public double? MedianBpm { get; init; }
+        public EzLocalProfileBpmRange? BpmRange { get; init; }
+        public IReadOnlyList<EzLocalProfileBpmByKey> BpmByKeyMode { get; init; } = Array.Empty<EzLocalProfileBpmByKey>();
+        public EzLocalProfileInsightPlay? NewestTopPlay { get; init; }
+        public EzLocalProfileInsightPlay? OldestTopPlay { get; init; }
+        public EzLocalProfilePpRange? PpRange { get; init; }
+        public IReadOnlyList<EzLocalProfilePpDistributionBucket> PpDistribution { get; init; } = Array.Empty<EzLocalProfilePpDistributionBucket>();
+        public IReadOnlyList<EzLocalProfilePpCumulativeRow> PpCumulative { get; init; } = Array.Empty<EzLocalProfilePpCumulativeRow>();
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileInsightScoreBuilder.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileInsightScoreBuilder.cs
@@ -1,0 +1,141 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using osu.Game.Beatmaps;
+using osu.Game.Online.API;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    /// <summary>
+    /// Builds Insight plays from archived drill rows + live beatmap metadata (BPM / CS / convert).
+    /// </summary>
+    public static class EzLocalProfileInsightScoreBuilder
+    {
+        public static IReadOnlyList<EzLocalProfileInsightPlay> Build(
+            IEnumerable<EzLocalProfileDrillScoreRow> drillScores,
+            BeatmapManager beatmapManager,
+            RulesetStore rulesets)
+        {
+            var plays = new List<EzLocalProfileInsightPlay>();
+
+            foreach (var row in drillScores
+                                .Where(r => r.RulesetId == EzLocalProfileConstants.MANIA_RULESET_ID && r.PpResolved > 0)
+                                .OrderByDescending(r => r.PpResolved)
+                                .ThenByDescending(r => r.Date))
+            {
+                var beatmap = !string.IsNullOrEmpty(row.BeatmapHash)
+                    ? beatmapManager.QueryBeatmap(b => b.Hash == row.BeatmapHash)
+                    : null;
+
+                var mods = EzLocalProfileDrillMods.Resolve(row, rulesets);
+                var acronyms = resolveModAcronyms(row, mods);
+                double rate = resolveRate(mods);
+                int keyCount = resolveKeyCount(row, beatmap, mods, rulesets);
+                bool isConvert = beatmap != null && beatmap.Ruleset.OnlineID != EzLocalProfileConstants.MANIA_RULESET_ID;
+                double bpm = beatmap is { BPM: > 0 } ? beatmap.BPM : 0;
+                int onlineId = beatmap is { OnlineID: > 0 } ? beatmap.OnlineID : 0;
+
+                plays.Add(new EzLocalProfileInsightPlay
+                {
+                    Row = row,
+                    Pp = row.PpResolved,
+                    KeyCount = keyCount,
+                    BeatmapOnlineId = onlineId,
+                    IsConvert = isConvert,
+                    Bpm = bpm,
+                    Rate = rate,
+                    ModAcronyms = acronyms,
+                    Date = row.Date,
+                    Title = row.Title,
+                    Artist = row.Artist,
+                    DifficultyName = row.DifficultyName,
+                    StarRating = row.StarRating,
+                    Rank = row.Rank.ToString(),
+                });
+            }
+
+            return plays;
+        }
+
+        private static IReadOnlyList<string> resolveModAcronyms(EzLocalProfileDrillScoreRow row, Mod[] mods)
+        {
+            if (mods.Length > 0)
+                return mods.Select(m => m.Acronym).Where(a => !string.IsNullOrEmpty(a)).Distinct(StringComparer.Ordinal).ToList();
+
+            if (string.IsNullOrEmpty(row.ModsJson))
+                return Array.Empty<string>();
+
+            try
+            {
+                var apiMods = JsonConvert.DeserializeObject<APIMod[]>(row.ModsJson) ?? Array.Empty<APIMod>();
+                return apiMods
+                       .Select(m => m.Acronym)
+                       .Where(a => !string.IsNullOrEmpty(a))
+                       .Distinct(StringComparer.Ordinal)
+                       .ToList();
+            }
+            catch
+            {
+                return Array.Empty<string>();
+            }
+        }
+
+        private static double resolveRate(IEnumerable<Mod> mods)
+        {
+            double rate = 1;
+
+            foreach (var mod in mods)
+            {
+                if (mod is ModRateAdjust rateAdjust)
+                    rate *= rateAdjust.SpeedChange.Value;
+            }
+
+            if (!double.IsFinite(rate) || rate <= 0)
+                return 1;
+
+            return Math.Clamp(rate, 0.5, 2.0);
+        }
+
+        private static int resolveKeyCount(
+            EzLocalProfileDrillScoreRow row,
+            BeatmapInfo? beatmap,
+            Mod[] mods,
+            RulesetStore rulesets)
+        {
+            var maniaSummary = row.ReadManiaSummary();
+            if (maniaSummary.ColumnCounts.Count > 0)
+                return maniaSummary.ColumnCounts.Keys.Max() + 1;
+
+            if (beatmap != null)
+            {
+                try
+                {
+                    var ruleset = rulesets.GetRuleset(row.RulesetId)?.CreateInstance();
+
+                    if (ruleset != null)
+                    {
+                        int fromMods = ruleset.GetVariantForBeatmap(beatmap, mods);
+                        if (fromMods > 0)
+                            return fromMods;
+                    }
+                }
+                catch
+                {
+                    // fall through
+                }
+
+                int fromCs = (int)Math.Round(beatmap.Difficulty.CircleSize);
+                if (fromCs > 0)
+                    return fromCs;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileInsightsCalculator.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileInsightsCalculator.cs
@@ -1,0 +1,314 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    /// <summary>
+    /// Ports mania-hub <c>calculateUserProfileInsights</c> for local drill scores (no tracked tail merge).
+    /// </summary>
+    public static class EzLocalProfileInsightsCalculator
+    {
+        public const double KEY_PP_DECAY = 0.95;
+        public const int KEY_PP_WINDOW_MIN = 100;
+        public const int KEY_PP_LIST_LIMIT = 200;
+        public const int TOP_PLAY_WINDOW = 200;
+
+        public static EzLocalProfileInsights Calculate(IReadOnlyList<EzLocalProfileInsightPlay> windowPlays)
+        {
+            var scores = windowPlays
+                         .Where(p => p.Pp > 0 && p.KeyCount > 0)
+                         .OrderByDescending(p => p.Pp)
+                         .ThenBy(p => p.BeatmapOnlineId)
+                         .Take(TOP_PLAY_WINDOW)
+                         .ToList();
+
+            var keyCounts = new Dictionary<int, int>();
+            var keyPpByKey = new Dictionary<int, List<(int BeatmapId, double Pp)>>();
+            int convertPlays = 0;
+            var modCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+            int moddedPlayCount = 0;
+            var bpmEntries = new List<(double Bpm, double Weight, int? KeyCount, EzLocalProfileInsightPlay Play)>();
+            var ppValues = new List<double>();
+            var datedScores = new List<(EzLocalProfileInsightPlay Play, long Ms)>();
+
+            for (int index = 0; index < scores.Count; index++)
+            {
+                var play = scores[index];
+
+                if (play.KeyCount > 0)
+                {
+                    keyCounts.TryGetValue(play.KeyCount, out int existing);
+                    keyCounts[play.KeyCount] = existing + 1;
+                }
+
+                if (play.IsConvert)
+                {
+                    convertPlays++;
+                }
+                else if (play.KeyCount > 0)
+                {
+                    if (!keyPpByKey.TryGetValue(play.KeyCount, out var bucket))
+                        keyPpByKey[play.KeyCount] = bucket = new List<(int, double)>();
+
+                    int beatmapId = play.BeatmapOnlineId > 0 ? play.BeatmapOnlineId : -(index + 1);
+                    bucket.Add((beatmapId, play.Pp));
+                }
+
+                if (play.ModAcronyms.Count > 0)
+                {
+                    moddedPlayCount++;
+
+                    foreach (string mod in play.ModAcronyms)
+                    {
+                        modCounts.TryGetValue(mod, out int count);
+                        modCounts[mod] = count + 1;
+                    }
+                }
+
+                if (play.Bpm > 0 && double.IsFinite(play.Bpm))
+                {
+                    double rate = play.Rate > 0 && double.IsFinite(play.Rate) ? play.Rate : 1;
+                    bpmEntries.Add((play.Bpm * rate, Math.Pow(KEY_PP_DECAY, index), play.KeyCount > 0 ? play.KeyCount : null, play));
+                }
+
+                ppValues.Add(play.Pp);
+
+                long ms = play.Date.ToUnixTimeMilliseconds();
+                if (ms > 0)
+                    datedScores.Add((play, ms));
+            }
+
+            var sortedKeySplit = keyCounts
+                                 .Select(kv => new EzLocalProfileKeySplit(kv.Key, kv.Value))
+                                 .OrderByDescending(k => k.Count)
+                                 .ThenBy(k => k.KeyCount)
+                                 .ToList();
+
+            datedScores.Sort((a, b) => a.Ms.CompareTo(b.Ms));
+            var sortedPpValues = ppValues.OrderByDescending(v => v).ToList();
+
+            EzLocalProfileBpmRange? bpmRange = null;
+
+            if (bpmEntries.Count > 0)
+            {
+                var minEntry = bpmEntries[0];
+                var maxEntry = bpmEntries[0];
+
+                foreach (var entry in bpmEntries)
+                {
+                    if (entry.Bpm < minEntry.Bpm)
+                        minEntry = entry;
+                    if (entry.Bpm > maxEntry.Bpm)
+                        maxEntry = entry;
+                }
+
+                bpmRange = new EzLocalProfileBpmRange(minEntry.Bpm, maxEntry.Bpm, minEntry.Play, maxEntry.Play);
+            }
+
+            var bpmByKeyMap = new Dictionary<int, List<(double Value, double Weight)>>();
+
+            foreach (var entry in bpmEntries)
+            {
+                if (entry.KeyCount is not int key)
+                    continue;
+
+                if (!bpmByKeyMap.TryGetValue(key, out var list))
+                    bpmByKeyMap[key] = list = new List<(double, double)>();
+
+                list.Add((entry.Bpm, entry.Weight));
+            }
+
+            var bpmByKeyMode = bpmByKeyMap
+                               .Select(kv => new EzLocalProfileBpmByKey(kv.Key, GetWeightedMedian(kv.Value) ?? 0, kv.Value.Count))
+                               .OrderBy(b => b.KeyCount)
+                               .ToList();
+
+            double keyPpCutoff = scores.Count >= KEY_PP_WINDOW_MIN && sortedPpValues.Count > 0
+                ? sortedPpValues[^1]
+                : 0;
+
+            var keyPp = buildKeyPpBuckets(keyPpByKey, keyPpCutoff);
+
+            return new EzLocalProfileInsights
+            {
+                SampleSize = scores.Count,
+                KeySplit = sortedKeySplit,
+                KeyPp = keyPp,
+                KeyPpConverts = convertPlays,
+                KeyPpCutoff = keyPpCutoff,
+                MostUsedMod = getTopCountEntry(modCounts, moddedPlayCount),
+                ModBreakdown = modCounts
+                               .OrderByDescending(kv => kv.Value)
+                               .ThenBy(kv => kv.Key, StringComparer.Ordinal)
+                               .Select(kv => new EzLocalProfileCountEntry(kv.Key, kv.Value, scores.Count))
+                               .ToList(),
+                MedianBpm = GetWeightedMedian(bpmEntries.Select(e => (e.Bpm, e.Weight)).ToList()),
+                BpmRange = bpmRange,
+                BpmByKeyMode = bpmByKeyMode,
+                NewestTopPlay = datedScores.Count > 0 ? datedScores[^1].Play : null,
+                OldestTopPlay = datedScores.Count > 0 ? datedScores[0].Play : null,
+                PpRange = sortedPpValues.Count > 0
+                    ? new EzLocalProfilePpRange(sortedPpValues[0], sortedPpValues[^1])
+                    : null,
+                PpDistribution = BuildPpDistribution(sortedPpValues),
+                PpCumulative = BuildPpCumulativeDistribution(sortedPpValues),
+            };
+        }
+
+        public static IReadOnlyList<EzLocalProfilePpDistributionBucket> BuildPpDistribution(IReadOnlyList<double> ppValues)
+        {
+            if (ppValues.Count == 0)
+                return Array.Empty<EzLocalProfilePpDistributionBucket>();
+
+            double top = ppValues.Max();
+            double bottom = ppValues.Min();
+            int step = getPpDistributionStep(top);
+            int maxThreshold = Math.Max(step, (int)Math.Floor(top / step) * step);
+            int minThreshold = Math.Max(step, (int)Math.Floor(bottom / step) * step);
+            int total = ppValues.Count;
+            var buckets = new List<EzLocalProfilePpDistributionBucket>();
+
+            for (int threshold = maxThreshold; threshold >= minThreshold; threshold -= step)
+            {
+                int? upper = threshold == maxThreshold ? null : threshold + step;
+                int count = ppValues.Count(pp => pp >= threshold && (upper == null || pp < upper));
+
+                if (count > 0)
+                {
+                    buckets.Add(new EzLocalProfilePpDistributionBucket(
+                        threshold,
+                        upper - 1,
+                        count,
+                        total));
+                }
+            }
+
+            int belowCount = ppValues.Count(pp => pp < minThreshold);
+
+            if (belowCount > 0)
+            {
+                buckets.Add(new EzLocalProfilePpDistributionBucket(
+                    null,
+                    minThreshold - 1,
+                    belowCount,
+                    total));
+            }
+
+            return buckets;
+        }
+
+        public static IReadOnlyList<EzLocalProfilePpCumulativeRow> BuildPpCumulativeDistribution(IReadOnlyList<double> ppValuesDescending)
+        {
+            var ppValues = ppValuesDescending
+                           .Where(double.IsFinite)
+                           .OrderByDescending(pp => pp)
+                           .ToList();
+
+            if (ppValues.Count == 0)
+                return Array.Empty<EzLocalProfilePpCumulativeRow>();
+
+            double top = ppValues[0];
+            double bottom = ppValues[^1];
+            int step = top < 250 ? 50 : 100;
+            int maxThreshold = Math.Max(0, (int)Math.Floor(top / step) * step);
+            int minThreshold = Math.Max(0, (int)Math.Floor(bottom / step) * step);
+            var rows = new List<EzLocalProfilePpCumulativeRow>();
+            int count = 0;
+
+            for (int threshold = maxThreshold; threshold >= minThreshold; threshold -= step)
+            {
+                while (count < ppValues.Count && ppValues[count] >= threshold)
+                    count++;
+
+                rows.Add(new EzLocalProfilePpCumulativeRow(threshold, count, ppValues.Count));
+            }
+
+            return rows;
+        }
+
+        public static double? GetWeightedMedian(IReadOnlyList<(double Value, double Weight)> entries)
+        {
+            if (entries.Count == 0)
+                return null;
+
+            var sorted = entries.OrderBy(e => e.Value).ToList();
+            double totalWeight = sorted.Sum(e => e.Weight);
+            if (totalWeight <= 0)
+                return null;
+
+            double cumulative = 0;
+
+            foreach (var entry in sorted)
+            {
+                cumulative += entry.Weight;
+                if (cumulative >= totalWeight / 2)
+                    return entry.Value;
+            }
+
+            return sorted[^1].Value;
+        }
+
+        private static IReadOnlyList<EzLocalProfileKeyPpBucket> buildKeyPpBuckets(
+            Dictionary<int, List<(int BeatmapId, double Pp)>> windowByKeyCount,
+            double cutoffPp)
+        {
+            return windowByKeyCount
+                   .Select(kv =>
+                   {
+                       var merged = kv.Value
+                                      .OrderByDescending(p => p.Pp)
+                                      .ThenBy(p => p.BeatmapId)
+                                      .Take(KEY_PP_LIST_LIMIT)
+                                      .ToList();
+
+                       double weighted = 0;
+
+                       for (int i = 0; i < merged.Count; i++)
+                           weighted += merged[i].Pp * Math.Pow(KEY_PP_DECAY, i);
+
+                       return new EzLocalProfileKeyPpBucket(
+                           kv.Key,
+                           weighted,
+                           merged.Count,
+                           getKeyPpMissingBound(merged.Count, cutoffPp));
+                   })
+                   .OrderByDescending(b => b.WeightedPp)
+                   .ThenBy(b => b.KeyCount)
+                   .ToList();
+        }
+
+        private static double getKeyPpMissingBound(int count, double cutoffPp)
+        {
+            if (cutoffPp <= 0)
+                return 0;
+
+            return cutoffPp * Math.Pow(KEY_PP_DECAY, count) / (1 - KEY_PP_DECAY);
+        }
+
+        private static int getPpDistributionStep(double top)
+        {
+            if (top < 250) return 50;
+            if (top < 1000) return 100;
+            if (top < 2000) return 250;
+
+            return 500;
+        }
+
+        private static EzLocalProfileCountEntry? getTopCountEntry(Dictionary<string, int> counts, int total)
+        {
+            if (counts.Count == 0 || total <= 0)
+                return null;
+
+            var top = counts
+                      .OrderByDescending(kv => kv.Value)
+                      .ThenBy(kv => kv.Key, StringComparer.Ordinal)
+                      .First();
+
+            return new EzLocalProfileCountEntry(top.Key, top.Value, total);
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOverlay.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOverlay.cs
@@ -320,25 +320,36 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
             if (trackMode)
             {
-                Drawable trackBody;
-
                 if (string.Equals(selectedPlayer.Value, EzLocalProfileConstants.ALL_PLAYERS, StringComparison.Ordinal))
                 {
-                    trackBody = new OsuSpriteText
-                    {
-                        RelativeSizeAxes = Axes.X,
-                        Text = EzSettingsProfile.LOCAL_PROFILE_TRACK_NEEDS_PLAYER,
-                        Font = OsuFont.GetFont(size: 14),
-                    };
+                    contentFlow.Add(new EzLocalProfileSection(
+                        EzSettingsProfile.LOCAL_PROFILE_SECTION_TRACK_INSIGHTS,
+                        new OsuSpriteText
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            Text = EzSettingsProfile.LOCAL_PROFILE_TRACK_NEEDS_PLAYER,
+                            Font = OsuFont.GetFont(size: 14),
+                        }));
+
+                    contentFlow.Add(new EzLocalProfileSection(
+                        EzSettingsProfile.LOCAL_PROFILE_SECTION_TRACK_SKILLS,
+                        new OsuSpriteText
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            Text = EzSettingsProfile.LOCAL_PROFILE_TRACK_NEEDS_PLAYER,
+                            Font = OsuFont.GetFont(size: 14),
+                        }));
                 }
                 else
                 {
-                    trackBody = new EzLocalProfileTrackSkillsBody(selectedPlayer.Value);
-                }
+                    contentFlow.Add(new EzLocalProfileSection(
+                        EzSettingsProfile.LOCAL_PROFILE_SECTION_TRACK_INSIGHTS,
+                        new EzLocalProfileTrackInsightsBody(selectedPlayer.Value, currentDrillScore)));
 
-                contentFlow.Add(new EzLocalProfileSection(
-                    EzSettingsProfile.LOCAL_PROFILE_SECTION_TRACK_SKILLS,
-                    trackBody));
+                    contentFlow.Add(new EzLocalProfileSection(
+                        EzSettingsProfile.LOCAL_PROFILE_SECTION_TRACK_SKILLS,
+                        new EzLocalProfileTrackSkillsBody(selectedPlayer.Value)));
+                }
             }
             else
             {

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileTrackInsightsBody.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileTrackInsightsBody.cs
@@ -1,0 +1,576 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Globalization;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
+using osu.Game.Beatmaps;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
+using osu.Game.Rulesets;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    /// <summary>
+    /// Track-mode Profile Insights: Key Split / Mod / BPM / PP + newest/oldest top plays.
+    /// </summary>
+    public partial class EzLocalProfileTrackInsightsBody : FillFlowContainer
+    {
+        private readonly string username;
+        private readonly Bindable<EzLocalProfileDrillScoreRow?>? selectDrillScore;
+
+        private enum DetailKind
+        {
+            None,
+            KeyPp,
+            Mods,
+            Bpm,
+            Pp,
+        }
+
+        private DetailKind openDetail = DetailKind.None;
+        private FillFlowContainer summaryFlow = null!;
+        private Container detailContainer = null!;
+        private FillFlowContainer playCardsFlow = null!;
+        private OsuSpriteText emptyHint = null!;
+        private EzLocalProfileInsights? insights;
+
+        [Resolved]
+        private EzLocalProfileService profileService { get; set; } = null!;
+
+        [Resolved]
+        private BeatmapManager beatmapManager { get; set; } = null!;
+
+        [Resolved]
+        private RulesetStore rulesets { get; set; } = null!;
+
+        public EzLocalProfileTrackInsightsBody(string username, Bindable<EzLocalProfileDrillScoreRow?>? selectDrillScore = null)
+        {
+            this.username = username;
+            this.selectDrillScore = selectDrillScore;
+
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            Direction = FillDirection.Vertical;
+            Spacing = new Vector2(0, 12);
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Children = new Drawable[]
+            {
+                emptyHint = new OsuSpriteText
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Font = OsuFont.GetFont(size: 14),
+                    Alpha = 0,
+                },
+                summaryFlow = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Full,
+                    Spacing = new Vector2(10),
+                },
+                detailContainer = new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                },
+                playCardsFlow = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Full,
+                    Spacing = new Vector2(10),
+                },
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            rebuild();
+        }
+
+        private void rebuild()
+        {
+            summaryFlow.Clear();
+            detailContainer.Clear();
+            playCardsFlow.Clear();
+            openDetail = DetailKind.None;
+
+            var rows = profileService.LoadDrillScores(EzLocalProfileConstants.MANIA_RULESET_ID, username);
+            var plays = EzLocalProfileInsightScoreBuilder.Build(rows, beatmapManager, rulesets);
+            insights = EzLocalProfileInsightsCalculator.Calculate(plays);
+
+            if (insights.SampleSize == 0)
+            {
+                emptyHint.Text = EzSettingsProfile.LOCAL_PROFILE_INSIGHTS_EMPTY;
+                emptyHint.Show();
+                return;
+            }
+
+            emptyHint.Hide();
+
+            summaryFlow.Add(new InsightChip(
+                EzSettingsProfile.LOCAL_PROFILE_INSIGHTS_KEY_SPLIT,
+                formatKeySplitSummary(insights),
+                () => toggleDetail(DetailKind.KeyPp)));
+
+            summaryFlow.Add(new InsightChip(
+                EzSettingsProfile.LOCAL_PROFILE_INSIGHTS_MOST_USED_MOD,
+                formatMostUsedMod(insights),
+                () => toggleDetail(DetailKind.Mods)));
+
+            summaryFlow.Add(new InsightChip(
+                EzSettingsProfile.LOCAL_PROFILE_INSIGHTS_MEDIAN_BPM,
+                formatMedianBpm(insights),
+                () => toggleDetail(DetailKind.Bpm)));
+
+            summaryFlow.Add(new InsightChip(
+                EzSettingsProfile.LOCAL_PROFILE_INSIGHTS_PP_RANGE,
+                formatPpRange(insights),
+                () => toggleDetail(DetailKind.Pp)));
+
+            if (insights.NewestTopPlay != null)
+            {
+                playCardsFlow.Add(new TopPlayCard(
+                    EzSettingsProfile.LOCAL_PROFILE_INSIGHTS_NEWEST_TOP,
+                    insights.NewestTopPlay,
+                    () => selectPlay(insights.NewestTopPlay)));
+            }
+
+            if (insights.OldestTopPlay != null)
+            {
+                playCardsFlow.Add(new TopPlayCard(
+                    EzSettingsProfile.LOCAL_PROFILE_INSIGHTS_OLDEST_TOP,
+                    insights.OldestTopPlay,
+                    () => selectPlay(insights.OldestTopPlay)));
+            }
+        }
+
+        private void selectPlay(EzLocalProfileInsightPlay play)
+        {
+            selectDrillScore?.Value = play.Row;
+        }
+
+        private void toggleDetail(DetailKind kind)
+        {
+            openDetail = openDetail == kind ? DetailKind.None : kind;
+            refreshDetail();
+        }
+
+        private void refreshDetail()
+        {
+            detailContainer.Clear();
+
+            if (insights == null || openDetail == DetailKind.None)
+                return;
+
+            Drawable body = openDetail switch
+            {
+                DetailKind.KeyPp => createKeyPpDetail(insights),
+                DetailKind.Mods => createModDetail(insights),
+                DetailKind.Bpm => createBpmDetail(insights),
+                DetailKind.Pp => createPpDetail(insights),
+                _ => new Container { RelativeSizeAxes = Axes.X, Height = 0 },
+            };
+
+            detailContainer.Child = new EzLocalProfileChartCard(detailTitle(openDetail), body);
+        }
+
+        private static LocalisableString detailTitle(DetailKind kind) => kind switch
+        {
+            DetailKind.KeyPp => (LocalisableString)EzSettingsProfile.LOCAL_PROFILE_INSIGHTS_KEY_PP,
+            DetailKind.Mods => (LocalisableString)EzSettingsProfile.LOCAL_PROFILE_INSIGHTS_MOD_USAGE,
+            DetailKind.Bpm => (LocalisableString)EzSettingsProfile.LOCAL_PROFILE_INSIGHTS_BPM_BREAKDOWN,
+            DetailKind.Pp => (LocalisableString)EzSettingsProfile.LOCAL_PROFILE_INSIGHTS_PP_DISTRIBUTION,
+            _ => (LocalisableString)string.Empty,
+        };
+
+        private static Drawable createKeyPpDetail(EzLocalProfileInsights data)
+        {
+            var flow = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(0, 8),
+            };
+
+            if (data.KeyPp.Count == 0)
+            {
+                flow.Add(new OsuSpriteText
+                {
+                    Text = EzSettingsProfile.LOCAL_PROFILE_NO_RULESET_DATA,
+                    Font = OsuFont.GetFont(size: 13),
+                });
+                return flow;
+            }
+
+            double max = data.KeyPp.Max(k => k.WeightedPp);
+
+            foreach (var bucket in data.KeyPp)
+            {
+                float ratio = max <= 0 ? 0 : (float)(bucket.WeightedPp / max);
+                flow.Add(new LabeledBarRow(
+                    $"{bucket.KeyCount}K",
+                    $"{EzLocalProfileFormat.FormatPp(bucket.WeightedPp)}pp · {bucket.Count}",
+                    ratio));
+            }
+
+            if (data.KeyPpConverts > 0)
+            {
+                flow.Add(new OsuSpriteText
+                {
+                    Text = EzSettingsProfile.LOCAL_PROFILE_INSIGHTS_CONVERTS_EXCLUDED.Format(data.KeyPpConverts),
+                    Font = OsuFont.GetFont(size: 12),
+                });
+            }
+
+            return flow;
+        }
+
+        private static Drawable createModDetail(EzLocalProfileInsights data)
+        {
+            var flow = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(0, 8),
+            };
+
+            if (data.ModBreakdown.Count == 0)
+            {
+                flow.Add(new OsuSpriteText
+                {
+                    Text = EzSettingsProfile.LOCAL_PROFILE_INSIGHTS_NO_MODS,
+                    Font = OsuFont.GetFont(size: 13),
+                });
+                return flow;
+            }
+
+            int max = data.ModBreakdown.Max(m => m.Count);
+
+            foreach (var mod in data.ModBreakdown)
+            {
+                float ratio = max <= 0 ? 0 : (float)mod.Count / max;
+                double pct = mod.Total <= 0 ? 0 : 100.0 * mod.Count / mod.Total;
+                flow.Add(new LabeledBarRow(
+                    mod.Label,
+                    $"{mod.Count} ({pct.ToString("0.0", CultureInfo.InvariantCulture)}%)",
+                    ratio));
+            }
+
+            return flow;
+        }
+
+        private static Drawable createBpmDetail(EzLocalProfileInsights data)
+        {
+            var flow = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(0, 8),
+            };
+
+            if (data.BpmRange != null)
+            {
+                flow.Add(new OsuSpriteText
+                {
+                    Text = EzSettingsProfile.LOCAL_PROFILE_INSIGHTS_BPM_RANGE.Format(
+                        data.BpmRange.Min.ToString("0", CultureInfo.InvariantCulture),
+                        data.BpmRange.Max.ToString("0", CultureInfo.InvariantCulture)),
+                    Font = OsuFont.GetFont(size: 13),
+                });
+            }
+
+            if (data.BpmByKeyMode.Count == 0)
+            {
+                flow.Add(new OsuSpriteText
+                {
+                    Text = EzSettingsProfile.LOCAL_PROFILE_NO_RULESET_DATA,
+                    Font = OsuFont.GetFont(size: 13),
+                });
+                return flow;
+            }
+
+            double max = data.BpmByKeyMode.Max(b => b.Median);
+
+            foreach (var row in data.BpmByKeyMode)
+            {
+                float ratio = max <= 0 ? 0 : (float)(row.Median / max);
+                flow.Add(new LabeledBarRow(
+                    $"{row.KeyCount}K",
+                    $"{row.Median.ToString("0", CultureInfo.InvariantCulture)} BPM · {row.Count}",
+                    ratio));
+            }
+
+            return flow;
+        }
+
+        private static Drawable createPpDetail(EzLocalProfileInsights data)
+        {
+            var flow = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(0, 8),
+            };
+
+            if (data.PpDistribution.Count == 0)
+            {
+                flow.Add(new OsuSpriteText
+                {
+                    Text = EzSettingsProfile.LOCAL_PROFILE_NO_RULESET_DATA,
+                    Font = OsuFont.GetFont(size: 13),
+                });
+                return flow;
+            }
+
+            int max = data.PpDistribution.Max(b => b.Count);
+
+            foreach (var bucket in data.PpDistribution)
+            {
+                float ratio = max <= 0 ? 0 : (float)bucket.Count / max;
+                string label = formatPpBucketLabel(bucket);
+                flow.Add(new LabeledBarRow(label, bucket.Count.ToString("N0"), ratio));
+            }
+
+            if (data.PpCumulative.Count > 0)
+            {
+                flow.Add(new OsuSpriteText
+                {
+                    Margin = new MarginPadding { Top = 8 },
+                    Text = EzSettingsProfile.LOCAL_PROFILE_INSIGHTS_PP_CUMULATIVE,
+                    Font = OsuFont.GetFont(size: 13, weight: FontWeight.Bold),
+                });
+
+                int cumMax = data.PpCumulative.Max(r => r.Count);
+
+                foreach (var row in data.PpCumulative.Take(12))
+                {
+                    float ratio = cumMax <= 0 ? 0 : (float)row.Count / cumMax;
+                    flow.Add(new LabeledBarRow(
+                        $"≥{row.Threshold}",
+                        $"{row.Count}/{row.Total}",
+                        ratio));
+                }
+            }
+
+            return flow;
+        }
+
+        private static string formatPpBucketLabel(EzLocalProfilePpDistributionBucket bucket)
+        {
+            if (bucket.Min is null)
+                return $"<{bucket.Max + 1}";
+            if (bucket.Max is null)
+                return $"≥{bucket.Min}";
+
+            return $"{bucket.Min}–{bucket.Max}";
+        }
+
+        private static string formatKeySplitSummary(EzLocalProfileInsights data)
+        {
+            if (data.KeySplit.Count == 0)
+                return "—";
+
+            var top = data.KeySplit[0];
+            double pct = data.SampleSize <= 0 ? 0 : 100.0 * top.Count / data.SampleSize;
+            return $"{top.KeyCount}K {pct.ToString("0", CultureInfo.InvariantCulture)}%";
+        }
+
+        private static string formatMostUsedMod(EzLocalProfileInsights data)
+        {
+            if (data.MostUsedMod == null)
+                return "NM";
+
+            double pct = data.MostUsedMod.Total <= 0 ? 0 : 100.0 * data.MostUsedMod.Count / data.MostUsedMod.Total;
+            return $"{data.MostUsedMod.Label} {pct.ToString("0", CultureInfo.InvariantCulture)}%";
+        }
+
+        private static string formatMedianBpm(EzLocalProfileInsights data)
+        {
+            if (data.MedianBpm is not double bpm)
+                return "—";
+
+            if (data.BpmRange != null)
+            {
+                return $"{bpm.ToString("0", CultureInfo.InvariantCulture)} ({data.BpmRange.Min.ToString("0", CultureInfo.InvariantCulture)}–{data.BpmRange.Max.ToString("0", CultureInfo.InvariantCulture)})";
+            }
+
+            return bpm.ToString("0", CultureInfo.InvariantCulture);
+        }
+
+        private static string formatPpRange(EzLocalProfileInsights data)
+        {
+            if (data.PpRange == null)
+                return "—";
+
+            return $"{EzLocalProfileFormat.FormatPp(data.PpRange.Top)}–{EzLocalProfileFormat.FormatPp(data.PpRange.Bottom)}";
+        }
+
+        private partial class InsightChip : OsuClickableContainer
+        {
+            private readonly LocalisableString title;
+            private readonly string value;
+
+            public InsightChip(LocalisableString title, string value, Action action)
+            {
+                this.title = title;
+                this.value = value;
+
+                AutoSizeAxes = Axes.Both;
+                Masking = true;
+                CornerRadius = 8;
+                Action = action;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colours)
+            {
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = colours.Background5,
+                    },
+                    new FillFlowContainer
+                    {
+                        AutoSizeAxes = Axes.Both,
+                        Direction = FillDirection.Vertical,
+                        Padding = new MarginPadding { Horizontal = 14, Vertical = 10 },
+                        Spacing = new Vector2(0, 2),
+                        Children = new Drawable[]
+                        {
+                            new OsuSpriteText
+                            {
+                                Text = title,
+                                Font = OsuFont.GetFont(size: 11, weight: FontWeight.SemiBold),
+                                Colour = colours.Content2,
+                            },
+                            new OsuSpriteText
+                            {
+                                Text = value,
+                                Font = OsuFont.GetFont(size: 16, weight: FontWeight.Bold),
+                            },
+                        }
+                    }
+                };
+            }
+        }
+
+        private partial class TopPlayCard : OsuClickableContainer
+        {
+            private readonly LocalisableString caption;
+            private readonly EzLocalProfileInsightPlay play;
+
+            public TopPlayCard(LocalisableString caption, EzLocalProfileInsightPlay play, Action action)
+            {
+                this.caption = caption;
+                this.play = play;
+
+                Width = 320;
+                AutoSizeAxes = Axes.Y;
+                Masking = true;
+                CornerRadius = 8;
+                Action = action;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colours)
+            {
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = colours.Background5,
+                    },
+                    new FillFlowContainer
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Direction = FillDirection.Vertical,
+                        Padding = new MarginPadding(12),
+                        Spacing = new Vector2(0, 4),
+                        Children = new Drawable[]
+                        {
+                            new OsuSpriteText
+                            {
+                                Text = caption,
+                                Font = OsuFont.GetFont(size: 11, weight: FontWeight.SemiBold),
+                                Colour = colours.Content2,
+                            },
+                            new TruncatingSpriteText
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                Text = string.IsNullOrEmpty(play.Artist) ? play.Title : $"{play.Artist} - {play.Title}",
+                                Font = OsuFont.GetFont(size: 13, weight: FontWeight.Bold),
+                            },
+                            new TruncatingSpriteText
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                Text = $"{play.DifficultyName} · {EzLocalProfileFormat.FormatPp(play.Pp)}pp · {play.Rank}",
+                                Font = OsuFont.GetFont(size: 12),
+                                Colour = colours.Content1,
+                            },
+                        }
+                    }
+                };
+            }
+        }
+
+        private partial class LabeledBarRow : Container
+        {
+            public LabeledBarRow(string label, string valueText, float ratio)
+            {
+                RelativeSizeAxes = Axes.X;
+                Height = 22;
+                Padding = new MarginPadding { Horizontal = 4 };
+
+                Children = new Drawable[]
+                {
+                    new OsuSpriteText
+                    {
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Text = label,
+                        Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
+                        Width = 72,
+                    },
+                    new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Padding = new MarginPadding { Left = 80, Right = 96 },
+                        Child = new EzLocalProfileRoundedBar(ratio),
+                    },
+                    new OsuSpriteText
+                    {
+                        Anchor = Anchor.CentreRight,
+                        Origin = Anchor.CentreRight,
+                        Text = valueText,
+                        Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
+                    },
+                };
+            }
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Localization/EzSettings.Profile.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettings.Profile.cs
@@ -123,6 +123,58 @@ namespace osu.Game.EzOsuGame.Localization
                 "Track 技能按玩家名计算。请在上方选择具体玩家（不要选 All）。",
                 "Track skills are per player. Select a specific player above (not All).");
 
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SECTION_TRACK_INSIGHTS =
+            new EzLocalizationManager.EzLocalisableString("成绩洞察", "Profile Insights");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_INSIGHTS_EMPTY =
+            new EzLocalizationManager.EzLocalisableString(
+                "暂无可用的 Mania 成绩洞察（需要已计算的 PP）。",
+                "No mania profile insights yet (computed PP scores required).");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_INSIGHTS_KEY_SPLIT =
+            new EzLocalizationManager.EzLocalisableString("键数分布", "Key Split");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_INSIGHTS_MOST_USED_MOD =
+            new EzLocalizationManager.EzLocalisableString("最常用 Mod", "Most Used Mod");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_INSIGHTS_MEDIAN_BPM =
+            new EzLocalizationManager.EzLocalisableString("中位 BPM", "Median BPM");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_INSIGHTS_PP_RANGE =
+            new EzLocalizationManager.EzLocalisableString("PP 范围", "PP Range");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_INSIGHTS_KEY_PP =
+            new EzLocalizationManager.EzLocalisableString("各键数加权 PP", "PP by Keymode");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_INSIGHTS_MOD_USAGE =
+            new EzLocalizationManager.EzLocalisableString("Mod 使用", "Mod Usage");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_INSIGHTS_BPM_BREAKDOWN =
+            new EzLocalizationManager.EzLocalisableString("BPM 明细", "BPM Breakdown");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_INSIGHTS_PP_DISTRIBUTION =
+            new EzLocalizationManager.EzLocalisableString("PP 分布", "PP Distribution");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_INSIGHTS_PP_CUMULATIVE =
+            new EzLocalizationManager.EzLocalisableString("累计（≥ 阈值）", "Cumulative (≥ threshold)");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_INSIGHTS_BPM_RANGE =
+            new EzLocalizationManager.EzLocalisableString("范围 {0}–{1} BPM", "Range {0}–{1} BPM");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_INSIGHTS_CONVERTS_EXCLUDED =
+            new EzLocalizationManager.EzLocalisableString(
+                "已排除 {0} 条 convert（不计入键数 PP）",
+                "{0} convert plays excluded from keymode PP");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_INSIGHTS_NO_MODS =
+            new EzLocalizationManager.EzLocalisableString("窗口内成绩均为无 Mod。", "All window plays are nomod.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_INSIGHTS_NEWEST_TOP =
+            new EzLocalizationManager.EzLocalisableString("最新 Top Play", "Newest Top Play");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_INSIGHTS_OLDEST_TOP =
+            new EzLocalizationManager.EzLocalisableString("最早 Top Play", "Oldest Top Play");
+
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_XXY_PLAY_DISTRIBUTION =
             new EzLocalizationManager.EzLocalisableString("xxy 星级分布", "Plays by xxy SR");
 


### PR DESCRIPTION
## Summary
- Port mania-hub Profile Insights onto Local Profile **Track** (above SSR skills): Key Split, Most Used Mod, Median BPM, PP Range, Newest/Oldest Top Play.
- Compute from archived mania Top-200 PP drill scores (no online BP API); convert plays excluded from keymode weighted PP.
- No `EZ_REALM_SCHEMA_VERSION` bump.

## Test plan
- [x] Mania + Track + specific player: Insights chips appear above Track Skills
- [x] Click chips: Key PP / Mod / BPM / PP distribution expand with bars
- [x] Newest/Oldest cards select the matching drill score
- [x] Player = All: Insights/Skills show select-player hint
- [x] `dotnet build`; Insights calculator unit tests pass

Made with [Cursor](https://cursor.com)