### PR TITLE
Add EzAnalysis Skill dual-layer radar (UX-1)

### DIFF
--- a/osu.Game/EzOsuGame/HUD/EzHUDRadarPanel.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDRadarPanel.cs
@@ -21,6 +21,7 @@ using osu.Game.Configuration;
 using osu.Game.EzOsuGame.Analysis;
 using osu.Game.EzOsuGame.Localization;
 using osu.Game.EzOsuGame.Screens;
+using osu.Game.EzOsuGame.Skills;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
 using osu.Game.Rulesets;
@@ -45,7 +46,10 @@ namespace osu.Game.EzOsuGame.HUD
         KeyPattern,
 
         [Description("XxySR Pattern")]
-        XxySrPattern
+        XxySrPattern,
+
+        [Description("Skill")]
+        Skill
     }
 
     /// <summary>
@@ -112,6 +116,15 @@ namespace osu.Game.EzOsuGame.HUD
         [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.RADAR_DATA_AREA_COLOUR), nameof(EzHUDStrings.RADAR_DATA_AREA_COLOUR_TOOLTIP), SettingControlType = typeof(EzSettingsColour))]
         public BindableColour4 DataAreaColour { get; } = new BindableColour4(new Color4(255, 215, 0, 128));
 
+        [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.RADAR_PLAYER_DATA_LINE_COLOUR), nameof(EzHUDStrings.RADAR_PLAYER_DATA_LINE_COLOUR_TOOLTIP), SettingControlType = typeof(EzSettingsColour))]
+        public BindableColour4 PlayerDataLineColour { get; } = new BindableColour4(new Color4(80, 220, 120, 230));
+
+        [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.RADAR_PLAYER_DATA_AREA_COLOUR), nameof(EzHUDStrings.RADAR_PLAYER_DATA_AREA_COLOUR_TOOLTIP), SettingControlType = typeof(EzSettingsColour))]
+        public BindableColour4 PlayerDataAreaColour { get; } = new BindableColour4(new Color4(80, 220, 120, 128));
+
+        /// <summary>Target player for Skill-mode SSR overlay. Externally bindable (e.g. EzAnalysis header).</summary>
+        public Bindable<string?> TargetUsername { get; } = new Bindable<string?>();
+
         public int AxisCount
         {
             get => chart?.AxisCount ?? parameterRatios.Length;
@@ -150,6 +163,12 @@ namespace osu.Game.EzOsuGame.HUD
 
         [Resolved]
         private BeatmapDifficultyCache difficultyCache { get; set; } = null!;
+
+        [Resolved]
+        private EzSkillProvider? skillProvider { get; set; }
+
+        [Resolved]
+        private EzBeatmapMsdComputer? beatmapMsdComputer { get; set; }
 
         private IBindable<StarDifficulty>? difficultyBindable;
         private CancellationTokenSource? difficultyCancellationSource;
@@ -227,6 +246,8 @@ namespace osu.Game.EzOsuGame.HUD
             bindPreserveAlpha(BaseAreaColour);
             bindPreserveAlpha(DataLineColour);
             bindPreserveAlpha(DataAreaColour);
+            bindPreserveAlpha(PlayerDataLineColour);
+            bindPreserveAlpha(PlayerDataAreaColour);
             bindPreserveAlpha(BackgroundColour);
             bindPreserveAlpha(LabelColour);
 
@@ -238,19 +259,20 @@ namespace osu.Game.EzOsuGame.HUD
             BaseAreaColour.BindValueChanged(_ => applyChartColours(), true);
             DataLineColour.BindValueChanged(_ => applyChartColours(), true);
             DataAreaColour.BindValueChanged(_ => applyChartColours(), true);
+            PlayerDataLineColour.BindValueChanged(_ => applyChartColours(), true);
+            PlayerDataAreaColour.BindValueChanged(_ => applyChartColours(), true);
             BackgroundColour.BindValueChanged(e =>
             {
                 background.Colour = e.NewValue;
             }, true);
             LabelColour.BindValueChanged(_ => applyChartColours(), true);
-            RadarDisplayMode.BindValueChanged(_ =>
+            RadarDisplayMode.BindValueChanged(_ => refreshRadarPresentation(), true);
+            UseAbsoluteValue.BindValueChanged(_ => refreshRadarPresentation(), true);
+            TargetUsername.BindValueChanged(_ =>
             {
-                if (RadarDisplayMode.Value == EzRadarDisplayMode.Metadate)
-                    updateParameterRatios(difficultyBindable?.Value ?? default);
-                else
-                    updateRulesetSpecificRadarPresentation();
-            }, true);
-            UseAbsoluteValue.BindValueChanged(_ => updateRulesetSpecificRadarPresentation(), true);
+                if (RadarDisplayMode.Value == EzRadarDisplayMode.Skill)
+                    updateSkillRadarPresentation();
+            });
 
             chart?.SetData(parameterRatios);
             updateAxisTexts();
@@ -287,6 +309,22 @@ namespace osu.Game.EzOsuGame.HUD
             }, true);
         }
 
+        private void refreshRadarPresentation()
+        {
+            if (RadarDisplayMode.Value == EzRadarDisplayMode.Metadate)
+            {
+                chart?.ClearSecondaryData();
+                updateParameterRatios(difficultyBindable?.Value ?? default);
+            }
+            else if (RadarDisplayMode.Value == EzRadarDisplayMode.Skill)
+                updateSkillRadarPresentation();
+            else
+            {
+                chart?.ClearSecondaryData();
+                updateRulesetSpecificRadarPresentation();
+            }
+        }
+
         private static void bindPreserveAlpha(BindableColour4 colourBindable)
         {
             colourBindable.BindValueChanged(e =>
@@ -308,22 +346,124 @@ namespace osu.Game.EzOsuGame.HUD
 
         private void updateParameterRatios(StarDifficulty difficulty)
         {
+            if (RadarDisplayMode.Value == EzRadarDisplayMode.Skill)
+            {
+                updateSkillRadarPresentation();
+                return;
+            }
+
             if (RadarDisplayMode.Value != EzRadarDisplayMode.Metadate && beginRulesetSpecificRadarUpdate())
                 return;
 
             cancelRadarAnalysis();
+            chart?.ClearSecondaryData();
             applyRadarData(createGeneralRadarData(difficulty), getGeneralAxisMaxValues());
         }
 
         private void updateRulesetSpecificRadarPresentation()
         {
-            if (RadarDisplayMode.Value == EzRadarDisplayMode.Metadate)
+            if (RadarDisplayMode.Value is EzRadarDisplayMode.Metadate or EzRadarDisplayMode.Skill)
                 return;
 
             if (cachedRulesetSpecificRadarResult is EzRulesetSpecificRadarResult cachedResult)
                 applyRulesetSpecificRadarResult(cachedResult);
             else
                 updateParameterRatios(difficultyBindable?.Value ?? default);
+        }
+
+        private void updateSkillRadarPresentation()
+        {
+            cancelRadarAnalysis();
+
+            string[] axes = skill_radar_axes;
+            AxisCount = axes.Length;
+            activeAxisLabels = axes.Select(skillAxisDisplayName).ToArray();
+            activeAxisFormats = Enumerable.Repeat("0.00", axes.Length).ToArray();
+
+            var beatmapInfo = beatmap.Value.BeatmapInfo;
+
+            if (beatmapInfo == null || beatmapInfo.Ruleset.OnlineID != 3)
+            {
+                clearChartData();
+                chart?.ClearSecondaryData();
+                return;
+            }
+
+            IReadOnlyDictionary<string, double> msd = skillProvider?.GetBeatmapMsd(beatmapInfo.Hash)
+                                                      ?? new Dictionary<string, double>();
+
+            if (msd.Count == 0 && beatmapMsdComputer != null)
+                msd = beatmapMsdComputer.TryGetOrCompute(beatmapInfo) ?? new Dictionary<string, double>();
+
+            int keyCount = 0;
+
+            try
+            {
+                var working = beatmap.Value;
+                var playable = working.GetPlayableBeatmap(beatmapInfo.Ruleset, mods.Value);
+                keyCount = EzMinaNoteConverter.ResolveKeyCount(playable);
+            }
+            catch
+            {
+                // fall through with keyCount 0
+            }
+
+            IReadOnlyDictionary<string, double> ssr = new Dictionary<string, double>();
+
+            string? username = TargetUsername.Value;
+            if (!string.IsNullOrWhiteSpace(username) && keyCount > 0 && skillProvider != null)
+                ssr = skillProvider.GetPlayerSsrSnapshot(username, keyCount).Values;
+
+            double max = 0;
+
+            for (int i = 0; i < axes.Length; i++)
+            {
+                string axis = axes[i];
+                double beatmapValue = msd.GetValueOrDefault(EzSkillIds.Msd(axis), 0);
+                double playerValue = ssr.GetValueOrDefault(EzSkillIds.Ssr(axis), 0);
+                parameterValues[i] = (float)beatmapValue;
+                max = Math.Max(max, Math.Max(beatmapValue, playerValue));
+            }
+
+            if (max <= 0)
+                max = 1;
+
+            float[] playerRatios = new float[axes.Length];
+
+            for (int i = 0; i < axes.Length; i++)
+            {
+                string axis = axes[i];
+                parameterRatios[i] = (float)(parameterValues[i] / max);
+                playerRatios[i] = (float)(ssr.GetValueOrDefault(EzSkillIds.Ssr(axis), 0) / max);
+            }
+
+            chart?.SetData(parameterRatios);
+            chart?.SetSecondaryData(playerRatios);
+            updateAxisTexts();
+            applyChartColours();
+        }
+
+        private static readonly string[] skill_radar_axes = EzSkillIds.MINA_SKILLSETS
+                                                                      .Where(a => a != EzSkillIds.OVERALL)
+                                                                      .ToArray();
+
+        private static string skillAxisDisplayName(string axis) => axis switch
+        {
+            EzSkillIds.STREAM => "Stream",
+            EzSkillIds.JUMPSTREAM => "JS",
+            EzSkillIds.HANDSTREAM => "HS",
+            EzSkillIds.STAMINA => "Stam",
+            EzSkillIds.JACK_SPEED => "Jack",
+            EzSkillIds.CHORDJACK => "CJ",
+            EzSkillIds.TECHNICAL => "Tech",
+            _ => axis,
+        };
+
+        private void cancelRadarAnalysis()
+        {
+            radarAnalysisCancellationSource?.Cancel();
+            radarAnalysisCancellationSource?.Dispose();
+            radarAnalysisCancellationSource = null;
         }
 
         private bool beginRulesetSpecificRadarUpdate()
@@ -429,11 +569,13 @@ namespace osu.Game.EzOsuGame.HUD
             }
 
             chart?.SetData(parameterRatios);
+            chart?.ClearSecondaryData();
             updateAxisTexts();
         }
 
         private void applyRulesetSpecificRadarResult(EzRulesetSpecificRadarResult radarResult)
         {
+            chart?.ClearSecondaryData();
             EzRadarChartData<string> displayedRadarData = createDisplayedRulesetRadarData(radarResult);
             applyRadarData(displayedRadarData, getRulesetSpecificAxisMaxValues());
         }
@@ -485,14 +627,8 @@ namespace osu.Game.EzOsuGame.HUD
             Array.Clear(parameterValues, 0, parameterValues.Length);
             Array.Clear(parameterRatios, 0, parameterRatios.Length);
             chart?.SetData(parameterRatios);
+            chart?.ClearSecondaryData();
             updateAxisTexts();
-        }
-
-        private void cancelRadarAnalysis()
-        {
-            radarAnalysisCancellationSource?.Cancel();
-            radarAnalysisCancellationSource?.Dispose();
-            radarAnalysisCancellationSource = null;
         }
 
         private static float normalise(float value, float maxValue)
@@ -514,6 +650,9 @@ namespace osu.Game.EzOsuGame.HUD
             chart.DataStrokeColour = DataLineColour.Value;
             chart.DataPointColour = DataLineColour.Value;
             chart.DataFillColour = DataAreaColour.Value;
+            chart.SecondaryDataStrokeColour = PlayerDataLineColour.Value;
+            chart.SecondaryDataPointColour = PlayerDataLineColour.Value;
+            chart.SecondaryDataFillColour = PlayerDataAreaColour.Value;
             chart.Invalidate(Invalidation.DrawNode);
 
             foreach (var container in axisLabelContainers)
@@ -636,6 +775,7 @@ namespace osu.Game.EzOsuGame.HUD
     {
         private int axisCount = 6;
         private float[] dataRatios = new float[6];
+        private float[]? secondaryDataRatios;
         private Texture? whitePixel;
 
         public int AxisCount
@@ -650,6 +790,8 @@ namespace osu.Game.EzOsuGame.HUD
 
                 axisCount = clamped;
                 Array.Resize(ref dataRatios, axisCount);
+                if (secondaryDataRatios != null)
+                    Array.Resize(ref secondaryDataRatios, axisCount);
                 Invalidate(Invalidation.DrawNode);
             }
         }
@@ -677,6 +819,12 @@ namespace osu.Game.EzOsuGame.HUD
         public Color4 DataStrokeColour { get; set; } = new Color4(255, 230, 128, 230);
 
         public Color4 DataPointColour { get; set; } = new Color4(255, 242, 176, 255);
+
+        public Color4 SecondaryDataFillColour { get; set; } = new Color4(80, 220, 120, 95);
+
+        public Color4 SecondaryDataStrokeColour { get; set; } = new Color4(80, 220, 120, 230);
+
+        public Color4 SecondaryDataPointColour { get; set; } = new Color4(120, 240, 160, 255);
 
         public RadarChart()
         {
@@ -715,6 +863,24 @@ namespace osu.Game.EzOsuGame.HUD
             Invalidate(Invalidation.DrawNode);
         }
 
+        public void SetSecondaryData(IReadOnlyList<float> ratios)
+        {
+            secondaryDataRatios ??= new float[axisCount];
+            if (secondaryDataRatios.Length != axisCount)
+                Array.Resize(ref secondaryDataRatios, axisCount);
+
+            for (int i = 0; i < axisCount; i++)
+                secondaryDataRatios[i] = i < ratios.Count ? Math.Clamp(ratios[i], 0, 1) : 0;
+
+            Invalidate(Invalidation.DrawNode);
+        }
+
+        public void ClearSecondaryData()
+        {
+            secondaryDataRatios = null;
+            Invalidate(Invalidation.DrawNode);
+        }
+
         protected override DrawNode CreateDrawNode() => new RadarChartDrawNode(this);
 
         private class RadarChartDrawNode : DrawNode
@@ -722,6 +888,7 @@ namespace osu.Game.EzOsuGame.HUD
             private readonly RadarChart source;
 
             private float[] ratios = Array.Empty<float>();
+            private float[]? secondaryRatios;
             private int axisCount;
 
             private int gridLevels;
@@ -737,6 +904,9 @@ namespace osu.Game.EzOsuGame.HUD
             private Color4 dataFillColour;
             private Color4 dataStrokeColour;
             private Color4 dataPointColour;
+            private Color4 secondaryDataFillColour;
+            private Color4 secondaryDataStrokeColour;
+            private Color4 secondaryDataPointColour;
 
             private Vector2 drawSize;
             private Texture? texture;
@@ -772,9 +942,26 @@ namespace osu.Game.EzOsuGame.HUD
                 dataFillColour = source.DataFillColour;
                 dataStrokeColour = source.DataStrokeColour;
                 dataPointColour = source.DataPointColour;
+                secondaryDataFillColour = source.SecondaryDataFillColour;
+                secondaryDataStrokeColour = source.SecondaryDataStrokeColour;
+                secondaryDataPointColour = source.SecondaryDataPointColour;
 
                 for (int i = 0; i < axisCount; i++)
                     ratios[i] = source.dataRatios[i];
+
+                if (source.secondaryDataRatios == null)
+                {
+                    secondaryRatios = null;
+                }
+                else
+                {
+                    secondaryRatios ??= new float[axisCount];
+                    if (secondaryRatios.Length != axisCount)
+                        Array.Resize(ref secondaryRatios, axisCount);
+
+                    for (int i = 0; i < axisCount; i++)
+                        secondaryRatios[i] = source.secondaryDataRatios[i];
+                }
             }
 
             protected override void Draw(IRenderer renderer)
@@ -809,6 +996,14 @@ namespace osu.Game.EzOsuGame.HUD
                 drawFanFill(renderer, center, dataVertices, dataFillColour);
                 drawPolygonOutline(renderer, dataVertices, dataStrokeColour, dataOutlineThickness);
                 drawPoints(renderer, dataVertices, dataPointColour, dataPointSize);
+
+                if (secondaryRatios != null)
+                {
+                    var secondaryVertices = createVertices(center, radius, secondaryRatios);
+                    drawFanFill(renderer, center, secondaryVertices, secondaryDataFillColour);
+                    drawPolygonOutline(renderer, secondaryVertices, secondaryDataStrokeColour, dataOutlineThickness);
+                    drawPoints(renderer, secondaryVertices, secondaryDataPointColour, dataPointSize);
+                }
 
                 renderer.PopLocalMatrix();
             }

--- a/osu.Game/EzOsuGame/HUD/EzHUDRadarPanel.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDRadarPanel.cs
@@ -991,21 +991,55 @@ namespace osu.Game.EzOsuGame.HUD
                 for (int i = 0; i < axisCount; i++)
                     drawLine(renderer, center, outerVertices[i], axisColour, axisThickness);
 
-                var dataVertices = createVertices(center, radius, ratios);
+                var primaryVertices = createVertices(center, radius, ratios);
 
-                drawFanFill(renderer, center, dataVertices, dataFillColour);
-                drawPolygonOutline(renderer, dataVertices, dataStrokeColour, dataOutlineThickness);
-                drawPoints(renderer, dataVertices, dataPointColour, dataPointSize);
-
-                if (secondaryRatios != null)
+                if (secondaryRatios == null)
+                {
+                    drawFanFill(renderer, center, primaryVertices, dataFillColour);
+                    drawPolygonOutline(renderer, primaryVertices, dataStrokeColour, dataOutlineThickness);
+                    drawPoints(renderer, primaryVertices, dataPointColour, dataPointSize);
+                }
+                else
                 {
                     var secondaryVertices = createVertices(center, radius, secondaryRatios);
-                    drawFanFill(renderer, center, secondaryVertices, secondaryDataFillColour);
-                    drawPolygonOutline(renderer, secondaryVertices, secondaryDataStrokeColour, dataOutlineThickness);
+
+                    // Smaller coverage draws above so both polygons stay readable when nested.
+                    bool primaryIsSmaller = averageRatio(ratios) <= averageRatio(secondaryRatios);
+
+                    if (primaryIsSmaller)
+                    {
+                        drawFanFill(renderer, center, secondaryVertices, secondaryDataFillColour);
+                        drawPolygonOutline(renderer, secondaryVertices, secondaryDataStrokeColour, dataOutlineThickness);
+                        drawFanFill(renderer, center, primaryVertices, dataFillColour);
+                        drawPolygonOutline(renderer, primaryVertices, dataStrokeColour, dataOutlineThickness);
+                    }
+                    else
+                    {
+                        drawFanFill(renderer, center, primaryVertices, dataFillColour);
+                        drawPolygonOutline(renderer, primaryVertices, dataStrokeColour, dataOutlineThickness);
+                        drawFanFill(renderer, center, secondaryVertices, secondaryDataFillColour);
+                        drawPolygonOutline(renderer, secondaryVertices, secondaryDataStrokeColour, dataOutlineThickness);
+                    }
+
+                    // Endpoint nodes always on top of both fills/strokes.
+                    drawPoints(renderer, primaryVertices, dataPointColour, dataPointSize);
                     drawPoints(renderer, secondaryVertices, secondaryDataPointColour, dataPointSize);
                 }
 
                 renderer.PopLocalMatrix();
+            }
+
+            private static float averageRatio(IReadOnlyList<float> values)
+            {
+                if (values.Count == 0)
+                    return 0;
+
+                float sum = 0;
+
+                for (int i = 0; i < values.Count; i++)
+                    sum += Math.Clamp(values[i], 0, 1);
+
+                return sum / values.Count;
             }
 
             private Vector2[] createVertices(Vector2 center, float radius, float ratio)

--- a/osu.Game/EzOsuGame/Localization/EzHUDStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzHUDStrings.cs
@@ -22,6 +22,12 @@ namespace osu.Game.EzOsuGame.Localization
         public static readonly LocalisableString RADAR_DATA_AREA_COLOUR = new EzLocalizationManager.EzLocalisableString("雷达数据区色", "Radar Data Area Colour");
         public static readonly LocalisableString RADAR_DATA_AREA_COLOUR_TOOLTIP = new EzLocalizationManager.EzLocalisableString("数据填充区域的颜色", "Colour of data filled area.");
 
+        public static readonly LocalisableString RADAR_PLAYER_DATA_LINE_COLOUR = new EzLocalizationManager.EzLocalisableString("雷达玩家数据线色", "Radar Player Data Line Colour");
+        public static readonly LocalisableString RADAR_PLAYER_DATA_LINE_COLOUR_TOOLTIP = new EzLocalizationManager.EzLocalisableString("Skill 模式下玩家 SSR 层轮廓线与顶点颜色", "Stroke/point colour for the player SSR layer in Skill mode.");
+
+        public static readonly LocalisableString RADAR_PLAYER_DATA_AREA_COLOUR = new EzLocalizationManager.EzLocalisableString("雷达玩家数据区色", "Radar Player Data Area Colour");
+        public static readonly LocalisableString RADAR_PLAYER_DATA_AREA_COLOUR_TOOLTIP = new EzLocalizationManager.EzLocalisableString("Skill 模式下玩家 SSR 层填充颜色", "Fill colour for the player SSR layer in Skill mode.");
+
         public static readonly LocalisableString BACKGROUND_COLOUR = new EzLocalizationManager.EzLocalisableString("雷达背景色", "Radar Background Colour");
         public static readonly LocalisableString RADAR_BOX_COLOUR_TOOLTIP = new EzLocalizationManager.EzLocalisableString("雷达图圆角背景的颜色，设置为透明可隐藏背景", "Colour of radar chart rounded background. Set to transparent to hide background.");
 
@@ -34,12 +40,13 @@ namespace osu.Game.EzOsuGame.Localization
             "切换不同数据源的显示模式："
             + "\n- 全局：显示常规Metadate数据。"
             + "\n- Key Pattern: 显示类PS Mod风格的并行键型数据。衡量谱面中不同键型的相对难度关系。"
-            + "\n- xxySR Pattern: 显示xxySR星级分析的键型数据。衡量谱面中不同键型变化的难度系数，提现谱中键型变化差异程度，这里的bracket除了切指外还视为常规类型。",
+            + "\n- xxySR Pattern: 显示xxySR星级分析的键型数据。衡量谱面中不同键型变化的难度系数，提现谱中键型变化差异程度，这里的bracket除了切指外还视为常规类型。"
+            + "\n- Skill: 同一雷达叠加谱面 MSD（黄）与玩家 SSR（绿）。",
             "Switch between different data sources to display:"
             + "\n- Global: Display the standard Metadata data."
             + "\n- Key Pattern: Display the parallel key type data of the PS Mod style."
             + "\n- xxySR Pattern: Display the key type data of the xxySR star rating analysis."
-            + "\n- xxySR Pattern: Display the key type data of the xxySR star rating analysis.");
+            + "\n- Skill: Overlay beatmap MSD (yellow) and player SSR (green) on one chart.");
 
         public static readonly LocalisableString RADAR_USE_ABSOLUTE_VALUE = new EzLocalizationManager.EzLocalisableString("使用星数绝对值", "Use Star Absolute Value");
 

--- a/osu.Game/EzOsuGame/Localization/EzSongSelectStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSongSelectStrings.cs
@@ -66,6 +66,22 @@ namespace osu.Game.EzOsuGame.Localization
             "Ez分析",
             "EzAnalysis");
 
+        public static readonly LocalisableString EZ_ANALYSIS_PLAYER = new EzLocalizationManager.EzLocalisableString(
+            "玩家",
+            "Player");
+
+        public static readonly LocalisableString EZ_ANALYSIS_RADAR_LEFT = new EzLocalizationManager.EzLocalisableString(
+            "雷达 L",
+            "Radar L");
+
+        public static readonly LocalisableString EZ_ANALYSIS_RADAR_RIGHT = new EzLocalizationManager.EzLocalisableString(
+            "雷达 R",
+            "Radar R");
+
+        public static readonly LocalisableString RADAR_MODE_SKILL = new EzLocalizationManager.EzLocalisableString(
+            "Skill",
+            "Skill");
+
         public static readonly LocalisableString RESTORE_MOD_SELECTION = new EzLocalizationManager.EzLocalisableString(
             "恢复上一次选择",
             "Restore previous selection");

--- a/osu.Game/EzOsuGame/Overlays/BeatmapEzAnalysisWedge.cs
+++ b/osu.Game/EzOsuGame/Overlays/BeatmapEzAnalysisWedge.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.EzOsuGame.HUD;
@@ -14,8 +15,14 @@ namespace osu.Game.EzOsuGame.Overlays
 {
     public partial class BeatmapEzAnalysisWedge : VisibilityContainer
     {
-        private EzHUDRadarPanel xxySrRadar = null!;
-        private EzHUDRadarPanel keyPatternRadar = null!;
+        private EzHUDRadarPanel leftRadar = null!;
+        private EzHUDRadarPanel rightRadar = null!;
+
+        public Bindable<string?> TargetUsername { get; } = new Bindable<string?>();
+
+        public Bindable<EzRadarDisplayMode> LeftRadarMode { get; } = new Bindable<EzRadarDisplayMode>(EzRadarDisplayMode.XxySrPattern);
+
+        public Bindable<EzRadarDisplayMode> RightRadarMode { get; } = new Bindable<EzRadarDisplayMode>(EzRadarDisplayMode.Skill);
 
         [BackgroundDependencyLoader]
         private void load()
@@ -49,27 +56,33 @@ namespace osu.Game.EzOsuGame.Overlays
                             Spacing = new Vector2(-10f, 0f),
                             Children = new Drawable[]
                             {
-                                // 左侧雷达图 - XxySR Pattern
-                                xxySrRadar = new EzHUDRadarPanel
+                                leftRadar = new EzHUDRadarPanel
                                 {
                                     Anchor = Anchor.TopLeft,
                                     Origin = Anchor.TopLeft,
                                     Shear = -OsuGame.SHEAR,
-                                    RadarDisplayMode = { Value = EzRadarDisplayMode.XxySrPattern },
                                 },
-                                // 右侧雷达图 - Key Pattern
-                                keyPatternRadar = new EzHUDRadarPanel
+                                rightRadar = new EzHUDRadarPanel
                                 {
                                     Anchor = Anchor.TopLeft,
                                     Origin = Anchor.TopLeft,
                                     Shear = -OsuGame.SHEAR,
-                                    RadarDisplayMode = { Value = EzRadarDisplayMode.KeyPattern },
                                 },
                             },
                         },
                     },
                 },
             });
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            leftRadar.RadarDisplayMode.BindTo(LeftRadarMode);
+            rightRadar.RadarDisplayMode.BindTo(RightRadarMode);
+            leftRadar.TargetUsername.BindTo(TargetUsername);
+            rightRadar.TargetUsername.BindTo(TargetUsername);
         }
 
         protected override void PopIn()
@@ -80,7 +93,7 @@ namespace osu.Game.EzOsuGame.Overlays
 
         protected override void PopOut()
         {
-            this.MoveToX(-150, SongSelect.ENTER_DURATION, Easing.OutQuint)
+            this.MoveToX(-100, SongSelect.ENTER_DURATION, Easing.OutQuint)
                 .FadeOut(SongSelect.ENTER_DURATION / 3, Easing.In);
         }
     }

--- a/osu.Game/Screens/Select/BeatmapDetailsArea.Header.cs
+++ b/osu.Game/Screens/Select/BeatmapDetailsArea.Header.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
@@ -11,13 +12,16 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
 using osu.Game.EzOsuGame.Configuration;
+using osu.Game.EzOsuGame.HUD;
 using osu.Game.EzOsuGame.Localization;
+using osu.Game.EzOsuGame.LocalProfile;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Localisation;
 using osu.Game.Online.Leaderboards;
 using osu.Game.Screens.Play.Leaderboards;
 using osuTK;
+using DescriptionAttribute = System.ComponentModel.DescriptionAttribute;
 
 namespace osu.Game.Screens.Select
 {
@@ -27,10 +31,15 @@ namespace osu.Game.Screens.Select
         {
             private WedgeSelector<Selection> tabControl = null!;
             private FillFlowContainer leaderboardControls = null!;
+            private FillFlowContainer ezAnalysisControls = null!;
 
             private ShearedDropdown<BeatmapLeaderboardScope> scopeDropdown = null!;
             private ShearedDropdown<LeaderboardSortMode> sortDropdown = null!;
             private ShearedToggleButton selectedModsToggle = null!;
+
+            private ShearedDropdown<string> ezPlayerDropdown = null!;
+            private ShearedDropdown<EzRadarDisplayMode> leftRadarDropdown = null!;
+            private ShearedDropdown<EzRadarDisplayMode> rightRadarDropdown = null!;
 
             private Bindable<bool> flowMode = null!;
 
@@ -45,6 +54,15 @@ namespace osu.Game.Screens.Select
             private readonly Bindable<LeaderboardSortMode> configLeaderboardSortMode = new Bindable<LeaderboardSortMode>();
 
             public IBindable<bool> FilterBySelectedMods => selectedModsToggle.Active;
+
+            public Bindable<string?> EzAnalysisPlayer { get; } = new Bindable<string?>();
+
+            public Bindable<EzRadarDisplayMode> LeftRadarMode { get; } = new Bindable<EzRadarDisplayMode>(EzRadarDisplayMode.XxySrPattern);
+
+            public Bindable<EzRadarDisplayMode> RightRadarMode { get; } = new Bindable<EzRadarDisplayMode>(EzRadarDisplayMode.Skill);
+
+            [Resolved]
+            private EzLocalProfileService? localProfileService { get; set; }
 
             [BackgroundDependencyLoader]
             private void load(OsuConfigManager config, Ez2ConfigManager ezConfig)
@@ -84,7 +102,6 @@ namespace osu.Game.Screens.Select
                                         AutoSizeAxes = Axes.X,
                                         Text = UserInterfaceStrings.SelectedMods,
                                         Height = 30f,
-                                        // Eyeballed to make spacing match. Because shear is silly and implemented in different ways between dropdown and button.
                                         Margin = new MarginPadding { Left = -9.2f },
                                     },
                                     sortDropdown = new ShearedDropdown<LeaderboardSortMode>(BeatmapLeaderboardWedgeStrings.Sort)
@@ -102,6 +119,41 @@ namespace osu.Game.Screens.Select
                                         RelativeSizeAxes = Axes.X,
                                         Width = 0.4f,
                                         Current = { Value = BeatmapLeaderboardScope.Global },
+                                    },
+                                },
+                            },
+                            ezAnalysisControls = new FillFlowContainer
+                            {
+                                Anchor = Anchor.CentreRight,
+                                Origin = Anchor.CentreRight,
+                                RelativeSizeAxes = Axes.X,
+                                Height = 30,
+                                Spacing = new Vector2(5f, 0f),
+                                Direction = FillDirection.Horizontal,
+                                Padding = new MarginPadding { Left = 258 },
+                                Alpha = 0,
+                                Children = new Drawable[]
+                                {
+                                    rightRadarDropdown = new RadarModeDropdown(EzSongSelectStrings.EZ_ANALYSIS_RADAR_RIGHT)
+                                    {
+                                        Anchor = Anchor.TopRight,
+                                        Origin = Anchor.TopRight,
+                                        RelativeSizeAxes = Axes.X,
+                                        Width = 0.32f,
+                                    },
+                                    leftRadarDropdown = new RadarModeDropdown(EzSongSelectStrings.EZ_ANALYSIS_RADAR_LEFT)
+                                    {
+                                        Anchor = Anchor.TopRight,
+                                        Origin = Anchor.TopRight,
+                                        RelativeSizeAxes = Axes.X,
+                                        Width = 0.32f,
+                                    },
+                                    ezPlayerDropdown = new ShearedDropdown<string>(EzSongSelectStrings.EZ_ANALYSIS_PLAYER)
+                                    {
+                                        Anchor = Anchor.TopRight,
+                                        Origin = Anchor.TopRight,
+                                        RelativeSizeAxes = Axes.X,
+                                        Width = 0.32f,
                                     },
                                 },
                             },
@@ -127,9 +179,25 @@ namespace osu.Game.Screens.Select
 
                 tabControl.IsItemActivatable = type => !flowMode.Value || !EqualityComparer<Selection>.Default.Equals(type, Selection.Ranking);
 
+                leftRadarDropdown.Current.BindTo(LeftRadarMode);
+                rightRadarDropdown.Current.BindTo(RightRadarMode);
+
+                refreshPlayerDropdownItems();
+                ezPlayerDropdown.Current.BindValueChanged(e => EzAnalysisPlayer.Value = string.IsNullOrWhiteSpace(e.NewValue) ? null : e.NewValue);
+                EzAnalysisPlayer.BindValueChanged(e =>
+                {
+                    if (e.NewValue != null && ezPlayerDropdown.Items.Contains(e.NewValue))
+                        ezPlayerDropdown.Current.Value = e.NewValue;
+                });
+
                 tabControl.Current.BindValueChanged(v =>
                 {
                     leaderboardControls.FadeTo(v.NewValue == Selection.Ranking ? 1 : 0, 300, Easing.OutQuint);
+                    ezAnalysisControls.FadeTo(v.NewValue == Selection.EzAnalysis ? 1 : 0, 300, Easing.OutQuint);
+
+                    if (v.NewValue == Selection.EzAnalysis)
+                        refreshPlayerDropdownItems();
+
                     updateConfigDetailTab();
                 }, true);
 
@@ -145,12 +213,33 @@ namespace osu.Game.Screens.Select
                     }
                     else
                     {
-                        // future implementation when we have web-side support.
                         sortDropdown.Current.UnbindFrom(configLeaderboardSortMode);
                         sortDropdown.Current.Value = LeaderboardSortMode.Score;
                         sortDropdown.Current.Disabled = true;
                     }
                 }, true);
+            }
+
+            private void refreshPlayerDropdownItems()
+            {
+                var names = localProfileService?.GetPreviouslyIncludedUsernames().ToList() ?? new List<string>();
+                ezPlayerDropdown.Items = names;
+
+                if (names.Count == 0)
+                {
+                    EzAnalysisPlayer.Value = null;
+                    return;
+                }
+
+                if (EzAnalysisPlayer.Value == null || !names.Contains(EzAnalysisPlayer.Value))
+                {
+                    EzAnalysisPlayer.Value = names[0];
+                    ezPlayerDropdown.Current.Value = names[0];
+                }
+                else
+                {
+                    ezPlayerDropdown.Current.Value = EzAnalysisPlayer.Value;
+                }
             }
 
             private void applyFlowModeState(bool enabled)
@@ -182,7 +271,6 @@ namespace osu.Game.Screens.Select
                         return;
 
                     case Selection.EzAnalysis:
-                        // 此处不需要处理
                         return;
 
                     default:
@@ -261,6 +349,27 @@ namespace osu.Game.Screens.Select
                 }
 
                 protected override LocalisableString GenerateItemText(BeatmapLeaderboardScope item) => item.GetLocalisableDescription();
+            }
+
+            private partial class RadarModeDropdown : ShearedDropdown<EzRadarDisplayMode>
+            {
+                public RadarModeDropdown(LocalisableString label)
+                    : base(label)
+                {
+                    Items = Enum.GetValues<EzRadarDisplayMode>();
+                }
+
+                protected override LocalisableString GenerateItemText(EzRadarDisplayMode item)
+                {
+                    if (item == EzRadarDisplayMode.Skill)
+                        return EzSongSelectStrings.RADAR_MODE_SKILL;
+
+                    var attr = typeof(EzRadarDisplayMode).GetField(item.ToString())
+                                                         ?.GetCustomAttributes(typeof(DescriptionAttribute), false)
+                                                         .OfType<DescriptionAttribute>()
+                                                         .FirstOrDefault();
+                    return attr?.Description ?? item.ToString();
+                }
             }
         }
     }

--- a/osu.Game/Screens/Select/BeatmapDetailsArea.cs
+++ b/osu.Game/Screens/Select/BeatmapDetailsArea.cs
@@ -102,7 +102,12 @@ namespace osu.Game.Screens.Select
                     break;
 
                 case Header.Selection.EzAnalysis:
-                    currentContent = new BeatmapEzAnalysisWedge();
+                    currentContent = new BeatmapEzAnalysisWedge
+                    {
+                        TargetUsername = { BindTarget = header.EzAnalysisPlayer },
+                        LeftRadarMode = { BindTarget = header.LeftRadarMode },
+                        RightRadarMode = { BindTarget = header.RightRadarMode },
+                    };
                     break;
             }
 


### PR DESCRIPTION
## Summary
- Master: Skills Track Dan Master · UX-1（选歌 me vs chart 改为 EzAnalysis Skill 双层雷达；TitleWedge 段位 chip 后置）
- `EzRadarDisplayMode.Skill`：同一 HUD 叠加谱面 MSD（现有黄系数据色）+ 玩家 SSR（默认可配绿色）
- Header 右侧三 `ShearedDropdown`（玩家 / 雷达 L / 雷达 R），样式位置对齐 Ranking
- 默认：左雷达仍 Xxy（仅接下拉）；右雷达 Skill；`TargetUsername` 可外绑

## Test plan
- [x] EzAnalysis 顶栏三下拉可见；切 Ranking 时隐藏
- [x] 右雷达默认 Skill：黄+绿双层；换玩家只动绿层
- [x] 左雷达默认 Xxy；改 L 下拉可切 Metadate/Key/Skill
- [x] 无档案用户名时不崩；缺 MSD/SSR 显示空/0 轴
- [x] `dotnet build` osu.Game