### PR TITLE
UX-5: RC|LN DualPanel with EzDisplaySkillsDan + mania EzAnalysis default

### DIFF
--- a/osu.Game.Tests/EzOsuGame/Skills/EzDanSkillsetBucketsTest.cs
+++ b/osu.Game.Tests/EzOsuGame/Skills/EzDanSkillsetBucketsTest.cs
@@ -1,0 +1,104 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.EzOsuGame.Skills;
+
+namespace osu.Game.Tests.EzOsuGame.Skills
+{
+    [TestFixture]
+    public class EzDanSkillsetBucketsTest
+    {
+        [TestCase(4, EzDanSide.Rc, 4, new[] { "jack", "tech", "speed", "stamina" })]
+        [TestCase(6, EzDanSide.Rc, 4, new[] { "jack", "tech", "speed", "stream" })]
+        [TestCase(7, EzDanSide.Rc, 4, new[] { "jack", "tech", "speed", "stream" })]
+        [TestCase(4, EzDanSide.Ln, 0, new string[0])]
+        [TestCase(6, EzDanSide.Ln, 0, new string[0])]
+        [TestCase(7, EzDanSide.Ln, 4, new[] { "lngeneral", "lntech", "lninverse", "lnrelease" })]
+        public void SlotsMatchHubTable(int keyCount, EzDanSide side, int expectedCount, string[] expectedIds)
+        {
+            var slots = EzDanSkillsetBuckets.Slots(keyCount, side);
+            Assert.That(slots.Count, Is.EqualTo(expectedCount));
+            Assert.That(slots.Select(s => s.Id).ToArray(), Is.EqualTo(expectedIds));
+        }
+
+        [Test]
+        public void FourKeyRcFilingAveragesDominantAxisBuckets()
+        {
+            var clears = new List<EzDanClearEvidenceRow>();
+
+            // 5 jack clears (Chordjack) + 4 tech (Technical) — both above CLEAR_QUORUM.
+            for (int i = 0; i < 5; i++)
+            {
+                clears.Add(clear($"jack-{i}", 8.0 + i * 0.1));
+            }
+
+            for (int i = 0; i < 4; i++)
+            {
+                clears.Add(clear($"tech-{i}", 7.0 + i * 0.2));
+            }
+
+            // Under quorum for speed — must not appear.
+            clears.Add(clear("speed-0", 9.0));
+            clears.Add(clear("speed-1", 9.1));
+
+            EzMinaSkillAxis? resolve(string hash) => hash switch
+            {
+                var h when h.StartsWith("jack-", StringComparison.Ordinal) => EzMinaSkillAxis.Chordjack,
+                var h when h.StartsWith("tech-", StringComparison.Ordinal) => EzMinaSkillAxis.Technical,
+                var h when h.StartsWith("speed-", StringComparison.Ordinal) => EzMinaSkillAxis.Stream,
+                _ => null,
+            };
+
+            var verdicts = EzDanSkillsetBuckets.ComputeFromClears(4, EzDanSide.Rc, clears, resolve);
+
+            Assert.That(verdicts.ContainsKey(EzDanSkillsetBuckets.JACK), Is.True);
+            Assert.That(verdicts.ContainsKey(EzDanSkillsetBuckets.TECH), Is.True);
+            Assert.That(verdicts.ContainsKey(EzDanSkillsetBuckets.SPEED), Is.False);
+            Assert.That(verdicts[EzDanSkillsetBuckets.JACK].Clears, Is.EqualTo(5));
+            Assert.That(verdicts[EzDanSkillsetBuckets.TECH].Clears, Is.EqualTo(4));
+            Assert.That(verdicts[EzDanSkillsetBuckets.JACK].Label, Is.Not.Empty);
+            Assert.That(verdicts[EzDanSkillsetBuckets.JACK].RawDan, Is.GreaterThan(0));
+        }
+
+        [Test]
+        public void NonFourKeyOrLnReturnsEmptyVerdicts()
+        {
+            var clears = Enumerable.Range(0, 8)
+                                   .Select(i => clear($"m-{i}", 8.0, keyCount: 7))
+                                   .ToList();
+
+            var empty7 = EzDanSkillsetBuckets.ComputeFromClears(7, EzDanSide.Rc, clears, _ => EzMinaSkillAxis.JackSpeed);
+            Assert.That(empty7, Is.Empty);
+
+            var emptyLn = EzDanSkillsetBuckets.ComputeFromClears(7, EzDanSide.Ln, clears, _ => EzMinaSkillAxis.JackSpeed);
+            Assert.That(emptyLn, Is.Empty);
+        }
+
+        [Test]
+        public void MinaAxisMapsToFourKeyBuckets()
+        {
+            Assert.That(EzDanSkillsetBuckets.TryMapMinaAxisToSkillset(EzMinaSkillAxis.JackSpeed), Is.EqualTo("jack"));
+            Assert.That(EzDanSkillsetBuckets.TryMapMinaAxisToSkillset(EzMinaSkillAxis.Technical), Is.EqualTo("tech"));
+            Assert.That(EzDanSkillsetBuckets.TryMapMinaAxisToSkillset(EzMinaSkillAxis.Stream), Is.EqualTo("speed"));
+            Assert.That(EzDanSkillsetBuckets.TryMapMinaAxisToSkillset(EzMinaSkillAxis.Stamina), Is.EqualTo("stamina"));
+        }
+
+        private static EzDanClearEvidenceRow clear(string hash, double credited, int keyCount = 4, string side = "rc")
+            => new EzDanClearEvidenceRow
+            {
+                Username = "tester",
+                KeyCount = keyCount,
+                Side = side,
+                BeatmapHash = hash,
+                CreditedDan = credited,
+                Accuracy = 0.98,
+                Rate = 1,
+                ScoredAt = DateTimeOffset.UtcNow,
+                AlgorithmVersion = EzDanAlgorithm.VERSION,
+            };
+    }
+}

--- a/osu.Game.Tests/Visual/EzOsuGame/TestSceneBeatmapEzAnalysisWedge.cs
+++ b/osu.Game.Tests/Visual/EzOsuGame/TestSceneBeatmapEzAnalysisWedge.cs
@@ -122,6 +122,66 @@ namespace osu.Game.Tests.Visual.EzOsuGame
             AddStep("layout Auto", () => wedge.DanPanel.DualLayout.Value = EzDanPanelDualLayout.Auto);
         }
 
+        [Test]
+        public void TestRcAxesOnlyAndLnSkillSlotEmpty()
+        {
+            AddStep("seed mania + skills", seedPopulatedScene);
+            AddUntilStep("rc axis chips visible", () =>
+                wedge.ChildrenOfType<EzDanLabeledStatList>()
+                     .Where(l => l.Side == EzDanSide.Rc)
+                     .SelectMany(l => l.ChildrenOfType<EzDisplaySkillsDan>())
+                     .Count(c => c.Alpha > 0) >= 3);
+
+            AddAssert("ln column has no mina axis chips", () =>
+                wedge.ChildrenOfType<EzDanLabeledStatList>()
+                     .Where(l => l.Side == EzDanSide.Ln)
+                     .SelectMany(l => l.ChildrenOfType<EzDisplaySkillsDan>())
+                     .All(c => c.Alpha <= 0));
+
+            AddAssert("visible skill chips at most one mina set", () =>
+                wedge.ChildrenOfType<EzDisplaySkillsDan>().Count(c => c.Alpha > 0)
+                <= EzMinaSkillAxisExtensions.RadarAxes.Length);
+        }
+
+        [Test]
+        public void TestSkillAxisDansUseReformNotLnLadder()
+        {
+            // High MSD through LN 1–17 would mint labels like "15"/"17"; reform uses greek past 10.
+            AddAssert("stream sr maps to reform kappa band not ln-17", () =>
+            {
+                double raw = EzDanLabels.SrToRawDan(22.0, EzMinaSkillAxis.Stream);
+                string reformBare = EzDanLadders.BareLabel(EzDanLadders.For(test_keys, EzDanSide.Rc).ParseLabel(raw));
+                string lnBare = EzDanLadders.BareLabel(EzDanLadders.For(test_keys, EzDanSide.Ln).ParseLabel(raw));
+
+                bool reformGreek = reformBare is "kappa" or "iota" or "theta" or "eta" or "zeta"
+                    or "epsilon" or "delta" or "gamma" or "beta" or "alpha";
+                bool reformNumeric = int.TryParse(reformBare, out int n) && n is >= 1 and <= 10;
+                bool lnHighNumeric = int.TryParse(lnBare, out int lnN) && lnN > 10;
+
+                return (reformGreek || reformNumeric) && lnHighNumeric && reformBare != lnBare;
+            });
+        }
+
+        [Test]
+        public void TestHeaderAggregatesBothSides()
+        {
+            AddStep("seed mania + skills", seedPopulatedScene);
+            AddUntilStep("both side lists present", () =>
+                wedge.ChildrenOfType<EzDanLabeledStatList>().Count() == 2);
+
+            AddAssert("rc and ln player aggregates seeded", () =>
+            {
+                var rc = skillStore.GetDanEstimate(test_player, test_keys, EzDanSide.Rc.ToId());
+                var ln = skillStore.GetDanEstimate(test_player, test_keys, EzDanSide.Ln.ToId());
+                return rc != null && ln != null
+                       && !string.IsNullOrEmpty(rc.Label) && !string.IsNullOrEmpty(ln.Label)
+                       && rc.Label != ln.Label;
+            });
+
+            AddUntilStep("header aggregate dans visible", () =>
+                wedge.ChildrenOfType<EzDisplayDan>().Count(c => c.Alpha > 0 && Precision.AlmostEquals(c.Scale.X, 1.5f)) >= 2);
+        }
+
         private void seedPopulatedScene()
         {
             wedge.DanPanel.DataSource.Value = EzDanPanelDataSource.Both;

--- a/osu.Game.Tests/Visual/EzOsuGame/TestSceneBeatmapEzAnalysisWedge.cs
+++ b/osu.Game.Tests/Visual/EzOsuGame/TestSceneBeatmapEzAnalysisWedge.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Tests.Visual.EzOsuGame
         public void TestPopulatedWedge()
         {
             AddStep("seed mania + skills", seedPopulatedScene);
-            AddUntilStep("skills dan chips visible", () =>
+            AddUntilStep("skillset chips visible", () =>
                 wedge.ChildrenOfType<EzDisplaySkillsDan>().Count(c => c.Alpha > 0) >= 3);
             AddAssert("aggregate dan visible", () =>
                 wedge.ChildrenOfType<EzDisplayDan>().Any(c => c.Alpha > 0 && Precision.AlmostEquals(c.Scale.X, 1.5f)));
@@ -77,7 +77,7 @@ namespace osu.Game.Tests.Visual.EzOsuGame
             AddAssert("dan panel present", () => wedge.DanPanel != null);
             AddAssert("dan panel visible width", () => wedge.DanPanel.DrawWidth > 0);
 
-            AddUntilStep("axis chips loaded", () =>
+            AddUntilStep("skillset chips loaded", () =>
                 wedge.ChildrenOfType<EzDisplaySkillsDan>().Any(c => c.Alpha > 0));
 
             AddAssert("display chips scaled 1.5", () =>
@@ -123,43 +123,24 @@ namespace osu.Game.Tests.Visual.EzOsuGame
         }
 
         [Test]
-        public void TestRcAxesOnlyAndLnSkillSlotEmpty()
+        public void TestFourKeySkillsetSlotsNotMinaAxes()
         {
             AddStep("seed mania + skills", seedPopulatedScene);
-            AddUntilStep("rc axis chips visible", () =>
+            AddUntilStep("rc has four skillset chips", () =>
                 wedge.ChildrenOfType<EzDanLabeledStatList>()
                      .Where(l => l.Side == EzDanSide.Rc)
                      .SelectMany(l => l.ChildrenOfType<EzDisplaySkillsDan>())
-                     .Count(c => c.Alpha > 0) >= 3);
+                     .Count(c => c.Alpha > 0) == 4);
 
-            AddAssert("ln column has no mina axis chips", () =>
+            AddAssert("ln 4k has no skillset chips", () =>
                 wedge.ChildrenOfType<EzDanLabeledStatList>()
                      .Where(l => l.Side == EzDanSide.Ln)
                      .SelectMany(l => l.ChildrenOfType<EzDisplaySkillsDan>())
                      .All(c => c.Alpha <= 0));
 
-            AddAssert("visible skill chips at most one mina set", () =>
-                wedge.ChildrenOfType<EzDisplaySkillsDan>().Count(c => c.Alpha > 0)
-                <= EzMinaSkillAxisExtensions.RadarAxes.Length);
-        }
-
-        [Test]
-        public void TestSkillAxisDansUseReformNotLnLadder()
-        {
-            // High MSD through LN 1–17 would mint labels like "15"/"17"; reform uses greek past 10.
-            AddAssert("stream sr maps to reform kappa band not ln-17", () =>
-            {
-                double raw = EzDanLabels.SrToRawDan(22.0, EzMinaSkillAxis.Stream);
-                string reformBare = EzDanLadders.BareLabel(EzDanLadders.For(test_keys, EzDanSide.Rc).ParseLabel(raw));
-                string lnBare = EzDanLadders.BareLabel(EzDanLadders.For(test_keys, EzDanSide.Ln).ParseLabel(raw));
-
-                bool reformGreek = reformBare is "kappa" or "iota" or "theta" or "eta" or "zeta"
-                    or "epsilon" or "delta" or "gamma" or "beta" or "alpha";
-                bool reformNumeric = int.TryParse(reformBare, out int n) && n is >= 1 and <= 10;
-                bool lnHighNumeric = int.TryParse(lnBare, out int lnN) && lnN > 10;
-
-                return (reformGreek || reformNumeric) && lnHighNumeric && reformBare != lnBare;
-            });
+            AddAssert("slot table is four for 4k rc", () =>
+                EzDanSkillsetBuckets.Slots(test_keys, EzDanSide.Rc).Count == 4
+                && EzDanSkillsetBuckets.Slots(test_keys, EzDanSide.Ln).Count == 0);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/EzOsuGame/TestSceneBeatmapEzAnalysisWedge.cs
+++ b/osu.Game.Tests/Visual/EzOsuGame/TestSceneBeatmapEzAnalysisWedge.cs
@@ -1,0 +1,194 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
+using osu.Framework.Utils;
+using osu.Game.Database;
+using osu.Game.EzOsuGame.HUD;
+using osu.Game.EzOsuGame.Overlays;
+using osu.Game.EzOsuGame.Skills;
+using osu.Game.EzOsuGame.Skills.Dan;
+using osu.Game.EzOsuGame.UserInterface;
+using osu.Game.Rulesets.Mania;
+using osu.Game.Tests.Beatmaps;
+using osu.Game.Tests.Visual.SongSelect;
+using osuTK;
+
+namespace osu.Game.Tests.Visual.EzOsuGame
+{
+    public partial class TestSceneBeatmapEzAnalysisWedge : SongSelectComponentsTestScene
+    {
+        private const string test_player = "ez-test-player";
+        private const int test_keys = 4;
+
+        private BeatmapEzAnalysisWedge wedge = null!;
+        private EzSkillStore skillStore = null!;
+
+        /// <summary>Match MetadataWedge host; DualPanel uses Horizontal RC|LN (not Auto on a pinned narrow box).</summary>
+        protected override float InitialRelativeWidth => 0.5f;
+
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+        {
+            var dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
+            skillStore = new EzSkillStore(dependencies.Get<RealmAccess>());
+            dependencies.CacheAs(new EzSkillProvider(skillStore));
+            return dependencies;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            Child = wedge = new BeatmapEzAnalysisWedge
+            {
+                State = { Value = Visibility.Visible },
+            };
+        }
+
+        [Test]
+        public void TestPopulatedWedge()
+        {
+            AddStep("seed mania + skills", seedPopulatedScene);
+            AddUntilStep("skills dan chips visible", () =>
+                wedge.ChildrenOfType<EzDisplaySkillsDan>().Count(c => c.Alpha > 0) >= 3);
+            AddAssert("aggregate dan visible", () =>
+                wedge.ChildrenOfType<EzDisplayDan>().Any(c => c.Alpha > 0 && Precision.AlmostEquals(c.Scale.X, 1.5f)));
+        }
+
+        [Test]
+        public void TestShowHide()
+        {
+            AddStep("seed mania + skills", seedPopulatedScene);
+            AddStep("hide wedge", () => wedge.Hide());
+            AddStep("show wedge", () => wedge.Show());
+            AddUntilStep("chips still visible", () =>
+                wedge.ChildrenOfType<EzDisplaySkillsDan>().Any(c => c.Alpha > 0));
+        }
+
+        [Test]
+        public void TestDanPanelPresentAndScaled()
+        {
+            AddStep("seed mania + skills", seedPopulatedScene);
+            AddAssert("dan panel present", () => wedge.DanPanel != null);
+            AddAssert("dan panel visible width", () => wedge.DanPanel.DrawWidth > 0);
+
+            AddUntilStep("axis chips loaded", () =>
+                wedge.ChildrenOfType<EzDisplaySkillsDan>().Any(c => c.Alpha > 0));
+
+            AddAssert("display chips scaled 1.5", () =>
+                wedge.ChildrenOfType<EzDisplaySkillsDan>().Where(c => c.Alpha > 0).All(c =>
+                    Precision.AlmostEquals(c.Scale.X, 1.5f) && Precision.AlmostEquals(c.Scale.Y, 1.5f)));
+
+            AddAssert("header aggregate dan uses 1.5 scale", () =>
+                wedge.ChildrenOfType<EzDisplayDan>().Any(c =>
+                    Precision.AlmostEquals(c.Scale.X, 1.5f) && Precision.AlmostEquals(c.Scale.Y, 1.5f)));
+        }
+
+        [Test]
+        public void TestDanPanelStaysInsideWedge()
+        {
+            AddStep("seed mania + skills", seedPopulatedScene);
+            AddUntilStep("layout settled", () => wedge.DanPanel.DrawWidth > 0);
+
+            AddAssert("dan panel left edge within wedge", () =>
+            {
+                float panelLeft = wedge.DanPanel.ToSpaceOfOtherDrawable(Vector2.Zero, wedge).X;
+                return panelLeft >= -2f;
+            });
+        }
+
+        [Test]
+        public void TestDataSourceAndLayout()
+        {
+            AddStep("seed mania + skills", seedPopulatedScene);
+
+            AddStep("source Chart", () => wedge.DanPanel.DataSource.Value = EzDanPanelDataSource.Chart);
+            AddUntilStep("chart chips visible", () =>
+                wedge.ChildrenOfType<EzDisplaySkillsDan>().Any(c => c.Alpha > 0));
+
+            AddStep("source Player", () => wedge.DanPanel.DataSource.Value = EzDanPanelDataSource.Player);
+            AddUntilStep("player chips visible", () =>
+                wedge.ChildrenOfType<EzDisplaySkillsDan>().Any(c => c.Alpha > 0));
+
+            AddStep("source Both", () => wedge.DanPanel.DataSource.Value = EzDanPanelDataSource.Both);
+
+            AddStep("layout Horizontal", () => wedge.DanPanel.DualLayout.Value = EzDanPanelDualLayout.Horizontal);
+            AddStep("layout Vertical", () => wedge.DanPanel.DualLayout.Value = EzDanPanelDualLayout.Vertical);
+            AddStep("layout Auto", () => wedge.DanPanel.DualLayout.Value = EzDanPanelDualLayout.Auto);
+        }
+
+        private void seedPopulatedScene()
+        {
+            wedge.DanPanel.DataSource.Value = EzDanPanelDataSource.Both;
+            wedge.DanPanel.DualLayout.Value = EzDanPanelDualLayout.Horizontal;
+            var beatmap = CreateWorkingBeatmap(new TestBeatmap(new ManiaRuleset().RulesetInfo));
+            beatmap.BeatmapInfo.Difficulty.CircleSize = test_keys;
+            beatmap.BeatmapInfo.XxyStarRating = 18.5;
+
+            string hash = beatmap.BeatmapInfo.Hash;
+
+            if (string.IsNullOrEmpty(hash))
+            {
+                // Test beatmaps sometimes ship empty hash; DualPanel keys off Hash for MSD lookup.
+                hash = "ez-analysis-wedge-test-hash";
+                beatmap.BeatmapInfo.Hash = hash;
+            }
+
+            var chartMsd = new EzSkillsetVector(
+                Overall: 22.4,
+                Stream: 21.0,
+                Jumpstream: 23.5,
+                Handstream: 20.2,
+                Stamina: 19.8,
+                JackSpeed: 24.1,
+                Chordjack: 18.6,
+                Technical: 22.0);
+
+            var playerSsr = new EzSkillsetVector(
+                Overall: 20.1,
+                Stream: 19.5,
+                Jumpstream: 21.2,
+                Handstream: 18.8,
+                Stamina: 17.9,
+                JackSpeed: 22.4,
+                Chordjack: 16.5,
+                Technical: 20.0);
+
+            skillStore.WriteBeatmapMsd(hash, chartMsd, beatmap.BeatmapInfo.ID, holdRatio: 0.22);
+            skillStore.WritePlayerSsr(test_player, test_keys, playerSsr, analyzedPlays: 40, provisional: false);
+
+            writeDan(test_player, EzDanSide.Rc, chartMsd.Overall, clears: 12);
+            writeDan(test_player, EzDanSide.Ln, chartMsd.Overall * 0.92, clears: 5);
+
+            Beatmap.Value = beatmap;
+            SelectedMods.Value = [];
+            wedge.TargetUsername.Value = test_player;
+            wedge.LeftRadarMode.Value = EzRadarDisplayMode.XxySrPattern;
+            wedge.RightRadarMode.Value = EzRadarDisplayMode.Skill;
+            wedge.Show();
+        }
+
+        private void writeDan(string username, EzDanSide side, double overallSr, int clears)
+        {
+            double raw = EzDanLabels.SrToRawDan(overallSr, EzMinaSkillAxis.Stream);
+            string label = EzDanLadders.For(test_keys, side).ParseLabel(raw);
+
+            skillStore.WriteDanEstimate(new EzDanEstimate
+            {
+                Username = username,
+                KeyCount = test_keys,
+                Side = side.ToId(),
+                RawDan = raw,
+                Label = label,
+                Clears = clears,
+                AlgorithmVersion = EzDanAlgorithm.VERSION,
+                ComputedAt = DateTimeOffset.UtcNow,
+            });
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/HUD/EzDanPanelEnums.cs
+++ b/osu.Game/EzOsuGame/HUD/EzDanPanelEnums.cs
@@ -1,0 +1,43 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.ComponentModel;
+
+namespace osu.Game.EzOsuGame.HUD
+{
+    /// <summary>
+    /// Data sources for <see cref="EzHUDDanDualPanel"/>, mirroring Skill-radar A / B / AB.
+    /// </summary>
+    public enum EzDanPanelDataSource
+    {
+        /// <summary>Chart MSD only (radar primary / yellow layer).</summary>
+        [Description("Chart")]
+        Chart,
+
+        /// <summary>Player SSR / dan only (radar secondary / green layer).</summary>
+        [Description("Player")]
+        Player,
+
+        /// <summary>Chart + player together.</summary>
+        [Description("Both")]
+        Both,
+    }
+
+    /// <summary>
+    /// How RC and LN lists are arranged relative to each other.
+    /// </summary>
+    public enum EzDanPanelDualLayout
+    {
+        /// <summary>Horizontal when wide enough, otherwise vertical.</summary>
+        [Description("Auto")]
+        Auto,
+
+        /// <summary>RC | LN side-by-side; axis chips stack vertically inside each list.</summary>
+        [Description("Horizontal")]
+        Horizontal,
+
+        /// <summary>RC above LN; axis chips flow horizontally inside each list.</summary>
+        [Description("Vertical")]
+        Vertical,
+    }
+}

--- a/osu.Game/EzOsuGame/HUD/EzHUDDanDualPanel.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDDanDualPanel.cs
@@ -15,6 +15,7 @@ using osu.Game.Configuration;
 using osu.Game.EzOsuGame.Localization;
 using osu.Game.EzOsuGame.LocalProfile;
 using osu.Game.EzOsuGame.Skills;
+using osu.Game.EzOsuGame.Skills.Dan;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
@@ -252,7 +253,11 @@ namespace osu.Game.EzOsuGame.HUD
             bool showEvidence = ShowEvidence.Value && wantPlayer && hasUser;
 
             updateSide(rcList, EzDanSide.Rc, user, keys, chartAxes, playerAxes, wantChart, wantPlayer, showEvidence);
-            updateSide(lnList, EzDanSide.Ln, user, keys, chartAxes, playerAxes, wantChart, wantPlayer, showEvidence);
+            // LN has no Mina skill axes yet — pass empty skill dicts; aggregate dan still resolves per side.
+            updateSide(lnList, EzDanSide.Ln, user, keys,
+                new Dictionary<string, double>(),
+                new Dictionary<string, double>(),
+                wantChart, wantPlayer, showEvidence);
         }
 
         private void showEmpty(LocalisableString text)
@@ -288,14 +293,7 @@ namespace osu.Game.EzOsuGame.HUD
             }
 
             if (wantChart && beatmap?.Value.BeatmapInfo != null && skillProvider != null)
-            {
-                var modsList = mods?.Value ?? Array.Empty<Mod>();
-                var chart = skillProvider.TryGetChartDan(beatmap.Value.BeatmapInfo, modsList)
-                            ?? skillProvider.TryGetCachedChartDan(beatmap.Value.BeatmapInfo);
-
-                if (chart != null && (keys <= 0 || chart.KeyCount == keys) && chart.Side == side && !string.IsNullOrEmpty(chart.Label))
-                    chartLabel = chart.Label;
-            }
+                chartLabel = resolveChartAggregateLabel(side, keys);
 
             list.UpdateContent(
                 keys,
@@ -307,6 +305,34 @@ namespace osu.Game.EzOsuGame.HUD
                 resolveTitle,
                 onSelectClear,
                 showEvidence);
+        }
+
+        /// <summary>
+        /// Hub-style RC|LN chart halves: prefer Sunny xxy lookup per side; else primary-side TryGetChartDan only.
+        /// </summary>
+        private string? resolveChartAggregateLabel(EzDanSide side, int keys)
+        {
+            if (beatmap?.Value.BeatmapInfo == null || skillProvider == null)
+                return null;
+
+            var info = beatmap.Value.BeatmapInfo;
+            double xxy = info.XxyStarRating;
+
+            if (keys > 0 && xxy >= 0 && double.IsFinite(xxy)
+                && EzSunnyDanIntervals.TryLookup(keys, side.ToId(), xxy, out var sunny)
+                && !string.IsNullOrEmpty(sunny.DisplayLabel))
+            {
+                return sunny.DisplayLabel;
+            }
+
+            var modsList = mods?.Value ?? Array.Empty<Mod>();
+            var chart = skillProvider.TryGetChartDan(info, modsList)
+                        ?? skillProvider.TryGetCachedChartDan(info);
+
+            if (chart != null && (keys <= 0 || chart.KeyCount == keys) && chart.Side == side && !string.IsNullOrEmpty(chart.Label))
+                return chart.Label;
+
+            return null;
         }
 
         private string resolveTitle(string beatmapHash)

--- a/osu.Game/EzOsuGame/HUD/EzHUDDanDualPanel.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDDanDualPanel.cs
@@ -203,45 +203,44 @@ namespace osu.Game.EzOsuGame.HUD
             bool wantChart = source is EzDanPanelDataSource.Chart or EzDanPanelDataSource.Both;
             bool wantPlayer = source is EzDanPanelDataSource.Player or EzDanPanelDataSource.Both;
 
-            IReadOnlyDictionary<string, double> chartAxes = new Dictionary<string, double>();
-            IReadOnlyDictionary<string, double> playerAxes = new Dictionary<string, double>();
+            IReadOnlyDictionary<string, string> chartSkillsetLabels = new Dictionary<string, string>();
 
             if (wantChart && beatmap?.Value.BeatmapInfo != null)
             {
                 var modsList = mods?.Value ?? Array.Empty<Mod>();
-                chartAxes = skillProvider.GetBeatmapMsd(beatmap.Value.BeatmapInfo.Hash);
+                var info = beatmap.Value.BeatmapInfo;
 
-                if (chartAxes.Count == 0)
-                {
-                    skillProvider.TryGetChartDan(beatmap.Value.BeatmapInfo, modsList);
-                    chartAxes = skillProvider.GetBeatmapMsd(beatmap.Value.BeatmapInfo.Hash);
-                }
+                // Warm MSD cache when missing (chart skillset filing + key resolve helpers).
+                if (skillProvider.GetBeatmapMsd(info.Hash).Count == 0)
+                    skillProvider.TryGetChartDan(info, modsList);
+
+                chartSkillsetLabels = skillProvider.GetChartDanSkillsetLabels(info, modsList);
 
                 if (keys <= 0)
                 {
                     try
                     {
-                        var playable = beatmap.Value.GetPlayableBeatmap(beatmap.Value.BeatmapInfo.Ruleset, modsList);
+                        var playable = beatmap.Value.GetPlayableBeatmap(info.Ruleset, modsList);
                         keys = EzMinaNoteConverter.ResolveKeyCount(playable);
                         if (KeyCount.Value <= 0 && keys > 0)
                             KeyCount.Value = keys;
                     }
                     catch
                     {
-                        // keep keys
+                        if (info.Difficulty.CircleSize > 0)
+                            keys = (int)info.Difficulty.CircleSize;
                     }
                 }
             }
 
-            if (wantPlayer && hasUser && keys > 0)
-                playerAxes = skillProvider.GetPlayerSsr(user!, keys);
+            bool hasBeatmap = beatmap?.Value.BeatmapInfo != null;
+            bool canShowChart = wantChart && hasBeatmap && keys > 0;
+            bool canShowPlayer = wantPlayer && hasUser && keys > 0;
 
-            bool hasChartData = chartAxes.Count > 0;
-            bool hasPlayerData = playerAxes.Count > 0 || (hasUser && keys > 0);
-
-            if (keys <= 0 || (wantChart && !hasChartData && wantPlayer && !hasPlayerData)
-                || (wantChart && !wantPlayer && !hasChartData)
-                || (wantPlayer && !wantChart && !hasUser))
+            if (keys <= 0
+                || (!canShowChart && !canShowPlayer)
+                || (wantPlayer && !wantChart && !hasUser)
+                || (wantChart && !wantPlayer && !hasBeatmap))
             {
                 showEmpty(EzSettingsProfile.LOCAL_PROFILE_TRACK_NEEDS_PLAYER);
                 return;
@@ -252,11 +251,10 @@ namespace osu.Game.EzOsuGame.HUD
 
             bool showEvidence = ShowEvidence.Value && wantPlayer && hasUser;
 
-            updateSide(rcList, EzDanSide.Rc, user, keys, chartAxes, playerAxes, wantChart, wantPlayer, showEvidence);
-            // LN has no Mina skill axes yet — pass empty skill dicts; aggregate dan still resolves per side.
+            updateSide(rcList, EzDanSide.Rc, user, keys, chartSkillsetLabels, wantChart, wantPlayer, showEvidence);
             updateSide(lnList, EzDanSide.Ln, user, keys,
-                new Dictionary<string, double>(),
-                new Dictionary<string, double>(),
+                // LN skillset chart labels: empty until TODO(data) LN pattern filing.
+                new Dictionary<string, string>(),
                 wantChart, wantPlayer, showEvidence);
         }
 
@@ -272,8 +270,7 @@ namespace osu.Game.EzOsuGame.HUD
             EzDanSide side,
             string? user,
             int keys,
-            IReadOnlyDictionary<string, double> chartAxes,
-            IReadOnlyDictionary<string, double> playerAxes,
+            IReadOnlyDictionary<string, string> chartSkillsetLabels,
             bool wantChart,
             bool wantPlayer,
             bool showEvidence)
@@ -281,12 +278,18 @@ namespace osu.Game.EzOsuGame.HUD
             string? chartLabel = null;
             string? playerLabel = null;
             IReadOnlyList<EzDanClearEvidenceRow> clears = Array.Empty<EzDanClearEvidenceRow>();
+            IReadOnlyDictionary<string, EzDanSkillsetVerdict> playerSkillsets =
+                new Dictionary<string, EzDanSkillsetVerdict>();
+
+            var slots = skillProvider?.GetDanSkillsetSlots(keys, side) ?? Array.Empty<EzDanSkillsetSlot>();
 
             if (wantPlayer && !string.IsNullOrWhiteSpace(user) && keys > 0 && skillProvider != null)
             {
                 var estimate = skillProvider.GetDan(user, keys, side.ToId());
                 if (estimate != null && !string.IsNullOrEmpty(estimate.Label) && estimate.RawDan >= 0)
                     playerLabel = estimate.Label;
+
+                playerSkillsets = skillProvider.GetDanSkillsets(user, keys, side.ToId());
 
                 if (showEvidence)
                     clears = skillProvider.GetDanClears(user, keys, side.ToId(), EzDanAlgorithm.VERSION);
@@ -299,8 +302,9 @@ namespace osu.Game.EzOsuGame.HUD
                 keys,
                 wantChart ? chartLabel : null,
                 wantPlayer ? playerLabel : null,
-                wantChart ? chartAxes : new Dictionary<string, double>(),
-                wantPlayer ? playerAxes : new Dictionary<string, double>(),
+                slots,
+                wantChart ? chartSkillsetLabels : new Dictionary<string, string>(),
+                wantPlayer ? playerSkillsets : new Dictionary<string, EzDanSkillsetVerdict>(),
                 clears,
                 resolveTitle,
                 onSelectClear,

--- a/osu.Game/EzOsuGame/HUD/EzHUDDanDualPanel.cs
+++ b/osu.Game/EzOsuGame/HUD/EzHUDDanDualPanel.cs
@@ -1,0 +1,353 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Layout;
+using osu.Framework.Localisation;
+using osu.Game.Beatmaps;
+using osu.Game.Configuration;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.EzOsuGame.LocalProfile;
+using osu.Game.EzOsuGame.Skills;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Skinning;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.HUD
+{
+    /// <summary>
+    /// HUD RC|LN skills-dan dual panel (Skill-radar style Chart / Player / Both sources).
+    /// Borrowed by EzAnalysis wedge and Local Profile Track with bindable settings.
+    /// </summary>
+    public partial class EzHUDDanDualPanel : CompositeDrawable, ISerialisableDrawable
+    {
+        /// <summary>
+        /// Song-select wedge content is often ~450–550px; keep Auto on Horizontal RC|LN there.
+        /// Vertical dual stacks both sides and clips under BeatmapDetailsArea height.
+        /// </summary>
+        private float wideThreshold => 420f;
+
+        public static readonly Colour4 RC_ACCENT = Colour4.FromHex("#e0b04c");
+        public static readonly Colour4 LN_ACCENT = Colour4.FromHex("#f07474");
+
+        public bool UsesFixedAnchor { get; set; }
+
+        /// <summary>Chart MSD / Player SSR / Both — same idea as Skill radar layers.</summary>
+        [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.DAN_PANEL_DATA_SOURCE), nameof(EzHUDStrings.DAN_PANEL_DATA_SOURCE_TOOLTIP))]
+        public Bindable<EzDanPanelDataSource> DataSource { get; } = new Bindable<EzDanPanelDataSource>(EzDanPanelDataSource.Both);
+
+        /// <summary>RC|LN dual arrangement (auto / horizontal / vertical).</summary>
+        [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.DAN_PANEL_DUAL_LAYOUT), nameof(EzHUDStrings.DAN_PANEL_DUAL_LAYOUT_TOOLTIP))]
+        public Bindable<EzDanPanelDualLayout> DualLayout { get; } = new Bindable<EzDanPanelDualLayout>(EzDanPanelDualLayout.Auto);
+
+        [SettingSource(typeof(EzHUDStrings), nameof(EzHUDStrings.DAN_PANEL_SHOW_EVIDENCE), nameof(EzHUDStrings.DAN_PANEL_SHOW_EVIDENCE_TOOLTIP))]
+        public BindableBool ShowEvidence { get; } = new BindableBool(false);
+
+        /// <summary>Target player for SSR / dan / clear evidence. Externally bindable (EzAnalysis header).</summary>
+        public Bindable<string?> TargetUsername { get; } = new Bindable<string?>();
+
+        public BindableInt KeyCount { get; } = new BindableInt();
+
+        private FillFlowContainer dualFlow = null!;
+        private EzDanLabeledStatList rcList = null!;
+        private EzDanLabeledStatList lnList = null!;
+        private OsuSpriteText emptyHint = null!;
+
+        private IReadOnlyList<EzLocalProfileDrillScoreRow>? drillScores;
+        private Action<EzLocalProfileDrillScoreRow>? onSelectDrill;
+
+        private readonly LayoutValue sizeLayout = new LayoutValue(Invalidation.DrawSize);
+
+        [Resolved]
+        private EzSkillProvider? skillProvider { get; set; }
+
+        [Resolved(canBeNull: true)]
+        private IBindable<WorkingBeatmap>? beatmap { get; set; }
+
+        [Resolved(canBeNull: true)]
+        private IBindable<IReadOnlyList<Mod>>? mods { get; set; }
+
+        public EzHUDDanDualPanel()
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            AddLayout(sizeLayout);
+        }
+
+        /// <summary>Optional Local Profile drill wiring for clear-evidence click-through.</summary>
+        public void ConfigureEvidence(
+            IReadOnlyList<EzLocalProfileDrillScoreRow>? drills = null,
+            Action<EzLocalProfileDrillScoreRow>? selectDrill = null)
+        {
+            drillScores = drills;
+            onSelectDrill = selectDrill;
+            Schedule(refresh);
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colours)
+        {
+            InternalChildren = new Drawable[]
+            {
+                emptyHint = new OsuSpriteText
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Font = OsuFont.GetFont(size: 13),
+                    Colour = colours.Content2,
+                    Text = EzSettingsProfile.LOCAL_PROFILE_TRACK_NEEDS_PLAYER,
+                    Alpha = 0,
+                },
+                dualFlow = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Spacing = new Vector2(0, 12),
+                    Children = new Drawable[]
+                    {
+                        rcList = new EzDanLabeledStatList(EzDanSide.Rc, RC_ACCENT)
+                        {
+                            RelativeSizeAxes = Axes.X,
+                        },
+                        lnList = new EzDanLabeledStatList(EzDanSide.Ln, LN_ACCENT)
+                        {
+                            RelativeSizeAxes = Axes.X,
+                        },
+                    },
+                },
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            TargetUsername.BindValueChanged(_ => refresh(), true);
+            KeyCount.BindValueChanged(_ => refresh());
+            DataSource.BindValueChanged(_ => refresh());
+            DualLayout.BindValueChanged(_ => applyLayoutMode(), true);
+            ShowEvidence.BindValueChanged(_ => refresh());
+
+            beatmap?.BindValueChanged(_ => refresh());
+            mods?.BindValueChanged(_ => refresh());
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (!sizeLayout.IsValid)
+            {
+                sizeLayout.Validate();
+                applyLayoutMode();
+            }
+        }
+
+        private void applyLayoutMode()
+        {
+            bool wide = DualLayout.Value switch
+            {
+                EzDanPanelDualLayout.Horizontal => true,
+                EzDanPanelDualLayout.Vertical => false,
+                _ => DrawWidth >= wideThreshold,
+            };
+
+            if (wide)
+            {
+                dualFlow.Direction = FillDirection.Horizontal;
+                dualFlow.Spacing = Vector2.Zero;
+                rcList.Width = 0.45f;
+                lnList.Width = 0.45f;
+                rcList.SetLayoutInset(new MarginPadding { Right = 4 });
+                lnList.SetLayoutInset(new MarginPadding { Left = 4 });
+                rcList.SetCellsDirection(FillDirection.Vertical);
+                lnList.SetCellsDirection(FillDirection.Vertical);
+            }
+            else
+            {
+                dualFlow.Direction = FillDirection.Vertical;
+                dualFlow.Spacing = new Vector2(0, 12);
+                rcList.Width = 1;
+                lnList.Width = 1;
+                rcList.SetLayoutInset(new MarginPadding());
+                lnList.SetLayoutInset(new MarginPadding());
+                rcList.SetCellsDirection(FillDirection.Horizontal);
+                lnList.SetCellsDirection(FillDirection.Horizontal);
+            }
+        }
+
+        private void refresh()
+        {
+            applyLayoutMode();
+
+            if (skillProvider == null)
+            {
+                showEmpty(EzSettingsProfile.LOCAL_PROFILE_TRACK_NEEDS_PLAYER);
+                return;
+            }
+
+            int keys = KeyCount.Value;
+            string? user = TargetUsername.Value;
+            bool hasUser = !string.IsNullOrWhiteSpace(user);
+            var source = DataSource.Value;
+
+            bool wantChart = source is EzDanPanelDataSource.Chart or EzDanPanelDataSource.Both;
+            bool wantPlayer = source is EzDanPanelDataSource.Player or EzDanPanelDataSource.Both;
+
+            IReadOnlyDictionary<string, double> chartAxes = new Dictionary<string, double>();
+            IReadOnlyDictionary<string, double> playerAxes = new Dictionary<string, double>();
+
+            if (wantChart && beatmap?.Value.BeatmapInfo != null)
+            {
+                var modsList = mods?.Value ?? Array.Empty<Mod>();
+                chartAxes = skillProvider.GetBeatmapMsd(beatmap.Value.BeatmapInfo.Hash);
+
+                if (chartAxes.Count == 0)
+                {
+                    skillProvider.TryGetChartDan(beatmap.Value.BeatmapInfo, modsList);
+                    chartAxes = skillProvider.GetBeatmapMsd(beatmap.Value.BeatmapInfo.Hash);
+                }
+
+                if (keys <= 0)
+                {
+                    try
+                    {
+                        var playable = beatmap.Value.GetPlayableBeatmap(beatmap.Value.BeatmapInfo.Ruleset, modsList);
+                        keys = EzMinaNoteConverter.ResolveKeyCount(playable);
+                        if (KeyCount.Value <= 0 && keys > 0)
+                            KeyCount.Value = keys;
+                    }
+                    catch
+                    {
+                        // keep keys
+                    }
+                }
+            }
+
+            if (wantPlayer && hasUser && keys > 0)
+                playerAxes = skillProvider.GetPlayerSsr(user!, keys);
+
+            bool hasChartData = chartAxes.Count > 0;
+            bool hasPlayerData = playerAxes.Count > 0 || (hasUser && keys > 0);
+
+            if (keys <= 0 || (wantChart && !hasChartData && wantPlayer && !hasPlayerData)
+                || (wantChart && !wantPlayer && !hasChartData)
+                || (wantPlayer && !wantChart && !hasUser))
+            {
+                showEmpty(EzSettingsProfile.LOCAL_PROFILE_TRACK_NEEDS_PLAYER);
+                return;
+            }
+
+            emptyHint.Hide();
+            dualFlow.Show();
+
+            bool showEvidence = ShowEvidence.Value && wantPlayer && hasUser;
+
+            updateSide(rcList, EzDanSide.Rc, user, keys, chartAxes, playerAxes, wantChart, wantPlayer, showEvidence);
+            updateSide(lnList, EzDanSide.Ln, user, keys, chartAxes, playerAxes, wantChart, wantPlayer, showEvidence);
+        }
+
+        private void showEmpty(LocalisableString text)
+        {
+            emptyHint.Text = text;
+            emptyHint.Show();
+            dualFlow.Hide();
+        }
+
+        private void updateSide(
+            EzDanLabeledStatList list,
+            EzDanSide side,
+            string? user,
+            int keys,
+            IReadOnlyDictionary<string, double> chartAxes,
+            IReadOnlyDictionary<string, double> playerAxes,
+            bool wantChart,
+            bool wantPlayer,
+            bool showEvidence)
+        {
+            string? chartLabel = null;
+            string? playerLabel = null;
+            IReadOnlyList<EzDanClearEvidenceRow> clears = Array.Empty<EzDanClearEvidenceRow>();
+
+            if (wantPlayer && !string.IsNullOrWhiteSpace(user) && keys > 0 && skillProvider != null)
+            {
+                var estimate = skillProvider.GetDan(user, keys, side.ToId());
+                if (estimate != null && !string.IsNullOrEmpty(estimate.Label) && estimate.RawDan >= 0)
+                    playerLabel = estimate.Label;
+
+                if (showEvidence)
+                    clears = skillProvider.GetDanClears(user, keys, side.ToId(), EzDanAlgorithm.VERSION);
+            }
+
+            if (wantChart && beatmap?.Value.BeatmapInfo != null && skillProvider != null)
+            {
+                var modsList = mods?.Value ?? Array.Empty<Mod>();
+                var chart = skillProvider.TryGetChartDan(beatmap.Value.BeatmapInfo, modsList)
+                            ?? skillProvider.TryGetCachedChartDan(beatmap.Value.BeatmapInfo);
+
+                if (chart != null && (keys <= 0 || chart.KeyCount == keys) && chart.Side == side && !string.IsNullOrEmpty(chart.Label))
+                    chartLabel = chart.Label;
+            }
+
+            list.UpdateContent(
+                keys,
+                wantChart ? chartLabel : null,
+                wantPlayer ? playerLabel : null,
+                wantChart ? chartAxes : new Dictionary<string, double>(),
+                wantPlayer ? playerAxes : new Dictionary<string, double>(),
+                clears,
+                resolveTitle,
+                onSelectClear,
+                showEvidence);
+        }
+
+        private string resolveTitle(string beatmapHash)
+        {
+            if (string.IsNullOrEmpty(beatmapHash) || drillScores == null)
+                return EzSettingsProfile.LOCAL_PROFILE_AXIS_UNKNOWN_MAP.ToString();
+
+            var drill = drillScores
+                        .Where(r => string.Equals(r.BeatmapHash, beatmapHash, StringComparison.Ordinal))
+                        .OrderByDescending(r => r.PpResolved)
+                        .ThenByDescending(r => r.Date)
+                        .FirstOrDefault();
+
+            if (drill == null)
+                return EzSettingsProfile.LOCAL_PROFILE_AXIS_UNKNOWN_MAP.ToString();
+
+            if (string.IsNullOrEmpty(drill.Artist))
+            {
+                return string.IsNullOrEmpty(drill.DifficultyName)
+                    ? drill.Title
+                    : $"{drill.Title} [{drill.DifficultyName}]";
+            }
+
+            return string.IsNullOrEmpty(drill.DifficultyName)
+                ? $"{drill.Artist} - {drill.Title}"
+                : $"{drill.Artist} - {drill.Title} [{drill.DifficultyName}]";
+        }
+
+        private void onSelectClear(EzDanClearEvidenceRow clear)
+        {
+            if (onSelectDrill == null || drillScores == null)
+                return;
+
+            var drill = drillScores
+                        .Where(r => string.Equals(r.BeatmapHash, clear.BeatmapHash, StringComparison.Ordinal))
+                        .OrderByDescending(r => r.PpResolved)
+                        .ThenByDescending(r => r.Date)
+                        .FirstOrDefault();
+
+            if (drill != null)
+                onSelectDrill(drill);
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileTrackSkillsBody.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileTrackSkillsBody.cs
@@ -26,13 +26,11 @@ using osuTK;
 namespace osu.Game.EzOsuGame.LocalProfile
 {
     /// <summary>
-    /// Track-mode skills: key chips + rating + dan (left) beside radar with axis
-    /// indicators (right); SSR bars below; selecting a skill shows trend + plays.
+    /// Track-mode skills: key chips + rating beside radar; RC|LN DualPanel; SSR bars; skill detail.
     /// </summary>
     public partial class EzLocalProfileTrackSkillsBody : FillFlowContainer
     {
         private const int axis_plays_top_n = 15;
-        private const int dan_clears_top_n = 15;
 
         private readonly string username;
         private readonly Bindable<EzLocalProfileDrillScoreRow?>? selectDrillScore;
@@ -40,12 +38,12 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
         private readonly BindableInt selectedKeyCount = new BindableInt();
         private readonly Bindable<string?> selectedSkillId = new Bindable<string?>();
-        private readonly Bindable<string?> selectedDanSide = new Bindable<string?>();
 
         private Container overviewContainer = null!;
         private FillFlowContainer keyChipFlow = null!;
         private Container headerSlot = null!;
         private Container radarSlot = null!;
+        private EzHUDDanDualPanel danPanel = null!;
         private FillFlowContainer skillBarsFlow = null!;
         private Container detailContainer = null!;
         private OsuSpriteText emptyHint = null!;
@@ -120,6 +118,10 @@ namespace osu.Game.EzOsuGame.LocalProfile
                     Font = OsuFont.GetFont(size: 14),
                     Alpha = 0,
                 },
+                danPanel = new EzHUDDanDualPanel
+                {
+                    RelativeSizeAxes = Axes.X,
+                },
                 skillBarsFlow = new FillFlowContainer
                 {
                     RelativeSizeAxes = Axes.X,
@@ -139,6 +141,18 @@ namespace osu.Game.EzOsuGame.LocalProfile
         {
             base.LoadComplete();
 
+            danPanel.TargetUsername.Value = username;
+            danPanel.KeyCount.BindTo(selectedKeyCount);
+            danPanel.DataSource.Value = EzDanPanelDataSource.Player;
+            danPanel.DualLayout.Value = EzDanPanelDualLayout.Auto;
+            danPanel.ShowEvidence.Value = true;
+            danPanel.ConfigureEvidence(
+                preloadedDrillScores,
+                drill =>
+                {
+                    selectDrillScore?.Value = drill;
+                });
+
             selectedKeyCount.BindValueChanged(_ =>
             {
                 clearDetailSelection();
@@ -149,18 +163,12 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 refreshSkillBarSelection();
                 refreshDetailPanel();
             }, false);
-            selectedDanSide.BindValueChanged(_ =>
-            {
-                refreshDetailPanel();
-                refreshSkills();
-            }, false);
             rebuild();
         }
 
         private void clearDetailSelection()
         {
             selectedSkillId.Value = null;
-            selectedDanSide.Value = null;
         }
 
         private void toggleSkill(string skillId)
@@ -171,20 +179,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 return;
             }
 
-            selectedDanSide.Value = null;
             selectedSkillId.Value = skillId;
-        }
-
-        private void toggleDanClears(string side)
-        {
-            if (string.Equals(selectedDanSide.Value, side, StringComparison.Ordinal))
-            {
-                selectedDanSide.Value = null;
-                return;
-            }
-
-            selectedSkillId.Value = null;
-            selectedDanSide.Value = side;
         }
 
         private void rebuild()
@@ -203,11 +198,13 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 emptyHint.Text = EzSettingsProfile.LOCAL_PROFILE_TRACK_EMPTY;
                 emptyHint.Show();
                 overviewContainer.Hide();
+                danPanel.Hide();
                 return;
             }
 
             emptyHint.Hide();
             overviewContainer.Show();
+            danPanel.Show();
 
             foreach (int key in keyCounts)
             {
@@ -238,7 +235,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
             var definitions = skillProvider.Registry.GetSystem(EzSkillSystems.PLAYER_SSR)?.Skills
                               ?? Array.Empty<EzSkillDefinition>();
 
-            headerSlot.Child = new SkillsHeader(keyCount, snapshot, username, skillProvider, toggleDanClears, selectedDanSide);
+            headerSlot.Child = new SkillsHeader(keyCount, snapshot);
 
             var radarAxes = definitions.Where(d => d.SkillId != EzMinaSkillAxis.Overall.ToSsrSkillId()).ToList();
             double radarMax = radarAxes
@@ -248,7 +245,6 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
             if (radarAxes.Count >= 3 && radarMax > 0)
             {
-                var danSide = EzDanSideExtensions.ParseOrRc(selectedDanSide.Value);
                 var axes = radarAxes
                            .Select(d =>
                            {
@@ -262,7 +258,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
                                    (float)(v / radarMax),
                                    Colour4.FromHex(d.AccentHex),
                                    keyCount,
-                                   danSide);
+                                   EzDanSide.Rc);
                            })
                            .ToList();
 
@@ -309,12 +305,6 @@ namespace osu.Game.EzOsuGame.LocalProfile
             int keyCount = selectedKeyCount.Value;
             if (keyCount <= 0)
                 return;
-
-            if (!string.IsNullOrEmpty(selectedDanSide.Value))
-            {
-                showDanClears(selectedDanSide.Value, keyCount);
-                return;
-            }
 
             string? skillId = selectedSkillId.Value;
             if (string.IsNullOrEmpty(skillId))
@@ -400,55 +390,6 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
             return new EzLocalProfileChartCard(
                 EzSettingsProfile.LOCAL_PROFILE_AXIS_PLAYS_FOR.Format(displayName),
-                list);
-        }
-
-        private void showDanClears(string side, int keyCount)
-        {
-            string sideLabel = side == DanSkillSystem.SIDE_LN
-                ? EzSettingsProfile.LOCAL_PROFILE_DAN_SIDE_LN.ToString()
-                : EzSettingsProfile.LOCAL_PROFILE_DAN_SIDE_RC.ToString();
-
-            var clears = skillProvider
-                         .GetDanClears(username, keyCount, side, EzDanAlgorithm.VERSION)
-                         .Take(dan_clears_top_n)
-                         .ToList();
-
-            if (clears.Count == 0)
-            {
-                detailContainer.Child = new EzLocalProfileChartCard(
-                    EzSettingsProfile.LOCAL_PROFILE_DAN_CLEARS_FOR.Format(sideLabel),
-                    new OsuSpriteText
-                    {
-                        Text = EzSettingsProfile.LOCAL_PROFILE_DAN_CLEARS_EMPTY,
-                        Font = OsuFont.GetFont(size: 13),
-                    });
-                return;
-            }
-
-            var list = new FillFlowContainer
-            {
-                RelativeSizeAxes = Axes.X,
-                AutoSizeAxes = Axes.Y,
-                Direction = FillDirection.Vertical,
-                Spacing = new Vector2(0, 6),
-            };
-
-            foreach (var clear in clears)
-            {
-                var drill = findDrillRow(clear.BeatmapHash);
-                string title = formatPlayTitle(drill);
-
-                list.Add(new EzEvidenceScoreRow(
-                    title,
-                    EzEvidenceScoreRow.FormatDanMeta(clear.CreditedDan, clear.Accuracy, clear.Rate, clear.ScoredAt),
-                    drill != null && selectDrillScore != null
-                        ? () => selectDrillScore.Value = drill
-                        : null));
-            }
-
-            detailContainer.Child = new EzLocalProfileChartCard(
-                EzSettingsProfile.LOCAL_PROFILE_DAN_CLEARS_FOR.Format(sideLabel),
                 list);
         }
 
@@ -636,20 +577,14 @@ namespace osu.Game.EzOsuGame.LocalProfile
 
         private partial class SkillsHeader : FillFlowContainer
         {
-            public SkillsHeader(
-                int keyCount,
-                EzPlayerSsrSnapshot snapshot,
-                string username,
-                EzSkillProvider skillProvider,
-                Action<string> onDanSideClick,
-                IBindable<string?> selectedDanSide)
+            public SkillsHeader(int keyCount, EzPlayerSsrSnapshot snapshot)
             {
                 RelativeSizeAxes = Axes.X;
                 AutoSizeAxes = Axes.Y;
                 Direction = FillDirection.Vertical;
                 Spacing = new Vector2(0, 4);
 
-                var children = new List<Drawable>
+                Children = new Drawable[]
                 {
                     new OsuSpriteText
                     {
@@ -667,40 +602,6 @@ namespace osu.Game.EzOsuGame.LocalProfile
                         Font = OsuFont.GetFont(size: 12),
                     },
                 };
-
-                var danFlow = new FillFlowContainer
-                {
-                    RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y,
-                    Direction = FillDirection.Full,
-                    Spacing = new Vector2(8),
-                    Margin = new MarginPadding { Top = 4 },
-                };
-
-                addDanChip(danFlow, skillProvider.GetDan(username, keyCount, DanSkillSystem.SIDE_RC), DanSkillSystem.SIDE_RC, onDanSideClick, selectedDanSide);
-                addDanChip(danFlow, skillProvider.GetDan(username, keyCount, DanSkillSystem.SIDE_LN), DanSkillSystem.SIDE_LN, onDanSideClick, selectedDanSide);
-
-                if (danFlow.Children.Count > 0)
-                    children.Add(danFlow);
-
-                Children = children;
-            }
-
-            private static void addDanChip(
-                FillFlowContainer flow,
-                EzDanEstimate? estimate,
-                string side,
-                Action<string> onDanSideClick,
-                IBindable<string?> selectedDanSide)
-            {
-                if (estimate == null || string.IsNullOrEmpty(estimate.Label) || estimate.RawDan < 0)
-                    return;
-
-                flow.Add(new DanChip(side, estimate, () => onDanSideClick(side), selectedDanSide)
-                {
-                    Anchor = Anchor.TopLeft,
-                    Origin = Anchor.TopLeft,
-                });
             }
 
             [BackgroundDependencyLoader]
@@ -726,119 +627,6 @@ namespace osu.Game.EzOsuGame.LocalProfile
                     parts.Add(EzSettingsProfile.LOCAL_PROFILE_SKILL_STALE.ToString());
 
                 return string.Join(" · ", parts);
-            }
-        }
-
-        private partial class DanChip : OsuClickableContainer
-        {
-            private readonly string side;
-            private readonly EzDanEstimate estimate;
-            private readonly IBindable<string?> selectedDanSide;
-            private Box background = null!;
-
-            public DanChip(string side, EzDanEstimate estimate, Action action, IBindable<string?> selectedDanSide)
-            {
-                this.side = side;
-                this.estimate = estimate;
-                this.selectedDanSide = selectedDanSide.GetBoundCopy();
-
-                AutoSizeAxes = Axes.Both;
-                Masking = true;
-                CornerRadius = 8;
-                Action = action;
-            }
-
-            [BackgroundDependencyLoader]
-            private void load(OverlayColourProvider colours)
-            {
-                string sideLabel = side == DanSkillSystem.SIDE_LN
-                    ? EzSettingsProfile.LOCAL_PROFILE_DAN_SIDE_LN.ToString()
-                    : EzSettingsProfile.LOCAL_PROFILE_DAN_SIDE_RC.ToString();
-
-                var danDisplay = new EzDisplayDan
-                {
-                    Anchor = Anchor.CentreLeft,
-                    Origin = Anchor.CentreLeft,
-                    PreferImage = true,
-                    BadgeSize = 16,
-                };
-                danDisplay.SetLabel(estimate.Label, estimate.KeyCount, side);
-
-                var bodyFlow = new FillFlowContainer
-                {
-                    AutoSizeAxes = Axes.Both,
-                    Direction = FillDirection.Vertical,
-                    Padding = new MarginPadding { Horizontal = 12, Vertical = 8 },
-                    Spacing = new Vector2(0, 2),
-                    Children = new Drawable[]
-                    {
-                        new OsuSpriteText
-                        {
-                            Text = EzSettingsProfile.LOCAL_PROFILE_DAN_CHIP_TITLE,
-                            Font = OsuFont.GetFont(size: 10, weight: FontWeight.SemiBold),
-                            Colour = colours.Content2,
-                        },
-                        new FillFlowContainer
-                        {
-                            AutoSizeAxes = Axes.Both,
-                            Direction = FillDirection.Horizontal,
-                            Spacing = new Vector2(6, 0),
-                            Children = new Drawable[]
-                            {
-                                new OsuSpriteText
-                                {
-                                    Anchor = Anchor.CentreLeft,
-                                    Origin = Anchor.CentreLeft,
-                                    Text = sideLabel,
-                                    Font = OsuFont.GetFont(size: 13, weight: FontWeight.Bold),
-                                },
-                                danDisplay,
-                            }
-                        },
-                        new OsuSpriteText
-                        {
-                            Text = estimate.Clears > 0
-                                ? $"{EzSettingsProfile.LOCAL_PROFILE_DAN_CHIP_HINT} · {estimate.Clears}"
-                                : EzSettingsProfile.LOCAL_PROFILE_DAN_CHIP_HINT,
-                            Font = OsuFont.GetFont(size: 10),
-                            Colour = colours.Content2,
-                        },
-                    }
-                };
-
-                Children = new Drawable[]
-                {
-                    background = new Box
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Colour = colours.Background5,
-                    },
-                    bodyFlow,
-                };
-            }
-
-            protected override void LoadComplete()
-            {
-                base.LoadComplete();
-                selectedDanSide.BindValueChanged(_ => updateVisual(), true);
-            }
-
-            protected override bool OnHover(HoverEvent e)
-            {
-                updateVisual();
-                return base.OnHover(e);
-            }
-
-            protected override void OnHoverLost(HoverLostEvent e)
-            {
-                updateVisual();
-                base.OnHoverLost(e);
-            }
-
-            private void updateVisual()
-            {
-                bool active = string.Equals(selectedDanSide.Value, side, StringComparison.Ordinal);
-                background.FadeTo(active || IsHovered ? 1f : 0.7f, 80);
             }
         }
 

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileTrackSkillsBody.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileTrackSkillsBody.cs
@@ -15,8 +15,6 @@ using osu.Framework.Localisation;
 using osu.Game.EzOsuGame.HUD;
 using osu.Game.EzOsuGame.Localization;
 using osu.Game.EzOsuGame.Skills;
-using osu.Game.EzOsuGame.Skills.Dan;
-using osu.Game.EzOsuGame.UserInterface;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
@@ -525,7 +523,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
         }
 
         /// <summary>
-        /// One axis metric: per-axis dan badge, skill short name, then numeric SSR.
+        /// One axis metric: skill short name + numeric SSR. Skillset dans live on DualPanel only (no SrToRawDan badges).
         /// </summary>
         private partial class RadarAxisIndicator : FillFlowContainer
         {
@@ -535,26 +533,8 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 Direction = FillDirection.Vertical;
                 Spacing = new Vector2(0, 2);
 
-                var dan = new EzDisplayDan
-                {
-                    Anchor = Anchor.TopCentre,
-                    Origin = Anchor.TopCentre,
-                    BadgeSize = 18,
-                    PreferImage = true,
-                    Alpha = 0,
-                };
-
-                if (data.Value > 0 && double.IsFinite(data.Value))
-                {
-                    double rawDan = EzDanLabels.SrToRawDan(data.Value, data.Axis);
-                    string label = EzDanLadders.For(data.KeyCount, data.Side).ParseLabel(rawDan);
-                    dan.SetLabel(label, data.KeyCount, data.Side);
-                    dan.Show();
-                }
-
                 Children = new Drawable[]
                 {
-                    dan,
                     new OsuSpriteText
                     {
                         Anchor = Anchor.TopCentre,

--- a/osu.Game/EzOsuGame/Localization/EzHUDStrings.cs
+++ b/osu.Game/EzOsuGame/Localization/EzHUDStrings.cs
@@ -245,5 +245,23 @@ namespace osu.Game.EzOsuGame.Localization
         public static readonly LocalisableString SONG_PROGRESS_SHOW_REST_MARKERS_DESCRIPTION = new EzLocalizationManager.EzLocalisableString(
             "在进度条主体上用淡绿→淡黄渐变标出谱面休息区间。",
             "Tint rest intervals on the progress bar with a light-green to light-yellow gradient.");
+
+        public static readonly LocalisableString DAN_PANEL_DATA_SOURCE = new EzLocalizationManager.EzLocalisableString("段位数据源", "Dan Data Source");
+
+        public static readonly LocalisableString DAN_PANEL_DATA_SOURCE_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "Chart：谱面 MSD；Player：玩家 SSR/段位；Both：双源叠加（对齐 Skill 雷达黄/绿层）。",
+            "Chart: beatmap MSD; Player: SSR/dan; Both: overlay both (Skill radar yellow/green).");
+
+        public static readonly LocalisableString DAN_PANEL_DUAL_LAYOUT = new EzLocalizationManager.EzLocalisableString("RC|LN 布局", "RC|LN Layout");
+
+        public static readonly LocalisableString DAN_PANEL_DUAL_LAYOUT_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "Auto：按宽度切换；Horizontal：左右分列；Vertical：上下堆叠。",
+            "Auto by width; Horizontal side-by-side; Vertical stacked.");
+
+        public static readonly LocalisableString DAN_PANEL_SHOW_EVIDENCE = new EzLocalizationManager.EzLocalisableString("显示 Clear", "Show Clear");
+
+        public static readonly LocalisableString DAN_PANEL_SHOW_EVIDENCE_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
+            "仅个人档案建议开启：Player/Both 时在每侧下方显示 Top-15 Clear 成绩卡。选歌 HUD 默认关闭。",
+            "Prefer Local Profile only: when Player/Both, show Top-15 Clear cards under each side. Song-select HUD defaults off.");
     }
 }

--- a/osu.Game/EzOsuGame/Localization/EzSettings.Profile.cs
+++ b/osu.Game/EzOsuGame/Localization/EzSettings.Profile.cs
@@ -174,16 +174,19 @@ namespace osu.Game.EzOsuGame.Localization
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_DAN_CHIP_HINT =
             new EzLocalizationManager.EzLocalisableString(
-                "点击查看清除记录 · 启发式非 LeoBlack",
-                "Tap for clear evidence · heuristic, not LeoBlack");
+                "点击查看 Clear · 启发式非 LeoBlack",
+                "Tap for Clear · heuristic, not LeoBlack");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_DAN_CLEARS_FOR =
-            new EzLocalizationManager.EzLocalisableString("清除记录 · {0}", "Clear evidence · {0}");
+            new EzLocalizationManager.EzLocalisableString("Clear · {0}", "Clear · {0}");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_DAN_CLEARS_EMPTY =
             new EzLocalizationManager.EzLocalisableString(
-                "暂无该侧清除记录。请重新计算成绩分析。",
-                "No clear evidence for this side yet. Recompute Score Analysis.");
+                "暂无该侧 Clear。请重新计算成绩分析。",
+                "No Clear for this side yet. Recompute Score Analysis.");
+
+        public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_DAN_CELL_CLEARS =
+            new EzLocalizationManager.EzLocalisableString("Clear", "Clear");
 
         public static readonly EzLocalizationManager.EzLocalisableString LOCAL_PROFILE_DAN_HEURISTIC_HINT =
             new EzLocalizationManager.EzLocalisableString(

--- a/osu.Game/EzOsuGame/Overlays/BeatmapEzAnalysisWedge.cs
+++ b/osu.Game/EzOsuGame/Overlays/BeatmapEzAnalysisWedge.cs
@@ -1,13 +1,17 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Beatmaps;
 using osu.Game.EzOsuGame.HUD;
+using osu.Game.EzOsuGame.Skills;
 using osu.Game.EzOsuGame.UI;
 using osu.Game.Graphics.Containers;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Select;
 using osuTK;
 
@@ -24,6 +28,15 @@ namespace osu.Game.EzOsuGame.Overlays
 
         public Bindable<EzRadarDisplayMode> RightRadarMode { get; } = new Bindable<EzRadarDisplayMode>(EzRadarDisplayMode.Skill);
 
+        /// <summary>Exposed for visual tests / host configuration.</summary>
+        public EzHUDDanDualPanel DanPanel { get; private set; } = null!;
+
+        [Resolved]
+        private IBindable<WorkingBeatmap> beatmap { get; set; } = null!;
+
+        [Resolved]
+        private IBindable<IReadOnlyList<Mod>> mods { get; set; } = null!;
+
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -31,7 +44,7 @@ namespace osu.Game.EzOsuGame.Overlays
             AutoSizeAxes = Axes.Y;
             Padding = new MarginPadding { Top = 4f };
 
-            Width = 0.9f;
+            Width = 0.8f;
 
             InternalChild = new ShearAligningWrapper(new Container
             {
@@ -39,7 +52,7 @@ namespace osu.Game.EzOsuGame.Overlays
                 Masking = true,
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,
-                Shear = OsuGame.SHEAR,
+                // Shear = OsuGame.SHEAR,
                 Children = new Drawable[]
                 {
                     new EzSongSelectWedgeBackground(),
@@ -47,26 +60,40 @@ namespace osu.Game.EzOsuGame.Overlays
                     {
                         RelativeSizeAxes = Axes.X,
                         AutoSizeAxes = Axes.Y,
+                        // Shear = -OsuGame.SHEAR,
                         Padding = new MarginPadding { Left = SongSelect.WEDGE_CONTENT_MARGIN, Right = 35, Vertical = 16 },
                         Child = new FillFlowContainer
                         {
                             RelativeSizeAxes = Axes.X,
                             AutoSizeAxes = Axes.Y,
-                            Direction = FillDirection.Horizontal,
-                            Spacing = new Vector2(-10f, 0f),
+                            Direction = FillDirection.Vertical,
+                            Spacing = new Vector2(0, 12),
                             Children = new Drawable[]
                             {
-                                leftRadar = new EzHUDRadarPanel
+                                new FillFlowContainer
                                 {
-                                    Anchor = Anchor.TopLeft,
-                                    Origin = Anchor.TopLeft,
-                                    Shear = -OsuGame.SHEAR,
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    Direction = FillDirection.Horizontal,
+                                    Spacing = new Vector2(16f, 0f),
+                                    Children = new Drawable[]
+                                    {
+                                        leftRadar = new EzHUDRadarPanel
+                                        {
+                                            Anchor = Anchor.TopLeft,
+                                            Origin = Anchor.TopLeft,
+                                        },
+                                        rightRadar = new EzHUDRadarPanel
+                                        {
+                                            Anchor = Anchor.TopLeft,
+                                            Origin = Anchor.TopLeft,
+                                        },
+                                    },
                                 },
-                                rightRadar = new EzHUDRadarPanel
+                                // Same pattern as radars: instantiate HUD component, bind hosts, set defaults.
+                                DanPanel = new EzHUDDanDualPanel
                                 {
-                                    Anchor = Anchor.TopLeft,
-                                    Origin = Anchor.TopLeft,
-                                    Shear = -OsuGame.SHEAR,
+                                    RelativeSizeAxes = Axes.X,
                                 },
                             },
                         },
@@ -83,6 +110,27 @@ namespace osu.Game.EzOsuGame.Overlays
             rightRadar.RadarDisplayMode.BindTo(RightRadarMode);
             leftRadar.TargetUsername.BindTo(TargetUsername);
             rightRadar.TargetUsername.BindTo(TargetUsername);
+
+            DanPanel.TargetUsername.BindTo(TargetUsername);
+            DanPanel.DataSource.Value = EzDanPanelDataSource.Both;
+            DanPanel.DualLayout.Value = EzDanPanelDualLayout.Auto;
+            DanPanel.ShowEvidence.Value = false;
+
+            beatmap.BindValueChanged(_ => updateDanKeyCount(), true);
+            mods.BindValueChanged(_ => updateDanKeyCount());
+        }
+
+        private void updateDanKeyCount()
+        {
+            try
+            {
+                var playable = beatmap.Value.GetPlayableBeatmap(beatmap.Value.BeatmapInfo.Ruleset, mods.Value);
+                DanPanel.KeyCount.Value = EzMinaNoteConverter.ResolveKeyCount(playable);
+            }
+            catch
+            {
+                DanPanel.KeyCount.Value = 0;
+            }
         }
 
         protected override void PopIn()

--- a/osu.Game/EzOsuGame/Skills/EzDanLabeledStatList.cs
+++ b/osu.Game/EzOsuGame/Skills/EzDanLabeledStatList.cs
@@ -10,7 +10,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Layout;
 using osu.Game.EzOsuGame.Localization;
 using osu.Game.EzOsuGame.LocalProfile;
-using osu.Game.EzOsuGame.Skills.Dan;
 using osu.Game.EzOsuGame.UserInterface;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
@@ -20,8 +19,8 @@ using osuTK;
 namespace osu.Game.EzOsuGame.Skills
 {
     /// <summary>
-    /// One RC/LN side: label + optional aggregate dans + (RC only) radar-axis <see cref="EzDisplaySkillsDan"/> + clear evidence.
-    /// Mina skill→dan always uses the keymode RC ladder (hub parseDan); LN column leaves the skill slot empty until LN skills exist.
+    /// One RC/LN side: aggregate dans + hub skillset chips (slots from <see cref="EzDanSkillsetBuckets"/>) + clear evidence.
+    /// UI never invents per-skill dans via <c>SrToRawDan</c> — only Provider verdicts / chart labels.
     /// </summary>
     public partial class EzDanLabeledStatList : CompositeDrawable
     {
@@ -46,7 +45,7 @@ namespace osu.Game.EzOsuGame.Skills
         private FillDirection cellsDirection = FillDirection.Horizontal;
         private readonly LayoutValue sizeLayout = new LayoutValue(Invalidation.DrawSize);
 
-        private readonly Dictionary<EzMinaSkillAxis, EzDisplaySkillsDan> axisChips = new Dictionary<EzMinaSkillAxis, EzDisplaySkillsDan>();
+        private readonly Dictionary<string, EzDisplaySkillsDan> skillsetChips = new Dictionary<string, EzDisplaySkillsDan>(StringComparer.Ordinal);
 
         public EzDanLabeledStatList(EzDanSide side, Colour4 accent)
         {
@@ -63,19 +62,6 @@ namespace osu.Game.EzOsuGame.Skills
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colours)
         {
-            foreach (var axis in EzMinaSkillAxisExtensions.RadarAxes)
-            {
-                axisChips[axis] = new EzDisplaySkillsDan
-                {
-                    PreferDanImage = true,
-                    ShowValue = true,
-                    Anchor = Anchor.TopLeft,
-                    Origin = Anchor.TopLeft,
-                    Scale = new Vector2(displayScale),
-                    Alpha = 0,
-                };
-            }
-
             InternalChild = new FillFlowContainer
             {
                 RelativeSizeAxes = Axes.X,
@@ -152,9 +138,6 @@ namespace osu.Game.EzOsuGame.Skills
                 },
             };
 
-            foreach (var chip in axisChips.Values)
-                cellsFlow.Add(chip);
-
             sideLabel.Text = Side == EzDanSide.Ln
                 ? EzSettingsProfile.LOCAL_PROFILE_DAN_SIDE_LN
                 : EzSettingsProfile.LOCAL_PROFILE_DAN_SIDE_RC;
@@ -172,8 +155,9 @@ namespace osu.Game.EzOsuGame.Skills
             int keyCount,
             string? chartAggregateLabel,
             string? playerAggregateLabel,
-            IReadOnlyDictionary<string, double> chartAxes,
-            IReadOnlyDictionary<string, double> playerAxes,
+            IReadOnlyList<EzDanSkillsetSlot> slots,
+            IReadOnlyDictionary<string, string> chartLabelsBySkillset,
+            IReadOnlyDictionary<string, EzDanSkillsetVerdict> playerSkillsets,
             IReadOnlyList<EzDanClearEvidenceRow> clears,
             Func<string, string> resolveTitle,
             Action<EzDanClearEvidenceRow>? onSelectClear,
@@ -183,7 +167,8 @@ namespace osu.Game.EzOsuGame.Skills
             {
                 Schedule(() => UpdateContent(
                     keyCount, chartAggregateLabel, playerAggregateLabel,
-                    chartAxes, playerAxes, clears, resolveTitle, onSelectClear, showEvidence));
+                    slots, chartLabelsBySkillset, playerSkillsets,
+                    clears, resolveTitle, onSelectClear, showEvidence));
                 return;
             }
 
@@ -196,34 +181,7 @@ namespace osu.Game.EzOsuGame.Skills
             setAggregate(chartAggregateDan, chartAggregateLabel, keyCount, Side);
             setAggregate(playerAggregateDan, playerAggregateLabel, keyCount, Side);
 
-            // Mina axes are RcMina only. Hub maps skill SR → parseDan (reform / keymode RC ladder),
-            // never through the 4K LN 1–17 ladder. LN column keeps an empty skill slot for later data.
-            if (Side == EzDanSide.Ln)
-            {
-                foreach (var chip in axisChips.Values)
-                    chip.Clear();
-
-                cellsFlow.Hide();
-            }
-            else
-            {
-                cellsFlow.Show();
-
-                // TODO: LN skill axes when LnSkillSystem lands — do not feed Mina into LN side.
-                var skillLadder = EzDanLadders.For(keyCount, EzDanSide.Rc);
-
-                foreach (var axis in EzMinaSkillAxisExtensions.RadarAxes)
-                {
-                    var chip = axisChips[axis];
-                    double chartValue = resolveAxisValue(chartAxes, axis);
-                    double playerValue = resolveAxisValue(playerAxes, axis);
-
-                    string? chartLabel = chartValue > 0 ? skillLadder.ParseLabel(EzDanLabels.SrToRawDan(chartValue, axis)) : null;
-                    string? playerLabel = playerValue > 0 ? skillLadder.ParseLabel(EzDanLabels.SrToRawDan(playerValue, axis)) : null;
-
-                    chip.Set(axis, chartLabel, chartValue > 0 ? chartValue : null, playerLabel, playerValue > 0 ? playerValue : null, keyCount, EzDanSide.Rc);
-                }
-            }
+            rebuildSkillsetChips(keyCount, slots, chartLabelsBySkillset, playerSkillsets);
 
             if (!showEvidence)
             {
@@ -233,6 +191,71 @@ namespace osu.Game.EzOsuGame.Skills
 
             evidenceSection.Show();
             rebuildEvidence(clears, resolveTitle, onSelectClear);
+        }
+
+        private void rebuildSkillsetChips(
+            int keyCount,
+            IReadOnlyList<EzDanSkillsetSlot> slots,
+            IReadOnlyDictionary<string, string> chartLabelsBySkillset,
+            IReadOnlyDictionary<string, EzDanSkillsetVerdict> playerSkillsets)
+        {
+            if (slots.Count == 0)
+            {
+                cellsFlow.Clear();
+                skillsetChips.Clear();
+                cellsFlow.Hide();
+                return;
+            }
+
+            cellsFlow.Show();
+
+            var keep = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var slot in slots)
+            {
+                keep.Add(slot.Id);
+
+                if (!skillsetChips.TryGetValue(slot.Id, out var chip))
+                {
+                    chip = new EzDisplaySkillsDan
+                    {
+                        PreferDanImage = true,
+                        ShowValue = true,
+                        Anchor = Anchor.TopLeft,
+                        Origin = Anchor.TopLeft,
+                        Scale = new Vector2(displayScale),
+                    };
+                    skillsetChips[slot.Id] = chip;
+                    cellsFlow.Add(chip);
+                }
+
+                chartLabelsBySkillset.TryGetValue(slot.Id, out string? chartLabel);
+
+                string? playerLabel = null;
+                int? playerClears = null;
+
+                if (playerSkillsets.TryGetValue(slot.Id, out var verdict))
+                {
+                    playerLabel = verdict.Label;
+                    playerClears = verdict.Clears;
+                }
+
+                chip.SetSkillset(slot, chartLabel, playerLabel, playerClears, keyCount, Side);
+            }
+
+            foreach (string id in skillsetChips.Keys.Where(id => !keep.Contains(id)).ToList())
+            {
+                cellsFlow.Remove(skillsetChips[id], true);
+                skillsetChips.Remove(id);
+            }
+
+            // Keep visual order = slots order.
+            for (int i = 0; i < slots.Count; i++)
+            {
+                var chip = skillsetChips[slots[i].Id];
+                if (cellsFlow.GetLayoutPosition(chip) != i)
+                    cellsFlow.SetLayoutPosition(chip, i);
+            }
         }
 
         private static void setAggregate(EzDisplayDan display, string? label, int keyCount, EzDanSide side)
@@ -246,18 +269,6 @@ namespace osu.Game.EzOsuGame.Skills
             {
                 display.Hide();
             }
-        }
-
-        private static double resolveAxisValue(IReadOnlyDictionary<string, double> values, EzMinaSkillAxis axis)
-        {
-            if (values.TryGetValue(axis.ToMsdSkillId(), out double msd) && msd > 0)
-                return msd;
-            if (values.TryGetValue(axis.ToSsrSkillId(), out double ssr) && ssr > 0)
-                return ssr;
-            if (values.TryGetValue(axis.ToId(), out double bare) && bare > 0)
-                return bare;
-
-            return 0;
         }
 
         private void rebuildEvidence(

--- a/osu.Game/EzOsuGame/Skills/EzDanLabeledStatList.cs
+++ b/osu.Game/EzOsuGame/Skills/EzDanLabeledStatList.cs
@@ -1,0 +1,317 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Layout;
+using osu.Game.EzOsuGame.Localization;
+using osu.Game.EzOsuGame.LocalProfile;
+using osu.Game.EzOsuGame.Skills.Dan;
+using osu.Game.EzOsuGame.UserInterface;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
+using osuTK;
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    /// <summary>
+    /// One RC/LN side: label + optional aggregate dans + full radar-axis <see cref="EzDisplaySkillsDan"/> + clear evidence.
+    /// </summary>
+    public partial class EzDanLabeledStatList : CompositeDrawable
+    {
+        /// <summary>Max clear-evidence cards under this side (player clears only).</summary>
+        private const int clears_top_n = 15;
+
+        private float displayScale => 1.5f;
+
+        private readonly EzDanSide side;
+        private readonly Colour4 accent;
+
+        private OsuSpriteText sideLabel = null!;
+        private EzDisplayDan chartAggregateDan = null!;
+        private EzDisplayDan playerAggregateDan = null!;
+        private FillFlowContainer cellsFlow = null!;
+        private FillFlowContainer evidenceFlow = null!;
+        private OsuSpriteText emptyEvidence = null!;
+        private Container evidenceSection = null!;
+
+        private FillDirection cellsDirection = FillDirection.Horizontal;
+        private readonly LayoutValue sizeLayout = new LayoutValue(Invalidation.DrawSize);
+
+        private readonly Dictionary<EzMinaSkillAxis, EzDisplaySkillsDan> axisChips = new Dictionary<EzMinaSkillAxis, EzDisplaySkillsDan>();
+
+        public EzDanLabeledStatList(EzDanSide side, Colour4 accent)
+        {
+            this.side = side;
+            this.accent = accent;
+
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            AddLayout(sizeLayout);
+        }
+
+        public void SetLayoutInset(MarginPadding padding) => Padding = padding;
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colours)
+        {
+            foreach (var axis in EzMinaSkillAxisExtensions.RadarAxes)
+            {
+                axisChips[axis] = new EzDisplaySkillsDan
+                {
+                    PreferDanImage = true,
+                    ShowValue = true,
+                    Anchor = Anchor.TopLeft,
+                    Origin = Anchor.TopLeft,
+                    Scale = new Vector2(displayScale),
+                    Alpha = 0,
+                };
+            }
+
+            InternalChild = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(0, 8),
+                Children = new Drawable[]
+                {
+                    new FillFlowContainer
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Direction = FillDirection.Horizontal,
+                        Spacing = new Vector2(8, 0),
+                        Children = new Drawable[]
+                        {
+                            sideLabel = new OsuSpriteText
+                            {
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                                Font = OsuFont.GetFont(size: 16, weight: FontWeight.Bold),
+                                Colour = accent,
+                            },
+                            chartAggregateDan = new EzDisplayDan
+                            {
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                                BadgeSize = 20,
+                                PreferImage = true,
+                                Scale = new Vector2(displayScale),
+                                Alpha = 0,
+                            },
+                            playerAggregateDan = new EzDisplayDan
+                            {
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                                BadgeSize = 18,
+                                PreferImage = true,
+                                Scale = new Vector2(displayScale),
+                                Alpha = 0,
+                            },
+                        },
+                    },
+                    cellsFlow = new FillFlowContainer
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Direction = cellsDirection,
+                        Spacing = new Vector2(10, 8),
+                    },
+                    evidenceSection = new Container
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Children = new Drawable[]
+                        {
+                            emptyEvidence = new OsuSpriteText
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                Font = OsuFont.GetFont(size: 12),
+                                Colour = colours.Content2,
+                                Text = EzSettingsProfile.LOCAL_PROFILE_DAN_CLEARS_EMPTY,
+                                Alpha = 0,
+                            },
+                            evidenceFlow = new FillFlowContainer
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y,
+                                Direction = FillDirection.Full,
+                                Spacing = new Vector2(8),
+                            },
+                        },
+                    },
+                },
+            };
+
+            foreach (var chip in axisChips.Values)
+                cellsFlow.Add(chip);
+
+            sideLabel.Text = side == EzDanSide.Ln
+                ? EzSettingsProfile.LOCAL_PROFILE_DAN_SIDE_LN
+                : EzSettingsProfile.LOCAL_PROFILE_DAN_SIDE_RC;
+        }
+
+        public void SetCellsDirection(FillDirection direction)
+        {
+            cellsDirection = direction;
+
+            if (LoadState >= LoadState.Ready)
+                cellsFlow.Direction = direction;
+        }
+
+        public void UpdateContent(
+            int keyCount,
+            string? chartAggregateLabel,
+            string? playerAggregateLabel,
+            IReadOnlyDictionary<string, double> chartAxes,
+            IReadOnlyDictionary<string, double> playerAxes,
+            IReadOnlyList<EzDanClearEvidenceRow> clears,
+            Func<string, string> resolveTitle,
+            Action<EzDanClearEvidenceRow>? onSelectClear,
+            bool showEvidence)
+        {
+            if (LoadState < LoadState.Ready)
+            {
+                Schedule(() => UpdateContent(
+                    keyCount, chartAggregateLabel, playerAggregateLabel,
+                    chartAxes, playerAxes, clears, resolveTitle, onSelectClear, showEvidence));
+                return;
+            }
+
+            cellsFlow.Direction = cellsDirection;
+
+            sideLabel.Text = side == EzDanSide.Ln
+                ? EzSettingsProfile.LOCAL_PROFILE_DAN_SIDE_LN
+                : EzSettingsProfile.LOCAL_PROFILE_DAN_SIDE_RC;
+
+            setAggregate(chartAggregateDan, chartAggregateLabel, keyCount, side);
+            setAggregate(playerAggregateDan, playerAggregateLabel, keyCount, side);
+
+            var ladder = EzDanLadders.For(keyCount, side);
+
+            foreach (var axis in EzMinaSkillAxisExtensions.RadarAxes)
+            {
+                var chip = axisChips[axis];
+                double chartValue = resolveAxisValue(chartAxes, axis);
+                double playerValue = resolveAxisValue(playerAxes, axis);
+
+                string? chartLabel = chartValue > 0 ? ladder.ParseLabel(EzDanLabels.SrToRawDan(chartValue, axis)) : null;
+                string? playerLabel = playerValue > 0 ? ladder.ParseLabel(EzDanLabels.SrToRawDan(playerValue, axis)) : null;
+
+                chip.Set(axis, chartLabel, chartValue > 0 ? chartValue : null, playerLabel, playerValue > 0 ? playerValue : null, keyCount, side);
+            }
+
+            if (!showEvidence)
+            {
+                evidenceSection.Hide();
+                return;
+            }
+
+            evidenceSection.Show();
+            rebuildEvidence(clears, resolveTitle, onSelectClear);
+        }
+
+        private static void setAggregate(EzDisplayDan display, string? label, int keyCount, EzDanSide side)
+        {
+            if (!string.IsNullOrEmpty(label))
+            {
+                display.SetLabel(label, keyCount, side);
+                display.Show();
+            }
+            else
+            {
+                display.Hide();
+            }
+        }
+
+        private static double resolveAxisValue(IReadOnlyDictionary<string, double> values, EzMinaSkillAxis axis)
+        {
+            if (values.TryGetValue(axis.ToMsdSkillId(), out double msd) && msd > 0)
+                return msd;
+            if (values.TryGetValue(axis.ToSsrSkillId(), out double ssr) && ssr > 0)
+                return ssr;
+            if (values.TryGetValue(axis.ToId(), out double bare) && bare > 0)
+                return bare;
+
+            return 0;
+        }
+
+        private void rebuildEvidence(
+            IReadOnlyList<EzDanClearEvidenceRow> clears,
+            Func<string, string> resolveTitle,
+            Action<EzDanClearEvidenceRow>? onSelectClear)
+        {
+            evidenceFlow.Clear();
+
+            var top = clears.Take(clears_top_n).ToList();
+
+            if (top.Count == 0)
+            {
+                emptyEvidence.Show();
+                evidenceFlow.Hide();
+                return;
+            }
+
+            emptyEvidence.Hide();
+            evidenceFlow.Show();
+
+            float colWidth = resolveEvidenceColumnWidth();
+
+            foreach (var clear in top)
+            {
+                evidenceFlow.Add(new EzEvidenceScoreRow(
+                    resolveTitle(clear.BeatmapHash),
+                    EzEvidenceScoreRow.FormatDanMeta(clear.CreditedDan, clear.Accuracy, clear.Rate, clear.ScoredAt),
+                    onSelectClear != null ? () => onSelectClear(clear) : null)
+                {
+                    Width = colWidth,
+                    RelativeSizeAxes = Axes.None,
+                    AutoSizeAxes = Axes.Y,
+                });
+            }
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (!sizeLayout.IsValid)
+            {
+                sizeLayout.Validate();
+                reflowEvidenceWidths();
+            }
+        }
+
+        private void reflowEvidenceWidths()
+        {
+            float colWidth = resolveEvidenceColumnWidth();
+
+            foreach (var child in evidenceFlow)
+                child.Width = colWidth;
+        }
+
+        private float resolveEvidenceColumnWidth()
+        {
+            float width = DrawWidth;
+            if (width <= 0)
+                width = 400;
+
+            int cols = width switch
+            {
+                < 280 => 1,
+                < 420 => 2,
+                < 560 => 3,
+                _ => 4,
+            };
+
+            const float gap = 8f;
+            return Math.Max(80, (width - gap * (cols - 1)) / cols);
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Skills/EzDanLabeledStatList.cs
+++ b/osu.Game/EzOsuGame/Skills/EzDanLabeledStatList.cs
@@ -20,7 +20,8 @@ using osuTK;
 namespace osu.Game.EzOsuGame.Skills
 {
     /// <summary>
-    /// One RC/LN side: label + optional aggregate dans + full radar-axis <see cref="EzDisplaySkillsDan"/> + clear evidence.
+    /// One RC/LN side: label + optional aggregate dans + (RC only) radar-axis <see cref="EzDisplaySkillsDan"/> + clear evidence.
+    /// Mina skill→dan always uses the keymode RC ladder (hub parseDan); LN column leaves the skill slot empty until LN skills exist.
     /// </summary>
     public partial class EzDanLabeledStatList : CompositeDrawable
     {
@@ -29,8 +30,10 @@ namespace osu.Game.EzOsuGame.Skills
 
         private float displayScale => 1.5f;
 
-        private readonly EzDanSide side;
         private readonly Colour4 accent;
+
+        /// <summary>RC or LN column this list represents.</summary>
+        public EzDanSide Side { get; }
 
         private OsuSpriteText sideLabel = null!;
         private EzDisplayDan chartAggregateDan = null!;
@@ -47,7 +50,7 @@ namespace osu.Game.EzOsuGame.Skills
 
         public EzDanLabeledStatList(EzDanSide side, Colour4 accent)
         {
-            this.side = side;
+            this.Side = side;
             this.accent = accent;
 
             RelativeSizeAxes = Axes.X;
@@ -152,7 +155,7 @@ namespace osu.Game.EzOsuGame.Skills
             foreach (var chip in axisChips.Values)
                 cellsFlow.Add(chip);
 
-            sideLabel.Text = side == EzDanSide.Ln
+            sideLabel.Text = Side == EzDanSide.Ln
                 ? EzSettingsProfile.LOCAL_PROFILE_DAN_SIDE_LN
                 : EzSettingsProfile.LOCAL_PROFILE_DAN_SIDE_RC;
         }
@@ -186,25 +189,40 @@ namespace osu.Game.EzOsuGame.Skills
 
             cellsFlow.Direction = cellsDirection;
 
-            sideLabel.Text = side == EzDanSide.Ln
+            sideLabel.Text = Side == EzDanSide.Ln
                 ? EzSettingsProfile.LOCAL_PROFILE_DAN_SIDE_LN
                 : EzSettingsProfile.LOCAL_PROFILE_DAN_SIDE_RC;
 
-            setAggregate(chartAggregateDan, chartAggregateLabel, keyCount, side);
-            setAggregate(playerAggregateDan, playerAggregateLabel, keyCount, side);
+            setAggregate(chartAggregateDan, chartAggregateLabel, keyCount, Side);
+            setAggregate(playerAggregateDan, playerAggregateLabel, keyCount, Side);
 
-            var ladder = EzDanLadders.For(keyCount, side);
-
-            foreach (var axis in EzMinaSkillAxisExtensions.RadarAxes)
+            // Mina axes are RcMina only. Hub maps skill SR → parseDan (reform / keymode RC ladder),
+            // never through the 4K LN 1–17 ladder. LN column keeps an empty skill slot for later data.
+            if (Side == EzDanSide.Ln)
             {
-                var chip = axisChips[axis];
-                double chartValue = resolveAxisValue(chartAxes, axis);
-                double playerValue = resolveAxisValue(playerAxes, axis);
+                foreach (var chip in axisChips.Values)
+                    chip.Clear();
 
-                string? chartLabel = chartValue > 0 ? ladder.ParseLabel(EzDanLabels.SrToRawDan(chartValue, axis)) : null;
-                string? playerLabel = playerValue > 0 ? ladder.ParseLabel(EzDanLabels.SrToRawDan(playerValue, axis)) : null;
+                cellsFlow.Hide();
+            }
+            else
+            {
+                cellsFlow.Show();
 
-                chip.Set(axis, chartLabel, chartValue > 0 ? chartValue : null, playerLabel, playerValue > 0 ? playerValue : null, keyCount, side);
+                // TODO: LN skill axes when LnSkillSystem lands — do not feed Mina into LN side.
+                var skillLadder = EzDanLadders.For(keyCount, EzDanSide.Rc);
+
+                foreach (var axis in EzMinaSkillAxisExtensions.RadarAxes)
+                {
+                    var chip = axisChips[axis];
+                    double chartValue = resolveAxisValue(chartAxes, axis);
+                    double playerValue = resolveAxisValue(playerAxes, axis);
+
+                    string? chartLabel = chartValue > 0 ? skillLadder.ParseLabel(EzDanLabels.SrToRawDan(chartValue, axis)) : null;
+                    string? playerLabel = playerValue > 0 ? skillLadder.ParseLabel(EzDanLabels.SrToRawDan(playerValue, axis)) : null;
+
+                    chip.Set(axis, chartLabel, chartValue > 0 ? chartValue : null, playerLabel, playerValue > 0 ? playerValue : null, keyCount, EzDanSide.Rc);
+                }
             }
 
             if (!showEvidence)

--- a/osu.Game/EzOsuGame/Skills/EzDanSkillsetBuckets.cs
+++ b/osu.Game/EzOsuGame/Skills/EzDanSkillsetBuckets.cs
@@ -1,0 +1,166 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Localisation;
+using osu.Game.EzOsuGame.Skills.Dan;
+
+namespace osu.Game.EzOsuGame.Skills
+{
+    /// <summary>
+    ///     Hub-aligned dan skillset slot (evidence-window tiles). Layout is keyed by this, not Mina axes.
+    /// </summary>
+    public readonly record struct EzDanSkillsetSlot(string Id, LocalisableString DisplayName, string AccentHex);
+
+    /// <summary>
+    ///     One skillset dan verdict (clear-bucket average). Absent from <see cref="EzSkillProvider.GetDanSkillsets" /> when
+    ///     under quorum / no filing data.
+    /// </summary>
+    public readonly record struct EzDanSkillsetVerdict(string SkillsetId, double RawDan, string Label, int Clears);
+
+    /// <summary>
+    ///     Hub <c>danSkillsetBuckets</c> slot table + thin 4K RC filing.
+    ///     <para>
+    ///         Capability matrix (do not silently drop keys in UI — always call <see cref="Slots" />):
+    ///         4K RC: jack/tech/speed/stamina (MSD DominantAxis filing — this PR);
+    ///         6/7K RC: jack/tech/speed/stream — TODO(data): pattern-tag / cluster filing;
+    ///         4K/6K LN: empty slots (side aggregate only);
+    ///         7K LN: lngeneral/lntech/lninverse/lnrelease — TODO(data): LN pattern filing;
+    ///         LeoBlack jackDemand / Jumpstream arbitration — TODO(data).
+    ///     </para>
+    /// </summary>
+    public static class EzDanSkillsetBuckets
+    {
+        public const string JACK = "jack";
+        public const string TECH = "tech";
+        public const string SPEED = "speed";
+        public const string STAMINA = "stamina";
+        public const string STREAM = "stream";
+        public const string LN_GENERAL = "lngeneral";
+        public const string LN_TECH = "lntech";
+        public const string LN_INVERSE = "lninverse";
+        public const string LN_RELEASE = "lnrelease";
+
+        private static readonly EzDanSkillsetSlot[] rc_4k =
+        {
+            new EzDanSkillsetSlot(JACK, "Jack", "#ec6a9c"),
+            new EzDanSkillsetSlot(TECH, "Tech", "#83cf6b"),
+            new EzDanSkillsetSlot(SPEED, "Speed", "#5ab2f2"),
+            new EzDanSkillsetSlot(STAMINA, "Stamina", "#ad6b5d")
+        };
+
+        private static readonly EzDanSkillsetSlot[] rc_pattern =
+        {
+            new EzDanSkillsetSlot(JACK, "Jack", "#ec6a9c"),
+            new EzDanSkillsetSlot(TECH, "Tech", "#83cf6b"),
+            new EzDanSkillsetSlot(SPEED, "Speed", "#5ab2f2"),
+            new EzDanSkillsetSlot(STREAM, "Stream", "#8f6bd8")
+        };
+
+        private static readonly EzDanSkillsetSlot[] ln_7k =
+        {
+            new EzDanSkillsetSlot(LN_GENERAL, "General", "#f07474"),
+            new EzDanSkillsetSlot(LN_TECH, "Tech", "#83cf6b"),
+            new EzDanSkillsetSlot(LN_INVERSE, "Inverse", "#c59a5c"),
+            new EzDanSkillsetSlot(LN_RELEASE, "Release", "#46c7b8")
+        };
+
+        /// <summary>Ordered slots for DualPanel layout — returned even when verdicts are empty.</summary>
+        public static IReadOnlyList<EzDanSkillsetSlot> Slots(int keyCount, EzDanSide side)
+        {
+            if (side == EzDanSide.Ln)
+            {
+                // Hub: only 7K LN publishes skillset tiles.
+                return keyCount == 7 ? ln_7k : Array.Empty<EzDanSkillsetSlot>();
+            }
+
+            return keyCount == 4 ? rc_4k : rc_pattern;
+        }
+
+        public static IReadOnlyList<EzDanSkillsetSlot> Slots(int keyCount, string sideId)
+        {
+            return Slots(keyCount, EzDanSideExtensions.ParseOrRc(sideId));
+        }
+
+        /// <summary>4K RC: map Mina DominantAxis → skillset id. Null when unmapped.</summary>
+        public static string? TryMapMinaAxisToSkillset(EzMinaSkillAxis axis)
+        {
+            return axis switch
+            {
+                EzMinaSkillAxis.JackSpeed or EzMinaSkillAxis.Chordjack => JACK,
+                EzMinaSkillAxis.Technical or EzMinaSkillAxis.Jumpstream => TECH,
+                EzMinaSkillAxis.Stream => SPEED,
+                EzMinaSkillAxis.Handstream or EzMinaSkillAxis.Stamina => STAMINA,
+                _ => null
+            };
+        }
+
+        /// <summary>
+        ///     Thin 4K RC skillset dans from clears + MSD dominant axis.
+        ///     Other key×side: empty (slots still from <see cref="Slots" />).
+        /// </summary>
+        public static IReadOnlyDictionary<string, EzDanSkillsetVerdict> ComputeFromClears(
+            int keyCount,
+            EzDanSide side,
+            IReadOnlyList<EzDanClearEvidenceRow> clears,
+            Func<string, EzMinaSkillAxis?> resolveDominantAxis)
+        {
+            var result = new Dictionary<string, EzDanSkillsetVerdict>(StringComparer.Ordinal);
+
+            if (side != EzDanSide.Rc || keyCount != 4 || clears.Count == 0)
+            {
+                // TODO(data): 6/7K RC pattern-tag / cluster filing
+                // TODO(data): 7K LN pattern (lngeneral/lntech/lninverse/lnrelease) filing
+                return result;
+            }
+
+            var buckets = new Dictionary<string, List<double>>(StringComparer.Ordinal)
+            {
+                [JACK] = new List<double>(),
+                [TECH] = new List<double>(),
+                [SPEED] = new List<double>(),
+                [STAMINA] = new List<double>()
+            };
+
+            foreach (var clear in clears)
+            {
+                if (clear.KeyCount != keyCount)
+                    continue;
+                if (!string.Equals(clear.Side, side.ToId(), StringComparison.OrdinalIgnoreCase))
+                    continue;
+                if (string.IsNullOrEmpty(clear.BeatmapHash))
+                    continue;
+
+                var axis = resolveDominantAxis(clear.BeatmapHash);
+                if (axis is not EzMinaSkillAxis a)
+                    continue;
+
+                string? skillsetId = TryMapMinaAxisToSkillset(a);
+                if (skillsetId == null)
+                    continue;
+
+                buckets[skillsetId].Add(clear.CreditedDan);
+            }
+
+            var ladder = EzDanLadders.For(keyCount, EzDanSide.Rc);
+
+            foreach ((string id, var values) in buckets)
+            {
+                if (values.Count < EzDanAlgorithm.CLEAR_QUORUM)
+                    continue;
+
+                var window = values
+                             .OrderByDescending(v => v)
+                             .Take(EzDanAlgorithm.CLEAR_WINDOW)
+                             .ToList();
+
+                double rawDan = window.Average();
+                result[id] = new EzDanSkillsetVerdict(id, rawDan, ladder.ParseLabel(rawDan), values.Count);
+            }
+
+            return result;
+        }
+    }
+}

--- a/osu.Game/EzOsuGame/Skills/EzSkillProvider.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSkillProvider.cs
@@ -118,6 +118,51 @@ namespace osu.Game.EzOsuGame.Skills
             => store.GetDanEstimate(username, keyCount, side);
 
         /// <summary>
+        /// Ordered DualPanel skillset slots for <paramref name="keyCount"/>×<paramref name="side"/> (hub table; may be empty).
+        /// </summary>
+        public IReadOnlyList<EzDanSkillsetSlot> GetDanSkillsetSlots(int keyCount, EzDanSide side)
+            => EzDanSkillsetBuckets.Slots(keyCount, side);
+
+        public IReadOnlyList<EzDanSkillsetSlot> GetDanSkillsetSlots(int keyCount, string sideId)
+            => GetDanSkillsetSlots(keyCount, EzDanSideExtensions.ParseOrRc(sideId));
+
+        /// <summary>
+        /// Skillset dan verdicts (clear-bucket averages). Missing keys = under quorum / no filing data yet.
+        /// 4K RC: thin MSD DominantAxis filing. Other modes: empty until TODO(data) pattern/LN filing.
+        /// </summary>
+        public IReadOnlyDictionary<string, EzDanSkillsetVerdict> GetDanSkillsets(string username, int keyCount, string side)
+        {
+            var sideEnum = EzDanSideExtensions.ParseOrRc(side);
+            var clears = GetDanClears(username, keyCount, side, EzDanAlgorithm.VERSION);
+            return EzDanSkillsetBuckets.ComputeFromClears(keyCount, sideEnum, clears, hash =>
+            {
+                var msd = GetBeatmapMsd(hash);
+                if (msd.Count == 0)
+                    return null;
+
+                return EzDanLabels.DominantAxis(msd);
+            });
+        }
+
+        /// <summary>
+        /// Chart-side: at most one skillset gets the real chart label (DominantAxis → bucket).
+        /// </summary>
+        public IReadOnlyDictionary<string, string> GetChartDanSkillsetLabels(BeatmapInfo beatmapInfo, IReadOnlyList<Mod>? mods = null)
+        {
+            var result = new Dictionary<string, string>(StringComparer.Ordinal);
+            var chart = TryGetChartDan(beatmapInfo, mods) ?? TryGetCachedChartDan(beatmapInfo);
+            if (chart == null || string.IsNullOrEmpty(chart.Label))
+                return result;
+
+            string? skillsetId = EzDanSkillsetBuckets.TryMapMinaAxisToSkillset(chart.DominantAxis);
+            if (skillsetId != null && chart.KeyCount == 4 && chart.Side == EzDanSide.Rc)
+                result[skillsetId] = chart.Label;
+
+            // TODO(data): 6/7K chart skillset filing via pattern tags
+            return result;
+        }
+
+        /// <summary>
         /// Chart-side dan for song select me-vs-chart. Null when estimator unset or chart cannot be rated.
         /// </summary>
         public EzChartDanVerdict? TryGetChartDan(BeatmapInfo beatmapInfo, IReadOnlyList<Mod>? mods = null)

--- a/osu.Game/EzOsuGame/UserInterface/EzDisplay.Dan.cs
+++ b/osu.Game/EzOsuGame/UserInterface/EzDisplay.Dan.cs
@@ -29,7 +29,28 @@ namespace osu.Game.EzOsuGame.UserInterface
         private EzResourceStore? resources;
         private TextureStore? textures;
 
-        public bool PreferImage { get; set; } = true;
+        private string? pendingLabel;
+        private int pendingKeyCount = 4;
+        private EzDanSide pendingSide = EzDanSide.Rc;
+        private bool hasPendingLabel;
+
+        private bool preferImage = true;
+
+        /// <summary>When true, prefer badge texture over bare text (retries after DI load).</summary>
+        public bool PreferImage
+        {
+            get => preferImage;
+            set
+            {
+                if (preferImage == value)
+                    return;
+
+                preferImage = value;
+
+                if (hasPendingLabel)
+                    applyPendingLabel();
+            }
+        }
 
         public float BadgeSize { get; set; } = 22f;
 
@@ -101,10 +122,34 @@ namespace osu.Game.EzOsuGame.UserInterface
             this.textures = textures;
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            if (hasPendingLabel)
+                applyPendingLabel();
+        }
+
         public void SetLabel(string label, int keyCount = 4, EzDanSide side = EzDanSide.Rc)
         {
-            string bare = EzDanLadders.BareLabel(label);
-            string suffix = EzDanLadders.TierSuffix(label);
+            pendingLabel = label;
+            pendingKeyCount = keyCount;
+            pendingSide = side;
+            hasPendingLabel = true;
+
+            applyPendingLabel();
+        }
+
+        public void SetLabel(string label, int keyCount, string sideId)
+            => SetLabel(label, keyCount, EzDanSideExtensions.ParseOrRc(sideId));
+
+        private void applyPendingLabel()
+        {
+            if (!hasPendingLabel || string.IsNullOrEmpty(pendingLabel))
+                return;
+
+            string bare = EzDanLadders.BareLabel(pendingLabel);
+            string suffix = EzDanLadders.TierSuffix(pendingLabel);
 
             bareText.Text = bare;
             bareText.Alpha = 1;
@@ -115,11 +160,8 @@ namespace osu.Game.EzOsuGame.UserInterface
             suffixText.Colour = tierColour ?? Colour4.White.Opacity(0.85f);
             suffixText.Alpha = string.IsNullOrEmpty(suffix) ? 0 : 1;
 
-            updateBadge(keyCount, side, bare);
+            updateBadge(pendingKeyCount, pendingSide, bare);
         }
-
-        public void SetLabel(string label, int keyCount, string sideId)
-            => SetLabel(label, keyCount, EzDanSideExtensions.ParseOrRc(sideId));
 
         private void updateBadge(int keyCount, EzDanSide side, string bare)
         {
@@ -130,6 +172,10 @@ namespace osu.Game.EzOsuGame.UserInterface
             contentPad.Padding = new MarginPadding { Horizontal = 5, Vertical = 2 };
 
             if (!PreferImage)
+                return;
+
+            // DI may not be ready yet (e.g. SetLabel from a parent ctor); LoadComplete retries.
+            if (resources == null && textures == null && LoadState < LoadState.Ready)
                 return;
 
             string? relative = EzDanLadders.TryGetTexturePath(keyCount, side, bare);

--- a/osu.Game/EzOsuGame/UserInterface/EzDisplay.SkillName.cs
+++ b/osu.Game/EzOsuGame/UserInterface/EzDisplay.SkillName.cs
@@ -51,6 +51,9 @@ namespace osu.Game.EzOsuGame.UserInterface
         public void SetFromAxis(EzMinaSkillAxis axis, LocalisableString? overrideText = null)
             => apply(axis.Chip(), overrideText);
 
+        public void Set(LocalisableString name, string accentHex)
+            => apply(new EzSkillChip(name, accentHex), null);
+
         public void SetFromAxisId(string? axisId, LocalisableString? overrideText = null)
         {
             if (EzMinaSkillAxisExtensions.TryParse(axisId, out var axis))

--- a/osu.Game/EzOsuGame/UserInterface/EzDisplay.SkillsDan.cs
+++ b/osu.Game/EzOsuGame/UserInterface/EzDisplay.SkillsDan.cs
@@ -91,6 +91,7 @@ namespace osu.Game.EzOsuGame.UserInterface
 
         public void SetFrom(EzChartDanVerdict verdict)
         {
+            // Aggregate chart verdict keeps its RC/LN side for badge art.
             Set(verdict.DominantAxis, verdict.Label, verdict.OverallMsd, null, null, verdict.KeyCount, verdict.Side);
         }
 
@@ -99,6 +100,7 @@ namespace osu.Game.EzOsuGame.UserInterface
 
         /// <summary>
         /// Chart (primary) and optional player (secondary) values — Skill-radar AB style.
+        /// For Mina per-skill dans, pass <see cref="EzDanSide.Rc"/> so badge art uses reform / keymode RC ladders (hub parseDan), not LN 1–17.
         /// </summary>
         public void Set(
             EzMinaSkillAxis axis,

--- a/osu.Game/EzOsuGame/UserInterface/EzDisplay.SkillsDan.cs
+++ b/osu.Game/EzOsuGame/UserInterface/EzDisplay.SkillsDan.cs
@@ -13,20 +13,26 @@ namespace osu.Game.EzOsuGame.UserInterface
 {
     /// <summary>
     /// Composite skill + dan tag: e.g. <c>技 7++ (20.5)</c>.
-    /// Skill chip and dan container stay separate drawables.
+    /// Optional secondary (player) dan + value for AB overlays.
     /// </summary>
     public partial class EzDisplaySkillsDan : FillFlowContainer
     {
         private readonly EzDisplaySkillName skillName;
-        private readonly EzDisplayDan dan;
-        private readonly OsuSpriteText valueText;
+        private readonly EzDisplayDan chartDan;
+        private readonly OsuSpriteText chartValueText;
+        private readonly EzDisplayDan playerDan;
+        private readonly OsuSpriteText playerValueText;
 
         public bool ShowValue { get; set; } = true;
 
         public bool PreferDanImage
         {
-            get => dan.PreferImage;
-            set => dan.PreferImage = value;
+            get => chartDan.PreferImage;
+            set
+            {
+                chartDan.PreferImage = value;
+                playerDan.PreferImage = value;
+            }
         }
 
         public EzDisplaySkillsDan()
@@ -44,19 +50,35 @@ namespace osu.Game.EzOsuGame.UserInterface
                     Anchor = Anchor.CentreLeft,
                     Origin = Anchor.CentreLeft,
                 },
-                dan = new EzDisplayDan
+                chartDan = new EzDisplayDan
                 {
                     Anchor = Anchor.CentreLeft,
                     Origin = Anchor.CentreLeft,
                     BadgeSize = 22,
                     PreferImage = true,
                 },
-                valueText = new OsuSpriteText
+                chartValueText = new OsuSpriteText
                 {
                     Anchor = Anchor.CentreLeft,
                     Origin = Anchor.CentreLeft,
                     Font = OsuFont.GetFont(size: 11, weight: FontWeight.SemiBold),
                     Colour = Colour4.White.Opacity(0.75f),
+                    Alpha = 0,
+                },
+                playerDan = new EzDisplayDan
+                {
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    BadgeSize = 20,
+                    PreferImage = true,
+                    Alpha = 0,
+                },
+                playerValueText = new OsuSpriteText
+                {
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    Font = OsuFont.GetFont(size: 11, weight: FontWeight.SemiBold),
+                    Colour = Colour4.FromHex("#50dc78").Opacity(0.9f),
                     Alpha = 0,
                 },
             };
@@ -69,26 +91,74 @@ namespace osu.Game.EzOsuGame.UserInterface
 
         public void SetFrom(EzChartDanVerdict verdict)
         {
-            Set(verdict.DominantAxis, verdict.Label, verdict.OverallMsd, verdict.KeyCount, verdict.Side);
+            Set(verdict.DominantAxis, verdict.Label, verdict.OverallMsd, null, null, verdict.KeyCount, verdict.Side);
         }
 
         public void Set(EzMinaSkillAxis axis, string danLabel, double? overallMsd, int keyCount, EzDanSide side)
+            => Set(axis, danLabel, overallMsd, null, null, keyCount, side);
+
+        /// <summary>
+        /// Chart (primary) and optional player (secondary) values — Skill-radar AB style.
+        /// </summary>
+        public void Set(
+            EzMinaSkillAxis axis,
+            string? chartLabel,
+            double? chartValue,
+            string? playerLabel,
+            double? playerValue,
+            int keyCount,
+            EzDanSide side)
         {
             skillName.SetFromAxis(axis);
-            dan.SetLabel(danLabel, keyCount, side);
 
-            if (ShowValue && overallMsd is double msd && double.IsFinite(msd) && msd > 0)
+            bool hasChart = !string.IsNullOrEmpty(chartLabel) && chartValue is > 0;
+            bool hasPlayer = !string.IsNullOrEmpty(playerLabel) && playerValue is > 0;
+
+            if (!hasChart && !hasPlayer)
             {
-                valueText.Text = $"({msd.ToString("0.0", CultureInfo.InvariantCulture)})";
-                valueText.Alpha = 1;
+                Alpha = 0;
+                return;
+            }
+
+            if (hasChart)
+            {
+                chartDan.SetLabel(chartLabel!, keyCount, side);
+                chartDan.Show();
+                setValueText(chartValueText, chartValue);
             }
             else
             {
-                valueText.Text = string.Empty;
-                valueText.Alpha = 0;
+                chartDan.Hide();
+                chartValueText.Alpha = 0;
+            }
+
+            if (hasPlayer)
+            {
+                playerDan.SetLabel(playerLabel!, keyCount, side);
+                playerDan.Show();
+                setValueText(playerValueText, playerValue);
+            }
+            else
+            {
+                playerDan.Hide();
+                playerValueText.Alpha = 0;
             }
 
             Alpha = 1;
+        }
+
+        private void setValueText(OsuSpriteText text, double? value)
+        {
+            if (ShowValue && value is double v && double.IsFinite(v) && v > 0)
+            {
+                text.Text = $"({v.ToString("0.0", CultureInfo.InvariantCulture)})";
+                text.Alpha = 1;
+            }
+            else
+            {
+                text.Text = string.Empty;
+                text.Alpha = 0;
+            }
         }
     }
 }

--- a/osu.Game/EzOsuGame/UserInterface/EzDisplay.SkillsDan.cs
+++ b/osu.Game/EzOsuGame/UserInterface/EzDisplay.SkillsDan.cs
@@ -149,6 +149,58 @@ namespace osu.Game.EzOsuGame.UserInterface
             Alpha = 1;
         }
 
+        /// <summary>
+        /// Hub skillset tile: always shows the slot name; dan badges only when labels are present (no SrToRawDan).
+        /// </summary>
+        public void SetSkillset(
+            EzDanSkillsetSlot slot,
+            string? chartLabel,
+            string? playerLabel,
+            int? playerClears,
+            int keyCount,
+            EzDanSide side)
+        {
+            skillName.Set(slot.DisplayName, slot.AccentHex);
+
+            if (!string.IsNullOrEmpty(chartLabel))
+            {
+                chartDan.SetLabel(chartLabel, keyCount, side);
+                chartDan.Show();
+            }
+            else
+            {
+                chartDan.Hide();
+            }
+
+            chartValueText.Alpha = 0;
+            chartValueText.Text = string.Empty;
+
+            if (!string.IsNullOrEmpty(playerLabel))
+            {
+                playerDan.SetLabel(playerLabel, keyCount, side);
+                playerDan.Show();
+
+                if (ShowValue && playerClears is int clears && clears > 0)
+                {
+                    playerValueText.Text = $"({clears.ToString(CultureInfo.InvariantCulture)})";
+                    playerValueText.Alpha = 1;
+                }
+                else
+                {
+                    playerValueText.Text = string.Empty;
+                    playerValueText.Alpha = 0;
+                }
+            }
+            else
+            {
+                playerDan.Hide();
+                playerValueText.Text = string.Empty;
+                playerValueText.Alpha = 0;
+            }
+
+            Alpha = 1;
+        }
+
         private void setValueText(OsuSpriteText text, double? value)
         {
             if (ShowValue && value is double v && double.IsFinite(v) && v > 0)

--- a/osu.Game/Screens/Select/BeatmapDetailsArea.Header.cs
+++ b/osu.Game/Screens/Select/BeatmapDetailsArea.Header.cs
@@ -15,11 +15,13 @@ using osu.Game.EzOsuGame.Configuration;
 using osu.Game.EzOsuGame.HUD;
 using osu.Game.EzOsuGame.Localization;
 using osu.Game.EzOsuGame.LocalProfile;
+using osu.Game.EzOsuGame.Overlays.Preview;
 using osu.Game.EzOsuGame.Skills;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Localisation;
 using osu.Game.Online.Leaderboards;
+using osu.Game.Rulesets;
 using osu.Game.Screens.Play.Leaderboards;
 using osuTK;
 using DescriptionAttribute = System.ComponentModel.DescriptionAttribute;
@@ -43,6 +45,9 @@ namespace osu.Game.Screens.Select
             private ShearedDropdown<EzRadarDisplayMode> rightRadarDropdown = null!;
 
             private Bindable<bool> flowMode = null!;
+
+            [Resolved]
+            private IBindable<RulesetInfo> ruleset { get; set; } = null!;
 
             public IBindable<Selection> Type => tabControl.Current;
 
@@ -206,6 +211,12 @@ namespace osu.Game.Screens.Select
                 }, true);
 
                 flowMode.BindValueChanged(e => applyFlowModeState(e.NewValue), true);
+
+                ruleset.BindValueChanged(e =>
+                {
+                    if (EzBeatmapPreviewModes.IsManiaRuleset(e.NewValue))
+                        tabControl.Current.Value = Selection.EzAnalysis;
+                }, true);
 
                 scopeDropdown.Current.BindValueChanged(scope =>
                 {


### PR DESCRIPTION
## Summary
- Rewrite DualPanel on current master: RC|LN both visible under EzAnalysis radars; each side shows all radar-axis `EzDisplaySkillsDan` (name + dan badge + MSD/SSR) plus Top-15 clear evidence.
- Local Profile Track shares the same DualPanel (SSR axes); removes exclusive RC/LN chip toggle.
- Mania ruleset selects DetailsArea `EzAnalysis` by default (session; leaving mania does not force-revert).
- Zero schema / algorithm VERSION.

## Master
Skills Track Dan Master — UX-5

## Test plan
- [ ] Mania song select opens on Ez Analysis
- [ ] Narrow: RC then LN rows of full-axis SkillsDan chips; wide: two columns
- [ ] Chart MSD fills wedge axes; player dan/clears when username set
- [ ] Track: DualPanel always; skill bar still opens history + axis plays
- [ ] `dotnet build` osu.Game