### PR TITLE
DATA-1: rate-aware MSD chart dan + SR calibration

### DIFF
--- a/osu.Game.Tests/EzOsuGame/Skills/EzDanCreditTest.cs
+++ b/osu.Game.Tests/EzOsuGame/Skills/EzDanCreditTest.cs
@@ -60,5 +60,13 @@ namespace osu.Game.Tests.EzOsuGame.Skills
             Assert.That(ln!.Side, Is.EqualTo(DanSkillSystem.SIDE_LN));
             Assert.That(ln.RawDan, Is.EqualTo(rc.RawDan).Within(0.001));
         }
+
+        [Test]
+        public void SrCalibrationChangesHighSrRawDan()
+        {
+            double plain = EzDanLabels.SrToRawDan(9.0, "stream", calibrate: false);
+            double calibrated = EzDanLabels.SrToRawDan(9.0, "stream", calibrate: true);
+            Assert.That(calibrated, Is.Not.EqualTo(plain).Within(0.001));
+        }
     }
 }

--- a/osu.Game/EzOsuGame/Skills/EzChartDanEstimator.cs
+++ b/osu.Game/EzOsuGame/Skills/EzChartDanEstimator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
@@ -11,8 +12,9 @@ using osu.Game.Rulesets.Objects.Types;
 namespace osu.Game.EzOsuGame.Skills
 {
     /// <summary>
-    /// Public chart-dan entry for song select and player credit. Swap internals later (LeoBlack / rate MSD)
-    /// without changing consumers that read <see cref="EzChartDanVerdict"/>.
+    /// Public chart-dan entry for song select and player credit.
+    /// Rate≠1 uses live MinaCalc MSD (not persisted); 1.0x may use Realm cache.
+    /// LeoBlack deferred (DATA-LB).
     /// </summary>
     public sealed class EzChartDanEstimator
     {
@@ -26,8 +28,7 @@ namespace osu.Game.EzOsuGame.Skills
         }
 
         /// <summary>
-        /// Estimates chart dan for a beatmap. MSD is currently NoMod 1.0x only; <paramref name="mods"/>
-        /// only affect key count / LN-side classification via the playable beatmap.
+        /// Estimates chart dan. <paramref name="mods"/> affect rate (MSD) and key/LN classification.
         /// </summary>
         public EzChartDanVerdict? TryEstimate(BeatmapInfo beatmapInfo, IReadOnlyList<Mod>? mods = null)
         {
@@ -36,18 +37,34 @@ namespace osu.Game.EzOsuGame.Skills
             if (beatmapInfo.Ruleset.OnlineID != 3)
                 return null;
 
-            var msd = msdComputer.TryGetOrCompute(beatmapInfo);
+            mods ??= Array.Empty<Mod>();
+            float rate = EzModRate.Resolve(mods);
+
+            var working = beatmapManager.GetWorkingBeatmap(beatmapInfo);
+            var playable = working.GetPlayableBeatmap(beatmapInfo.Ruleset, mods);
+
+            IReadOnlyDictionary<string, double>? msd;
+
+            if (EzModRate.IsNomodRate(rate))
+            {
+                msd = msdComputer.TryGetOrCompute(beatmapInfo);
+            }
+            else
+            {
+                using var calc = new EzMinaCalcFacade();
+                var vector = calc.CalculateMsd(playable, rate);
+                if (vector.Overall <= 0 && vector.Stream <= 0)
+                    return null;
+
+                msd = vectorToMsdDict(vector);
+            }
+
             if (msd == null || msd.Count == 0)
                 return null;
 
-            var working = beatmapManager.GetWorkingBeatmap(beatmapInfo);
-            var playable = working.GetPlayableBeatmap(beatmapInfo.Ruleset, mods ?? Array.Empty<Mod>());
             return FromMsdAndPlayable(msd, playable);
         }
 
-        /// <summary>
-        /// Shared path used by player aggregation when MSD and playable are already loaded.
-        /// </summary>
         public static EzChartDanVerdict? FromMsdAndPlayable(IReadOnlyDictionary<string, double> msd, IBeatmap playable)
         {
             ArgumentNullException.ThrowIfNull(msd);
@@ -64,9 +81,6 @@ namespace osu.Game.EzOsuGame.Skills
             return FromMsd(msd, keyCount, holdRatio);
         }
 
-        /// <summary>
-        /// Pure mapping for tests and callers that already know key/LN ratio.
-        /// </summary>
         public static EzChartDanVerdict? FromMsd(IReadOnlyDictionary<string, double> msd, int keyCount, double holdRatio)
         {
             ArgumentNullException.ThrowIfNull(msd);
@@ -116,5 +130,11 @@ namespace osu.Game.EzOsuGame.Skills
 
             return total <= 0 ? 0 : (double)holds / total;
         }
+
+        public static IReadOnlyDictionary<string, double> VectorToMsdDict(EzSkillsetVector vector)
+            => vectorToMsdDict(vector);
+
+        private static IReadOnlyDictionary<string, double> vectorToMsdDict(EzSkillsetVector vector)
+            => vector.Enumerate().ToDictionary(p => EzSkillIds.Msd(p.AxisId), p => p.Value, StringComparer.Ordinal);
     }
 }

--- a/osu.Game/EzOsuGame/Skills/EzDanAlgorithm.cs
+++ b/osu.Game/EzOsuGame/Skills/EzDanAlgorithm.cs
@@ -4,7 +4,9 @@
 namespace osu.Game.EzOsuGame.Skills
 {
     /// <summary>
-    /// Bump when dan credit / chart→rawDan semantics change (not <see cref="osu.Game.Database.RealmAccess.EZ_REALM_SCHEMA_VERSION"/>).
+    /// Pre-release: corrective formula fixes keep this at 1 (no client shipped yet).
+    /// After public release, bump when dan credit / chart→rawDan semantics change
+    /// (not <see cref="osu.Game.Database.RealmAccess.EZ_REALM_SCHEMA_VERSION"/>).
     /// Independent from <see cref="EzManiaSkillAlgorithm.VERSION"/>. Reads via <see cref="EzSkillStore.GetDanEstimate"/> filter on this value.
     /// </summary>
     public static class EzDanAlgorithm

--- a/osu.Game/EzOsuGame/Skills/EzDanLabels.cs
+++ b/osu.Game/EzOsuGame/Skills/EzDanLabels.cs
@@ -63,12 +63,37 @@ namespace osu.Game.EzOsuGame.Skills
 
         public const int LN_LADDER_TOP = 17;
 
-        public static double SrToRawDan(double sr, string family = "stream")
+        public static double SrToRawDan(double sr, string family = "stream", bool calibrate = true)
         {
             if (!double.IsFinite(sr) || sr <= 0)
                 return 1;
 
-            return rawDanFromMeans(sr, meansFor(family));
+            string calibrationFamily = family == "jumpstream" ? "handstream" : family;
+            double calibratedSr = calibrate ? calibrateSrForFamily(sr, calibrationFamily) : sr;
+            return rawDanFromMeans(calibratedSr, meansFor(calibrationFamily));
+        }
+
+        private readonly record struct SrCalibration(double Slope, double Offset, double GateStart, double GateWidth);
+
+        private static readonly Dictionary<string, SrCalibration> sr_calibration = new Dictionary<string, SrCalibration>
+        {
+            ["jack"] = new SrCalibration(0.74, 1.3, 7.4, 0.3),
+            ["stream"] = new SrCalibration(0.92, -0.4, 7, 0.9),
+            ["jumpstream"] = new SrCalibration(1.02, -0.45, 7.25, 0.55),
+            ["handstream"] = new SrCalibration(1.16, -2, 7.4, 0.2),
+            ["stamina"] = new SrCalibration(1.12, -1.5, 7.3, 0.55),
+            ["chordjack"] = new SrCalibration(1, 0, 7.15, 0.85),
+            ["tech"] = new SrCalibration(0.95, -0.9, 7.6, 0.9),
+        };
+
+        private static double calibrateSrForFamily(double sr, string family)
+        {
+            if (!sr_calibration.TryGetValue(family, out var calibration))
+                calibration = sr_calibration["stream"];
+
+            double targetSr = sr * calibration.Slope + calibration.Offset;
+            double gate = Math.Clamp((sr - calibration.GateStart) / calibration.GateWidth, 0, 1);
+            return sr + (targetSr - sr) * gate;
         }
 
         public static string LabelFor(double rawDan, string side, int keyCount)

--- a/osu.Game/EzOsuGame/Skills/EzModRate.cs
+++ b/osu.Game/EzOsuGame/Skills/EzModRate.cs
@@ -1,0 +1,33 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    /// <summary>
+    /// Shared DT/HT rate resolution for MSD/SSR/Dan (clamp matches lazer ModRateAdjust bounds).
+    /// </summary>
+    public static class EzModRate
+    {
+        public static float Resolve(IEnumerable<Mod>? mods)
+        {
+            double rate = 1;
+
+            if (mods != null)
+            {
+                foreach (var mod in mods)
+                {
+                    if (mod is ModRateAdjust rateAdjust)
+                        rate *= rateAdjust.SpeedChange.Value;
+                }
+            }
+
+            return (float)Math.Clamp(rate, 0.5, 2.0);
+        }
+
+        public static bool IsNomodRate(float rate) => Math.Abs(rate - 1f) < 0.001f;
+    }
+}

--- a/osu.Game/EzOsuGame/Skills/EzPlayerDanAggregator.cs
+++ b/osu.Game/EzOsuGame/Skills/EzPlayerDanAggregator.cs
@@ -10,8 +10,8 @@ using osu.Game.Scoring;
 namespace osu.Game.EzOsuGame.Skills
 {
     /// <summary>
-    /// MVP player dan: chart verdict → credit clears → average window. Chart side via <see cref="EzChartDanEstimator"/>.
-    /// Not comparable to mania-hub LeoBlack verdicts; estimates are provisional.
+    /// Player dan: rate-aware chart verdict → credit clears → average window.
+    /// Not LeoBlack; estimates are provisional (DATA-1 heuristic + rate).
     /// </summary>
     public sealed class EzPlayerDanAggregator
     {
@@ -31,6 +31,7 @@ namespace osu.Game.EzOsuGame.Skills
             ArgumentException.ThrowIfNullOrWhiteSpace(username);
 
             var clearsByBucket = new Dictionary<(int KeyCount, string Side), List<double>>();
+            var msdCache = new Dictionary<(string Hash, int RateMilli), IReadOnlyDictionary<string, double>>();
 
             foreach (var score in scores)
             {
@@ -44,13 +45,36 @@ namespace osu.Game.EzOsuGame.Skills
                 if (beatmapInfo == null)
                     continue;
 
-                // Converts excluded from dan (same spirit as keymode PP).
                 if (beatmapInfo.Ruleset.OnlineID != 3)
                     continue;
 
-                var msd = msdComputer.TryGetOrCompute(beatmapInfo);
-                if (msd == null || msd.Count == 0)
-                    continue;
+                float rate = EzModRate.Resolve(score.Mods);
+                int rateMilli = (int)Math.Round(rate * 1000);
+                var cacheKey = (beatmapInfo.Hash, rateMilli);
+
+                if (!msdCache.TryGetValue(cacheKey, out var msd))
+                {
+                    if (EzModRate.IsNomodRate(rate))
+                    {
+                        msd = msdComputer.TryGetOrCompute(beatmapInfo);
+                    }
+                    else
+                    {
+                        var workingForMsd = beatmapManager.GetWorkingBeatmap(beatmapInfo);
+                        var playableForMsd = workingForMsd.GetPlayableBeatmap(score.Ruleset, score.Mods);
+                        using var calc = new EzMinaCalcFacade();
+                        var vector = calc.CalculateMsd(playableForMsd, rate);
+                        if (vector.Overall <= 0 && vector.Stream <= 0)
+                            continue;
+
+                        msd = EzChartDanEstimator.VectorToMsdDict(vector);
+                    }
+
+                    if (msd == null || msd.Count == 0)
+                        continue;
+
+                    msdCache[cacheKey] = msd;
+                }
 
                 var working = beatmapManager.GetWorkingBeatmap(beatmapInfo);
                 var playable = working.GetPlayableBeatmap(score.Ruleset, score.Mods);

--- a/osu.Game/EzOsuGame/Skills/EzPlayerSsrAggregator.cs
+++ b/osu.Game/EzOsuGame/Skills/EzPlayerSsrAggregator.cs
@@ -4,14 +4,13 @@
 using System;
 using System.Collections.Generic;
 using osu.Game.Beatmaps;
-using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 
 namespace osu.Game.EzOsuGame.Skills
 {
     /// <summary>
     /// Aggregates per-play SSR vectors into independent player skills (Etterna AggregateSSRs).
-    /// Accuracy→goal is a simplified mapping for foundation; Wife estimate can be refined later.
+    /// Accuracy→goal is a simplified mapping for foundation; Wife estimate can be refined later (DATA-2).
     /// </summary>
     public sealed class EzPlayerSsrAggregator
     {
@@ -47,7 +46,7 @@ namespace osu.Game.EzOsuGame.Skills
                 var working = beatmapManager.GetWorkingBeatmap(beatmapInfo);
                 var playable = working.GetPlayableBeatmap(score.Ruleset, score.Mods);
                 int keyCount = EzMinaNoteConverter.ResolveKeyCount(playable);
-                float rate = resolveRate(score.Mods);
+                float rate = EzModRate.Resolve(score.Mods);
                 float goal = accuracyToGoal(score.Accuracy);
 
                 if (goal <= 0.8f)
@@ -73,19 +72,6 @@ namespace osu.Game.EzOsuGame.Skills
                 bool provisional = plays.Count < EzPlayerSsrSnapshot.QUALIFYING_PLAYS;
                 skillStore.WritePlayerSsr(username, keyCount, aggregated, plays.Count, provisional);
             }
-        }
-
-        private static float resolveRate(IEnumerable<Mod> mods)
-        {
-            double rate = 1;
-
-            foreach (var mod in mods)
-            {
-                if (mod is ModRateAdjust rateAdjust)
-                    rate *= rateAdjust.SpeedChange.Value;
-            }
-
-            return (float)Math.Clamp(rate, 0.5, 2.0);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- **Master:** Skills Track Dan Master · **DATA-1**
- Shared `EzModRate.Resolve` for DT/HT
- Chart/player dan use rate MSD when rate≠1 (live calc; Realm still caches 1.0x only)
- Port hub `SR_CALIBRATION` into `EzDanLabels.SrToRawDan`
- **Pre-release:** no `EzDanAlgorithm.VERSION` bump (no client shipped yet)
- Zero `EZ_REALM_SCHEMA_VERSION`

## Test plan
- [ ] `dotnet test --filter EzDanCreditTest`
- [ ] Recompute Local Profile: DT clears should rate higher chart dan than 1.0x
- [ ] `TryGetChartDan` with DT mods differs from nomod when MSD rises

## Out of scope
- DATA-2 Wife SSR goal
- DATA-3 evidence SQLite
- UX / LeoBlack