### PR TITLE
Speed up Track local profile Insights + Guest username

### DIFF
--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileAggregator.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileAggregator.cs
@@ -523,12 +523,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
         }
 
         private static string normaliseUsername(string? username)
-        {
-            if (string.IsNullOrWhiteSpace(username))
-                return EzLocalProfileConstants.UNKNOWN_USERNAME;
-
-            return username.Trim();
-        }
+            => EzLocalProfileConstants.NormaliseUsername(username);
 
         private static long countKeys(ScoreInfo score)
         {

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileDrillMods.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileDrillMods.cs
@@ -13,12 +13,11 @@ namespace osu.Game.EzOsuGame.LocalProfile
     public static class EzLocalProfileDrillMods
     {
         public static Mod[] Resolve(EzLocalProfileDrillScoreRow row, RulesetStore rulesets)
-        {
-            if (string.IsNullOrEmpty(row.ModsJson))
-                return Array.Empty<Mod>();
+            => Resolve(row, rulesets.GetRuleset(row.RulesetId)?.CreateInstance());
 
-            var ruleset = rulesets.GetRuleset(row.RulesetId)?.CreateInstance();
-            if (ruleset == null)
+        public static Mod[] Resolve(EzLocalProfileDrillScoreRow row, Ruleset? ruleset)
+        {
+            if (string.IsNullOrEmpty(row.ModsJson) || ruleset == null)
                 return Array.Empty<Mod>();
 
             try

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileHeader.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileHeader.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -173,7 +174,9 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
             string names = snapshot.IncludedUsernames.Count == 0
                 ? "-"
-                : string.Join(", ", snapshot.IncludedUsernames);
+                : string.Join(", ", snapshot.IncludedUsernames
+                                            .Select(EzLocalProfileConstants.NormaliseUsername)
+                                            .Distinct(StringComparer.Ordinal));
 
             string baseText = $"{EzSettingsProfile.LOCAL_PROFILE_SHARED_HINT} · {snapshot.LastComputedAt.Value.LocalDateTime:g} · {names}";
 

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileInsightScoreBuilder.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileInsightScoreBuilder.cs
@@ -6,9 +6,11 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using osu.Game.Beatmaps;
+using osu.Game.Database;
 using osu.Game.Online.API;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
+using Realms;
 
 namespace osu.Game.EzOsuGame.LocalProfile
 {
@@ -20,23 +22,31 @@ namespace osu.Game.EzOsuGame.LocalProfile
         public static IReadOnlyList<EzLocalProfileInsightPlay> Build(
             IEnumerable<EzLocalProfileDrillScoreRow> drillScores,
             BeatmapManager beatmapManager,
-            RulesetStore rulesets)
+            RulesetStore rulesets,
+            RealmAccess? realm = null)
         {
-            var plays = new List<EzLocalProfileInsightPlay>();
+            var rows = drillScores
+                       .Where(r => r.RulesetId == EzLocalProfileConstants.MANIA_RULESET_ID && r.PpResolved > 0)
+                       .OrderByDescending(r => r.PpResolved)
+                       .ThenByDescending(r => r.Date)
+                       .ToList();
 
-            foreach (var row in drillScores
-                                .Where(r => r.RulesetId == EzLocalProfileConstants.MANIA_RULESET_ID && r.PpResolved > 0)
-                                .OrderByDescending(r => r.PpResolved)
-                                .ThenByDescending(r => r.Date))
+            var beatmapsByHash = loadBeatmapsByHash(rows, beatmapManager, realm);
+            var rulesetCache = new Dictionary<int, Ruleset?>();
+
+            var plays = new List<EzLocalProfileInsightPlay>(rows.Count);
+
+            foreach (var row in rows)
             {
-                var beatmap = !string.IsNullOrEmpty(row.BeatmapHash)
-                    ? beatmapManager.QueryBeatmap(b => b.Hash == row.BeatmapHash)
-                    : null;
+                BeatmapInfo? beatmap = null;
+                if (!string.IsNullOrEmpty(row.BeatmapHash))
+                    beatmapsByHash.TryGetValue(row.BeatmapHash, out beatmap);
 
-                var mods = EzLocalProfileDrillMods.Resolve(row, rulesets);
+                var ruleset = getRuleset(row.RulesetId, rulesets, rulesetCache);
+                var mods = EzLocalProfileDrillMods.Resolve(row, ruleset);
                 var acronyms = resolveModAcronyms(row, mods);
                 double rate = resolveRate(mods);
-                int keyCount = resolveKeyCount(row, beatmap, mods, rulesets);
+                int keyCount = resolveKeyCount(row, beatmap, mods, ruleset);
                 bool isConvert = beatmap != null && beatmap.Ruleset.OnlineID != EzLocalProfileConstants.MANIA_RULESET_ID;
                 double bpm = beatmap is { BPM: > 0 } ? beatmap.BPM : 0;
                 int onlineId = beatmap is { OnlineID: > 0 } ? beatmap.OnlineID : 0;
@@ -61,6 +71,61 @@ namespace osu.Game.EzOsuGame.LocalProfile
             }
 
             return plays;
+        }
+
+        private static Dictionary<string, BeatmapInfo> loadBeatmapsByHash(
+            IReadOnlyList<EzLocalProfileDrillScoreRow> rows,
+            BeatmapManager beatmapManager,
+            RealmAccess? realm)
+        {
+            var hashes = rows
+                         .Select(r => r.BeatmapHash)
+                         .Where(h => !string.IsNullOrEmpty(h))
+                         .Distinct(StringComparer.Ordinal)
+                         .ToList();
+
+            var result = new Dictionary<string, BeatmapInfo>(hashes.Count, StringComparer.Ordinal);
+
+            if (hashes.Count == 0)
+                return result;
+
+            if (realm != null)
+            {
+                realm.Run(r =>
+                {
+                    foreach (string hash in hashes)
+                    {
+                        var beatmap = r.All<BeatmapInfo>()
+                                       .Filter($"{nameof(BeatmapInfo.BeatmapSet)}.{nameof(BeatmapSetInfo.DeletePending)} == false && {nameof(BeatmapInfo.Hash)} == $0", hash)
+                                       .FirstOrDefault()
+                                       ?.Detach();
+
+                        if (beatmap != null)
+                            result[hash] = beatmap;
+                    }
+                });
+
+                return result;
+            }
+
+            foreach (string hash in hashes)
+            {
+                var beatmap = beatmapManager.QueryBeatmap(b => b.Hash == hash);
+                if (beatmap != null)
+                    result[hash] = beatmap;
+            }
+
+            return result;
+        }
+
+        private static Ruleset? getRuleset(int rulesetId, RulesetStore rulesets, Dictionary<int, Ruleset?> cache)
+        {
+            if (cache.TryGetValue(rulesetId, out var cached))
+                return cached;
+
+            var instance = rulesets.GetRuleset(rulesetId)?.CreateInstance();
+            cache[rulesetId] = instance;
+            return instance;
         }
 
         private static IReadOnlyList<string> resolveModAcronyms(EzLocalProfileDrillScoreRow row, Mod[] mods)
@@ -106,7 +171,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
             EzLocalProfileDrillScoreRow row,
             BeatmapInfo? beatmap,
             Mod[] mods,
-            RulesetStore rulesets)
+            Ruleset? ruleset)
         {
             var maniaSummary = row.ReadManiaSummary();
             if (maniaSummary.ColumnCounts.Count > 0)
@@ -116,8 +181,6 @@ namespace osu.Game.EzOsuGame.LocalProfile
             {
                 try
                 {
-                    var ruleset = rulesets.GetRuleset(row.RulesetId)?.CreateInstance();
-
                     if (ruleset != null)
                     {
                         int fromMods = ruleset.GetVariantForBeatmap(beatmap, mods);

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileModels.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileModels.cs
@@ -9,7 +9,14 @@ namespace osu.Game.EzOsuGame.LocalProfile
 {
     public static class EzLocalProfileConstants
     {
-        public const string UNKNOWN_USERNAME = "(unknown)";
+        /// <summary>Canonical bucket for scores with empty Realm username (matches API <c>GuestUser</c>).</summary>
+        public const string GUEST_USERNAME = "Guest";
+
+        /// <summary>Legacy empty-username bucket written before Guest normalisation.</summary>
+        public const string LEGACY_UNKNOWN_USERNAME = "(unknown)";
+
+        [Obsolete("Use GUEST_USERNAME")]
+        public const string UNKNOWN_USERNAME = GUEST_USERNAME;
 
         /// <summary>
         /// Sentinel value for the player filter dropdown: show merged archive totals.
@@ -18,6 +25,24 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
         public const int OSU_RULESET_ID = 0;
         public const int MANIA_RULESET_ID = 3;
+
+        public static string NormaliseUsername(string? username)
+        {
+            if (string.IsNullOrWhiteSpace(username))
+                return GUEST_USERNAME;
+
+            string trimmed = username.Trim();
+
+            if (string.Equals(trimmed, LEGACY_UNKNOWN_USERNAME, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(trimmed, "unknown", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(trimmed, GUEST_USERNAME, StringComparison.OrdinalIgnoreCase))
+                return GUEST_USERNAME;
+
+            return trimmed;
+        }
+
+        public static bool IsGuestUsername(string? username)
+            => string.Equals(NormaliseUsername(username), GUEST_USERNAME, StringComparison.Ordinal);
     }
 
     public readonly record struct EzLocalProfileUsernameCount(string Username, int ScoreCount);

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOverlay.Drill.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOverlay.Drill.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Bindables;
 using osu.Game.EzOsuGame.Localization;
 
@@ -11,9 +12,12 @@ namespace osu.Game.EzOsuGame.LocalProfile
         private readonly Bindable<EzLocalProfileDrillScoreRow?> currentDrillScore = new Bindable<EzLocalProfileDrillScoreRow?>();
         private readonly Bindable<string> drillSearchQuery = new Bindable<string>(string.Empty);
 
-        private void refreshDrillContent(EzLocalProfileSnapshot snapshot, int rulesetId)
+        private void refreshDrillContent(
+            EzLocalProfileSnapshot snapshot,
+            int rulesetId,
+            IReadOnlyList<EzLocalProfileDrillScoreRow>? preloadedScores = null)
         {
-            var allScores = profileService.LoadDrillScores(rulesetId, selectedPlayer.Value);
+            var allScores = preloadedScores ?? profileService.LoadDrillScores(rulesetId, selectedPlayer.Value);
 
             contentFlow.Add(new EzLocalProfileSection(
                 EzSettingsProfile.LOCAL_PROFILE_SECTION_SCORE_DRILL,

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOverlay.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOverlay.cs
@@ -279,7 +279,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
             var items = new List<string> { EzLocalProfileConstants.ALL_PLAYERS };
 
             foreach (string name in archiveSnapshot.IncludedUsernames
-                                                   .Where(n => !string.IsNullOrWhiteSpace(n))
+                                                   .Select(EzLocalProfileConstants.NormaliseUsername)
                                                    .Distinct(StringComparer.Ordinal)
                                                    .OrderBy(n => n, StringComparer.OrdinalIgnoreCase))
             {

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOverlay.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOverlay.cs
@@ -271,7 +271,6 @@ namespace osu.Game.EzOsuGame.LocalProfile
         {
             base.PopIn();
             profileService.ReloadFromDisk();
-            refreshContent();
         }
 
         private void refreshPlayerDropdownItems(EzLocalProfileSnapshot archiveSnapshot)
@@ -337,16 +336,22 @@ namespace osu.Game.EzOsuGame.LocalProfile
                             Text = EzSettingsProfile.LOCAL_PROFILE_TRACK_NEEDS_PLAYER,
                             Font = OsuFont.GetFont(size: 14),
                         }));
+
+                    refreshDrillContent(snapshot, rulesetId);
                 }
                 else
                 {
+                    var drillScores = profileService.LoadDrillScores(rulesetId, selectedPlayer.Value);
+
                     contentFlow.Add(new EzLocalProfileSection(
                         EzSettingsProfile.LOCAL_PROFILE_SECTION_TRACK_INSIGHTS,
-                        new EzLocalProfileTrackInsightsBody(selectedPlayer.Value, currentDrillScore)));
+                        new EzLocalProfileTrackInsightsBody(selectedPlayer.Value, currentDrillScore, drillScores)));
 
                     contentFlow.Add(new EzLocalProfileSection(
                         EzSettingsProfile.LOCAL_PROFILE_SECTION_TRACK_SKILLS,
                         new EzLocalProfileTrackSkillsBody(selectedPlayer.Value)));
+
+                    refreshDrillContent(snapshot, rulesetId, drillScores);
                 }
             }
             else
@@ -354,9 +359,9 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 contentFlow.Add(new EzLocalProfileSection(
                     EzSettingsProfile.LOCAL_PROFILE_SECTION_MODE_DATA,
                     new EzLocalProfileModeDataBody(snapshot, rulesetId)));
-            }
 
-            refreshDrillContent(snapshot, rulesetId);
+                refreshDrillContent(snapshot, rulesetId);
+            }
         }
     }
 }

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileService.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileService.cs
@@ -57,12 +57,29 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
         public IReadOnlyList<EzLocalProfileUsernameCount> ScanUsernameCounts() => aggregator.ScanUsernameCounts();
 
-        public IReadOnlyList<string> GetPreviouslyIncludedUsernames() => Store.LoadIncludedUsernames();
+        public IReadOnlyList<string> GetPreviouslyIncludedUsernames()
+            => Store.LoadIncludedUsernames()
+                    .Select(EzLocalProfileConstants.NormaliseUsername)
+                    .Distinct(StringComparer.Ordinal)
+                    .ToList();
 
         /// <summary>
         /// Display snapshot for the player filter: <see cref="EzLocalProfileConstants.ALL_PLAYERS"/> or one stored username.
+        /// Guest also falls back to legacy <c>(unknown)</c> partitions.
         /// </summary>
-        public EzLocalProfileSnapshot LoadDisplaySnapshot(string? usernameFilter) => Store.LoadSnapshotForUsername(usernameFilter);
+        public EzLocalProfileSnapshot LoadDisplaySnapshot(string? usernameFilter)
+        {
+            if (EzLocalProfileConstants.IsGuestUsername(usernameFilter))
+            {
+                var guest = Store.LoadSnapshotForUsername(EzLocalProfileConstants.GUEST_USERNAME);
+                if (guest.HasData)
+                    return guest;
+
+                return Store.LoadSnapshotForUsername(EzLocalProfileConstants.LEGACY_UNKNOWN_USERNAME);
+            }
+
+            return Store.LoadSnapshotForUsername(usernameFilter);
+        }
 
         public IReadOnlyList<EzLocalProfileDrillScoreRow> LoadDrillScores(int rulesetId, string? usernameFilter = null)
             => Store.LoadDrillScores(rulesetId, usernameFilter);

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileTrackInsightsBody.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileTrackInsightsBody.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -11,6 +12,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
+using osu.Game.Database;
 using osu.Game.EzOsuGame.Localization;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
@@ -28,6 +30,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
     {
         private readonly string username;
         private readonly Bindable<EzLocalProfileDrillScoreRow?>? selectDrillScore;
+        private readonly IReadOnlyList<EzLocalProfileDrillScoreRow>? preloadedDrillScores;
 
         private enum DetailKind
         {
@@ -54,10 +57,17 @@ namespace osu.Game.EzOsuGame.LocalProfile
         [Resolved]
         private RulesetStore rulesets { get; set; } = null!;
 
-        public EzLocalProfileTrackInsightsBody(string username, Bindable<EzLocalProfileDrillScoreRow?>? selectDrillScore = null)
+        [Resolved]
+        private RealmAccess realm { get; set; } = null!;
+
+        public EzLocalProfileTrackInsightsBody(
+            string username,
+            Bindable<EzLocalProfileDrillScoreRow?>? selectDrillScore = null,
+            IReadOnlyList<EzLocalProfileDrillScoreRow>? preloadedDrillScores = null)
         {
             this.username = username;
             this.selectDrillScore = selectDrillScore;
+            this.preloadedDrillScores = preloadedDrillScores;
 
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
@@ -111,8 +121,9 @@ namespace osu.Game.EzOsuGame.LocalProfile
             playCardsFlow.Clear();
             openDetail = DetailKind.None;
 
-            var rows = profileService.LoadDrillScores(EzLocalProfileConstants.MANIA_RULESET_ID, username);
-            var plays = EzLocalProfileInsightScoreBuilder.Build(rows, beatmapManager, rulesets);
+            var rows = preloadedDrillScores
+                       ?? profileService.LoadDrillScores(EzLocalProfileConstants.MANIA_RULESET_ID, username);
+            var plays = EzLocalProfileInsightScoreBuilder.Build(rows, beatmapManager, rulesets, realm);
             insights = EzLocalProfileInsightsCalculator.Calculate(plays);
 
             if (insights.SampleSize == 0)

--- a/osu.Game/EzOsuGame/Skills/EzSkillProvider.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSkillProvider.cs
@@ -38,16 +38,34 @@ namespace osu.Game.EzOsuGame.Skills
             => store.TryGetBeatmapSkill(beatmapHash, EzSkillIds.Msd(axisId), out value);
 
         public IReadOnlyDictionary<string, double> GetPlayerSsr(string username, int keyCount)
-            => store.GetPlayerSkills(username, keyCount, EzSkillSystems.PLAYER_SSR);
+            => GetPlayerSsrSnapshot(username, keyCount).Values;
 
         public EzPlayerSsrSnapshot GetPlayerSsrSnapshot(string username, int keyCount)
-            => store.GetPlayerSsrSnapshot(username, keyCount);
+        {
+            var snapshot = store.GetPlayerSsrSnapshot(username, keyCount);
+            if (snapshot.Values.Count > 0 || !EzLocalProfileConstants.IsGuestUsername(username))
+                return snapshot;
+
+            return store.GetPlayerSsrSnapshot(EzLocalProfileConstants.LEGACY_UNKNOWN_USERNAME, keyCount);
+        }
 
         public IReadOnlyList<int> GetPlayerSsrKeyCounts(string username)
-            => store.GetPlayerSsrKeyCounts(username);
+        {
+            var keys = store.GetPlayerSsrKeyCounts(username);
+            if (keys.Count > 0 || !EzLocalProfileConstants.IsGuestUsername(username))
+                return keys;
+
+            return store.GetPlayerSsrKeyCounts(EzLocalProfileConstants.LEGACY_UNKNOWN_USERNAME);
+        }
 
         public IReadOnlyList<EzPlayerSkillHistoryPoint> GetPlayerSkillHistory(string username, int keyCount, string skillId, int maxPoints = 64)
-            => store.GetPlayerSkillHistory(username, keyCount, skillId, maxPoints);
+        {
+            var history = store.GetPlayerSkillHistory(username, keyCount, skillId, maxPoints);
+            if (history.Count > 0 || !EzLocalProfileConstants.IsGuestUsername(username))
+                return history;
+
+            return store.GetPlayerSkillHistory(EzLocalProfileConstants.LEGACY_UNKNOWN_USERNAME, keyCount, skillId, maxPoints);
+        }
 
         public EzDanEstimate? GetDan(string username, int keyCount, string side)
             => store.GetDanEstimate(username, keyCount, side);

--- a/osu.Game/Screens/Select/BeatmapDetailsArea.Header.cs
+++ b/osu.Game/Screens/Select/BeatmapDetailsArea.Header.cs
@@ -15,6 +15,7 @@ using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.HUD;
 using osu.Game.EzOsuGame.Localization;
 using osu.Game.EzOsuGame.LocalProfile;
+using osu.Game.EzOsuGame.Skills;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Localisation;
@@ -63,6 +64,9 @@ namespace osu.Game.Screens.Select
 
             [Resolved]
             private EzLocalProfileService? localProfileService { get; set; }
+
+            [Resolved]
+            private EzSkillProvider? skillProvider { get; set; }
 
             [BackgroundDependencyLoader]
             private void load(OsuConfigManager config, Ez2ConfigManager ezConfig)
@@ -222,7 +226,10 @@ namespace osu.Game.Screens.Select
 
             private void refreshPlayerDropdownItems()
             {
-                var names = localProfileService?.GetPreviouslyIncludedUsernames().ToList() ?? new List<string>();
+                var names = localProfileService?.GetPreviouslyIncludedUsernames()
+                                               .Where(playerHasSkillData)
+                                               .ToList()
+                            ?? new List<string>();
                 ezPlayerDropdown.Items = names;
 
                 if (names.Count == 0)
@@ -231,16 +238,24 @@ namespace osu.Game.Screens.Select
                     return;
                 }
 
-                if (EzAnalysisPlayer.Value == null || !names.Contains(EzAnalysisPlayer.Value))
+                string? current = EzAnalysisPlayer.Value != null
+                    ? EzLocalProfileConstants.NormaliseUsername(EzAnalysisPlayer.Value)
+                    : null;
+
+                if (current == null || !names.Contains(current))
                 {
                     EzAnalysisPlayer.Value = names[0];
                     ezPlayerDropdown.Current.Value = names[0];
                 }
                 else
                 {
-                    ezPlayerDropdown.Current.Value = EzAnalysisPlayer.Value;
+                    EzAnalysisPlayer.Value = current;
+                    ezPlayerDropdown.Current.Value = current;
                 }
             }
+
+            private bool playerHasSkillData(string username)
+                => skillProvider == null || skillProvider.GetPlayerSsrKeyCounts(username).Count > 0;
 
             private void applyFlowModeState(bool enabled)
             {


### PR DESCRIPTION
## Summary
- Map empty / legacy `(unknown)` usernames to literal `Guest` (no localisation), with legacy skill/profile partition fallback until recompute.
- Speed up Track Insights open path: batch unique beatmap hash lookups in one Realm run, cache Ruleset instances, share one `LoadDrillScores` pass between Insights and Drill, and drop PopIn double `refreshContent`.

## Test plan
- [ ] Open Local Profile → Mania Track with a player that has many scores; confirm load is interactive (not multi-second freeze).
- [ ] Player dropdown shows `Guest` instead of `(unknown)` / `unknown`; Guest without SSR does not appear in EzAnalysis player list.
- [ ] After recompute (optional), Guest SSR/insights still resolve; legacy `(unknown)` partitions remain readable via fallback.