### PR TITLE
Dan foundation: chart→credit→player estimate pipeline

### DIFF
--- a/osu.Game.Tests/EzOsuGame/Skills/EzDanCreditTest.cs
+++ b/osu.Game.Tests/EzOsuGame/Skills/EzDanCreditTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using NUnit.Framework;
 using osu.Game.EzOsuGame.Skills;
 
@@ -36,6 +37,28 @@ namespace osu.Game.Tests.EzOsuGame.Skills
             double low = EzDanLabels.SrToRawDan(4.0, "stream");
             double high = EzDanLabels.SrToRawDan(8.0, "stream");
             Assert.That(high, Is.GreaterThan(low));
+        }
+
+        [Test]
+        public void ChartDanFromMsdClassifiesLnSideByHoldRatio()
+        {
+            var msd = new Dictionary<string, double>
+            {
+                [EzSkillIds.Msd(EzSkillIds.OVERALL)] = 6.5,
+                [EzSkillIds.Msd(EzSkillIds.STREAM)] = 6.0,
+                [EzSkillIds.Msd(EzSkillIds.JUMPSTREAM)] = 5.0,
+            };
+
+            var rc = EzChartDanEstimator.FromMsd(msd, keyCount: 4, holdRatio: 0.1);
+            Assert.That(rc, Is.Not.Null);
+            Assert.That(rc!.Side, Is.EqualTo(DanSkillSystem.SIDE_RC));
+            Assert.That(rc.RawDan, Is.GreaterThan(0));
+            Assert.That(rc.Label, Is.Not.Empty);
+
+            var ln = EzChartDanEstimator.FromMsd(msd, keyCount: 4, holdRatio: 0.5);
+            Assert.That(ln, Is.Not.Null);
+            Assert.That(ln!.Side, Is.EqualTo(DanSkillSystem.SIDE_LN));
+            Assert.That(ln.RawDan, Is.EqualTo(rc.RawDan).Within(0.001));
         }
     }
 }

--- a/osu.Game.Tests/EzOsuGame/Skills/EzDanCreditTest.cs
+++ b/osu.Game.Tests/EzOsuGame/Skills/EzDanCreditTest.cs
@@ -1,0 +1,41 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.EzOsuGame.Skills;
+
+namespace osu.Game.Tests.EzOsuGame.Skills
+{
+    [TestFixture]
+    public class EzDanCreditTest
+    {
+        [Test]
+        public void AtBarCreditsFullChartDan()
+        {
+            double? credited = EzDanCredit.CreditedDanFor(10, 0.96, DanSkillSystem.SIDE_RC, 4);
+            Assert.That(credited, Is.EqualTo(10).Within(0.001));
+        }
+
+        [Test]
+        public void FarBelowBarCreditsNothing()
+        {
+            double? credited = EzDanCredit.CreditedDanFor(10, 0.80, DanSkillSystem.SIDE_RC, 4);
+            Assert.That(credited, Is.Null);
+        }
+
+        [Test]
+        public void ParseDanLabelsGreek()
+        {
+            Assert.That(EzDanLabels.LabelFor(11, DanSkillSystem.SIDE_RC, 4), Does.StartWith("alpha"));
+            Assert.That(EzDanLabels.LabelFor(10.0, DanSkillSystem.SIDE_LN, 4), Is.EqualTo("10"));
+        }
+
+        [Test]
+        public void SrToRawDanIncreasesWithSr()
+        {
+            double low = EzDanLabels.SrToRawDan(4.0, "stream");
+            double high = EzDanLabels.SrToRawDan(8.0, "stream");
+            Assert.That(high, Is.GreaterThan(low));
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileService.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileService.cs
@@ -27,6 +27,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
         private readonly EzLocalProfileStore store;
         private readonly EzLocalProfileAggregator aggregator;
         private readonly EzPlayerSsrAggregator? ssrAggregator;
+        private readonly EzPlayerDanAggregator? danAggregator;
         private readonly Lock computeLock = new Lock();
         private CancellationTokenSource? computeCts;
 
@@ -41,11 +42,13 @@ namespace osu.Game.EzOsuGame.LocalProfile
             BeatmapManager beatmapManager,
             ScoreManager scoreManager,
             IEzReplaySession replaySession,
-            EzPlayerSsrAggregator? ssrAggregator = null)
+            EzPlayerSsrAggregator? ssrAggregator = null,
+            EzPlayerDanAggregator? danAggregator = null)
         {
             store = new EzLocalProfileStore(storage);
             aggregator = new EzLocalProfileAggregator(realm, analysisStore, beatmapManager, scoreManager, replaySession);
             this.ssrAggregator = ssrAggregator;
+            this.danAggregator = danAggregator;
             Snapshot.Value = store.LoadSnapshot();
         }
 
@@ -109,8 +112,8 @@ namespace osu.Game.EzOsuGame.LocalProfile
                         var localOnlineIds = aggregator.CollectLocalOnlineScoreIds();
                         store.ApplyUsernamePartitions(byUser, replaceOtherUsernames, online, localOnlineIds);
 
-                        if (ssrAggregator != null && selected.Count > 0)
-                            writePlayerSsr(selected, token);
+                        if (selected.Count > 0)
+                            writePlayerSkills(selected, token);
                     }
                     catch (OperationCanceledException)
                     {
@@ -129,8 +132,11 @@ namespace osu.Game.EzOsuGame.LocalProfile
             }
         }
 
-        private void writePlayerSsr(IReadOnlyList<string> usernames, CancellationToken token)
+        private void writePlayerSkills(IReadOnlyList<string> usernames, CancellationToken token)
         {
+            if (ssrAggregator == null && danAggregator == null)
+                return;
+
             try
             {
                 var maniaScores = aggregator.CollectDetachedManiaScores(usernames);
@@ -142,7 +148,23 @@ namespace osu.Game.EzOsuGame.LocalProfile
                     if (scores.Count == 0)
                         continue;
 
-                    ssrAggregator!.ComputeAndStore(username, scores);
+                    try
+                    {
+                        ssrAggregator?.ComputeAndStore(username, scores);
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    {
+                        Logger.Error(ex, "[EzLocalProfile] Failed to compute player SSR skills after profile save.", Ez2ConfigManager.LOGGER_NAME);
+                    }
+
+                    try
+                    {
+                        danAggregator?.ComputeAndStore(username, scores);
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    {
+                        Logger.Error(ex, "[EzLocalProfile] Failed to compute player Dan estimates after profile save.", Ez2ConfigManager.LOGGER_NAME);
+                    }
                 }
             }
             catch (OperationCanceledException)
@@ -151,8 +173,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
             }
             catch (Exception ex)
             {
-                // Profile archive already saved; SSR is best-effort for Track mode.
-                Logger.Error(ex, "[EzLocalProfile] Failed to compute player SSR skills after profile save.", Ez2ConfigManager.LOGGER_NAME);
+                Logger.Error(ex, "[EzLocalProfile] Failed to collect mania scores for skill/dan compute.", Ez2ConfigManager.LOGGER_NAME);
             }
         }
 

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileTrackSkillsBody.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileTrackSkillsBody.cs
@@ -159,7 +159,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
             var definitions = skillProvider.Registry.GetSystem(EzSkillSystems.PLAYER_SSR)?.Skills
                               ?? Array.Empty<EzSkillDefinition>();
 
-            headerContainer.Child = new SkillsHeader(keyCount, snapshot);
+            headerContainer.Child = new SkillsHeader(keyCount, snapshot, username, skillProvider);
 
             var radarAxes = definitions.Where(d => d.SkillId != EzSkillIds.Ssr(EzSkillIds.OVERALL)).ToList();
             double radarMax = radarAxes
@@ -259,14 +259,14 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
         private partial class SkillsHeader : FillFlowContainer
         {
-            public SkillsHeader(int keyCount, EzPlayerSsrSnapshot snapshot)
+            public SkillsHeader(int keyCount, EzPlayerSsrSnapshot snapshot, string username, EzSkillProvider skillProvider)
             {
                 RelativeSizeAxes = Axes.X;
                 AutoSizeAxes = Axes.Y;
                 Direction = FillDirection.Vertical;
                 Spacing = new Vector2(0, 4);
 
-                Children = new Drawable[]
+                var children = new List<Drawable>
                 {
                     new OsuSpriteText
                     {
@@ -284,6 +284,35 @@ namespace osu.Game.EzOsuGame.LocalProfile
                         Font = OsuFont.GetFont(size: 12),
                     },
                 };
+
+                var danFlow = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Full,
+                    Spacing = new Vector2(8),
+                    Margin = new MarginPadding { Top = 4 },
+                };
+
+                addDanChip(danFlow, skillProvider.GetDan(username, keyCount, DanSkillSystem.SIDE_RC), DanSkillSystem.SIDE_RC);
+                addDanChip(danFlow, skillProvider.GetDan(username, keyCount, DanSkillSystem.SIDE_LN), DanSkillSystem.SIDE_LN);
+
+                if (danFlow.Children.Count > 0)
+                    children.Add(danFlow);
+
+                Children = children;
+            }
+
+            private static void addDanChip(FillFlowContainer flow, EzDanEstimate? estimate, string side)
+            {
+                if (estimate == null || string.IsNullOrEmpty(estimate.Label) || estimate.RawDan < 0)
+                    return;
+
+                flow.Add(new DanChip(side, estimate)
+                {
+                    Anchor = Anchor.TopLeft,
+                    Origin = Anchor.TopLeft,
+                });
             }
 
             [BackgroundDependencyLoader]
@@ -307,6 +336,70 @@ namespace osu.Game.EzOsuGame.LocalProfile
                     parts.Add(EzSettingsProfile.LOCAL_PROFILE_SKILL_STALE.ToString());
 
                 return string.Join(" · ", parts);
+            }
+        }
+
+        private partial class DanChip : Container
+        {
+            private readonly string side;
+            private readonly EzDanEstimate estimate;
+
+            public DanChip(string side, EzDanEstimate estimate)
+            {
+                this.side = side;
+                this.estimate = estimate;
+
+                AutoSizeAxes = Axes.Both;
+                Masking = true;
+                CornerRadius = 8;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colours)
+            {
+                string sideLabel = side == DanSkillSystem.SIDE_LN
+                    ? EzSettingsProfile.LOCAL_PROFILE_DAN_SIDE_LN.ToString()
+                    : EzSettingsProfile.LOCAL_PROFILE_DAN_SIDE_RC.ToString();
+
+                string body = $"{sideLabel} {estimate.Label}";
+                if (estimate.Clears > 0)
+                    body += $" · {estimate.Clears}";
+
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = colours.Background5,
+                    },
+                    new FillFlowContainer
+                    {
+                        AutoSizeAxes = Axes.Both,
+                        Direction = FillDirection.Vertical,
+                        Padding = new MarginPadding { Horizontal = 12, Vertical = 8 },
+                        Spacing = new Vector2(0, 2),
+                        Children = new Drawable[]
+                        {
+                            new OsuSpriteText
+                            {
+                                Text = EzSettingsProfile.LOCAL_PROFILE_DAN_CHIP_TITLE,
+                                Font = OsuFont.GetFont(size: 10, weight: FontWeight.SemiBold),
+                                Colour = colours.Content2,
+                            },
+                            new OsuSpriteText
+                            {
+                                Text = body,
+                                Font = OsuFont.GetFont(size: 13, weight: FontWeight.Bold),
+                            },
+                            new OsuSpriteText
+                            {
+                                Text = EzSettingsProfile.LOCAL_PROFILE_DAN_HEURISTIC_HINT,
+                                Font = OsuFont.GetFont(size: 10),
+                                Colour = colours.Content2,
+                            },
+                        }
+                    }
+                };
             }
         }
 

--- a/osu.Game/EzOsuGame/Localization/EzSettings.Profile.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettings.Profile.cs
@@ -146,6 +146,20 @@ namespace osu.Game.EzOsuGame.Localization
                 "暂无历史点。重新计算本地个人成绩后会写入。",
                 "No history points yet. Recompute Local Profile Stats to record them.");
 
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_DAN_CHIP_TITLE =
+            new EzLocalizationManager.EzLocalisableString("段位（启发式）", "Dan (heuristic)");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_DAN_SIDE_RC =
+            new EzLocalizationManager.EzLocalisableString("RC", "RC");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_DAN_SIDE_LN =
+            new EzLocalizationManager.EzLocalisableString("LN", "LN");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_DAN_HEURISTIC_HINT =
+            new EzLocalizationManager.EzLocalisableString(
+                "MSD→Dan 近似，非 LeoBlack",
+                "MSD→Dan approx, not LeoBlack");
+
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_SECTION_TRACK_INSIGHTS =
             new EzLocalizationManager.EzLocalisableString("成绩洞察", "Profile Insights");
 

--- a/osu.Game/EzOsuGame/Skills/DanSkillSystem.cs
+++ b/osu.Game/EzOsuGame/Skills/DanSkillSystem.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 namespace osu.Game.EzOsuGame.Skills
 {
     /// <summary>
-    /// Independent dan estimate system (LeoBlack / course clears). Stub skills only until estimator is ported.
+    /// Independent dan estimate system. Chart path: <see cref="EzChartDanEstimator"/>; player path: <see cref="EzPlayerDanAggregator"/>.
     /// Must not be mixed into MSD/SSR aggregation.
     /// </summary>
     public sealed class DanSkillSystem : IEzSkillSystem

--- a/osu.Game/EzOsuGame/Skills/EzChartDanEstimator.cs
+++ b/osu.Game/EzOsuGame/Skills/EzChartDanEstimator.cs
@@ -1,0 +1,120 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    /// <summary>
+    /// Public chart-dan entry for song select and player credit. Swap internals later (LeoBlack / rate MSD)
+    /// without changing consumers that read <see cref="EzChartDanVerdict"/>.
+    /// </summary>
+    public sealed class EzChartDanEstimator
+    {
+        private readonly BeatmapManager beatmapManager;
+        private readonly EzBeatmapMsdComputer msdComputer;
+
+        public EzChartDanEstimator(BeatmapManager beatmapManager, EzBeatmapMsdComputer msdComputer)
+        {
+            this.beatmapManager = beatmapManager;
+            this.msdComputer = msdComputer;
+        }
+
+        /// <summary>
+        /// Estimates chart dan for a beatmap. MSD is currently NoMod 1.0x only; <paramref name="mods"/>
+        /// only affect key count / LN-side classification via the playable beatmap.
+        /// </summary>
+        public EzChartDanVerdict? TryEstimate(BeatmapInfo beatmapInfo, IReadOnlyList<Mod>? mods = null)
+        {
+            ArgumentNullException.ThrowIfNull(beatmapInfo);
+
+            if (beatmapInfo.Ruleset.OnlineID != 3)
+                return null;
+
+            var msd = msdComputer.TryGetOrCompute(beatmapInfo);
+            if (msd == null || msd.Count == 0)
+                return null;
+
+            var working = beatmapManager.GetWorkingBeatmap(beatmapInfo);
+            var playable = working.GetPlayableBeatmap(beatmapInfo.Ruleset, mods ?? Array.Empty<Mod>());
+            return FromMsdAndPlayable(msd, playable);
+        }
+
+        /// <summary>
+        /// Shared path used by player aggregation when MSD and playable are already loaded.
+        /// </summary>
+        public static EzChartDanVerdict? FromMsdAndPlayable(IReadOnlyDictionary<string, double> msd, IBeatmap playable)
+        {
+            ArgumentNullException.ThrowIfNull(msd);
+            ArgumentNullException.ThrowIfNull(playable);
+
+            if (!msd.TryGetValue(EzSkillIds.Msd(EzSkillIds.OVERALL), out double overall) || overall <= 0)
+                return null;
+
+            int keyCount = EzMinaNoteConverter.ResolveKeyCount(playable);
+            if (keyCount <= 0)
+                return null;
+
+            double holdRatio = ComputeHoldRatio(playable);
+            return FromMsd(msd, keyCount, holdRatio);
+        }
+
+        /// <summary>
+        /// Pure mapping for tests and callers that already know key/LN ratio.
+        /// </summary>
+        public static EzChartDanVerdict? FromMsd(IReadOnlyDictionary<string, double> msd, int keyCount, double holdRatio)
+        {
+            ArgumentNullException.ThrowIfNull(msd);
+
+            if (keyCount <= 0)
+                return null;
+
+            if (!msd.TryGetValue(EzSkillIds.Msd(EzSkillIds.OVERALL), out double overall) || overall <= 0)
+                return null;
+
+            string family = EzDanLabels.DominantFamily(msd);
+            double rawDan = EzDanLabels.SrToRawDan(overall, family);
+            string side = holdRatio >= EzDanAlgorithm.LnPrimaryMinRatioFor(keyCount)
+                ? DanSkillSystem.SIDE_LN
+                : DanSkillSystem.SIDE_RC;
+
+            return new EzChartDanVerdict
+            {
+                RawDan = rawDan,
+                Label = EzDanLabels.LabelFor(rawDan, side, keyCount),
+                KeyCount = keyCount,
+                Side = side,
+                Family = family,
+                OverallMsd = overall,
+                HoldRatio = holdRatio,
+                AlgorithmVersion = EzDanAlgorithm.VERSION,
+            };
+        }
+
+        public static double ComputeHoldRatio(IBeatmap playable)
+        {
+            ArgumentNullException.ThrowIfNull(playable);
+
+            int total = 0;
+            int holds = 0;
+
+            foreach (HitObject obj in playable.HitObjects)
+            {
+                if (obj is not IHasColumn)
+                    continue;
+
+                total++;
+
+                if (obj is IHasDuration duration && duration.Duration > 0)
+                    holds++;
+            }
+
+            return total <= 0 ? 0 : (double)holds / total;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Skills/EzChartDanVerdict.cs
+++ b/osu.Game/EzOsuGame/Skills/EzChartDanVerdict.cs
@@ -1,0 +1,30 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    /// <summary>
+    /// Chart-side dan verdict for song select / credit input. Not a Realm row.
+    /// MVP uses MSD→rawDan heuristic; LeoBlack can replace the estimator without changing this shape.
+    /// </summary>
+    public sealed class EzChartDanVerdict
+    {
+        public double RawDan { get; init; }
+
+        public string Label { get; init; } = string.Empty;
+
+        public int KeyCount { get; init; }
+
+        /// <summary><see cref="DanSkillSystem.SIDE_RC"/> or <see cref="DanSkillSystem.SIDE_LN"/> from chart hold ratio.</summary>
+        public string Side { get; init; } = DanSkillSystem.SIDE_RC;
+
+        /// <summary>Dominant MSD family used for the SR→rawDan means table.</summary>
+        public string Family { get; init; } = "stream";
+
+        public double OverallMsd { get; init; }
+
+        public double HoldRatio { get; init; }
+
+        public int AlgorithmVersion { get; init; } = EzDanAlgorithm.VERSION;
+    }
+}

--- a/osu.Game/EzOsuGame/Skills/EzDanAlgorithm.cs
+++ b/osu.Game/EzOsuGame/Skills/EzDanAlgorithm.cs
@@ -1,0 +1,31 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    /// <summary>
+    /// Bump when MVP dan credit / MSD→rawDan heuristic semantics change.
+    /// Independent from <see cref="EzManiaSkillAlgorithm.VERSION"/>.
+    /// </summary>
+    public static class EzDanAlgorithm
+    {
+        public const int VERSION = 1;
+
+        public const int CLEAR_QUORUM = 4;
+        public const int CLEAR_WINDOW = 10;
+
+        public const double LN_PRIMARY_MIN_RATIO = 0.45;
+        public const double LN_PRIMARY_7K_MIN_RATIO = 0.375;
+
+        public static double LnPrimaryMinRatioFor(int keyCount)
+            => keyCount == 7 ? LN_PRIMARY_7K_MIN_RATIO : LN_PRIMARY_MIN_RATIO;
+
+        public static double AccuracyBarFor(string side, int keyCount)
+        {
+            if (side == DanSkillSystem.SIDE_LN)
+                return keyCount == 4 ? 0.97 : 0.95;
+
+            return 0.96;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Skills/EzDanCredit.cs
+++ b/osu.Game/EzOsuGame/Skills/EzDanCredit.cs
@@ -1,0 +1,135 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    /// <summary>
+    /// Ports mania-hub dan-credit.ts creditedDanFor / danCreditOffset (MVP subset).
+    /// </summary>
+    public static class EzDanCredit
+    {
+        public const double CREDIT_EDGE_TOLERANCE = 1e-9;
+        public const double BELOW_BAR_WINDOW_RC = 0.05;
+        public const double BELOW_BAR_WINDOW_LN = 0.03;
+        public const double BELOW_BAR_WINDOW_4K_LN = 0.025;
+        public const double BONUS_MIN_SPAN = 0.04;
+
+        private static readonly (double At, double Offset)[] above_bar_rc =
+        {
+            (0, 0), (0.25, 0), (0.675, 0.2), (0.75, 0.7), (0.875, 1.1), (1, 1.5),
+        };
+
+        private static readonly (double At, double Offset)[] below_bar_rc =
+        {
+            (0, 0), (0.2, -0.5075), (0.8, -1.25), (1, -1.5),
+        };
+
+        private static readonly (double At, double Offset)[] below_bar_ln =
+        {
+            (0, -0.26), (1.0 / 3.0, -1.25), (2.0 / 3.0, -1.5), (1, -1.75),
+        };
+
+        private static readonly (double At, double Offset)[] above_bar_4k_ln =
+        {
+            (0, 0), (0.01, 0), (0.015, 0.15), (0.02, 0.3), (0.025, 0.5), (0.027, 0.7),
+        };
+
+        private static readonly (double At, double Offset)[] below_bar_4k_ln =
+        {
+            (0, -0.3), (0.2, -0.9), (1, -1.55),
+        };
+
+        public static double? CreditedDanFor(double chartDan, double accuracy, string side, int keyCount)
+        {
+            double bar = EzDanAlgorithm.AccuracyBarFor(side, keyCount);
+            double? offset = creditOffset(accuracy, bar, side, keyCount);
+            if (offset is not double o)
+                return null;
+
+            double credited = chartDan + o;
+            double? ceiling = EzDanLabels.CeilingFor(side, keyCount);
+            if (ceiling is double c)
+                credited = Math.Min(credited, c);
+
+            return Math.Max(credited, EzDanLabels.FloorFor(side, keyCount));
+        }
+
+        private static double? creditOffset(double accuracy, double bar, string side, int keyCount)
+        {
+            if (!double.IsFinite(accuracy))
+                return null;
+
+            double window = belowBarWindow(side, keyCount);
+            double delta = accuracy - bar;
+
+            if (!(delta >= -window - CREDIT_EDGE_TOLERANCE))
+                return null;
+
+            if (delta < -CREDIT_EDGE_TOLERANCE)
+            {
+                var below = belowBarAnchors(side, keyCount);
+                double s = Math.Min(1, -delta / window);
+                double offset = interpolate(below, s);
+                double nearCap = nearBarCap(side, keyCount);
+                return Math.Min(offset, -nearCap);
+            }
+
+            if (side == DanSkillSystem.SIDE_LN && keyCount == 4)
+                return interpolate(above_bar_4k_ln, Math.Max(0, delta));
+
+            double headroom = Math.Max(1 - bar, BONUS_MIN_SPAN);
+            double t = headroom > 0 ? Math.Min(1, Math.Max(0, delta) / headroom) : 1;
+            return interpolate(above_bar_rc, t);
+        }
+
+        private static double belowBarWindow(string side, int keyCount)
+        {
+            if (side != DanSkillSystem.SIDE_LN)
+                return BELOW_BAR_WINDOW_RC;
+
+            return keyCount == 4 ? BELOW_BAR_WINDOW_4K_LN : BELOW_BAR_WINDOW_LN;
+        }
+
+        private static double nearBarCap(string side, int keyCount)
+        {
+            if (side == DanSkillSystem.SIDE_RC)
+                return 0;
+
+            return keyCount == 4 ? 0.3 : 0.26;
+        }
+
+        private static (double At, double Offset)[] belowBarAnchors(string side, int keyCount)
+        {
+            if (side == DanSkillSystem.SIDE_LN && keyCount == 4)
+                return below_bar_4k_ln;
+            if (side == DanSkillSystem.SIDE_LN)
+                return below_bar_ln;
+
+            return below_bar_rc;
+        }
+
+        private static double interpolate((double At, double Offset)[] anchors, double at)
+        {
+            if (at <= anchors[0].At)
+                return anchors[0].Offset;
+
+            for (int i = 1; i < anchors.Length; i++)
+            {
+                if (at > anchors[i].At)
+                    continue;
+
+                double lowerAt = anchors[i - 1].At;
+                double lowerOffset = anchors[i - 1].Offset;
+                double upperAt = anchors[i].At;
+                double upperOffset = anchors[i].Offset;
+                double span = upperAt - lowerAt;
+                double t = span > 0 ? (at - lowerAt) / span : 1;
+                return lowerOffset + (upperOffset - lowerOffset) * t;
+            }
+
+            return anchors[^1].Offset;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Skills/EzDanLabels.cs
+++ b/osu.Game/EzOsuGame/Skills/EzDanLabels.cs
@@ -1,0 +1,199 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    /// <summary>
+    /// Ports mania-hub labels.ts parseDan / srToRawDan (stream family default) and parseLnDan.
+    /// Chart rawDan is heuristic until LeoBlack is ported.
+    /// </summary>
+    public static class EzDanLabels
+    {
+        private static readonly string[] dan_labels =
+        {
+            "1", "2", "3", "4", "5", "6", "7", "8", "9", "10",
+            "alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta", "iota", "kappa",
+        };
+
+        // stream family means from mania-hub labels.ts
+        private static readonly double[] stream_means =
+        {
+            3.1, 3.5, 3.9, 4.3, 4.7, 5.05, 5.35, 5.6, 5.78, 5.92,
+            6.12, 6.5, 6.92, 7.42, 8.08, 8.8, 9.65, 10.42, 11.2, 12.0,
+        };
+
+        private static readonly double[] jack_means =
+        {
+            3.15, 3.55, 3.95, 4.35, 4.75, 5.15, 5.45, 5.7, 5.92, 6.1,
+            6.35, 6.75, 7.15, 7.65, 8.25, 8.85, 9.55, 10.25, 11.0, 11.8,
+        };
+
+        private static readonly double[] jumpstream_means =
+        {
+            3.15, 3.55, 3.95, 4.35, 4.75, 5.1, 5.4, 5.66, 5.86, 6.02,
+            6.35, 6.72, 7.08, 7.55, 8.15, 8.85, 9.65, 10.38, 11.14, 11.95,
+        };
+
+        private static readonly double[] handstream_means =
+        {
+            3.2, 3.6, 4.0, 4.4, 4.8, 5.15, 5.45, 5.72, 5.92, 6.08,
+            6.6, 6.9, 6.96, 7.72, 8.48, 9.18, 9.98, 10.72, 11.46, 12.2,
+        };
+
+        private static readonly double[] stamina_means =
+        {
+            3.2, 3.6, 4.0, 4.4, 4.8, 5.15, 5.45, 5.72, 5.92, 6.08,
+            6.3, 6.7, 7.12, 7.62, 8.28, 8.98, 9.78, 10.52, 11.26, 12.0,
+        };
+
+        private static readonly double[] chordjack_means =
+        {
+            3.2, 3.6, 4.0, 4.42, 4.82, 5.18, 5.48, 5.75, 5.95, 6.12,
+            6.35, 6.75, 7.15, 7.65, 8.25, 8.85, 9.55, 10.25, 11.0, 11.8,
+        };
+
+        private static readonly double[] tech_means =
+        {
+            3.25, 3.65, 4.05, 4.48, 4.88, 5.25, 5.55, 5.82, 6.02, 6.18,
+            6.42, 6.82, 7.22, 7.72, 8.35, 9.02, 9.8, 10.52, 11.26, 12.0,
+        };
+
+        public const int LN_LADDER_TOP = 17;
+
+        public static double SrToRawDan(double sr, string family = "stream")
+        {
+            if (!double.IsFinite(sr) || sr <= 0)
+                return 1;
+
+            return rawDanFromMeans(sr, meansFor(family));
+        }
+
+        public static string LabelFor(double rawDan, string side, int keyCount)
+        {
+            if (side == DanSkillSystem.SIDE_LN && keyCount == 4)
+                return parseLnDan(rawDan);
+
+            // Non-4K table labels deferred; use rice greek ladder as readable MVP.
+            return parseDan(rawDan);
+        }
+
+        public static double FloorFor(string side, int keyCount)
+            => keyCount == 4 ? 0.5 : 0;
+
+        public static double? CeilingFor(string side, int keyCount)
+        {
+            if (keyCount == 4 && side == DanSkillSystem.SIDE_LN)
+                return LN_LADDER_TOP + 0.5;
+
+            return null;
+        }
+
+        public static string DominantFamily(IReadOnlyDictionary<string, double> msdSkills)
+        {
+            (string axis, string family)[] map =
+            {
+                (EzSkillIds.Msd(EzSkillIds.STREAM), "stream"),
+                (EzSkillIds.Msd(EzSkillIds.JUMPSTREAM), "jumpstream"),
+                (EzSkillIds.Msd(EzSkillIds.HANDSTREAM), "handstream"),
+                (EzSkillIds.Msd(EzSkillIds.STAMINA), "stamina"),
+                (EzSkillIds.Msd(EzSkillIds.JACK_SPEED), "jack"),
+                (EzSkillIds.Msd(EzSkillIds.CHORDJACK), "chordjack"),
+                (EzSkillIds.Msd(EzSkillIds.TECHNICAL), "tech"),
+            };
+
+            string best = "stream";
+            double bestValue = -1;
+
+            foreach (var (axis, family) in map)
+            {
+                if (msdSkills.TryGetValue(axis, out double value) && value > bestValue)
+                {
+                    bestValue = value;
+                    best = family;
+                }
+            }
+
+            return best;
+        }
+
+        private static string parseDan(double rawDan)
+        {
+            int maxLevel = dan_labels.Length;
+            int level = Math.Min(maxLevel, Math.Max(1, (int)Math.Round(rawDan)));
+            double offset = rawDan - level;
+            string? variant = offset <= -0.45 ? "--" : offset <= -0.25 ? "-" : offset < 0.1 ? null : offset < 0.26 ? "+" : "++";
+            return $"{dan_labels[level - 1]}{variant ?? string.Empty}";
+        }
+
+        private static string parseLnDan(double rawDan)
+        {
+            int level = Math.Max(1, Math.Min(LN_LADDER_TOP, (int)Math.Round(rawDan)));
+            double offset = rawDan - level;
+            string? variant = offset <= -0.45 ? "--" : offset <= -0.25 ? "-" : offset < 0.1 ? null : offset < 0.26 ? "+" : "++";
+            return $"{level}{variant ?? string.Empty}";
+        }
+
+        private static double[] meansFor(string family) => family switch
+        {
+            "jack" => jack_means,
+            "jumpstream" => jumpstream_means,
+            "handstream" => handstream_means,
+            "stamina" => stamina_means,
+            "chordjack" => chordjack_means,
+            "tech" => tech_means,
+            _ => stream_means,
+        };
+
+        private static double rawDanFromMeans(double value, double[] means)
+        {
+            int maxIndex = dan_labels.Length - 1;
+            var capped = means.AsSpan(0, Math.Min(means.Length, maxIndex + 1));
+
+            if (value < boundaryLower(capped, 0))
+                return 1;
+
+            int last = capped.Length - 1;
+            if (value >= boundaryUpper(capped, last))
+                return maxIndex + 1;
+
+            for (int index = 0; index < capped.Length; index++)
+            {
+                double lower = boundaryLower(capped, index);
+                double upper = boundaryUpper(capped, index);
+
+                if (value >= lower && value < upper)
+                {
+                    double t = (value - lower) / Math.Max(0.001, upper - lower);
+                    return index + 1 + t - 0.5;
+                }
+            }
+
+            return 1;
+        }
+
+        private static double boundaryLower(ReadOnlySpan<double> means, int index)
+        {
+            double mean = means[index];
+
+            if (index == 0)
+            {
+                return mean - (means[
+                    index + 1] - mean) / 2;
+            }
+
+            return (means[index - 1] + mean) / 2;
+        }
+
+        private static double boundaryUpper(ReadOnlySpan<double> means, int index)
+        {
+            double mean = means[index];
+            if (index == means.Length - 1)
+                return mean + (mean - means[index - 1]) / 2;
+
+            return (mean + means[index + 1]) / 2;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Skills/EzPlayerDanAggregator.cs
+++ b/osu.Game/EzOsuGame/Skills/EzPlayerDanAggregator.cs
@@ -1,0 +1,137 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Scoring;
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    /// <summary>
+    /// MVP player dan: MSD Overall/family → chart rawDan heuristic, then credit clears and average.
+    /// Not comparable to mania-hub LeoBlack verdicts; estimates are provisional.
+    /// </summary>
+    public sealed class EzPlayerDanAggregator
+    {
+        private readonly BeatmapManager beatmapManager;
+        private readonly EzSkillStore skillStore;
+        private readonly EzBeatmapMsdComputer msdComputer;
+
+        public EzPlayerDanAggregator(BeatmapManager beatmapManager, EzSkillStore skillStore, EzBeatmapMsdComputer msdComputer)
+        {
+            this.beatmapManager = beatmapManager;
+            this.skillStore = skillStore;
+            this.msdComputer = msdComputer;
+        }
+
+        public void ComputeAndStore(string username, IEnumerable<ScoreInfo> scores)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(username);
+
+            var clearsByBucket = new Dictionary<(int KeyCount, string Side), List<double>>();
+
+            foreach (var score in scores)
+            {
+                if (score.Ruleset.OnlineID != 3)
+                    continue;
+
+                if (score.Accuracy <= 0 || !double.IsFinite(score.Accuracy))
+                    continue;
+
+                var beatmapInfo = score.BeatmapInfo ?? beatmapManager.QueryBeatmap(b => b.Hash == score.BeatmapHash);
+                if (beatmapInfo == null)
+                    continue;
+
+                // Converts excluded from dan (same spirit as keymode PP).
+                if (beatmapInfo.Ruleset.OnlineID != 3)
+                    continue;
+
+                var msd = msdComputer.TryGetOrCompute(beatmapInfo);
+                if (msd == null || msd.Count == 0)
+                    continue;
+
+                if (!msd.TryGetValue(EzSkillIds.Msd(EzSkillIds.OVERALL), out double overall) || overall <= 0)
+                    continue;
+
+                string family = EzDanLabels.DominantFamily(msd);
+                double chartDan = EzDanLabels.SrToRawDan(overall, family);
+
+                var working = beatmapManager.GetWorkingBeatmap(beatmapInfo);
+                var playable = working.GetPlayableBeatmap(score.Ruleset, score.Mods);
+                int keyCount = EzMinaNoteConverter.ResolveKeyCount(playable);
+                if (keyCount <= 0)
+                    continue;
+
+                double holdRatio = computeLnRatio(playable);
+                string side = holdRatio >= EzDanAlgorithm.LnPrimaryMinRatioFor(keyCount)
+                    ? DanSkillSystem.SIDE_LN
+                    : DanSkillSystem.SIDE_RC;
+
+                double? credited = EzDanCredit.CreditedDanFor(chartDan, score.Accuracy, side, keyCount);
+                if (credited is not double value)
+                    continue;
+
+                var key = (keyCount, side);
+                if (!clearsByBucket.TryGetValue(key, out var list))
+                    clearsByBucket[key] = list = new List<double>();
+
+                list.Add(value);
+            }
+
+            DateTimeOffset at = DateTimeOffset.UtcNow;
+
+            foreach (((int keyCount, string side), List<double> clears) in clearsByBucket)
+            {
+                if (clears.Count < EzDanAlgorithm.CLEAR_QUORUM)
+                    continue;
+
+                var window = clears
+                             .OrderByDescending(v => v)
+                             .Take(EzDanAlgorithm.CLEAR_WINDOW)
+                             .ToList();
+
+                double rawDan = window.Average();
+                string label = EzDanLabels.LabelFor(rawDan, side, keyCount);
+                double? ceiling = EzDanLabels.CeilingFor(side, keyCount);
+
+                skillStore.WriteDanEstimate(new EzDanEstimate
+                {
+                    Username = username,
+                    KeyCount = keyCount,
+                    Side = side,
+                    RawDan = rawDan,
+                    Label = label,
+                    Clears = clears.Count,
+                    BeyondTable = ceiling is double c && rawDan >= c,
+                    ClearWindowHave = window.Count,
+                    ClearWindowNeed = EzDanAlgorithm.CLEAR_WINDOW,
+                    AlgorithmVersion = EzDanAlgorithm.VERSION,
+                    ComputedAt = at,
+                });
+            }
+        }
+
+        private static double computeLnRatio(IBeatmap playable)
+        {
+            int total = 0;
+            int holds = 0;
+
+            foreach (HitObject obj in playable.HitObjects)
+            {
+                if (obj is not IHasColumn)
+                    continue;
+
+                total++;
+
+                if (obj is IHasDuration duration && duration.Duration > 0)
+                    holds++;
+            }
+
+            return total <= 0 ? 0 : (double)holds / total;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Skills/EzPlayerDanAggregator.cs
+++ b/osu.Game/EzOsuGame/Skills/EzPlayerDanAggregator.cs
@@ -5,14 +5,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
-using osu.Game.Rulesets.Objects;
-using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Scoring;
 
 namespace osu.Game.EzOsuGame.Skills
 {
     /// <summary>
-    /// MVP player dan: MSD Overall/family → chart rawDan heuristic, then credit clears and average.
+    /// MVP player dan: chart verdict → credit clears → average window. Chart side via <see cref="EzChartDanEstimator"/>.
     /// Not comparable to mania-hub LeoBlack verdicts; estimates are provisional.
     /// </summary>
     public sealed class EzPlayerDanAggregator
@@ -54,28 +52,17 @@ namespace osu.Game.EzOsuGame.Skills
                 if (msd == null || msd.Count == 0)
                     continue;
 
-                if (!msd.TryGetValue(EzSkillIds.Msd(EzSkillIds.OVERALL), out double overall) || overall <= 0)
-                    continue;
-
-                string family = EzDanLabels.DominantFamily(msd);
-                double chartDan = EzDanLabels.SrToRawDan(overall, family);
-
                 var working = beatmapManager.GetWorkingBeatmap(beatmapInfo);
                 var playable = working.GetPlayableBeatmap(score.Ruleset, score.Mods);
-                int keyCount = EzMinaNoteConverter.ResolveKeyCount(playable);
-                if (keyCount <= 0)
+                var chart = EzChartDanEstimator.FromMsdAndPlayable(msd, playable);
+                if (chart == null)
                     continue;
 
-                double holdRatio = computeLnRatio(playable);
-                string side = holdRatio >= EzDanAlgorithm.LnPrimaryMinRatioFor(keyCount)
-                    ? DanSkillSystem.SIDE_LN
-                    : DanSkillSystem.SIDE_RC;
-
-                double? credited = EzDanCredit.CreditedDanFor(chartDan, score.Accuracy, side, keyCount);
+                double? credited = EzDanCredit.CreditedDanFor(chart.RawDan, score.Accuracy, chart.Side, chart.KeyCount);
                 if (credited is not double value)
                     continue;
 
-                var key = (keyCount, side);
+                var key = (chart.KeyCount, chart.Side);
                 if (!clearsByBucket.TryGetValue(key, out var list))
                     clearsByBucket[key] = list = new List<double>();
 
@@ -113,25 +100,6 @@ namespace osu.Game.EzOsuGame.Skills
                     ComputedAt = at,
                 });
             }
-        }
-
-        private static double computeLnRatio(IBeatmap playable)
-        {
-            int total = 0;
-            int holds = 0;
-
-            foreach (HitObject obj in playable.HitObjects)
-            {
-                if (obj is not IHasColumn)
-                    continue;
-
-                total++;
-
-                if (obj is IHasDuration duration && duration.Duration > 0)
-                    holds++;
-            }
-
-            return total <= 0 ? 0 : (double)holds / total;
         }
     }
 }

--- a/osu.Game/EzOsuGame/Skills/EzSkillBoundary.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSkillBoundary.cs
@@ -8,7 +8,7 @@ namespace osu.Game.EzOsuGame.Skills
     /// <list type="bullet">
     /// <item><see cref="EzSkillSystems.BEATMAP_MSD"/> — chart difficulty axes from MinaCalc MSD. Not player skill.</item>
     /// <item><see cref="EzSkillSystems.PLAYER_SSR"/> — player skill axes from score-goal SSR + AggregateSSRs. Profile Skills radar source.</item>
-    /// <item><see cref="EzSkillSystems.DAN"/> — independent dan estimates (LeoBlack). Stub only in this foundation.</item>
+    /// <item><see cref="EzSkillSystems.DAN"/> — independent dan estimates. MVP uses MSD→rawDan heuristic + credit clears; full LeoBlack deferred.</item>
     /// <item>xxy radar skill-ification is explicitly deferred.</item>
     /// </list>
     /// Reference clone: sibling repo <c>Ez2Lazer/mania-hub</c>.

--- a/osu.Game/EzOsuGame/Skills/EzSkillBoundary.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSkillBoundary.cs
@@ -8,7 +8,7 @@ namespace osu.Game.EzOsuGame.Skills
     /// <list type="bullet">
     /// <item><see cref="EzSkillSystems.BEATMAP_MSD"/> — chart difficulty axes from MinaCalc MSD. Not player skill.</item>
     /// <item><see cref="EzSkillSystems.PLAYER_SSR"/> — player skill axes from score-goal SSR + AggregateSSRs. Profile Skills radar source.</item>
-    /// <item><see cref="EzSkillSystems.DAN"/> — independent dan estimates. MVP uses MSD→rawDan heuristic + credit clears; full LeoBlack deferred.</item>
+    /// <item><see cref="EzSkillSystems.DAN"/> — independent dan. Chart: <see cref="EzChartDanEstimator"/> / <see cref="EzSkillProvider.TryGetChartDan"/>; player: credit clears → <see cref="EzDanEstimate"/>. LeoBlack deferred.</item>
     /// <item>xxy radar skill-ification is explicitly deferred.</item>
     /// </list>
     /// Reference clone: sibling repo <c>Ez2Lazer/mania-hub</c>.

--- a/osu.Game/EzOsuGame/Skills/EzSkillProvider.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSkillProvider.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.EzOsuGame.Skills
 {
@@ -11,10 +13,12 @@ namespace osu.Game.EzOsuGame.Skills
     public sealed class EzSkillProvider
     {
         private readonly EzSkillStore store;
+        private readonly EzChartDanEstimator? chartDanEstimator;
 
-        public EzSkillProvider(EzSkillStore store, EzSkillRegistry? registry = null)
+        public EzSkillProvider(EzSkillStore store, EzSkillRegistry? registry = null, EzChartDanEstimator? chartDanEstimator = null)
         {
             this.store = store;
+            this.chartDanEstimator = chartDanEstimator;
             Registry = registry ?? new EzSkillRegistry();
         }
 
@@ -40,5 +44,11 @@ namespace osu.Game.EzOsuGame.Skills
 
         public EzDanEstimate? GetDan(string username, int keyCount, string side)
             => store.GetDanEstimate(username, keyCount, side);
+
+        /// <summary>
+        /// Chart-side dan for song select me-vs-chart. Null when estimator unset or chart cannot be rated.
+        /// </summary>
+        public EzChartDanVerdict? TryGetChartDan(BeatmapInfo beatmapInfo, IReadOnlyList<Mod>? mods = null)
+            => chartDanEstimator?.TryEstimate(beatmapInfo, mods);
     }
 }

--- a/osu.Game/EzOsuGame/Skills/EzSkillStore.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSkillStore.cs
@@ -271,7 +271,7 @@ namespace osu.Game.EzOsuGame.Skills
                     CourseAccuracy = estimate.CourseAccuracy,
                     ClearWindowHave = estimate.ClearWindowHave,
                     ClearWindowNeed = estimate.ClearWindowNeed,
-                    AlgorithmVersion = estimate.AlgorithmVersion != 0 ? estimate.AlgorithmVersion : EzManiaSkillAlgorithm.VERSION,
+                    AlgorithmVersion = estimate.AlgorithmVersion != 0 ? estimate.AlgorithmVersion : EzDanAlgorithm.VERSION,
                     ComputedAt = estimate.ComputedAt == default ? DateTimeOffset.UtcNow : estimate.ComputedAt,
                 });
             });

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -414,14 +414,17 @@ namespace osu.Game
 
             var skillRegistry = new EzSkillRegistry();
             var skillStore = new EzSkillStore(realm);
+            var beatmapMsdComputer = new EzBeatmapMsdComputer(BeatmapManager, skillStore);
             var playerSsrAggregator = new EzPlayerSsrAggregator(BeatmapManager, skillStore);
+            var playerDanAggregator = new EzPlayerDanAggregator(BeatmapManager, skillStore, beatmapMsdComputer);
             dependencies.Cache(skillRegistry);
             dependencies.Cache(skillStore);
             dependencies.Cache(new EzSkillProvider(skillStore, skillRegistry));
-            dependencies.Cache(new EzBeatmapMsdComputer(BeatmapManager, skillStore));
+            dependencies.Cache(beatmapMsdComputer);
             dependencies.Cache(playerSsrAggregator);
+            dependencies.Cache(playerDanAggregator);
 
-            dependencies.Cache(new EzLocalProfileService(Storage, realm, ezAnalysisPersistentStore, BeatmapManager, ScoreManager, ReplaySession, playerSsrAggregator));
+            dependencies.Cache(new EzLocalProfileService(Storage, realm, ezAnalysisPersistentStore, BeatmapManager, ScoreManager, ReplaySession, playerSsrAggregator, playerDanAggregator));
             dependencies.Cache(new EzLocalProfileOnlinePullService(API, ScoreManager, BeatmapManager, realm, Storage));
 
             if (Ez2ConfigManager.Get<bool>(Ez2Setting.EzScoreRaceServiceEnabled))

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -415,12 +415,14 @@ namespace osu.Game
             var skillRegistry = new EzSkillRegistry();
             var skillStore = new EzSkillStore(realm);
             var beatmapMsdComputer = new EzBeatmapMsdComputer(BeatmapManager, skillStore);
+            var chartDanEstimator = new EzChartDanEstimator(BeatmapManager, beatmapMsdComputer);
             var playerSsrAggregator = new EzPlayerSsrAggregator(BeatmapManager, skillStore);
             var playerDanAggregator = new EzPlayerDanAggregator(BeatmapManager, skillStore, beatmapMsdComputer);
             dependencies.Cache(skillRegistry);
             dependencies.Cache(skillStore);
-            dependencies.Cache(new EzSkillProvider(skillStore, skillRegistry));
+            dependencies.Cache(new EzSkillProvider(skillStore, skillRegistry, chartDanEstimator));
             dependencies.Cache(beatmapMsdComputer);
+            dependencies.Cache(chartDanEstimator);
             dependencies.Cache(playerSsrAggregator);
             dependencies.Cache(playerDanAggregator);
 


### PR DESCRIPTION
## Summary
Dan **foundation** — shared pipeline so later PRs can hang product UI (especially **song select**) without redesigning the core.

### What this PR lands
- Chart `rawDan` input (MSD Overall → `srToRawDan` heuristic; **not** LeoBlack)
- **Public chart API**: `EzChartDanEstimator` / `EzChartDanVerdict` + `EzSkillProvider.TryGetChartDan` (song-select ready; MSD still NoMod 1.0x)
- Credit clears (`dan-credit` subset) → quorum ≥4 → top-10 aggregate
- Persist `EzDanEstimate` per username / keyCount / side (RC·LN); player aggregator reuses chart API
- Hook after Local Profile compute (best-effort, does not block SSR)
- Optional smoke UI: Track Skills RC/LN chips — **not** the product goal

No `EZ_REALM_SCHEMA_VERSION` bump.

### Prepared for (follow-up PRs)
| Scene | Needs from this foundation | Later PR |
|---|---|---|
| **Song select: me vs chart** (primary) | `GetDan` + `TryGetChartDan` + shared labels | Select overlay: player vs chart + gap |
| LeoBlack / community chart verdicts | Swap chart estimator internals | Chart Dan accuracy |
| Evidence / supporting clears | Estimate + clears count stored; list TBD (SQLite) | Evidence UI |
| Profile Track chips polish | Read path wired | Optional polish |
| Other key / ladder / BMS | Same shell; new side/systemId + label tables | Parallel ladders |

### Product note
Dan is **not** primarily score analytics. Primary UX is: under current key + dan system, compare **player rating** vs **chart rating** at song select. This PR only builds the shared rating pipeline.

## Test plan
- [ ] Recompute Local Profile with enough mania clears (≥4 per key/side)
- [ ] `EzDanEstimate` rows written (RC/LN when quorum met)
- [ ] `dotnet test --filter EzDanCreditTest`
- [ ] (Optional) Track chips appear — smoke only
- [ ] Labels are approximate (heuristic, not mania-hub parity)

## Out of scope
- Song select me-vs-chart UI
- LeoBlack realtime chart verdicts / rate MSD
- Evidence modal, courses, 6/7K community tables