### PR TITLE
Track axis supporting plays (UX-2)

### DIFF
--- a/osu.Game/EzOsuGame/LocalProfile/EzEvidenceScoreRow.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzEvidenceScoreRow.cs
@@ -1,0 +1,91 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Globalization;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.LocalProfile
+{
+    /// <summary>
+    /// Shared evidence list row (UX-2 axis plays; UX-4 dan clears).
+    /// </summary>
+    public partial class EzEvidenceScoreRow : OsuClickableContainer
+    {
+        private readonly string title;
+        private readonly string meta;
+
+        public EzEvidenceScoreRow(string title, string meta, Action? action = null)
+        {
+            this.title = title;
+            this.meta = meta;
+
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            Action = action;
+            Masking = true;
+            CornerRadius = 6;
+            Alpha = action != null ? 0.9f : 0.75f;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colours)
+        {
+            Children = new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = colours.Background5,
+                },
+                new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Vertical,
+                    Padding = new MarginPadding { Horizontal = 10, Vertical = 8 },
+                    Spacing = new Vector2(0, 2),
+                    Children = new Drawable[]
+                    {
+                        new TruncatingSpriteText
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            Text = title,
+                            Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
+                        },
+                        new TruncatingSpriteText
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            Text = meta,
+                            Font = OsuFont.GetFont(size: 11),
+                            Colour = colours.Content2,
+                        },
+                    }
+                }
+            };
+        }
+
+        public static string FormatAxisMeta(double axisValue, double accuracy, double rate, DateTimeOffset scoredAt)
+        {
+            string rateText = Math.Abs(rate - 1) < 0.001
+                ? "1.0x"
+                : rate.ToString("0.##x", CultureInfo.InvariantCulture);
+
+            return string.Join(" · ", new[]
+            {
+                axisValue.ToString("0.00", CultureInfo.InvariantCulture),
+                accuracy.ToString("0.00%", CultureInfo.InvariantCulture),
+                rateText,
+                scoredAt.ToLocalTime().ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+            });
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOverlay.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOverlay.cs
@@ -349,7 +349,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
                     contentFlow.Add(new EzLocalProfileSection(
                         EzSettingsProfile.LOCAL_PROFILE_SECTION_TRACK_SKILLS,
-                        new EzLocalProfileTrackSkillsBody(selectedPlayer.Value)));
+                        new EzLocalProfileTrackSkillsBody(selectedPlayer.Value, currentDrillScore, drillScores)));
 
                     refreshDrillContent(snapshot, rulesetId, drillScores);
                 }

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileTrackSkillsBody.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileTrackSkillsBody.cs
@@ -23,28 +23,38 @@ using osuTK;
 namespace osu.Game.EzOsuGame.LocalProfile
 {
     /// <summary>
-    /// Track-mode skills: key chips, Overall header, radar, SSR bars, optional history.
+    /// Track-mode skills: key chips, Overall header, radar, SSR bars, axis supporting plays, optional history.
     /// </summary>
     public partial class EzLocalProfileTrackSkillsBody : FillFlowContainer
     {
+        private const int axis_plays_top_n = 15;
+
         private readonly string username;
+        private readonly Bindable<EzLocalProfileDrillScoreRow?>? selectDrillScore;
+        private readonly IReadOnlyList<EzLocalProfileDrillScoreRow>? preloadedDrillScores;
 
         private readonly BindableInt selectedKeyCount = new BindableInt();
+        private readonly Bindable<string?> selectedAxisSkillId = new Bindable<string?>();
         private readonly Bindable<string?> selectedHistorySkillId = new Bindable<string?>();
 
         private FillFlowContainer keyChipFlow = null!;
         private Container headerContainer = null!;
         private Container radarContainer = null!;
         private FillFlowContainer skillBarsFlow = null!;
-        private Container historyContainer = null!;
+        private Container detailContainer = null!;
         private OsuSpriteText emptyHint = null!;
 
         [Resolved]
         private EzSkillProvider skillProvider { get; set; } = null!;
 
-        public EzLocalProfileTrackSkillsBody(string username)
+        public EzLocalProfileTrackSkillsBody(
+            string username,
+            Bindable<EzLocalProfileDrillScoreRow?>? selectDrillScore = null,
+            IReadOnlyList<EzLocalProfileDrillScoreRow>? preloadedDrillScores = null)
         {
             this.username = username;
+            this.selectDrillScore = selectDrillScore;
+            this.preloadedDrillScores = preloadedDrillScores;
 
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
@@ -88,7 +98,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
                     Direction = FillDirection.Vertical,
                     Spacing = new Vector2(0, 8),
                 },
-                historyContainer = new Container
+                detailContainer = new Container
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
@@ -102,11 +112,42 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
             selectedKeyCount.BindValueChanged(_ =>
             {
-                selectedHistorySkillId.Value = null;
+                clearDetailSelection();
                 refreshSkills();
             }, false);
-            selectedHistorySkillId.BindValueChanged(_ => refreshHistory(), false);
+            selectedAxisSkillId.BindValueChanged(_ => refreshDetailPanel(), false);
+            selectedHistorySkillId.BindValueChanged(_ => refreshDetailPanel(), false);
             rebuild();
+        }
+
+        private void clearDetailSelection()
+        {
+            selectedAxisSkillId.Value = null;
+            selectedHistorySkillId.Value = null;
+        }
+
+        private void toggleAxisPlays(string skillId)
+        {
+            if (string.Equals(selectedAxisSkillId.Value, skillId, StringComparison.Ordinal))
+            {
+                selectedAxisSkillId.Value = null;
+                return;
+            }
+
+            selectedHistorySkillId.Value = null;
+            selectedAxisSkillId.Value = skillId;
+        }
+
+        private void toggleHistory(string skillId)
+        {
+            if (string.Equals(selectedHistorySkillId.Value, skillId, StringComparison.Ordinal))
+            {
+                selectedHistorySkillId.Value = null;
+                return;
+            }
+
+            selectedAxisSkillId.Value = null;
+            selectedHistorySkillId.Value = skillId;
         }
 
         private void rebuild()
@@ -115,8 +156,8 @@ namespace osu.Game.EzOsuGame.LocalProfile
             headerContainer.Clear();
             radarContainer.Clear();
             skillBarsFlow.Clear();
-            historyContainer.Clear();
-            selectedHistorySkillId.Value = null;
+            detailContainer.Clear();
+            clearDetailSelection();
 
             var keyCounts = skillProvider.GetPlayerSsrKeyCounts(username);
 
@@ -207,39 +248,85 @@ namespace osu.Game.EzOsuGame.LocalProfile
                     value,
                     ratio,
                     Colour4.FromHex(def.AccentHex),
-                    () => selectedHistorySkillId.Value =
-                        string.Equals(selectedHistorySkillId.Value, skillId, StringComparison.Ordinal) ? null : skillId));
+                    () => toggleAxisPlays(skillId),
+                    () => toggleHistory(skillId)));
             }
 
-            refreshHistory();
+            refreshDetailPanel();
         }
 
-        private void refreshHistory()
+        private void refreshDetailPanel()
         {
-            historyContainer.Clear();
+            detailContainer.Clear();
 
-            string? skillId = selectedHistorySkillId.Value;
             int keyCount = selectedKeyCount.Value;
-
-            if (string.IsNullOrEmpty(skillId) || keyCount <= 0)
+            if (keyCount <= 0)
                 return;
 
-            var points = skillProvider.GetPlayerSkillHistory(username, keyCount, skillId);
-            string displayName = skillId;
-
-            foreach (var def in skillProvider.Registry.GetSystem(EzSkillSystems.PLAYER_SSR)?.Skills
-                                ?? Array.Empty<EzSkillDefinition>())
+            if (!string.IsNullOrEmpty(selectedAxisSkillId.Value))
             {
-                if (def.SkillId == skillId)
-                {
-                    displayName = def.DisplayName;
-                    break;
-                }
+                showAxisPlays(selectedAxisSkillId.Value, keyCount);
+                return;
             }
+
+            if (!string.IsNullOrEmpty(selectedHistorySkillId.Value))
+                showHistory(selectedHistorySkillId.Value, keyCount);
+        }
+
+        private void showAxisPlays(string skillId, int keyCount)
+        {
+            string displayName = resolveDisplayName(skillId);
+            var plays = skillProvider
+                        .GetAxisPlays(username, keyCount, skillId, EzManiaSkillAlgorithm.VERSION)
+                        .Take(axis_plays_top_n)
+                        .ToList();
+
+            if (plays.Count == 0)
+            {
+                detailContainer.Child = new EzLocalProfileChartCard(
+                    EzSettingsProfile.LOCAL_PROFILE_AXIS_PLAYS_FOR.Format(displayName),
+                    new OsuSpriteText
+                    {
+                        Text = EzSettingsProfile.LOCAL_PROFILE_AXIS_PLAYS_EMPTY,
+                        Font = OsuFont.GetFont(size: 13),
+                    });
+                return;
+            }
+
+            var list = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(0, 6),
+            };
+
+            foreach (var play in plays)
+            {
+                var drill = findDrillRow(play.BeatmapHash);
+                string title = formatPlayTitle(drill);
+
+                list.Add(new EzEvidenceScoreRow(
+                    title,
+                    EzEvidenceScoreRow.FormatAxisMeta(play.AxisValue, play.Accuracy, play.Rate, play.ScoredAt),
+                    drill != null && selectDrillScore != null
+                        ? () => selectDrillScore.Value = drill
+                        : null));
+            }
+
+            detailContainer.Child = new EzLocalProfileChartCard(
+                EzSettingsProfile.LOCAL_PROFILE_AXIS_PLAYS_FOR.Format(displayName),
+                list);
+        }
+
+        private void showHistory(string skillId, int keyCount)
+        {
+            var points = skillProvider.GetPlayerSkillHistory(username, keyCount, skillId);
+            string displayName = resolveDisplayName(skillId);
 
             if (points.Count == 0)
             {
-                historyContainer.Child = new EzLocalProfileChartCard(
+                detailContainer.Child = new EzLocalProfileChartCard(
                     EzSettingsProfile.LOCAL_PROFILE_SKILL_HISTORY,
                     new OsuSpriteText
                     {
@@ -252,9 +339,46 @@ namespace osu.Game.EzOsuGame.LocalProfile
             float[] values = points.Select(p => (float)p.Value).ToArray();
             string[] labels = points.Select(p => p.RecordedAt.ToLocalTime().ToString("MM-dd", CultureInfo.InvariantCulture)).ToArray();
 
-            historyContainer.Child = new EzLocalProfileChartCard(
+            detailContainer.Child = new EzLocalProfileChartCard(
                 EzSettingsProfile.LOCAL_PROFILE_SKILL_HISTORY_FOR.Format(displayName),
                 new EzLocalProfileLabeledLineChart(values, labels));
+        }
+
+        private string resolveDisplayName(string skillId)
+        {
+            foreach (var def in skillProvider.Registry.GetSystem(EzSkillSystems.PLAYER_SSR)?.Skills
+                                ?? Array.Empty<EzSkillDefinition>())
+            {
+                if (def.SkillId == skillId)
+                    return def.DisplayName;
+            }
+
+            return skillId;
+        }
+
+        private EzLocalProfileDrillScoreRow? findDrillRow(string beatmapHash)
+        {
+            if (string.IsNullOrEmpty(beatmapHash) || preloadedDrillScores == null)
+                return null;
+
+            return preloadedDrillScores
+                   .Where(r => string.Equals(r.BeatmapHash, beatmapHash, StringComparison.Ordinal))
+                   .OrderByDescending(r => r.PpResolved)
+                   .ThenByDescending(r => r.Date)
+                   .FirstOrDefault();
+        }
+
+        private static string formatPlayTitle(EzLocalProfileDrillScoreRow? drill)
+        {
+            if (drill == null)
+                return EzSettingsProfile.LOCAL_PROFILE_AXIS_UNKNOWN_MAP.ToString();
+
+            if (string.IsNullOrEmpty(drill.Artist))
+                return string.IsNullOrEmpty(drill.DifficultyName) ? drill.Title : $"{drill.Title} [{drill.DifficultyName}]";
+
+            return string.IsNullOrEmpty(drill.DifficultyName)
+                ? $"{drill.Artist} - {drill.Title}"
+                : $"{drill.Artist} - {drill.Title} [{drill.DifficultyName}]";
         }
 
         private partial class SkillsHeader : FillFlowContainer
@@ -471,43 +595,71 @@ namespace osu.Game.EzOsuGame.LocalProfile
             }
         }
 
-        private partial class SkillBarRow : OsuClickableContainer
+        private partial class SkillBarRow : Container
         {
-            public SkillBarRow(string displayName, double value, float ratio, Colour4 accent, Action action)
+            private const float trend_width = 44f;
+
+            public SkillBarRow(
+                string displayName,
+                double value,
+                float ratio,
+                Colour4 accent,
+                Action onAxisClick,
+                Action onTrendClick)
             {
                 RelativeSizeAxes = Axes.X;
                 Height = 22;
-                Action = action;
 
                 Children = new Drawable[]
                 {
-                    new Container
+                    new OsuClickableContainer
                     {
                         RelativeSizeAxes = Axes.Both,
-                        Padding = new MarginPadding { Horizontal = 4 },
-                        Children = new Drawable[]
+                        Padding = new MarginPadding { Right = trend_width },
+                        Action = onAxisClick,
+                        Child = new Container
                         {
-                            new OsuSpriteText
+                            RelativeSizeAxes = Axes.Both,
+                            Padding = new MarginPadding { Horizontal = 4 },
+                            Children = new Drawable[]
                             {
-                                Anchor = Anchor.CentreLeft,
-                                Origin = Anchor.CentreLeft,
-                                Text = displayName,
-                                Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
-                                Width = 96,
-                            },
-                            new Container
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Padding = new MarginPadding { Left = 104, Right = 56 },
-                                Child = new EzLocalProfileRoundedBar(ratio, accent),
-                            },
-                            new OsuSpriteText
-                            {
-                                Anchor = Anchor.CentreRight,
-                                Origin = Anchor.CentreRight,
-                                Text = value.ToString("0.00", CultureInfo.InvariantCulture),
-                                Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
-                            },
+                                new OsuSpriteText
+                                {
+                                    Anchor = Anchor.CentreLeft,
+                                    Origin = Anchor.CentreLeft,
+                                    Text = displayName,
+                                    Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
+                                    Width = 96,
+                                },
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Padding = new MarginPadding { Left = 104, Right = 56 },
+                                    Child = new EzLocalProfileRoundedBar(ratio, accent),
+                                },
+                                new OsuSpriteText
+                                {
+                                    Anchor = Anchor.CentreRight,
+                                    Origin = Anchor.CentreRight,
+                                    Text = value.ToString("0.00", CultureInfo.InvariantCulture),
+                                    Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
+                                },
+                            }
+                        }
+                    },
+                    new OsuClickableContainer
+                    {
+                        Anchor = Anchor.CentreRight,
+                        Origin = Anchor.CentreRight,
+                        RelativeSizeAxes = Axes.Y,
+                        Width = trend_width,
+                        Action = onTrendClick,
+                        Child = new OsuSpriteText
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Text = EzSettingsProfile.LOCAL_PROFILE_AXIS_TREND,
+                            Font = OsuFont.GetFont(size: 11, weight: FontWeight.SemiBold),
                         }
                     }
                 };

--- a/osu.Game/EzOsuGame/Localization/EzSettings.Profile.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettings.Profile.cs
@@ -146,6 +146,20 @@ namespace osu.Game.EzOsuGame.Localization
                 "暂无历史点。重新计算本地个人成绩后会写入。",
                 "No history points yet. Recompute Local Profile Stats to record them.");
 
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_AXIS_PLAYS_FOR =
+            new EzLocalizationManager.EzLocalisableString("支撑成绩 · {0}", "Supporting plays · {0}");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_AXIS_PLAYS_EMPTY =
+            new EzLocalizationManager.EzLocalisableString(
+                "暂无该轴的支撑成绩。请重新计算本地个人成绩。",
+                "No supporting plays for this axis yet. Recompute Local Profile Stats.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_AXIS_TREND =
+            new EzLocalizationManager.EzLocalisableString("趋势", "Trend");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_AXIS_UNKNOWN_MAP =
+            new EzLocalizationManager.EzLocalisableString("未知谱面", "Unknown beatmap");
+
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_DAN_CHIP_TITLE =
             new EzLocalizationManager.EzLocalisableString("段位（启发式）", "Dan (heuristic)");
 

--- a/osu.Game/EzOsuGame/Skills/EzSkillProvider.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSkillProvider.cs
@@ -82,6 +82,16 @@ namespace osu.Game.EzOsuGame.Skills
 
         /// <summary>SSR axis play evidence (sqlite). Empty when local-profile store unset.</summary>
         public IReadOnlyList<EzAxisPlayEvidenceRow> GetAxisPlays(string username, int? keyCount = null, string? skillId = null, int? algorithmVersion = null)
-            => localProfileStore?.GetAxisPlays(username, keyCount, skillId, algorithmVersion) ?? [];
+        {
+            var rows = localProfileStore?.GetAxisPlays(username, keyCount, skillId, algorithmVersion) ?? [];
+            if (rows.Count > 0 || !EzLocalProfileConstants.IsGuestUsername(username) || localProfileStore == null)
+                return rows;
+
+            return localProfileStore.GetAxisPlays(
+                EzLocalProfileConstants.LEGACY_UNKNOWN_USERNAME,
+                keyCount,
+                skillId,
+                algorithmVersion);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Master: Skills Track Dan Master · **UX-2** · zero schema / algorithm VERSION.
- Skill bar primary click shows Top-15 `axis_play_evidence` via `EzEvidenceScoreRow`; **Trend** opens existing skill history (mutually exclusive).
- Wire shared drill scores + `currentDrillScore` so rows can select Score Drill; Guest falls back to legacy `(unknown)` evidence partitions.

## Test plan
- [ ] Local Profile → Mania Track → specific player with recomputed skills.
- [ ] Click a skill axis → supporting plays list (or empty hint); click again to close.
- [ ] Click **Trend** → skill history chart; switching axis/trend clears the other panel.
- [ ] Click a supporting row with a known map → Score Drill selection updates.