### PR TITLE
AutoPlayPlus: 对齐 Autoplay 的 LN 尾音效归属

### DIFF
--- a/osu.Game/Rulesets/UI/GameplaySampleTriggerSource.cs
+++ b/osu.Game/Rulesets/UI/GameplaySampleTriggerSource.cs
@@ -5,10 +5,13 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Utils;
 using osu.Game.Audio;
 using osu.Game.EzOsuGame.Configuration;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.Play;
 using osu.Game.Skinning;
@@ -119,21 +122,33 @@ namespace osu.Game.Rulesets.UI
                 lastAutoPlayedObject = null;
             }
 
-            // Auto-play notes when KeySoundPreviewMode == 2
+            // AutoPlayPlus: match Autoplay hitsound ownership at precise object times (no input / hit-result gating).
             if (isAutoPlay)
             {
                 double referenceTime = getReferenceTime();
                 var obj = GetMostValidObject();
 
-                if (obj != null && obj != lastAutoPlayedObject)
+                if (obj != null && obj != lastAutoPlayedObject && referenceTime >= obj.StartTime)
                 {
-                    // Play when we've reached or passed the object's start time
-                    if (referenceTime >= obj.StartTime)
+                    // Parent fallback for IgnoreJudgement duration objects: Autoplay never PlaySamples the parent
+                    // (e.g. HoldNote). Prefer EndTime nested samples; empty tail stays silent — never replay head Samples.
+                    if (obj.NestedHitObjects.Count > 0 && obj.Judgement is IgnoreJudgement)
                     {
-                        var samples = obj.Samples.Cast<ISampleInfo>().ToArray();
-                        PlaySamples(samples);
-                        lastAutoPlayedObject = obj;
+                        if (obj is IHasDuration duration)
+                        {
+                            var release = obj.NestedHitObjects.FirstOrDefault(n =>
+                                n.Samples.Count > 0 && Precision.AlmostEquals(n.StartTime, duration.EndTime, 1));
+
+                            if (release != null)
+                                PlaySamples(release.Samples.Cast<ISampleInfo>().ToArray());
+                        }
                     }
+                    else if (obj.Samples.Count > 0)
+                    {
+                        PlaySamples(obj.Samples.Cast<ISampleInfo>().ToArray());
+                    }
+
+                    lastAutoPlayedObject = obj;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- AutoPlayPlus 在时长物件 EndTime 回落到 `IgnoreJudgement` 父级时，不再误播父级 Samples（如 HoldNote 头音）
- 仅当 EndTime 嵌套自有采样非空时播放，默认空尾 LN 与正式 Autoplay 一样静音
- Spinner 等非 Ignore 父级保持可播父采样，避免误伤

## Test plan
- [x] AutoPlayPlus + 默认 LN：头有音、尾静音（不再在尾时刻重播头音）
- [x] AutoPlayPlus + 带尾 NodeSamples 的 LN：尾时刻播尾自己的音
- [ ] （可选）osu Spinner：结束音仍正常