### PR TITLE
Harden skills data layer before UX (DATA-H)

### DIFF
--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileAggregator.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileAggregator.cs
@@ -100,12 +100,14 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
         /// <summary>
         /// Aggregate only the given usernames, returning one result slice per username (all scores counted).
+        /// Also returns detached mania scores from the same Realm pass (for skill/dan compute).
         /// Does not merge online contributions — that happens when rebuilding display totals.
         /// </summary>
-        public Dictionary<string, EzLocalProfileAggregationResult> AggregateByUsername(
-            IReadOnlyCollection<string> usernames,
-            IProgress<EzLocalProfileComputeProgress>? progress = null,
-            CancellationToken cancellationToken = default)
+        public (Dictionary<string, EzLocalProfileAggregationResult> Results, Dictionary<string, List<ScoreInfo>> ManiaScoresByUser)
+            AggregateByUsername(
+                IReadOnlyCollection<string> usernames,
+                IProgress<EzLocalProfileComputeProgress>? progress = null,
+                CancellationToken cancellationToken = default)
         {
             var includeSet = new HashSet<string>(usernames.Select(normaliseUsername), StringComparer.Ordinal);
             var byUser = new Dictionary<string, EzLocalProfileAggregationResult>(StringComparer.Ordinal);
@@ -153,6 +155,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
             report();
 
             var analysisCache = new Dictionary<string, CachedAnalysis>(StringComparer.Ordinal);
+            var maniaScoresByUser = new Dictionary<string, List<ScoreInfo>>(StringComparer.Ordinal);
 
             for (int i = 0; i < detachedScores.Count; i++)
             {
@@ -215,13 +218,18 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 {
                     int keyCount = resolveManiaKeyCount(score, analysis, hasKps);
                     accumulateMania(result, keyCount, analysis, hasKps, keys, avgKps, maxKps, pp, durationMs);
+
+                    if (!maniaScoresByUser.TryGetValue(username, out var maniaList))
+                        maniaScoresByUser[username] = maniaList = new List<ScoreInfo>();
+
+                    maniaList.Add(score);
                 }
 
                 if (rulesetId == EzLocalProfileConstants.OSU_RULESET_ID)
                     accumulateStdAttr(result, beatmap, score);
             }
 
-            return byUser;
+            return (byUser, maniaScoresByUser);
         }
 
         public HashSet<long> CollectLocalOnlineScoreIds()

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileService.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileService.cs
@@ -43,14 +43,18 @@ namespace osu.Game.EzOsuGame.LocalProfile
             ScoreManager scoreManager,
             IEzReplaySession replaySession,
             EzPlayerSsrAggregator? ssrAggregator = null,
-            EzPlayerDanAggregator? danAggregator = null)
+            EzPlayerDanAggregator? danAggregator = null,
+            EzLocalProfileStore? sharedStore = null)
         {
-            store = new EzLocalProfileStore(storage);
+            store = sharedStore ?? new EzLocalProfileStore(storage);
             aggregator = new EzLocalProfileAggregator(realm, analysisStore, beatmapManager, scoreManager, replaySession);
             this.ssrAggregator = ssrAggregator;
             this.danAggregator = danAggregator;
             Snapshot.Value = store.LoadSnapshot();
         }
+
+        /// <summary>Shared store for DI (e.g. <see cref="EzSkillProvider"/> evidence reads).</summary>
+        public EzLocalProfileStore Store => store;
 
         public IReadOnlyList<EzLocalProfileUsernameCount> ScanUsernameCounts() => aggregator.ScanUsernameCounts();
 
@@ -99,9 +103,18 @@ namespace osu.Game.EzOsuGame.LocalProfile
                                        .ToList();
 
                         // Online-only refresh path: no local usernames selected, just rebuild display from existing partitions + online.
-                        var byUser = selected.Count > 0
-                            ? aggregator.AggregateByUsername(selected, progress, token)
-                            : new Dictionary<string, EzLocalProfileAggregationResult>(StringComparer.Ordinal);
+                        Dictionary<string, EzLocalProfileAggregationResult> byUser;
+                        Dictionary<string, List<ScoreInfo>> maniaScores;
+
+                        if (selected.Count > 0)
+                        {
+                            (byUser, maniaScores) = aggregator.AggregateByUsername(selected, progress, token);
+                        }
+                        else
+                        {
+                            byUser = new Dictionary<string, EzLocalProfileAggregationResult>(StringComparer.Ordinal);
+                            maniaScores = new Dictionary<string, List<ScoreInfo>>(StringComparer.Ordinal);
+                        }
 
                         token.ThrowIfCancellationRequested();
 
@@ -113,7 +126,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
                         store.ApplyUsernamePartitions(byUser, replaceOtherUsernames, online, localOnlineIds);
 
                         if (selected.Count > 0)
-                            writePlayerSkills(selected, token);
+                            writePlayerSkills(maniaScores, token);
                     }
                     catch (OperationCanceledException)
                     {
@@ -132,80 +145,60 @@ namespace osu.Game.EzOsuGame.LocalProfile
             }
         }
 
-        private void writePlayerSkills(IReadOnlyList<string> usernames, CancellationToken token)
+        private void writePlayerSkills(Dictionary<string, List<ScoreInfo>> maniaScoresByUser, CancellationToken token)
         {
             if (ssrAggregator == null && danAggregator == null)
                 return;
 
-            try
+            foreach ((string username, List<ScoreInfo> scores) in maniaScoresByUser)
             {
-                var maniaScores = aggregator.CollectDetachedManiaScores(usernames);
+                token.ThrowIfCancellationRequested();
 
-                foreach ((string username, List<ScoreInfo> scores) in maniaScores)
-                {
-                    token.ThrowIfCancellationRequested();
+                if (scores.Count == 0)
+                    continue;
 
-                    if (scores.Count == 0)
-                        continue;
-
-                    try
+                tryComputeAndPersist(
+                    username,
+                    () =>
                     {
-                        if (ssrAggregator != null)
-                        {
-                            ssrAggregator.ComputeAndStore(username, scores);
+                        ssrAggregator!.ComputeAndStore(username, scores);
+                        store.ReplaceAxisPlays(username, ssrAggregator.PendingEvidence);
+                    },
+                    ssrAggregator != null,
+                    "[EzLocalProfile] Failed to compute/persist player SSR skills after profile save.");
 
-                            try
-                            {
-                                store.ReplaceAxisPlays(username, ssrAggregator.PendingEvidence);
-                            }
-                            catch (Exception ex) when (ex is not OperationCanceledException)
-                            {
-                                Logger.Error(ex, "[EzLocalProfile] Failed to persist axis play evidence after SSR compute.", Ez2ConfigManager.LOGGER_NAME);
-                            }
-                        }
-                    }
-                    catch (Exception ex) when (ex is not OperationCanceledException)
+                tryComputeAndPersist(
+                    username,
+                    () =>
                     {
-                        Logger.Error(ex, "[EzLocalProfile] Failed to compute player SSR skills after profile save.", Ez2ConfigManager.LOGGER_NAME);
-                    }
-
-                    try
-                    {
-                        if (danAggregator != null)
-                        {
-                            danAggregator.ComputeAndStore(username, scores);
-
-                            try
-                            {
-                                store.ReplaceDanClears(username, danAggregator.PendingEvidence);
-                            }
-                            catch (Exception ex) when (ex is not OperationCanceledException)
-                            {
-                                Logger.Error(ex, "[EzLocalProfile] Failed to persist dan clear evidence after Dan compute.", Ez2ConfigManager.LOGGER_NAME);
-                            }
-                        }
-                    }
-                    catch (Exception ex) when (ex is not OperationCanceledException)
-                    {
-                        Logger.Error(ex, "[EzLocalProfile] Failed to compute player Dan estimates after profile save.", Ez2ConfigManager.LOGGER_NAME);
-                    }
-                }
-            }
-            catch (OperationCanceledException)
-            {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex, "[EzLocalProfile] Failed to collect mania scores for skill/dan compute.", Ez2ConfigManager.LOGGER_NAME);
+                        danAggregator!.ComputeAndStore(username, scores);
+                        store.ReplaceDanClears(username, danAggregator.PendingEvidence);
+                    },
+                    danAggregator != null,
+                    "[EzLocalProfile] Failed to compute/persist player Dan estimates after profile save.");
             }
         }
 
-        public IReadOnlyList<EzDanClearEvidenceRow> GetDanClears(string username, int? keyCount = null, string? side = null)
-            => store.GetDanClears(username, keyCount, side);
+        private static void tryComputeAndPersist(string username, Action action, bool enabled, string errorMessage)
+        {
+            if (!enabled)
+                return;
 
-        public IReadOnlyList<EzAxisPlayEvidenceRow> GetAxisPlays(string username, int? keyCount = null, string? skillId = null)
-            => store.GetAxisPlays(username, keyCount, skillId);
+            try
+            {
+                action();
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                Logger.Error(ex, $"{errorMessage} ({username})", Ez2ConfigManager.LOGGER_NAME);
+            }
+        }
+
+        public IReadOnlyList<EzDanClearEvidenceRow> GetDanClears(string username, int? keyCount = null, string? side = null, int? algorithmVersion = null)
+            => store.GetDanClears(username, keyCount, side, algorithmVersion);
+
+        public IReadOnlyList<EzAxisPlayEvidenceRow> GetAxisPlays(string username, int? keyCount = null, string? skillId = null, int? algorithmVersion = null)
+            => store.GetAxisPlays(username, keyCount, skillId, algorithmVersion);
 
         public void ReloadFromDisk()
         {

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileStore.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileStore.cs
@@ -198,7 +198,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
         }
 
         /// <summary>
-        /// Replace all dan clear evidence rows for <paramref name="username"/> (DATA-3).
+        /// Replace all dan clear evidence rows for <paramref name="username"/> (DATA-3 / DATA-H).
         /// </summary>
         public void ReplaceDanClears(string username, IReadOnlyList<EzDanClearEvidenceRow> rows)
         {
@@ -209,25 +209,13 @@ namespace osu.Game.EzOsuGame.LocalProfile
             {
                 ensureInitialised();
                 using var connection = openConnection();
-                using var tx = connection.BeginTransaction();
-
-                using (var del = connection.CreateCommand())
+                replaceEvidenceRows(connection, "dan_clear_evidence", username, rows, (ins, row) =>
                 {
-                    del.Transaction = tx;
-                    del.CommandText = "DELETE FROM dan_clear_evidence WHERE username = $username;";
-                    del.Parameters.AddWithValue("$username", username);
-                    del.ExecuteNonQuery();
-                }
-
-                foreach (var row in rows)
-                {
-                    using var ins = connection.CreateCommand();
-                    ins.Transaction = tx;
                     ins.CommandText = """
                                       INSERT INTO dan_clear_evidence
-                                          (username, key_count, side, beatmap_hash, rate, credited_dan, accuracy, scored_at_ms)
+                                          (username, key_count, side, beatmap_hash, rate, credited_dan, accuracy, scored_at_ms, algorithm_version)
                                       VALUES
-                                          ($username, $key_count, $side, $beatmap_hash, $rate, $credited_dan, $accuracy, $scored_at_ms);
+                                          ($username, $key_count, $side, $beatmap_hash, $rate, $credited_dan, $accuracy, $scored_at_ms, $algorithm_version);
                                       """;
                     ins.Parameters.AddWithValue("$username", username);
                     ins.Parameters.AddWithValue("$key_count", row.KeyCount);
@@ -237,15 +225,13 @@ namespace osu.Game.EzOsuGame.LocalProfile
                     ins.Parameters.AddWithValue("$credited_dan", row.CreditedDan);
                     ins.Parameters.AddWithValue("$accuracy", row.Accuracy);
                     ins.Parameters.AddWithValue("$scored_at_ms", row.ScoredAt.ToUnixTimeMilliseconds());
-                    ins.ExecuteNonQuery();
-                }
-
-                tx.Commit();
+                    ins.Parameters.AddWithValue("$algorithm_version", row.AlgorithmVersion);
+                });
             }
         }
 
         /// <summary>
-        /// Replace all SSR axis play evidence rows for <paramref name="username"/> (DATA-3).
+        /// Replace all SSR axis play evidence rows for <paramref name="username"/> (DATA-3 / DATA-H).
         /// </summary>
         public void ReplaceAxisPlays(string username, IReadOnlyList<EzAxisPlayEvidenceRow> rows)
         {
@@ -256,25 +242,13 @@ namespace osu.Game.EzOsuGame.LocalProfile
             {
                 ensureInitialised();
                 using var connection = openConnection();
-                using var tx = connection.BeginTransaction();
-
-                using (var del = connection.CreateCommand())
+                replaceEvidenceRows(connection, "axis_play_evidence", username, rows, (ins, row) =>
                 {
-                    del.Transaction = tx;
-                    del.CommandText = "DELETE FROM axis_play_evidence WHERE username = $username;";
-                    del.Parameters.AddWithValue("$username", username);
-                    del.ExecuteNonQuery();
-                }
-
-                foreach (var row in rows)
-                {
-                    using var ins = connection.CreateCommand();
-                    ins.Transaction = tx;
                     ins.CommandText = """
                                       INSERT INTO axis_play_evidence
-                                          (username, key_count, skill_id, beatmap_hash, axis_value, accuracy, rate, scored_at_ms)
+                                          (username, key_count, skill_id, beatmap_hash, axis_value, accuracy, rate, scored_at_ms, algorithm_version)
                                       VALUES
-                                          ($username, $key_count, $skill_id, $beatmap_hash, $axis_value, $accuracy, $rate, $scored_at_ms);
+                                          ($username, $key_count, $skill_id, $beatmap_hash, $axis_value, $accuracy, $rate, $scored_at_ms, $algorithm_version);
                                       """;
                     ins.Parameters.AddWithValue("$username", username);
                     ins.Parameters.AddWithValue("$key_count", row.KeyCount);
@@ -284,16 +258,18 @@ namespace osu.Game.EzOsuGame.LocalProfile
                     ins.Parameters.AddWithValue("$accuracy", row.Accuracy);
                     ins.Parameters.AddWithValue("$rate", row.Rate);
                     ins.Parameters.AddWithValue("$scored_at_ms", row.ScoredAt.ToUnixTimeMilliseconds());
-                    ins.ExecuteNonQuery();
-                }
-
-                tx.Commit();
+                    ins.Parameters.AddWithValue("$algorithm_version", row.AlgorithmVersion);
+                });
             }
         }
 
-        public IReadOnlyList<EzDanClearEvidenceRow> GetDanClears(string username, int? keyCount = null, string? side = null)
+        /// <summary>
+        /// Dan clear evidence for <paramref name="username"/>. Defaults to current <see cref="EzDanAlgorithm.VERSION"/>.
+        /// </summary>
+        public IReadOnlyList<EzDanClearEvidenceRow> GetDanClears(string username, int? keyCount = null, string? side = null, int? algorithmVersion = null)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(username);
+            int version = algorithmVersion ?? EzDanAlgorithm.VERSION;
 
             lock (sync)
             {
@@ -301,14 +277,16 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 using var connection = openConnection();
                 using var cmd = connection.CreateCommand();
                 cmd.CommandText = """
-                                  SELECT username, key_count, side, beatmap_hash, rate, credited_dan, accuracy, scored_at_ms
+                                  SELECT username, key_count, side, beatmap_hash, rate, credited_dan, accuracy, scored_at_ms, algorithm_version
                                   FROM dan_clear_evidence
                                   WHERE username = $username
+                                    AND algorithm_version = $algorithm_version
                                     AND ($key_count IS NULL OR key_count = $key_count)
                                     AND ($side IS NULL OR side = $side)
                                   ORDER BY credited_dan DESC, scored_at_ms DESC;
                                   """;
                 cmd.Parameters.AddWithValue("$username", username);
+                cmd.Parameters.AddWithValue("$algorithm_version", version);
                 cmd.Parameters.AddWithValue("$key_count", (object?)keyCount ?? DBNull.Value);
                 cmd.Parameters.AddWithValue("$side", (object?)side ?? DBNull.Value);
 
@@ -327,6 +305,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
                         CreditedDan = reader.GetDouble(5),
                         Accuracy = reader.GetDouble(6),
                         ScoredAt = DateTimeOffset.FromUnixTimeMilliseconds(reader.GetInt64(7)),
+                        AlgorithmVersion = reader.GetInt32(8),
                     });
                 }
 
@@ -334,9 +313,13 @@ namespace osu.Game.EzOsuGame.LocalProfile
             }
         }
 
-        public IReadOnlyList<EzAxisPlayEvidenceRow> GetAxisPlays(string username, int? keyCount = null, string? skillId = null)
+        /// <summary>
+        /// Axis play evidence for <paramref name="username"/>. Defaults to current <see cref="EzManiaSkillAlgorithm.VERSION"/>.
+        /// </summary>
+        public IReadOnlyList<EzAxisPlayEvidenceRow> GetAxisPlays(string username, int? keyCount = null, string? skillId = null, int? algorithmVersion = null)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(username);
+            int version = algorithmVersion ?? EzManiaSkillAlgorithm.VERSION;
 
             lock (sync)
             {
@@ -344,14 +327,16 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 using var connection = openConnection();
                 using var cmd = connection.CreateCommand();
                 cmd.CommandText = """
-                                  SELECT username, key_count, skill_id, beatmap_hash, axis_value, accuracy, rate, scored_at_ms
+                                  SELECT username, key_count, skill_id, beatmap_hash, axis_value, accuracy, rate, scored_at_ms, algorithm_version
                                   FROM axis_play_evidence
                                   WHERE username = $username
+                                    AND algorithm_version = $algorithm_version
                                     AND ($key_count IS NULL OR key_count = $key_count)
                                     AND ($skill_id IS NULL OR skill_id = $skill_id)
                                   ORDER BY axis_value DESC, scored_at_ms DESC;
                                   """;
                 cmd.Parameters.AddWithValue("$username", username);
+                cmd.Parameters.AddWithValue("$algorithm_version", version);
                 cmd.Parameters.AddWithValue("$key_count", (object?)keyCount ?? DBNull.Value);
                 cmd.Parameters.AddWithValue("$skill_id", (object?)skillId ?? DBNull.Value);
 
@@ -370,11 +355,40 @@ namespace osu.Game.EzOsuGame.LocalProfile
                         Accuracy = reader.GetDouble(5),
                         Rate = reader.GetDouble(6),
                         ScoredAt = DateTimeOffset.FromUnixTimeMilliseconds(reader.GetInt64(7)),
+                        AlgorithmVersion = reader.GetInt32(8),
                     });
                 }
 
                 return list;
             }
+        }
+
+        private static void replaceEvidenceRows<T>(
+            SqliteConnection connection,
+            string table,
+            string username,
+            IReadOnlyList<T> rows,
+            Action<SqliteCommand, T> bindInsert)
+        {
+            using var tx = connection.BeginTransaction();
+
+            using (var del = connection.CreateCommand())
+            {
+                del.Transaction = tx;
+                del.CommandText = $"DELETE FROM {table} WHERE username = $username;";
+                del.Parameters.AddWithValue("$username", username);
+                del.ExecuteNonQuery();
+            }
+
+            foreach (var row in rows)
+            {
+                using var ins = connection.CreateCommand();
+                ins.Transaction = tx;
+                bindInsert(ins, row);
+                ins.ExecuteNonQuery();
+            }
+
+            tx.Commit();
         }
 
         public void UpsertOnlineScoreContribution(EzLocalProfileOnlineScoreContribution contribution)
@@ -1169,7 +1183,8 @@ namespace osu.Game.EzOsuGame.LocalProfile
                                       rate REAL NOT NULL,
                                       credited_dan REAL NOT NULL,
                                       accuracy REAL NOT NULL,
-                                      scored_at_ms INTEGER NOT NULL
+                                      scored_at_ms INTEGER NOT NULL,
+                                      algorithm_version INTEGER NOT NULL DEFAULT 1
                                   );
                                   CREATE TABLE IF NOT EXISTS axis_play_evidence (
                                       id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1180,7 +1195,8 @@ namespace osu.Game.EzOsuGame.LocalProfile
                                       axis_value REAL NOT NULL,
                                       accuracy REAL NOT NULL,
                                       rate REAL NOT NULL,
-                                      scored_at_ms INTEGER NOT NULL
+                                      scored_at_ms INTEGER NOT NULL,
+                                      algorithm_version INTEGER NOT NULL DEFAULT 1
                                   );
                                   CREATE INDEX IF NOT EXISTS idx_dan_clear_evidence_user
                                       ON dan_clear_evidence(username, key_count, side, credited_dan DESC);
@@ -1196,6 +1212,8 @@ namespace osu.Game.EzOsuGame.LocalProfile
             ensureColumn(connection, "mania_key_stats", "total_duration_ms", "INTEGER NOT NULL DEFAULT 0");
             ensureColumn(connection, "online_score_contributions", "pp", "REAL NOT NULL DEFAULT 0");
             ensureColumn(connection, "online_score_contributions", "duration_ms", "INTEGER NOT NULL DEFAULT 0");
+            ensureColumn(connection, "dan_clear_evidence", "algorithm_version", "INTEGER NOT NULL DEFAULT 1");
+            ensureColumn(connection, "axis_play_evidence", "algorithm_version", "INTEGER NOT NULL DEFAULT 1");
 
             setMeta(connection, "schema_version", SCHEMA_VERSION.ToString(CultureInfo.InvariantCulture));
         }
@@ -1253,6 +1271,8 @@ namespace osu.Game.EzOsuGame.LocalProfile
                               DELETE FROM xxy_play_counts WHERE TRUE;
                               DELETE FROM std_attr_affinity WHERE TRUE;
                               DELETE FROM drill_scores WHERE TRUE;
+                              DELETE FROM dan_clear_evidence WHERE TRUE;
+                              DELETE FROM axis_play_evidence WHERE TRUE;
                               """;
             cmd.ExecuteNonQuery();
         }

--- a/osu.Game/EzOsuGame/Skills/EzAbramowitzErf.cs
+++ b/osu.Game/EzOsuGame/Skills/EzAbramowitzErf.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    /// <summary>Abramowitz &amp; Stegun 7.1.26 (shared by SSR goal / AggregateSSRs).</summary>
+    internal static class EzAbramowitzErf
+    {
+        public static double Erf(double x)
+        {
+            int sign = x < 0 ? -1 : 1;
+            double ax = Math.Abs(x);
+            double t = 1 / (1 + 0.3275911 * ax);
+            double poly = ((((1.061405429 * t - 1.453152027) * t + 1.421413741) * t - 0.284496736) * t + 0.254829592) * t;
+            return sign * (1 - poly * Math.Exp(-ax * ax));
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Skills/EzPlayerDanAggregator.cs
+++ b/osu.Game/EzOsuGame/Skills/EzPlayerDanAggregator.cs
@@ -10,23 +10,23 @@ using osu.Game.Scoring;
 namespace osu.Game.EzOsuGame.Skills
 {
     /// <summary>
-    /// Player dan: rate-aware chart verdict → credit clears → average window.
+    /// Player dan: chart <see cref="EzChartDanEstimator.TryEstimate"/> → credit clears → average window.
     /// Not LeoBlack; estimates are provisional (DATA-1 heuristic + rate).
     /// </summary>
     public sealed class EzPlayerDanAggregator
     {
         private readonly BeatmapManager beatmapManager;
         private readonly EzSkillStore skillStore;
-        private readonly EzBeatmapMsdComputer msdComputer;
+        private readonly EzChartDanEstimator chartDanEstimator;
 
-        public EzPlayerDanAggregator(BeatmapManager beatmapManager, EzSkillStore skillStore, EzBeatmapMsdComputer msdComputer)
+        public EzPlayerDanAggregator(BeatmapManager beatmapManager, EzSkillStore skillStore, EzChartDanEstimator chartDanEstimator)
         {
             this.beatmapManager = beatmapManager;
             this.skillStore = skillStore;
-            this.msdComputer = msdComputer;
+            this.chartDanEstimator = chartDanEstimator;
         }
 
-        /// <summary>Credited clears collected during the last <see cref="ComputeAndStore"/> (for DATA-3 evidence).</summary>
+        /// <summary>Credited clears collected during the last <see cref="ComputeAndStore"/> (for evidence).</summary>
         public IReadOnlyList<EzDanClearEvidenceRow> PendingEvidence { get; private set; } = Array.Empty<EzDanClearEvidenceRow>();
 
         public void ComputeAndStore(string username, IEnumerable<ScoreInfo> scores)
@@ -35,7 +35,6 @@ namespace osu.Game.EzOsuGame.Skills
 
             var clearsByBucket = new Dictionary<(int KeyCount, string Side), List<double>>();
             var evidence = new List<EzDanClearEvidenceRow>();
-            var msdCache = new Dictionary<(string Hash, int RateMilli), IReadOnlyDictionary<string, double>>();
 
             foreach (var score in scores)
             {
@@ -52,37 +51,7 @@ namespace osu.Game.EzOsuGame.Skills
                 if (beatmapInfo.Ruleset.OnlineID != 3)
                     continue;
 
-                float rate = EzModRate.Resolve(score.Mods);
-                int rateMilli = (int)Math.Round(rate * 1000);
-                var cacheKey = (beatmapInfo.Hash, rateMilli);
-
-                if (!msdCache.TryGetValue(cacheKey, out var msd))
-                {
-                    if (EzModRate.IsNomodRate(rate))
-                    {
-                        msd = msdComputer.TryGetOrCompute(beatmapInfo);
-                    }
-                    else
-                    {
-                        var workingForMsd = beatmapManager.GetWorkingBeatmap(beatmapInfo);
-                        var playableForMsd = workingForMsd.GetPlayableBeatmap(score.Ruleset, score.Mods);
-                        using var calc = new EzMinaCalcFacade();
-                        var vector = calc.CalculateMsd(playableForMsd, rate);
-                        if (vector.Overall <= 0 && vector.Stream <= 0)
-                            continue;
-
-                        msd = EzChartDanEstimator.VectorToMsdDict(vector);
-                    }
-
-                    if (msd == null || msd.Count == 0)
-                        continue;
-
-                    msdCache[cacheKey] = msd;
-                }
-
-                var working = beatmapManager.GetWorkingBeatmap(beatmapInfo);
-                var playable = working.GetPlayableBeatmap(score.Ruleset, score.Mods);
-                var chart = EzChartDanEstimator.FromMsdAndPlayable(msd, playable);
+                var chart = chartDanEstimator.TryEstimate(beatmapInfo, score.Mods);
                 if (chart == null)
                     continue;
 
@@ -106,10 +75,11 @@ namespace osu.Game.EzOsuGame.Skills
                     KeyCount = chart.KeyCount,
                     Side = chart.Side,
                     BeatmapHash = hash,
-                    Rate = rate,
+                    Rate = EzModRate.Resolve(score.Mods),
                     CreditedDan = value,
                     Accuracy = score.Accuracy,
                     ScoredAt = score.Date,
+                    AlgorithmVersion = EzDanAlgorithm.VERSION,
                 });
             }
 

--- a/osu.Game/EzOsuGame/Skills/EzPlayerSsrAggregator.cs
+++ b/osu.Game/EzOsuGame/Skills/EzPlayerSsrAggregator.cs
@@ -86,6 +86,7 @@ namespace osu.Game.EzOsuGame.Skills
                         Accuracy = score.Accuracy,
                         Rate = rate,
                         ScoredAt = score.Date,
+                        AlgorithmVersion = EzManiaSkillAlgorithm.VERSION,
                     });
                 }
             }

--- a/osu.Game/EzOsuGame/Skills/EzSkillEvidenceRows.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSkillEvidenceRows.cs
@@ -6,7 +6,7 @@ using System;
 namespace osu.Game.EzOsuGame.Skills
 {
     /// <summary>
-    /// One credited dan clear stored in <c>ez-local-profile.sqlite</c> (DATA-3).
+    /// One credited dan clear stored in <c>ez-local-profile.sqlite</c> (DATA-3 / DATA-H).
     /// </summary>
     public sealed class EzDanClearEvidenceRow
     {
@@ -18,10 +18,11 @@ namespace osu.Game.EzOsuGame.Skills
         public double CreditedDan { get; init; }
         public double Accuracy { get; init; }
         public DateTimeOffset ScoredAt { get; init; }
+        public int AlgorithmVersion { get; init; } = EzDanAlgorithm.VERSION;
     }
 
     /// <summary>
-    /// One per-play SSR axis contribution stored in <c>ez-local-profile.sqlite</c> (DATA-3).
+    /// One per-play SSR axis contribution stored in <c>ez-local-profile.sqlite</c> (DATA-3 / DATA-H).
     /// </summary>
     public sealed class EzAxisPlayEvidenceRow
     {
@@ -33,5 +34,6 @@ namespace osu.Game.EzOsuGame.Skills
         public double Accuracy { get; init; }
         public double Rate { get; init; } = 1;
         public DateTimeOffset ScoredAt { get; init; }
+        public int AlgorithmVersion { get; init; } = EzManiaSkillAlgorithm.VERSION;
     }
 }

--- a/osu.Game/EzOsuGame/Skills/EzSkillProvider.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSkillProvider.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using osu.Game.Beatmaps;
+using osu.Game.EzOsuGame.LocalProfile;
 using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.EzOsuGame.Skills
@@ -14,11 +15,17 @@ namespace osu.Game.EzOsuGame.Skills
     {
         private readonly EzSkillStore store;
         private readonly EzChartDanEstimator? chartDanEstimator;
+        private readonly EzLocalProfileStore? localProfileStore;
 
-        public EzSkillProvider(EzSkillStore store, EzSkillRegistry? registry = null, EzChartDanEstimator? chartDanEstimator = null)
+        public EzSkillProvider(
+            EzSkillStore store,
+            EzSkillRegistry? registry = null,
+            EzChartDanEstimator? chartDanEstimator = null,
+            EzLocalProfileStore? localProfileStore = null)
         {
             this.store = store;
             this.chartDanEstimator = chartDanEstimator;
+            this.localProfileStore = localProfileStore;
             Registry = registry ?? new EzSkillRegistry();
         }
 
@@ -50,5 +57,13 @@ namespace osu.Game.EzOsuGame.Skills
         /// </summary>
         public EzChartDanVerdict? TryGetChartDan(BeatmapInfo beatmapInfo, IReadOnlyList<Mod>? mods = null)
             => chartDanEstimator?.TryEstimate(beatmapInfo, mods);
+
+        /// <summary>Dan clear evidence (sqlite). Empty when local-profile store unset.</summary>
+        public IReadOnlyList<EzDanClearEvidenceRow> GetDanClears(string username, int? keyCount = null, string? side = null, int? algorithmVersion = null)
+            => localProfileStore?.GetDanClears(username, keyCount, side, algorithmVersion) ?? [];
+
+        /// <summary>SSR axis play evidence (sqlite). Empty when local-profile store unset.</summary>
+        public IReadOnlyList<EzAxisPlayEvidenceRow> GetAxisPlays(string username, int? keyCount = null, string? skillId = null, int? algorithmVersion = null)
+            => localProfileStore?.GetAxisPlays(username, keyCount, skillId, algorithmVersion) ?? [];
     }
 }

--- a/osu.Game/EzOsuGame/Skills/EzSsrAggregator.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSsrAggregator.cs
@@ -32,8 +32,8 @@ namespace osu.Game.EzOsuGame.Skills
                     rating += res;
                     sum = 0;
 
-                    foreach (double ssr in ssrs)
-                        sum += Math.Max(0, 2 / (1 - erf(0.1 * (ssr - rating))) - 2);
+                        foreach (double ssr in ssrs)
+                        sum += Math.Max(0, 2 / (1 - EzAbramowitzErf.Erf(0.1 * (ssr - rating))) - 2);
                 }
                 while (Math.Pow(2, rating * 0.1) < sum);
 
@@ -61,16 +61,6 @@ namespace osu.Game.EzOsuGame.Skills
                 Aggregate(plays.Select(p => p.JackSpeed)),
                 Aggregate(plays.Select(p => p.Chordjack)),
                 Aggregate(plays.Select(p => p.Technical)));
-        }
-
-        /// <summary>Abramowitz &amp; Stegun 7.1.26.</summary>
-        private static double erf(double x)
-        {
-            int sign = x < 0 ? -1 : 1;
-            double ax = Math.Abs(x);
-            double t = 1 / (1 + 0.3275911 * ax);
-            double poly = ((((1.061405429 * t - 1.453152027) * t + 1.421413741) * t - 0.284496736) * t + 0.254829592) * t;
-            return sign * (1 - poly * Math.Exp(-ax * ax));
         }
     }
 }

--- a/osu.Game/EzOsuGame/Skills/EzSsrGoal.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSsrGoal.cs
@@ -175,14 +175,7 @@ namespace osu.Game.EzOsuGame.Skills
             return sum / steps;
         }
 
-        // Abramowitz & Stegun 7.1.26
-        private static double erf(double x)
-        {
-            int sign = x < 0 ? -1 : 1;
-            double ax = Math.Abs(x);
-            double t = 1 / (1 + 0.3275911 * ax);
-            double poly = ((((1.061405429 * t - 1.453152027) * t + 1.421413741) * t - 0.284496736) * t + 0.254829592) * t;
-            return sign * (1 - poly * Math.Exp(-ax * ax));
-        }
+        // Abramowitz & Stegun 7.1.26 — see EzAbramowitzErf.
+        private static double erf(double x) => EzAbramowitzErf.Erf(x);
     }
 }

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -417,16 +417,18 @@ namespace osu.Game
             var beatmapMsdComputer = new EzBeatmapMsdComputer(BeatmapManager, skillStore);
             var chartDanEstimator = new EzChartDanEstimator(BeatmapManager, beatmapMsdComputer);
             var playerSsrAggregator = new EzPlayerSsrAggregator(BeatmapManager, skillStore);
-            var playerDanAggregator = new EzPlayerDanAggregator(BeatmapManager, skillStore, beatmapMsdComputer);
+            var playerDanAggregator = new EzPlayerDanAggregator(BeatmapManager, skillStore, chartDanEstimator);
+            var localProfileStore = new EzLocalProfileStore(Storage);
             dependencies.Cache(skillRegistry);
             dependencies.Cache(skillStore);
-            dependencies.Cache(new EzSkillProvider(skillStore, skillRegistry, chartDanEstimator));
+            dependencies.Cache(localProfileStore);
+            dependencies.Cache(new EzSkillProvider(skillStore, skillRegistry, chartDanEstimator, localProfileStore));
             dependencies.Cache(beatmapMsdComputer);
             dependencies.Cache(chartDanEstimator);
             dependencies.Cache(playerSsrAggregator);
             dependencies.Cache(playerDanAggregator);
 
-            dependencies.Cache(new EzLocalProfileService(Storage, realm, ezAnalysisPersistentStore, BeatmapManager, ScoreManager, ReplaySession, playerSsrAggregator, playerDanAggregator));
+            dependencies.Cache(new EzLocalProfileService(Storage, realm, ezAnalysisPersistentStore, BeatmapManager, ScoreManager, ReplaySession, playerSsrAggregator, playerDanAggregator, localProfileStore));
             dependencies.Cache(new EzLocalProfileOnlinePullService(API, ScoreManager, BeatmapManager, realm, Storage));
 
             if (Ez2ConfigManager.Get<bool>(Ez2Setting.EzScoreRaceServiceEnabled))


### PR DESCRIPTION
## Summary
- DATA-H：复盘 #96～#105 后夯实 skills/local-profile 数据层（单 PR），再开 UX。
- Master: Skills Track Dan Master · DATA-H
- 零 `EZ_REALM_SCHEMA_VERSION`；local-profile `SCHEMA_VERSION` 仍为 1。

## 对照此前 PR

| 此前 | 做了什么 | 复盘结论 | 本 PR |
|------|----------|----------|-------|
| **#96** | MinaCalc + Realm 技能；EZ 7→8；SkillStore/Provider | Provider 为读门面；证据未挂上 → UX 会双注入 | 共享 `EzLocalProfileStore`；`EzSkillProvider.GetDanClears` / `GetAxisPlays` |
| **#97** | Compute 后写 SSR；Track Skills 走 Provider | 二次 Realm 扫分管线；Track 只读 Provider 保留 | `AggregateByUsername` 同趟产出 mania 列表 → `writePlayerSkills` |
| **#99** | Track Insights（drill） | Insights ≠ Skills，勿强行合并读 API | **无代码**（保留） |
| **#100** | Overall / 雷达 / provisional / history | Snapshot/history 已在数据层 | **无代码**（保留；UX-2 复用 history） |
| **#101** | chart→credit→player；`TryGetChartDan` | PlayerDan 未走 `TryEstimate` | `EzPlayerDanAggregator` 只调 `TryEstimate` |
| **VERSION 过滤** | Realm Dan 按 VERSION 读 | 证据无 version | 证据行 `algorithm_version`；Get 默认滤当前版 |
| **#103** | rate-aware MSD | Chart/PlayerDan 双抄 rate 路径 | 同上单一 `TryEstimate` |
| **#104** | SSR Wife goal | 双份 `erf`；双 try 样板 | `EzAbramowitzErf`；统一 compute→Replace→log |
| **#105** | 证据进 local-profile | Replace/Get 复制；clearTables 不清证据 | Store 内 DRY；clearTables 同清证据表 |

**刻意不做**：Insights 进 Provider；合并 SSR/Dan Aggregator；证据迁 Realm；升 EZ / analysis。

## Test plan
- [ ] `dotnet build` osu.Game
- [ ] Track Skills / Insights 冒烟不回归
- [ ] 全量重算后证据无幽灵用户；`Get*` 仅当前 `algorithm_version`
- [ ] 同局 chart `TryEstimate` 与 player dan 同源
- [ ] Provider 可读 clears / axis plays