### PR TITLE
Store dan/SSR evidence in ez-local-profile (DATA-3)

### DIFF
--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileService.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileService.cs
@@ -150,7 +150,19 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
                     try
                     {
-                        ssrAggregator?.ComputeAndStore(username, scores);
+                        if (ssrAggregator != null)
+                        {
+                            ssrAggregator.ComputeAndStore(username, scores);
+
+                            try
+                            {
+                                store.ReplaceAxisPlays(username, ssrAggregator.PendingEvidence);
+                            }
+                            catch (Exception ex) when (ex is not OperationCanceledException)
+                            {
+                                Logger.Error(ex, "[EzLocalProfile] Failed to persist axis play evidence after SSR compute.", Ez2ConfigManager.LOGGER_NAME);
+                            }
+                        }
                     }
                     catch (Exception ex) when (ex is not OperationCanceledException)
                     {
@@ -159,7 +171,19 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
                     try
                     {
-                        danAggregator?.ComputeAndStore(username, scores);
+                        if (danAggregator != null)
+                        {
+                            danAggregator.ComputeAndStore(username, scores);
+
+                            try
+                            {
+                                store.ReplaceDanClears(username, danAggregator.PendingEvidence);
+                            }
+                            catch (Exception ex) when (ex is not OperationCanceledException)
+                            {
+                                Logger.Error(ex, "[EzLocalProfile] Failed to persist dan clear evidence after Dan compute.", Ez2ConfigManager.LOGGER_NAME);
+                            }
+                        }
                     }
                     catch (Exception ex) when (ex is not OperationCanceledException)
                     {
@@ -176,6 +200,12 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 Logger.Error(ex, "[EzLocalProfile] Failed to collect mania scores for skill/dan compute.", Ez2ConfigManager.LOGGER_NAME);
             }
         }
+
+        public IReadOnlyList<EzDanClearEvidenceRow> GetDanClears(string username, int? keyCount = null, string? side = null)
+            => store.GetDanClears(username, keyCount, side);
+
+        public IReadOnlyList<EzAxisPlayEvidenceRow> GetAxisPlays(string username, int? keyCount = null, string? skillId = null)
+            => store.GetAxisPlays(username, keyCount, skillId);
 
         public void ReloadFromDisk()
         {

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileStore.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileStore.cs
@@ -12,6 +12,7 @@ using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Game.Beatmaps;
 using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.Skills;
 using osu.Game.Scoring;
 
 namespace osu.Game.EzOsuGame.LocalProfile
@@ -193,6 +194,186 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 ensureInitialised();
                 using var connection = openConnection();
                 setMeta(connection, pullOffsetKey(kind, rulesetId), Math.Max(0, offset).ToString(CultureInfo.InvariantCulture));
+            }
+        }
+
+        /// <summary>
+        /// Replace all dan clear evidence rows for <paramref name="username"/> (DATA-3).
+        /// </summary>
+        public void ReplaceDanClears(string username, IReadOnlyList<EzDanClearEvidenceRow> rows)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(username);
+            ArgumentNullException.ThrowIfNull(rows);
+
+            lock (sync)
+            {
+                ensureInitialised();
+                using var connection = openConnection();
+                using var tx = connection.BeginTransaction();
+
+                using (var del = connection.CreateCommand())
+                {
+                    del.Transaction = tx;
+                    del.CommandText = "DELETE FROM dan_clear_evidence WHERE username = $username;";
+                    del.Parameters.AddWithValue("$username", username);
+                    del.ExecuteNonQuery();
+                }
+
+                foreach (var row in rows)
+                {
+                    using var ins = connection.CreateCommand();
+                    ins.Transaction = tx;
+                    ins.CommandText = """
+                                      INSERT INTO dan_clear_evidence
+                                          (username, key_count, side, beatmap_hash, rate, credited_dan, accuracy, scored_at_ms)
+                                      VALUES
+                                          ($username, $key_count, $side, $beatmap_hash, $rate, $credited_dan, $accuracy, $scored_at_ms);
+                                      """;
+                    ins.Parameters.AddWithValue("$username", username);
+                    ins.Parameters.AddWithValue("$key_count", row.KeyCount);
+                    ins.Parameters.AddWithValue("$side", row.Side);
+                    ins.Parameters.AddWithValue("$beatmap_hash", row.BeatmapHash);
+                    ins.Parameters.AddWithValue("$rate", row.Rate);
+                    ins.Parameters.AddWithValue("$credited_dan", row.CreditedDan);
+                    ins.Parameters.AddWithValue("$accuracy", row.Accuracy);
+                    ins.Parameters.AddWithValue("$scored_at_ms", row.ScoredAt.ToUnixTimeMilliseconds());
+                    ins.ExecuteNonQuery();
+                }
+
+                tx.Commit();
+            }
+        }
+
+        /// <summary>
+        /// Replace all SSR axis play evidence rows for <paramref name="username"/> (DATA-3).
+        /// </summary>
+        public void ReplaceAxisPlays(string username, IReadOnlyList<EzAxisPlayEvidenceRow> rows)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(username);
+            ArgumentNullException.ThrowIfNull(rows);
+
+            lock (sync)
+            {
+                ensureInitialised();
+                using var connection = openConnection();
+                using var tx = connection.BeginTransaction();
+
+                using (var del = connection.CreateCommand())
+                {
+                    del.Transaction = tx;
+                    del.CommandText = "DELETE FROM axis_play_evidence WHERE username = $username;";
+                    del.Parameters.AddWithValue("$username", username);
+                    del.ExecuteNonQuery();
+                }
+
+                foreach (var row in rows)
+                {
+                    using var ins = connection.CreateCommand();
+                    ins.Transaction = tx;
+                    ins.CommandText = """
+                                      INSERT INTO axis_play_evidence
+                                          (username, key_count, skill_id, beatmap_hash, axis_value, accuracy, rate, scored_at_ms)
+                                      VALUES
+                                          ($username, $key_count, $skill_id, $beatmap_hash, $axis_value, $accuracy, $rate, $scored_at_ms);
+                                      """;
+                    ins.Parameters.AddWithValue("$username", username);
+                    ins.Parameters.AddWithValue("$key_count", row.KeyCount);
+                    ins.Parameters.AddWithValue("$skill_id", row.SkillId);
+                    ins.Parameters.AddWithValue("$beatmap_hash", row.BeatmapHash);
+                    ins.Parameters.AddWithValue("$axis_value", row.AxisValue);
+                    ins.Parameters.AddWithValue("$accuracy", row.Accuracy);
+                    ins.Parameters.AddWithValue("$rate", row.Rate);
+                    ins.Parameters.AddWithValue("$scored_at_ms", row.ScoredAt.ToUnixTimeMilliseconds());
+                    ins.ExecuteNonQuery();
+                }
+
+                tx.Commit();
+            }
+        }
+
+        public IReadOnlyList<EzDanClearEvidenceRow> GetDanClears(string username, int? keyCount = null, string? side = null)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(username);
+
+            lock (sync)
+            {
+                ensureInitialised();
+                using var connection = openConnection();
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = """
+                                  SELECT username, key_count, side, beatmap_hash, rate, credited_dan, accuracy, scored_at_ms
+                                  FROM dan_clear_evidence
+                                  WHERE username = $username
+                                    AND ($key_count IS NULL OR key_count = $key_count)
+                                    AND ($side IS NULL OR side = $side)
+                                  ORDER BY credited_dan DESC, scored_at_ms DESC;
+                                  """;
+                cmd.Parameters.AddWithValue("$username", username);
+                cmd.Parameters.AddWithValue("$key_count", (object?)keyCount ?? DBNull.Value);
+                cmd.Parameters.AddWithValue("$side", (object?)side ?? DBNull.Value);
+
+                var list = new List<EzDanClearEvidenceRow>();
+                using var reader = cmd.ExecuteReader();
+
+                while (reader.Read())
+                {
+                    list.Add(new EzDanClearEvidenceRow
+                    {
+                        Username = reader.GetString(0),
+                        KeyCount = reader.GetInt32(1),
+                        Side = reader.GetString(2),
+                        BeatmapHash = reader.GetString(3),
+                        Rate = reader.GetDouble(4),
+                        CreditedDan = reader.GetDouble(5),
+                        Accuracy = reader.GetDouble(6),
+                        ScoredAt = DateTimeOffset.FromUnixTimeMilliseconds(reader.GetInt64(7)),
+                    });
+                }
+
+                return list;
+            }
+        }
+
+        public IReadOnlyList<EzAxisPlayEvidenceRow> GetAxisPlays(string username, int? keyCount = null, string? skillId = null)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(username);
+
+            lock (sync)
+            {
+                ensureInitialised();
+                using var connection = openConnection();
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = """
+                                  SELECT username, key_count, skill_id, beatmap_hash, axis_value, accuracy, rate, scored_at_ms
+                                  FROM axis_play_evidence
+                                  WHERE username = $username
+                                    AND ($key_count IS NULL OR key_count = $key_count)
+                                    AND ($skill_id IS NULL OR skill_id = $skill_id)
+                                  ORDER BY axis_value DESC, scored_at_ms DESC;
+                                  """;
+                cmd.Parameters.AddWithValue("$username", username);
+                cmd.Parameters.AddWithValue("$key_count", (object?)keyCount ?? DBNull.Value);
+                cmd.Parameters.AddWithValue("$skill_id", (object?)skillId ?? DBNull.Value);
+
+                var list = new List<EzAxisPlayEvidenceRow>();
+                using var reader = cmd.ExecuteReader();
+
+                while (reader.Read())
+                {
+                    list.Add(new EzAxisPlayEvidenceRow
+                    {
+                        Username = reader.GetString(0),
+                        KeyCount = reader.GetInt32(1),
+                        SkillId = reader.GetString(2),
+                        BeatmapHash = reader.GetString(3),
+                        AxisValue = reader.GetDouble(4),
+                        Accuracy = reader.GetDouble(5),
+                        Rate = reader.GetDouble(6),
+                        ScoredAt = DateTimeOffset.FromUnixTimeMilliseconds(reader.GetInt64(7)),
+                    });
+                }
+
+                return list;
             }
         }
 
@@ -979,6 +1160,32 @@ namespace osu.Game.EzOsuGame.LocalProfile
                                   );
                                   CREATE INDEX IF NOT EXISTS idx_drill_scores_ruleset_pp
                                       ON drill_scores(ruleset_id, pp_resolved DESC, date_ms DESC);
+                                  CREATE TABLE IF NOT EXISTS dan_clear_evidence (
+                                      id INTEGER PRIMARY KEY AUTOINCREMENT,
+                                      username TEXT NOT NULL,
+                                      key_count INTEGER NOT NULL,
+                                      side TEXT NOT NULL,
+                                      beatmap_hash TEXT NOT NULL,
+                                      rate REAL NOT NULL,
+                                      credited_dan REAL NOT NULL,
+                                      accuracy REAL NOT NULL,
+                                      scored_at_ms INTEGER NOT NULL
+                                  );
+                                  CREATE TABLE IF NOT EXISTS axis_play_evidence (
+                                      id INTEGER PRIMARY KEY AUTOINCREMENT,
+                                      username TEXT NOT NULL,
+                                      key_count INTEGER NOT NULL,
+                                      skill_id TEXT NOT NULL,
+                                      beatmap_hash TEXT NOT NULL,
+                                      axis_value REAL NOT NULL,
+                                      accuracy REAL NOT NULL,
+                                      rate REAL NOT NULL,
+                                      scored_at_ms INTEGER NOT NULL
+                                  );
+                                  CREATE INDEX IF NOT EXISTS idx_dan_clear_evidence_user
+                                      ON dan_clear_evidence(username, key_count, side, credited_dan DESC);
+                                  CREATE INDEX IF NOT EXISTS idx_axis_play_evidence_user
+                                      ON axis_play_evidence(username, key_count, skill_id, axis_value DESC);
                                   """;
                 cmd.ExecuteNonQuery();
             }

--- a/osu.Game/EzOsuGame/Skills/EzPlayerDanAggregator.cs
+++ b/osu.Game/EzOsuGame/Skills/EzPlayerDanAggregator.cs
@@ -26,11 +26,15 @@ namespace osu.Game.EzOsuGame.Skills
             this.msdComputer = msdComputer;
         }
 
+        /// <summary>Credited clears collected during the last <see cref="ComputeAndStore"/> (for DATA-3 evidence).</summary>
+        public IReadOnlyList<EzDanClearEvidenceRow> PendingEvidence { get; private set; } = Array.Empty<EzDanClearEvidenceRow>();
+
         public void ComputeAndStore(string username, IEnumerable<ScoreInfo> scores)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(username);
 
             var clearsByBucket = new Dictionary<(int KeyCount, string Side), List<double>>();
+            var evidence = new List<EzDanClearEvidenceRow>();
             var msdCache = new Dictionary<(string Hash, int RateMilli), IReadOnlyDictionary<string, double>>();
 
             foreach (var score in scores)
@@ -91,6 +95,22 @@ namespace osu.Game.EzOsuGame.Skills
                     clearsByBucket[key] = list = new List<double>();
 
                 list.Add(value);
+
+                string hash = score.BeatmapHash;
+                if (string.IsNullOrWhiteSpace(hash))
+                    hash = beatmapInfo.Hash;
+
+                evidence.Add(new EzDanClearEvidenceRow
+                {
+                    Username = username,
+                    KeyCount = chart.KeyCount,
+                    Side = chart.Side,
+                    BeatmapHash = hash,
+                    Rate = rate,
+                    CreditedDan = value,
+                    Accuracy = score.Accuracy,
+                    ScoredAt = score.Date,
+                });
             }
 
             DateTimeOffset at = DateTimeOffset.UtcNow;
@@ -124,6 +144,8 @@ namespace osu.Game.EzOsuGame.Skills
                     ComputedAt = at,
                 });
             }
+
+            PendingEvidence = evidence;
         }
     }
 }

--- a/osu.Game/EzOsuGame/Skills/EzPlayerSsrAggregator.cs
+++ b/osu.Game/EzOsuGame/Skills/EzPlayerSsrAggregator.cs
@@ -23,11 +23,15 @@ namespace osu.Game.EzOsuGame.Skills
             this.skillStore = skillStore;
         }
 
+        /// <summary>Per-play axis rows collected during the last <see cref="ComputeAndStore"/> (for DATA-3 evidence).</summary>
+        public IReadOnlyList<EzAxisPlayEvidenceRow> PendingEvidence { get; private set; } = Array.Empty<EzAxisPlayEvidenceRow>();
+
         public void ComputeAndStore(string username, IEnumerable<ScoreInfo> scores)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(username);
 
             var byKey = new Dictionary<int, List<EzSkillsetVector>>();
+            var evidence = new List<EzAxisPlayEvidenceRow>();
 
             using var calc = new EzMinaCalcFacade();
 
@@ -66,6 +70,24 @@ namespace osu.Game.EzOsuGame.Skills
                     byKey[keyCount] = list = new List<EzSkillsetVector>();
 
                 list.Add(vector);
+
+                foreach ((string axisId, double axisValue) in vector.Enumerate())
+                {
+                    if (axisValue <= 0 || !double.IsFinite(axisValue))
+                        continue;
+
+                    evidence.Add(new EzAxisPlayEvidenceRow
+                    {
+                        Username = username,
+                        KeyCount = keyCount,
+                        SkillId = EzSkillIds.Ssr(axisId),
+                        BeatmapHash = score.BeatmapHash,
+                        AxisValue = axisValue,
+                        Accuracy = score.Accuracy,
+                        Rate = rate,
+                        ScoredAt = score.Date,
+                    });
+                }
             }
 
             foreach ((int keyCount, List<EzSkillsetVector> plays) in byKey)
@@ -74,6 +96,8 @@ namespace osu.Game.EzOsuGame.Skills
                 bool provisional = plays.Count < EzPlayerSsrSnapshot.QUALIFYING_PLAYS;
                 skillStore.WritePlayerSsr(username, keyCount, aggregated, plays.Count, provisional);
             }
+
+            PendingEvidence = evidence;
         }
 
         /// <summary>Accuracy-only clamp path (tests / callers without full score).</summary>

--- a/osu.Game/EzOsuGame/Skills/EzSkillEvidenceRows.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSkillEvidenceRows.cs
@@ -1,0 +1,37 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    /// <summary>
+    /// One credited dan clear stored in <c>ez-local-profile.sqlite</c> (DATA-3).
+    /// </summary>
+    public sealed class EzDanClearEvidenceRow
+    {
+        public string Username { get; init; } = string.Empty;
+        public int KeyCount { get; init; }
+        public string Side { get; init; } = DanSkillSystem.SIDE_RC;
+        public string BeatmapHash { get; init; } = string.Empty;
+        public double Rate { get; init; } = 1;
+        public double CreditedDan { get; init; }
+        public double Accuracy { get; init; }
+        public DateTimeOffset ScoredAt { get; init; }
+    }
+
+    /// <summary>
+    /// One per-play SSR axis contribution stored in <c>ez-local-profile.sqlite</c> (DATA-3).
+    /// </summary>
+    public sealed class EzAxisPlayEvidenceRow
+    {
+        public string Username { get; init; } = string.Empty;
+        public int KeyCount { get; init; }
+        public string SkillId { get; init; } = string.Empty;
+        public string BeatmapHash { get; init; } = string.Empty;
+        public double AxisValue { get; init; }
+        public double Accuracy { get; init; }
+        public double Rate { get; init; } = 1;
+        public DateTimeOffset ScoredAt { get; init; }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `dan_clear_evidence` / `axis_play_evidence` tables to existing `ez-local-profile.sqlite` (`SCHEMA_VERSION` stays 1; no new DB, no Realm/analysis bump).
- Aggregators collect evidence rows during SSR/Dan compute; `writePlayerSkills` best-effort `Replace*` so failures only log.
- Expose `GetDanClears` / `GetAxisPlays` on store and service for UX-2/4 later.

## Test plan
- [ ] `dotnet build` osu.Game succeeds
- [ ] Diff has no new sqlite filename constants outside local-profile
- [ ] After local profile recompute, evidence tables populate in same DB as drill
- [ ] Forced store write failure does not block profile snapshot save
- [ ] No `EZ_REALM_SCHEMA_VERSION` / analysis version constant changes