### PR TITLE
Filter GetDanEstimate by algorithm VERSION (DATA-0)

### DIFF
--- a/osu.Game/EzOsuGame/Skills/EzDanAlgorithm.cs
+++ b/osu.Game/EzOsuGame/Skills/EzDanAlgorithm.cs
@@ -4,8 +4,8 @@
 namespace osu.Game.EzOsuGame.Skills
 {
     /// <summary>
-    /// Bump when MVP dan credit / MSD→rawDan heuristic semantics change.
-    /// Independent from <see cref="EzManiaSkillAlgorithm.VERSION"/>.
+    /// Bump when dan credit / chart→rawDan semantics change (not <see cref="osu.Game.Database.RealmAccess.EZ_REALM_SCHEMA_VERSION"/>).
+    /// Independent from <see cref="EzManiaSkillAlgorithm.VERSION"/>. Reads via <see cref="EzSkillStore.GetDanEstimate"/> filter on this value.
     /// </summary>
     public static class EzDanAlgorithm
     {

--- a/osu.Game/EzOsuGame/Skills/EzSkillStore.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSkillStore.cs
@@ -233,12 +233,17 @@ namespace osu.Game.EzOsuGame.Skills
             });
         }
 
-        public EzDanEstimate? GetDanEstimate(string username, int keyCount, string side)
+        public EzDanEstimate? GetDanEstimate(string username, int keyCount, string side, int? algorithmVersion = null)
         {
+            int version = algorithmVersion ?? EzDanAlgorithm.VERSION;
+
             return realmAccess.Run(r =>
             {
                 var row = r.All<EzDanEstimate>()
-                           .FirstOrDefault(v => v.Username == username && v.KeyCount == keyCount && v.Side == side);
+                           .FirstOrDefault(v => v.Username == username
+                                                && v.KeyCount == keyCount
+                                                && v.Side == side
+                                                && v.AlgorithmVersion == version);
                 return row?.Detach();
             });
         }


### PR DESCRIPTION
## Summary
- **Master:** Skills Track Dan Master · **DATA-0** 尾巴（#101 后）
- `GetDanEstimate` only returns rows matching `EzDanAlgorithm.VERSION` (same pattern as MSD/SSR reads)
- Zero `EZ_REALM_SCHEMA_VERSION`; does not bump dan algorithm VERSION (semantics unchanged)

## Test plan
- [ ] `dotnet build osu.Game/osu.Game.csproj`
- [ ] After recompute, Track Dan chips still appear for current VERSION rows
- [ ] (Optional) Manually stale a row AlgorithmVersion → chip disappears until recompute

## Out of scope
- DATA-1 LeoBlack/rate
- DATA-2 SSR goal
- UX