### PR TITLE
DATA-2: SSR goal Wife3 subset

### DIFF
--- a/osu.Game.Tests/EzOsuGame/Skills/EzSsrGoalTest.cs
+++ b/osu.Game.Tests/EzOsuGame/Skills/EzSsrGoalTest.cs
@@ -1,0 +1,83 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Game.EzOsuGame.Skills;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
+
+namespace osu.Game.Tests.EzOsuGame.Skills
+{
+    [TestFixture]
+    public class EzSsrGoalTest
+    {
+        [Test]
+        public void AccuracyBelowFloorMapsToMin()
+        {
+            Assert.That(EzSsrGoal.ForAccuracy(0.5), Is.EqualTo(0.8f).Within(0.0001f));
+        }
+
+        [Test]
+        public void AccuracyCapsAtCalcGoal()
+        {
+            Assert.That(EzSsrGoal.ForAccuracy(1.0), Is.EqualTo(0.965f).Within(0.0001f));
+        }
+
+        [Test]
+        public void NonFiniteAccuracyFallsBack()
+        {
+            Assert.That(EzSsrGoal.ForAccuracy(double.NaN), Is.EqualTo(0.93f).Within(0.0001f));
+        }
+
+        [Test]
+        public void EmptyStatisticsFallsBackToAccuracyClamp()
+        {
+            var score = new ScoreInfo
+            {
+                Accuracy = 0.99,
+                IsLegacyScore = false,
+                Statistics = new Dictionary<HitResult, int>(),
+            };
+
+            float? goal = EzSsrGoal.ForScore(score, lnRatio: 0, od: 8);
+            Assert.That(goal, Is.EqualTo(EzSsrGoal.ForAccuracy(0.99)).Within(0.0001f));
+        }
+
+        [Test]
+        public void AllPerfectsYieldHighWifeGoalOnLegacy()
+        {
+            var score = new ScoreInfo
+            {
+                Accuracy = 1.0,
+                IsLegacyScore = true,
+                Statistics = new Dictionary<HitResult, int>
+                {
+                    [HitResult.Perfect] = 1000,
+                },
+            };
+
+            float? goal = EzSsrGoal.ForScore(score, lnRatio: 0, od: 8);
+            Assert.That(goal, Is.Not.Null);
+            Assert.That(goal!.Value, Is.GreaterThan(0.96f));
+            Assert.That(goal.Value, Is.LessThanOrEqualTo((float)EzSsrGoal.GOAL_CAP));
+        }
+
+        [Test]
+        public void VeryLowAccuracyWithMissesReturnsNull()
+        {
+            var score = new ScoreInfo
+            {
+                Accuracy = 0.5,
+                IsLegacyScore = true,
+                Statistics = new Dictionary<HitResult, int>
+                {
+                    [HitResult.Miss] = 100,
+                    [HitResult.Meh] = 10,
+                },
+            };
+
+            Assert.That(EzSsrGoal.ForScore(score, lnRatio: 0, od: 8), Is.Null);
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Skills/EzPlayerSsrAggregator.cs
+++ b/osu.Game/EzOsuGame/Skills/EzPlayerSsrAggregator.cs
@@ -10,7 +10,7 @@ namespace osu.Game.EzOsuGame.Skills
 {
     /// <summary>
     /// Aggregates per-play SSR vectors into independent player skills (Etterna AggregateSSRs).
-    /// Accuracy→goal is a simplified mapping for foundation; Wife estimate can be refined later (DATA-2).
+    /// Goal via <see cref="EzSsrGoal"/> (Wife subset when statistics exist).
     /// </summary>
     public sealed class EzPlayerSsrAggregator
     {
@@ -47,16 +47,18 @@ namespace osu.Game.EzOsuGame.Skills
                 var playable = working.GetPlayableBeatmap(score.Ruleset, score.Mods);
                 int keyCount = EzMinaNoteConverter.ResolveKeyCount(playable);
                 float rate = EzModRate.Resolve(score.Mods);
-                float goal = accuracyToGoal(score.Accuracy);
+                double holdRatio = EzChartDanEstimator.ComputeHoldRatio(playable);
+                double od = beatmapInfo.Difficulty.OverallDifficulty;
 
-                if (goal <= 0.8f)
+                float? goal = EzSsrGoal.ForScore(score, holdRatio, od);
+                if (goal is not float goalValue)
                     continue;
 
                 var notes = EzMinaNoteConverter.Convert(playable);
                 if (notes.Length == 0)
                     continue;
 
-                var vector = calc.CalculateSsr(notes, rate, goal);
+                var vector = calc.CalculateSsr(notes, rate, goalValue);
                 if (vector.Overall <= 0)
                     continue;
 
@@ -74,17 +76,7 @@ namespace osu.Game.EzOsuGame.Skills
             }
         }
 
-        /// <summary>
-        /// Maps display accuracy to MinaCalc SSR goal. Foundation: clamp accuracy into [0.8, 0.9975].
-        /// </summary>
-        public static float AccuracyToGoal(double accuracy) => accuracyToGoal(accuracy);
-
-        private static float accuracyToGoal(double accuracy)
-        {
-            if (!double.IsFinite(accuracy) || accuracy <= 0)
-                return 0.8f;
-
-            return (float)Math.Clamp(accuracy, 0.8, 0.9975);
-        }
+        /// <summary>Accuracy-only clamp path (tests / callers without full score).</summary>
+        public static float AccuracyToGoal(double accuracy) => EzSsrGoal.ForAccuracy(accuracy);
     }
 }

--- a/osu.Game/EzOsuGame/Skills/EzSkillIds.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSkillIds.cs
@@ -45,7 +45,8 @@ namespace osu.Game.EzOsuGame.Skills
     }
 
     /// <summary>
-    /// Bump when MinaCalc note conversion or aggregation semantics change; invalidates stored values.
+    /// Pre-release: corrective formula fixes keep this at 1 (no client shipped yet).
+    /// After public release, bump when MinaCalc note conversion or aggregation semantics change.
     /// </summary>
     public static class EzManiaSkillAlgorithm
     {

--- a/osu.Game/EzOsuGame/Skills/EzSsrGoal.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSsrGoal.cs
@@ -1,0 +1,188 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    /// <summary>
+    /// Ports mania-hub ssrGoalForScore / estimateWifeAccuracy (subset).
+    /// Pre-release corrective: does not bump <see cref="EzManiaSkillAlgorithm.VERSION"/>.
+    /// </summary>
+    public static class EzSsrGoal
+    {
+        public const double GOAL_MIN = 0.8;
+        public const double CALC_GOAL_CAP = 0.965;
+        public const double GOAL_CAP = 0.9975;
+        public const double ASSUMED_OD = 8;
+        private const double EZ_WINDOW_SCALE = 1.4;
+
+        private const double WIFE3_FULL_POINTS_MS = 5;
+        private const double WIFE3_ZERO_MS = 65;
+        private const double WIFE3_ERF_DEV_MS = 22.7;
+        private const double WIFE3_MISS_MS = 180;
+        private const double WIFE3_MISS_POINTS = -2.75;
+        private const double STABLE_MAX_WINDOW_MS = 16.5;
+        private const double OD_WINDOW_STEP_MS = 3;
+
+        private static readonly double[] stable_window_bases_ms = { 64, 97, 127, 151 };
+
+        private static readonly Dictionary<string, double[]> expected_points_cache = new Dictionary<string, double[]>();
+
+        /// <summary>
+        /// Returns null when goal would sit on the calc floor (play must not count).
+        /// </summary>
+        public static float? ForScore(ScoreInfo score, double? lnRatio = null, double? od = null)
+        {
+            double goal = forScoreUnchecked(score, lnRatio, od);
+            if (!(goal > GOAL_MIN))
+                return null;
+
+            return (float)goal;
+        }
+
+        public static float ForAccuracy(double accuracy)
+        {
+            double acc = double.IsFinite(accuracy) ? accuracy : 0.93;
+            return (float)(Math.Round(Math.Max(GOAL_MIN, Math.Min(CALC_GOAL_CAP, acc)) * 10_000) / 10_000);
+        }
+
+        private static double forScoreUnchecked(ScoreInfo score, double? lnRatio, double? od)
+        {
+            double? wife = estimateWifeAccuracy(score.Statistics, od, ezWindowScale(score.Mods));
+            if (wife is null)
+                return ForAccuracy(score.Accuracy);
+
+            double wifeGoal = Math.Max(GOAL_MIN, Math.Min(GOAL_CAP, wife.Value));
+
+            // Lazer judges LN head/tail separately — fade Wife toward plain accuracy by LN share.
+            if (!score.IsLegacyScore)
+            {
+                double accGoal = ForAccuracy(score.Accuracy);
+                double fade = lnRatio is null ? 1 : Math.Clamp(lnRatio.Value, 0, 1);
+                return Math.Round((wifeGoal * (1 - fade) + accGoal * fade) * 10_000) / 10_000;
+            }
+
+            return Math.Round(wifeGoal * 10_000) / 10_000;
+        }
+
+        private static double ezWindowScale(IEnumerable<Mod> mods)
+        {
+            double scale = 1;
+
+            foreach (var mod in mods)
+            {
+                string acronym = mod.Acronym;
+                if (acronym == "EZ")
+                    scale *= EZ_WINDOW_SCALE;
+                else if (acronym == "HR")
+                    scale /= EZ_WINDOW_SCALE;
+            }
+
+            return scale;
+        }
+
+        private static double? estimateWifeAccuracy(IReadOnlyDictionary<HitResult, int> statistics, double? od, double windowScale)
+        {
+            if (statistics == null || statistics.Count == 0)
+                return null;
+
+            double odValue = od is double o && double.IsFinite(o) ? Math.Clamp(o, 0, 10) : ASSUMED_OD;
+            double scale = double.IsFinite(windowScale) && windowScale > 0 ? windowScale : 1;
+            double[] expected = expectedWife3Points(odValue, scale);
+
+            int perfect = readCount(statistics, HitResult.Perfect);
+            int great = readCount(statistics, HitResult.Great);
+            int good = readCount(statistics, HitResult.Good);
+            int ok = readCount(statistics, HitResult.Ok);
+            int meh = readCount(statistics, HitResult.Meh);
+            int miss = readCount(statistics, HitResult.Miss);
+
+            int total = perfect + great + good + ok + meh + miss;
+            if (total <= 0)
+                return null;
+
+            double points = perfect * expected[0]
+                            + great * expected[1]
+                            + good * expected[2]
+                            + ok * expected[3]
+                            + meh * expected[4]
+                            + miss * expected[5];
+
+            return points / total;
+        }
+
+        private static int readCount(IReadOnlyDictionary<HitResult, int> statistics, HitResult result)
+            => statistics.TryGetValue(result, out int count) && count > 0 ? count : 0;
+
+        private static double[] expectedWife3Points(double od, double windowScale)
+        {
+            string key = $"{od}|{windowScale}";
+            if (expected_points_cache.TryGetValue(key, out var cached))
+                return cached;
+
+            double[] edges =
+            {
+                STABLE_MAX_WINDOW_MS * windowScale,
+                (stable_window_bases_ms[0] - OD_WINDOW_STEP_MS * od) * windowScale,
+                (stable_window_bases_ms[1] - OD_WINDOW_STEP_MS * od) * windowScale,
+                (stable_window_bases_ms[2] - OD_WINDOW_STEP_MS * od) * windowScale,
+                (stable_window_bases_ms[3] - OD_WINDOW_STEP_MS * od) * windowScale,
+            };
+
+            var points = new[]
+            {
+                wife3BandAverage(0, edges[0]),
+                wife3BandAverage(edges[0], edges[1]),
+                wife3BandAverage(edges[1], edges[2]),
+                wife3BandAverage(edges[2], edges[3]),
+                wife3BandAverage(edges[3], edges[4]),
+                WIFE3_MISS_POINTS,
+            };
+
+            expected_points_cache[key] = points;
+            return points;
+        }
+
+        private static double wife3PointsAt(double ms)
+        {
+            if (ms <= WIFE3_FULL_POINTS_MS)
+                return 1;
+            if (ms <= WIFE3_ZERO_MS)
+                return erf((WIFE3_ZERO_MS - ms) / WIFE3_ERF_DEV_MS);
+            if (ms >= WIFE3_MISS_MS)
+                return WIFE3_MISS_POINTS;
+
+            return WIFE3_MISS_POINTS * (ms - WIFE3_ZERO_MS) / (WIFE3_MISS_MS - WIFE3_ZERO_MS);
+        }
+
+        private static double wife3BandAverage(double fromMs, double toMs)
+        {
+            if (!(toMs > fromMs))
+                return wife3PointsAt(toMs);
+
+            const int steps = 512;
+            double step = (toMs - fromMs) / steps;
+            double sum = 0;
+
+            for (int i = 0; i < steps; i++)
+                sum += wife3PointsAt(fromMs + (i + 0.5) * step);
+
+            return sum / steps;
+        }
+
+        // Abramowitz & Stegun 7.1.26
+        private static double erf(double x)
+        {
+            int sign = x < 0 ? -1 : 1;
+            double ax = Math.Abs(x);
+            double t = 1 / (1 + 0.3275911 * ax);
+            double poly = ((((1.061405429 * t - 1.453152027) * t + 1.421413741) * t - 0.284496736) * t + 0.254829592) * t;
+            return sign * (1 - poly * Math.Exp(-ax * ax));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **Master:** Skills Track Dan Master · **DATA-2**
- Add `EzSsrGoal` (mania-hub `ssrGoalForScore` / `estimateWifeAccuracy` subset)
- Wire `EzPlayerSsrAggregator` to use Wife when `Statistics` exist; else accuracy clamp
- Lazer scores fade Wife→accuracy by LN hold ratio
- **Pre-release:** no `EzManiaSkillAlgorithm.VERSION` bump; zero `EZ_REALM_SCHEMA_VERSION`

## Test plan
- [ ] `dotnet test --filter EzSsrGoalTest`
- [ ] Recompute Local Profile; SSR still writes for high-acc mania plays
- [ ] Plays with empty statistics still count via accuracy clamp

## Out of scope
- DATA-3 evidence SQLite
- AggregateSSRs core changes
- UX / LeoBlack