### PR TITLE
Polish Track Skills with Overall, radar, and history

### DIFF
--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileTrackSkillsBody.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileTrackSkillsBody.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -10,6 +11,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
+using osu.Game.EzOsuGame.HUD;
 using osu.Game.EzOsuGame.Localization;
 using osu.Game.EzOsuGame.Skills;
 using osu.Game.Graphics;
@@ -21,15 +23,20 @@ using osuTK;
 namespace osu.Game.EzOsuGame.LocalProfile
 {
     /// <summary>
-    /// Track-mode skills body: key-count chips + SSR skill bars from Realm.
+    /// Track-mode skills: key chips, Overall header, radar, SSR bars, optional history.
     /// </summary>
     public partial class EzLocalProfileTrackSkillsBody : FillFlowContainer
     {
         private readonly string username;
 
         private readonly BindableInt selectedKeyCount = new BindableInt();
+        private readonly Bindable<string?> selectedHistorySkillId = new Bindable<string?>();
+
         private FillFlowContainer keyChipFlow = null!;
+        private Container headerContainer = null!;
+        private Container radarContainer = null!;
         private FillFlowContainer skillBarsFlow = null!;
+        private Container historyContainer = null!;
         private OsuSpriteText emptyHint = null!;
 
         [Resolved]
@@ -63,12 +70,28 @@ namespace osu.Game.EzOsuGame.LocalProfile
                     Font = OsuFont.GetFont(size: 14),
                     Alpha = 0,
                 },
+                headerContainer = new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                },
+                radarContainer = new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Height = 220,
+                    Alpha = 0,
+                },
                 skillBarsFlow = new FillFlowContainer
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
                     Direction = FillDirection.Vertical,
                     Spacing = new Vector2(0, 8),
+                },
+                historyContainer = new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
                 },
             };
         }
@@ -77,14 +100,23 @@ namespace osu.Game.EzOsuGame.LocalProfile
         {
             base.LoadComplete();
 
-            selectedKeyCount.BindValueChanged(_ => refreshSkillBars(), false);
+            selectedKeyCount.BindValueChanged(_ =>
+            {
+                selectedHistorySkillId.Value = null;
+                refreshSkills();
+            }, false);
+            selectedHistorySkillId.BindValueChanged(_ => refreshHistory(), false);
             rebuild();
         }
 
         private void rebuild()
         {
             keyChipFlow.Clear();
+            headerContainer.Clear();
+            radarContainer.Clear();
             skillBarsFlow.Clear();
+            historyContainer.Clear();
+            selectedHistorySkillId.Value = null;
 
             var keyCounts = skillProvider.GetPlayerSsrKeyCounts(username);
 
@@ -92,6 +124,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
             {
                 emptyHint.Text = EzSettingsProfile.LOCAL_PROFILE_TRACK_EMPTY;
                 emptyHint.Show();
+                radarContainer.Hide();
                 return;
             }
 
@@ -109,30 +142,171 @@ namespace osu.Game.EzOsuGame.LocalProfile
             if (!keyCounts.Contains(selectedKeyCount.Value))
                 selectedKeyCount.Value = keyCounts[0];
             else
-                refreshSkillBars();
+                refreshSkills();
         }
 
-        private void refreshSkillBars()
+        private void refreshSkills()
         {
+            headerContainer.Clear();
+            radarContainer.Clear();
             skillBarsFlow.Clear();
 
             int keyCount = selectedKeyCount.Value;
             if (keyCount <= 0)
                 return;
 
-            var skills = skillProvider.GetPlayerSsr(username, keyCount);
+            var snapshot = skillProvider.GetPlayerSsrSnapshot(username, keyCount);
             var definitions = skillProvider.Registry.GetSystem(EzSkillSystems.PLAYER_SSR)?.Skills
                               ?? Array.Empty<EzSkillDefinition>();
 
-            double max = skills.Values.DefaultIfEmpty(0).Max();
-            if (max <= 0)
-                max = 1;
+            headerContainer.Child = new SkillsHeader(keyCount, snapshot);
+
+            var radarAxes = definitions.Where(d => d.SkillId != EzSkillIds.Ssr(EzSkillIds.OVERALL)).ToList();
+            double radarMax = radarAxes
+                              .Select(d => snapshot.Values.GetValueOrDefault(d.SkillId, 0))
+                              .DefaultIfEmpty(0)
+                              .Max();
+
+            if (radarAxes.Count >= 3 && radarMax > 0)
+            {
+                var ratios = radarAxes
+                             .Select(d =>
+                             {
+                                 snapshot.Values.TryGetValue(d.SkillId, out double v);
+                                 return (float)(v / radarMax);
+                             })
+                             .ToList();
+
+                var chart = new RadarChart
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    AxisCount = ratios.Count,
+                };
+
+                radarContainer.Child = chart;
+                chart.SetData(ratios);
+                radarContainer.Show();
+            }
+            else
+            {
+                radarContainer.Hide();
+            }
+
+            double barMax = snapshot.Values.Values.DefaultIfEmpty(0).Max();
+            if (barMax <= 0)
+                barMax = 1;
 
             foreach (var def in definitions)
             {
-                skills.TryGetValue(def.SkillId, out double value);
-                float ratio = (float)(value / max);
-                skillBarsFlow.Add(new SkillBarRow(def.DisplayName, value, ratio, Colour4.FromHex(def.AccentHex)));
+                snapshot.Values.TryGetValue(def.SkillId, out double value);
+                float ratio = (float)(value / barMax);
+                string skillId = def.SkillId;
+
+                skillBarsFlow.Add(new SkillBarRow(
+                    def.DisplayName,
+                    value,
+                    ratio,
+                    Colour4.FromHex(def.AccentHex),
+                    () => selectedHistorySkillId.Value =
+                        string.Equals(selectedHistorySkillId.Value, skillId, StringComparison.Ordinal) ? null : skillId));
+            }
+
+            refreshHistory();
+        }
+
+        private void refreshHistory()
+        {
+            historyContainer.Clear();
+
+            string? skillId = selectedHistorySkillId.Value;
+            int keyCount = selectedKeyCount.Value;
+
+            if (string.IsNullOrEmpty(skillId) || keyCount <= 0)
+                return;
+
+            var points = skillProvider.GetPlayerSkillHistory(username, keyCount, skillId);
+            string displayName = skillId;
+
+            foreach (var def in skillProvider.Registry.GetSystem(EzSkillSystems.PLAYER_SSR)?.Skills
+                                ?? Array.Empty<EzSkillDefinition>())
+            {
+                if (def.SkillId == skillId)
+                {
+                    displayName = def.DisplayName;
+                    break;
+                }
+            }
+
+            if (points.Count == 0)
+            {
+                historyContainer.Child = new EzLocalProfileChartCard(
+                    EzSettingsProfile.LOCAL_PROFILE_SKILL_HISTORY,
+                    new OsuSpriteText
+                    {
+                        Text = EzSettingsProfile.LOCAL_PROFILE_SKILL_HISTORY_EMPTY,
+                        Font = OsuFont.GetFont(size: 13),
+                    });
+                return;
+            }
+
+            float[] values = points.Select(p => (float)p.Value).ToArray();
+            string[] labels = points.Select(p => p.RecordedAt.ToLocalTime().ToString("MM-dd", CultureInfo.InvariantCulture)).ToArray();
+
+            historyContainer.Child = new EzLocalProfileChartCard(
+                EzSettingsProfile.LOCAL_PROFILE_SKILL_HISTORY_FOR.Format(displayName),
+                new EzLocalProfileLabeledLineChart(values, labels));
+        }
+
+        private partial class SkillsHeader : FillFlowContainer
+        {
+            public SkillsHeader(int keyCount, EzPlayerSsrSnapshot snapshot)
+            {
+                RelativeSizeAxes = Axes.X;
+                AutoSizeAxes = Axes.Y;
+                Direction = FillDirection.Vertical;
+                Spacing = new Vector2(0, 4);
+
+                Children = new Drawable[]
+                {
+                    new OsuSpriteText
+                    {
+                        Text = EzSettingsProfile.LOCAL_PROFILE_SKILL_RATING.Format(keyCount),
+                        Font = OsuFont.GetFont(size: 13, weight: FontWeight.SemiBold),
+                    },
+                    new OsuSpriteText
+                    {
+                        Text = snapshot.Overall.ToString("0.00", CultureInfo.InvariantCulture),
+                        Font = OsuFont.GetFont(size: 36, weight: FontWeight.Bold),
+                    },
+                    new OsuSpriteText
+                    {
+                        Text = buildMeta(snapshot),
+                        Font = OsuFont.GetFont(size: 12),
+                    },
+                };
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colours)
+            {
+                if (Children.Count >= 3)
+                    Children[2].Colour = colours.Content2;
+            }
+
+            private static string buildMeta(EzPlayerSsrSnapshot snapshot)
+            {
+                var parts = new List<string>
+                {
+                    EzSettingsProfile.LOCAL_PROFILE_SKILL_PLAYS.Format(snapshot.AnalyzedPlays),
+                };
+
+                if (snapshot.IsEffectivelyProvisional)
+                    parts.Add(EzSettingsProfile.LOCAL_PROFILE_SKILL_PROVISIONAL.ToString());
+
+                if (snapshot.Stale)
+                    parts.Add(EzSettingsProfile.LOCAL_PROFILE_SKILL_STALE.ToString());
+
+                return string.Join(" · ", parts);
             }
         }
 
@@ -204,37 +378,45 @@ namespace osu.Game.EzOsuGame.LocalProfile
             }
         }
 
-        private partial class SkillBarRow : Container
+        private partial class SkillBarRow : OsuClickableContainer
         {
-            public SkillBarRow(string displayName, double value, float ratio, Colour4 accent)
+            public SkillBarRow(string displayName, double value, float ratio, Colour4 accent, Action action)
             {
                 RelativeSizeAxes = Axes.X;
                 Height = 22;
-                Padding = new MarginPadding { Horizontal = 4 };
+                Action = action;
 
                 Children = new Drawable[]
                 {
-                    new OsuSpriteText
-                    {
-                        Anchor = Anchor.CentreLeft,
-                        Origin = Anchor.CentreLeft,
-                        Text = displayName,
-                        Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
-                        Width = 96,
-                    },
                     new Container
                     {
                         RelativeSizeAxes = Axes.Both,
-                        Padding = new MarginPadding { Left = 104, Right = 56 },
-                        Child = new EzLocalProfileRoundedBar(ratio, accent),
-                    },
-                    new OsuSpriteText
-                    {
-                        Anchor = Anchor.CentreRight,
-                        Origin = Anchor.CentreRight,
-                        Text = value.ToString("0.00", CultureInfo.InvariantCulture),
-                        Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
-                    },
+                        Padding = new MarginPadding { Horizontal = 4 },
+                        Children = new Drawable[]
+                        {
+                            new OsuSpriteText
+                            {
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                                Text = displayName,
+                                Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
+                                Width = 96,
+                            },
+                            new Container
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Padding = new MarginPadding { Left = 104, Right = 56 },
+                                Child = new EzLocalProfileRoundedBar(ratio, accent),
+                            },
+                            new OsuSpriteText
+                            {
+                                Anchor = Anchor.CentreRight,
+                                Origin = Anchor.CentreRight,
+                                Text = value.ToString("0.00", CultureInfo.InvariantCulture),
+                                Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
+                            },
+                        }
+                    }
                 };
             }
         }

--- a/osu.Game/EzOsuGame/Localization/EzSettings.Profile.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettings.Profile.cs
@@ -123,6 +123,29 @@ namespace osu.Game.EzOsuGame.Localization
                 "Track 技能按玩家名计算。请在上方选择具体玩家（不要选 All）。",
                 "Track skills are per player. Select a specific player above (not All).");
 
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SKILL_RATING =
+            new EzLocalizationManager.EzLocalisableString("{0}K 技能评分", "{0}K skill rating");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SKILL_PLAYS =
+            new EzLocalizationManager.EzLocalisableString("{0} 局分析", "{0} analyzed plays");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SKILL_PROVISIONAL =
+            new EzLocalizationManager.EzLocalisableString("临时评分", "Provisional");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SKILL_STALE =
+            new EzLocalizationManager.EzLocalisableString("待更新", "Updating");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SKILL_HISTORY =
+            new EzLocalizationManager.EzLocalisableString("技能历史", "Skill History");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SKILL_HISTORY_FOR =
+            new EzLocalizationManager.EzLocalisableString("技能历史 · {0}", "Skill History · {0}");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SKILL_HISTORY_EMPTY =
+            new EzLocalizationManager.EzLocalisableString(
+                "暂无历史点。重新计算本地个人成绩后会写入。",
+                "No history points yet. Recompute Local Profile Stats to record them.");
+
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SECTION_TRACK_INSIGHTS =
             new EzLocalizationManager.EzLocalisableString("成绩洞察", "Profile Insights");
 

--- a/osu.Game/EzOsuGame/Skills/EzPlayerSsrAggregator.cs
+++ b/osu.Game/EzOsuGame/Skills/EzPlayerSsrAggregator.cs
@@ -70,7 +70,8 @@ namespace osu.Game.EzOsuGame.Skills
             foreach ((int keyCount, List<EzSkillsetVector> plays) in byKey)
             {
                 var aggregated = EzSsrAggregator.AggregateVectors(plays);
-                skillStore.WritePlayerSsr(username, keyCount, aggregated, plays.Count);
+                bool provisional = plays.Count < EzPlayerSsrSnapshot.QUALIFYING_PLAYS;
+                skillStore.WritePlayerSsr(username, keyCount, aggregated, plays.Count, provisional);
             }
         }
 

--- a/osu.Game/EzOsuGame/Skills/EzPlayerSsrSnapshot.cs
+++ b/osu.Game/EzOsuGame/Skills/EzPlayerSsrSnapshot.cs
@@ -1,0 +1,33 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    /// <summary>
+    /// Detached SSR snapshot for one username + keymode (values + row metadata).
+    /// </summary>
+    public sealed class EzPlayerSsrSnapshot
+    {
+        public const int QUALIFYING_PLAYS = 3;
+
+        public IReadOnlyDictionary<string, double> Values { get; init; } =
+            new Dictionary<string, double>(StringComparer.Ordinal);
+
+        public int AnalyzedPlays { get; init; }
+
+        public bool Provisional { get; init; }
+
+        public bool Stale { get; init; }
+
+        public DateTimeOffset? ComputedAt { get; init; }
+
+        public double Overall =>
+            Values.GetValueOrDefault(EzSkillIds.Ssr(EzSkillIds.OVERALL), 0);
+
+        /// <summary>Hub-style provisional: stored flag or fewer than qualifying plays.</summary>
+        public bool IsEffectivelyProvisional => Provisional || AnalyzedPlays < QUALIFYING_PLAYS;
+    }
+}

--- a/osu.Game/EzOsuGame/Skills/EzSkillProvider.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSkillProvider.cs
@@ -29,6 +29,9 @@ namespace osu.Game.EzOsuGame.Skills
         public IReadOnlyDictionary<string, double> GetPlayerSsr(string username, int keyCount)
             => store.GetPlayerSkills(username, keyCount, EzSkillSystems.PLAYER_SSR);
 
+        public EzPlayerSsrSnapshot GetPlayerSsrSnapshot(string username, int keyCount)
+            => store.GetPlayerSsrSnapshot(username, keyCount);
+
         public IReadOnlyList<int> GetPlayerSsrKeyCounts(string username)
             => store.GetPlayerSsrKeyCounts(username);
 

--- a/osu.Game/EzOsuGame/Skills/EzSkillStore.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSkillStore.cs
@@ -106,6 +106,36 @@ namespace osu.Game.EzOsuGame.Skills
             });
         }
 
+        public EzPlayerSsrSnapshot GetPlayerSsrSnapshot(string username, int keyCount, int? algorithmVersion = null)
+        {
+            int version = algorithmVersion ?? EzManiaSkillAlgorithm.VERSION;
+
+            return realmAccess.Run(r =>
+            {
+                var rows = r.All<EzPlayerSkillValue>()
+                            .Where(v => v.Username == username
+                                        && v.KeyCount == keyCount
+                                        && v.SystemId == EzSkillSystems.PLAYER_SSR
+                                        && v.AlgorithmVersion == version)
+                            .ToList();
+
+                if (rows.Count == 0)
+                    return new EzPlayerSsrSnapshot();
+
+                var values = rows.ToDictionary(v => v.SkillId, v => v.Value, StringComparer.Ordinal);
+                var meta = rows.FirstOrDefault(v => v.SkillId == EzSkillIds.Ssr(EzSkillIds.OVERALL)) ?? rows[0];
+
+                return new EzPlayerSsrSnapshot
+                {
+                    Values = values,
+                    AnalyzedPlays = meta.AnalyzedPlays,
+                    Provisional = meta.Provisional,
+                    Stale = meta.Stale,
+                    ComputedAt = meta.ComputedAt,
+                };
+            });
+        }
+
         public IReadOnlyList<int> GetPlayerSsrKeyCounts(string username, int? algorithmVersion = null)
         {
             int version = algorithmVersion ?? EzManiaSkillAlgorithm.VERSION;


### PR DESCRIPTION
## Summary
- **Step 1** of Local Profile roadmap (after #99): Track Skills Overall header, provisional/plays, radar (no Overall axis), clickable bars → skill history chart.
- `EzPlayerSsrSnapshot` + store/provider API; `AnalyzedPlays < 3` marks provisional on write and in UI.
- No `EZ_REALM_SCHEMA_VERSION` bump.

## Roadmap
1. **This PR** — Skills polish
2. Dan MVP
3. Axis supporting plays
4. Insights on Ez mode
5. SSR goal refinement

## Test plan
- [x] Mania + Track + player with SSR: Overall number, plays/provisional text, radar, bars
- [ ] Click a skill bar: history chart or empty hint
- [x] Switch key chips refreshes header/radar/bars
- [x] `dotnet build`

Made with [Cursor](https://cursor.com)