### PR TITLE
Show Profile Insights on Mania Ez mode (UX-3)

### DIFF
--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileInsightsBody.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileInsightsBody.cs
@@ -24,9 +24,9 @@ using osuTK;
 namespace osu.Game.EzOsuGame.LocalProfile
 {
     /// <summary>
-    /// Track-mode Profile Insights: Key Split / Mod / BPM / PP + newest/oldest top plays.
+    /// Profile Insights (Mania Ez / Track): Key Split / Mod / BPM / PP + newest/oldest top plays.
     /// </summary>
-    public partial class EzLocalProfileTrackInsightsBody : FillFlowContainer
+    public partial class EzLocalProfileInsightsBody : FillFlowContainer
     {
         private readonly string username;
         private readonly Bindable<EzLocalProfileDrillScoreRow?>? selectDrillScore;
@@ -60,7 +60,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
         [Resolved]
         private RealmAccess realm { get; set; } = null!;
 
-        public EzLocalProfileTrackInsightsBody(
+        public EzLocalProfileInsightsBody(
             string username,
             Bindable<EzLocalProfileDrillScoreRow?>? selectDrillScore = null,
             IReadOnlyList<EzLocalProfileDrillScoreRow>? preloadedDrillScores = null)

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOverlay.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileOverlay.cs
@@ -308,16 +308,19 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
             int rulesetId = ruleset.Value?.OnlineID ?? 0;
             var rulesetStats = snapshot.RulesetStats.FirstOrDefault(s => s.RulesetId == rulesetId);
-            bool trackMode = rulesetId == EzLocalProfileConstants.MANIA_RULESET_ID
-                             && analysisSystem.Value == EzLocalProfileAnalysisSystem.Track;
+            bool mania = rulesetId == EzLocalProfileConstants.MANIA_RULESET_ID;
+            bool trackMode = mania && analysisSystem.Value == EzLocalProfileAnalysisSystem.Track;
+            bool allPlayers = string.Equals(selectedPlayer.Value, EzLocalProfileConstants.ALL_PLAYERS, StringComparison.Ordinal);
 
             contentFlow.Add(new EzLocalProfileSection(
                 EzSettingsProfile.LOCAL_PROFILE_SECTION_CAREER,
                 new EzLocalProfileCareerBody(rulesetStats, snapshot.GradeCounts.Where(g => g.RulesetId == rulesetId))));
 
-            if (trackMode)
+            IReadOnlyList<EzLocalProfileDrillScoreRow>? sharedDrillScores = null;
+
+            if (mania)
             {
-                if (string.Equals(selectedPlayer.Value, EzLocalProfileConstants.ALL_PLAYERS, StringComparison.Ordinal))
+                if (allPlayers)
                 {
                     contentFlow.Add(new EzLocalProfileSection(
                         EzSettingsProfile.LOCAL_PROFILE_SECTION_TRACK_INSIGHTS,
@@ -327,32 +330,44 @@ namespace osu.Game.EzOsuGame.LocalProfile
                             Text = EzSettingsProfile.LOCAL_PROFILE_TRACK_NEEDS_PLAYER,
                             Font = OsuFont.GetFont(size: 14),
                         }));
-
-                    contentFlow.Add(new EzLocalProfileSection(
-                        EzSettingsProfile.LOCAL_PROFILE_SECTION_TRACK_SKILLS,
-                        new OsuSpriteText
-                        {
-                            RelativeSizeAxes = Axes.X,
-                            Text = EzSettingsProfile.LOCAL_PROFILE_TRACK_NEEDS_PLAYER,
-                            Font = OsuFont.GetFont(size: 14),
-                        }));
-
-                    refreshDrillContent(snapshot, rulesetId);
                 }
                 else
                 {
-                    var drillScores = profileService.LoadDrillScores(rulesetId, selectedPlayer.Value);
+                    sharedDrillScores = profileService.LoadDrillScores(rulesetId, selectedPlayer.Value);
 
                     contentFlow.Add(new EzLocalProfileSection(
                         EzSettingsProfile.LOCAL_PROFILE_SECTION_TRACK_INSIGHTS,
-                        new EzLocalProfileTrackInsightsBody(selectedPlayer.Value, currentDrillScore, drillScores)));
-
-                    contentFlow.Add(new EzLocalProfileSection(
-                        EzSettingsProfile.LOCAL_PROFILE_SECTION_TRACK_SKILLS,
-                        new EzLocalProfileTrackSkillsBody(selectedPlayer.Value, currentDrillScore, drillScores)));
-
-                    refreshDrillContent(snapshot, rulesetId, drillScores);
+                        new EzLocalProfileInsightsBody(selectedPlayer.Value, currentDrillScore, sharedDrillScores)));
                 }
+
+                if (trackMode)
+                {
+                    if (allPlayers)
+                    {
+                        contentFlow.Add(new EzLocalProfileSection(
+                            EzSettingsProfile.LOCAL_PROFILE_SECTION_TRACK_SKILLS,
+                            new OsuSpriteText
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                Text = EzSettingsProfile.LOCAL_PROFILE_TRACK_NEEDS_PLAYER,
+                                Font = OsuFont.GetFont(size: 14),
+                            }));
+                    }
+                    else
+                    {
+                        contentFlow.Add(new EzLocalProfileSection(
+                            EzSettingsProfile.LOCAL_PROFILE_SECTION_TRACK_SKILLS,
+                            new EzLocalProfileTrackSkillsBody(selectedPlayer.Value, currentDrillScore, sharedDrillScores)));
+                    }
+                }
+                else
+                {
+                    contentFlow.Add(new EzLocalProfileSection(
+                        EzSettingsProfile.LOCAL_PROFILE_SECTION_MODE_DATA,
+                        new EzLocalProfileModeDataBody(snapshot, rulesetId)));
+                }
+
+                refreshDrillContent(snapshot, rulesetId, sharedDrillScores);
             }
             else
             {


### PR DESCRIPTION
## Summary
- Master: Skills Track Dan Master · **UX-3** · zero schema.
- Mania + specific player: Insights on both Ez and Track (shared `EzLocalProfileInsightsBody`).
- Track Skills stay Track-only; Ez keeps Mode Data; All / non-Mania unchanged (#99).

## Test plan
- [ ] Local Profile → Mania → **Ez** → pick a player → Insights section appears above Mode Data.
- [ ] Mania → **Track** → same player → Insights + Skills still work.
- [ ] Mania → All players → Insights shows “select a player” hint (Ez and Track).
- [ ] Non-Mania ruleset → no Insights section.