### PR TITLE
skills: DATA-Skillset-Cache writers + Provider cache-hit

### DIFF
--- a/osu.Game.Tests/EzOsuGame/Skills/EzChartSkillInfoRealmStoreTest.cs
+++ b/osu.Game.Tests/EzOsuGame/Skills/EzChartSkillInfoRealmStoreTest.cs
@@ -1,7 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Game.Database;
@@ -87,25 +87,55 @@ namespace osu.Game.Tests.EzOsuGame.Skills
             {
                 var store = new EzSkillStore(realm);
 
-                store.WriteDanSkillsetValues("tester", 4, DanSkillSystem.SIDE_RC, new[]
+                store.WriteDanSkillsetVerdicts("tester", 4, DanSkillSystem.SIDE_RC, new Dictionary<string, EzDanSkillsetVerdict>
                 {
-                    new EzPlayerDanSkillsetValue
-                    {
-                        SkillsetId = EzDanSkillsetBuckets.JACK,
-                        RawDan = 12.5,
-                        Label = "Chuudan",
-                        Clears = 3,
-                        AlgorithmVersion = EzDanAlgorithm.VERSION,
-                        ComputedAt = DateTimeOffset.UtcNow,
-                    },
+                    [EzDanSkillsetBuckets.JACK] = new EzDanSkillsetVerdict(EzDanSkillsetBuckets.JACK, 12.5, "Chuudan", 3),
                 });
 
+                Assert.That(store.HasDanSkillsetCache("tester", 4, DanSkillSystem.SIDE_RC), Is.True);
                 var rows = store.GetDanSkillsetValues("tester", 4, DanSkillSystem.SIDE_RC);
                 Assert.That(rows, Has.Count.EqualTo(1));
                 Assert.That(rows[0].SkillsetId, Is.EqualTo(EzDanSkillsetBuckets.JACK));
                 Assert.That(rows[0].RawDan, Is.EqualTo(12.5).Within(1e-9));
                 Assert.That(rows[0].Label, Is.EqualTo("Chuudan"));
                 Assert.That(rows[0].Clears, Is.EqualTo(3));
+            });
+        }
+
+        [Test]
+        public void Skillset_empty_verdicts_write_sentinel_so_has_cache_is_true()
+        {
+            RunTestWithRealm((realm, _) =>
+            {
+                var store = new EzSkillStore(realm);
+
+                store.WriteDanSkillsetVerdicts("tester", 7, DanSkillSystem.SIDE_LN, new Dictionary<string, EzDanSkillsetVerdict>());
+
+                Assert.That(store.HasDanSkillsetCache("tester", 7, DanSkillSystem.SIDE_LN), Is.True);
+                Assert.That(store.GetDanSkillsetValues("tester", 7, DanSkillSystem.SIDE_LN), Is.Empty);
+
+                store.ClearDanSkillsetValues("tester");
+                Assert.That(store.HasDanSkillsetCache("tester", 7, DanSkillSystem.SIDE_LN), Is.False);
+            });
+        }
+
+        [Test]
+        public void Provider_GetDanSkillsets_uses_cache_without_clears()
+        {
+            RunTestWithRealm((realm, _) =>
+            {
+                var store = new EzSkillStore(realm);
+                store.WriteDanSkillsetVerdicts("cached-user", 4, DanSkillSystem.SIDE_RC, new Dictionary<string, EzDanSkillsetVerdict>
+                {
+                    [EzDanSkillsetBuckets.TECH] = new EzDanSkillsetVerdict(EzDanSkillsetBuckets.TECH, 9.1, "Shodan", 5),
+                });
+
+                var provider = new EzSkillProvider(store);
+                var verdicts = provider.GetDanSkillsets("cached-user", 4, DanSkillSystem.SIDE_RC);
+
+                Assert.That(verdicts, Has.Count.EqualTo(1));
+                Assert.That(verdicts[EzDanSkillsetBuckets.TECH].RawDan, Is.EqualTo(9.1).Within(1e-9));
+                Assert.That(verdicts[EzDanSkillsetBuckets.TECH].Label, Is.EqualTo("Shodan"));
             });
         }
 

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileService.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileService.cs
@@ -28,6 +28,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
         private readonly EzLocalProfileAggregator aggregator;
         private readonly EzPlayerSsrAggregator? ssrAggregator;
         private readonly EzPlayerDanAggregator? danAggregator;
+        private readonly EzSkillProvider? skillProvider;
         private readonly Lock computeLock = new Lock();
         private CancellationTokenSource? computeCts;
 
@@ -42,12 +43,14 @@ namespace osu.Game.EzOsuGame.LocalProfile
             BeatmapManager beatmapManager,
             EzPlayerSsrAggregator? ssrAggregator = null,
             EzPlayerDanAggregator? danAggregator = null,
-            EzLocalProfileStore? sharedStore = null)
+            EzLocalProfileStore? sharedStore = null,
+            EzSkillProvider? skillProvider = null)
         {
             Store = sharedStore ?? new EzLocalProfileStore(storage);
             aggregator = new EzLocalProfileAggregator(realm, analysisStore, beatmapManager);
             this.ssrAggregator = ssrAggregator;
             this.danAggregator = danAggregator;
+            this.skillProvider = skillProvider;
             Snapshot.Value = Store.LoadSnapshot();
         }
 
@@ -255,6 +258,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 {
                     danAggregator!.ComputeAndStore(username, scores, token, tick);
                     Store.ReplaceDanClears(username, danAggregator.PendingEvidence);
+                    skillProvider?.RefreshDanSkillsets(username);
                 },
                 danAggregator != null,
                 "[EzLocalProfile] Failed to compute/persist player Dan estimates after profile save.");

--- a/osu.Game/EzOsuGame/Skills/DATA-FOLLOWUPS.md
+++ b/osu.Game/EzOsuGame/Skills/DATA-FOLLOWUPS.md
@@ -9,8 +9,8 @@ Do **not** re-encode these as `// TODO(data)` in product code. Open a dedicated 
 | — | SCHEMA EZ9 | Typed `EzBeatmapChartSkillInfo` + `EzPlayerDanSkillsetValue` in Realm | **Done** |
 | — | Debt: SQLite ChartSkillInfo | Abandoned analysis `chart_skill_info` JSON; no import/migrate; miss → recompute | **Done** |
 | — | Debt: single Realm skill facade | ChartSkillInfo CRUD merged into `EzSkillStore`; deleted `EzChartSkillInfoStore` | **Done** |
+| — | DATA-Skillset-Cache | Writers + Provider cache-hit; LocalProfile rebuild calls `RefreshDanSkillsets` | **Done** |
 | 1 | DATA-LeoBlack-ChartDan | Full LeoBlack chart-side aggregate dan (optional). Also fills cluster columns if still null. | Wish-list |
-| 2 | DATA-Skillset-Cache | Writers for existing `EzPlayerDanSkillsetValue` + Provider cache-hit (DualPanel / profile stop re-filing every clear on read) | **Next light PR** |
 | 3 | DATA-Dan-Headline-Anchor | 7K LN `anchoredSkillsetDans`-style side headline (only if product moves titles off side-level `GetDan`). | Optional |
 | 4 | DATA-ChartSkillInfo-Batch | Background / library-wide ChartSkillInfo warm (beyond on-demand DualPanel + clear hashes). | Optional |
 

--- a/osu.Game/EzOsuGame/Skills/EzDanSkillsetBuckets.cs
+++ b/osu.Game/EzOsuGame/Skills/EzDanSkillsetBuckets.cs
@@ -41,6 +41,12 @@ namespace osu.Game.EzOsuGame.Skills
         public const string LN_INVERSE = "lninverse";
         public const string LN_RELEASE = "lnrelease";
 
+        /// <summary>
+        /// Persisted when a key×side was recomputed but produced no skillset tiles
+        /// (so readers can distinguish cache hit-empty from never cached).
+        /// </summary>
+        public const string CACHE_EMPTY_SENTINEL = "__empty__";
+
         private static readonly EzDanSkillsetSlot[] rc_4k =
         {
             new EzDanSkillsetSlot(JACK, "Jack", "#ec6a9c"),

--- a/osu.Game/EzOsuGame/Skills/EzPlayerDanSkillsetValue.cs
+++ b/osu.Game/EzOsuGame/Skills/EzPlayerDanSkillsetValue.cs
@@ -7,8 +7,9 @@ using Realms;
 namespace osu.Game.EzOsuGame.Skills
 {
     /// <summary>
-    /// Cached player skillset-dan tile (EZ≥9). Schema reserved so Cache PR needs no EZ bump.
-    /// Writers / Provider cache-hit wiring land in DATA-Skillset-Cache — do not delete this type.
+    /// Cached player skillset-dan tile (EZ≥9). Written by <see cref="EzSkillProvider.RefreshDanSkillsets"/> /
+    /// <see cref="EzSkillProvider.GetDanSkillsets"/>; DualPanel prefers cache hits.
+    /// Empty buckets use <see cref="EzDanSkillsetBuckets.CACHE_EMPTY_SENTINEL"/> so “computed empty” ≠ “never cached”.
     /// </summary>
     [MapTo("EzPlayerDanSkillsetValue")]
     public class EzPlayerDanSkillsetValue : RealmObject

--- a/osu.Game/EzOsuGame/Skills/EzSkillProvider.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSkillProvider.cs
@@ -131,9 +131,71 @@ namespace osu.Game.EzOsuGame.Skills
             => GetDanSkillsetSlots(keyCount, EzDanSideExtensions.ParseOrRc(sideId));
 
         /// <summary>
-        /// Skillset dan verdicts (clear-bucket averages). Missing keys = under quorum / no filing data yet.
+        /// Skillset dan verdicts (clear-bucket averages). Prefers Realm cache; miss → compute, write, return.
+        /// Missing keys = under quorum / no filing data yet.
         /// </summary>
         public IReadOnlyDictionary<string, EzDanSkillsetVerdict> GetDanSkillsets(string username, int keyCount, string side)
+        {
+            string resolvedUser = resolveSkillsUsername(username);
+
+            if (store.HasDanSkillsetCache(resolvedUser, keyCount, side))
+                return danSkillsetsFromCache(resolvedUser, keyCount, side);
+
+            if (!EzLocalProfileConstants.IsGuestUsername(username)
+                && !string.Equals(resolvedUser, username, StringComparison.Ordinal)
+                && store.HasDanSkillsetCache(username, keyCount, side))
+            {
+                return danSkillsetsFromCache(username, keyCount, side);
+            }
+
+            var verdicts = computeDanSkillsets(resolvedUser, keyCount, side, allowComputeChart: true);
+            store.WriteDanSkillsetVerdicts(resolvedUser, keyCount, side, verdicts);
+            return verdicts;
+        }
+
+        /// <summary>
+        /// Recompute and persist skillset caches for a user after dan clears are replaced.
+        /// Chart resolve uses stored ChartSkillInfo only (no WorkingBeatmap load) so profile rebuild stays light.
+        /// </summary>
+        public void RefreshDanSkillsets(string username)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(username);
+
+            string resolvedUser = resolveSkillsUsername(username);
+            store.ClearDanSkillsetValues(resolvedUser);
+
+            if (!string.Equals(resolvedUser, username, StringComparison.Ordinal))
+                store.ClearDanSkillsetValues(username);
+
+            foreach (int keyCount in tracked_skillset_key_counts)
+            {
+                foreach (var side in new[] { EzDanSide.Rc, EzDanSide.Ln })
+                {
+                    string sideId = side.ToId();
+                    var verdicts = computeDanSkillsets(resolvedUser, keyCount, sideId, allowComputeChart: false);
+                    store.WriteDanSkillsetVerdicts(resolvedUser, keyCount, sideId, verdicts);
+                }
+            }
+        }
+
+        private static readonly int[] tracked_skillset_key_counts = { 4, 5, 6, 7, 8, 9 };
+
+        private IReadOnlyDictionary<string, EzDanSkillsetVerdict> danSkillsetsFromCache(string username, int keyCount, string side)
+        {
+            var rows = store.GetDanSkillsetValues(username, keyCount, side);
+            var result = new Dictionary<string, EzDanSkillsetVerdict>(StringComparer.Ordinal);
+
+            foreach (var row in rows)
+                result[row.SkillsetId] = new EzDanSkillsetVerdict(row.SkillsetId, row.RawDan, row.Label, row.Clears);
+
+            return result;
+        }
+
+        private IReadOnlyDictionary<string, EzDanSkillsetVerdict> computeDanSkillsets(
+            string username,
+            int keyCount,
+            string side,
+            bool allowComputeChart)
         {
             var sideEnum = EzDanSideExtensions.ParseOrRc(side);
             var clears = GetDanClears(username, keyCount, side, EzDanAlgorithm.VERSION);
@@ -154,12 +216,27 @@ namespace osu.Game.EzOsuGame.Skills
                     if (store.TryGetChartSkillInfo(hash, out var stored) && stored != null)
                         return stored;
 
-                    if (beatmapManager == null)
+                    if (!allowComputeChart || beatmapManager == null)
                         return null;
 
                     var info = beatmapManager.QueryBeatmap(b => b.Hash == hash);
                     return info == null ? null : TryGetOrComputeChartSkillInfo(info);
                 });
+        }
+
+        private string resolveSkillsUsername(string username)
+        {
+            if (string.IsNullOrWhiteSpace(username))
+                return username;
+
+            if (!EzLocalProfileConstants.IsGuestUsername(username))
+                return username;
+
+            var clears = localProfileStore?.GetDanClears(username, algorithmVersion: EzDanAlgorithm.VERSION);
+            if (clears is { Count: > 0 })
+                return username;
+
+            return EzLocalProfileConstants.LEGACY_UNKNOWN_USERNAME;
         }
 
         /// <summary>

--- a/osu.Game/EzOsuGame/Skills/EzSkillStore.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSkillStore.cs
@@ -442,9 +442,20 @@ namespace osu.Game.EzOsuGame.Skills
             });
         }
 
-        /// <summary>
-        /// Reserved for DATA-Skillset-Cache: read cached skillset tiles. Product UI still computes via Provider until that PR wires writers.
-        /// </summary>
+        /// <summary>True when a skillset cache stamp exists for this username/key/side/version (including empty sentinel).</summary>
+        public bool HasDanSkillsetCache(string username, int keyCount, string side, int? algorithmVersion = null)
+        {
+            int version = algorithmVersion ?? EzDanAlgorithm.VERSION;
+
+            return realmAccess.Run(r =>
+                r.All<EzPlayerDanSkillsetValue>()
+                 .Any(v => v.Username == username
+                           && v.KeyCount == keyCount
+                           && v.Side == side
+                           && v.AlgorithmVersion == version));
+        }
+
+        /// <summary>Cached skillset tiles (excludes empty sentinel). Empty list may mean hit-empty or miss — use <see cref="HasDanSkillsetCache"/>.</summary>
         public IReadOnlyList<EzPlayerDanSkillsetValue> GetDanSkillsetValues(
             string username,
             int keyCount,
@@ -459,23 +470,26 @@ namespace osu.Game.EzOsuGame.Skills
                         .Where(v => v.Username == username
                                     && v.KeyCount == keyCount
                                     && v.Side == side
-                                    && v.AlgorithmVersion == version)
+                                    && v.AlgorithmVersion == version
+                                    && v.SkillsetId != EzDanSkillsetBuckets.CACHE_EMPTY_SENTINEL)
                         .ToList()
                         .Select(v => v.Detach())
                         .ToList();
             });
         }
 
-        /// <summary>
-        /// Reserved for DATA-Skillset-Cache: replace skillset cache rows for one username/key/side bucket.
-        /// </summary>
-        public void WriteDanSkillsetValues(string username, int keyCount, string side, IEnumerable<EzPlayerDanSkillsetValue> values)
+        /// <summary>Replace skillset cache for one username/key/side. Empty verdicts write a sentinel row.</summary>
+        public void WriteDanSkillsetVerdicts(
+            string username,
+            int keyCount,
+            string side,
+            IReadOnlyDictionary<string, EzDanSkillsetVerdict> verdicts,
+            DateTimeOffset? computedAt = null)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(username);
-            ArgumentNullException.ThrowIfNull(values);
+            ArgumentNullException.ThrowIfNull(verdicts);
 
-            var list = values as IList<EzPlayerDanSkillsetValue> ?? values.ToList();
-            DateTimeOffset at = DateTimeOffset.UtcNow;
+            DateTimeOffset at = computedAt ?? DateTimeOffset.UtcNow;
             int version = EzDanAlgorithm.VERSION;
 
             realmAccess.Write(r =>
@@ -489,22 +503,75 @@ namespace osu.Game.EzOsuGame.Skills
                 foreach (var row in existing)
                     r.Remove(row);
 
-                foreach (var value in list)
+                if (verdicts.Count == 0)
                 {
                     r.Add(new EzPlayerDanSkillsetValue
                     {
                         Username = username,
                         KeyCount = keyCount,
                         Side = side,
-                        SkillsetId = value.SkillsetId,
-                        RawDan = value.RawDan,
-                        Label = value.Label,
-                        Clears = value.Clears,
-                        AlgorithmVersion = value.AlgorithmVersion != 0 ? value.AlgorithmVersion : version,
-                        ComputedAt = value.ComputedAt == default ? at : value.ComputedAt,
+                        SkillsetId = EzDanSkillsetBuckets.CACHE_EMPTY_SENTINEL,
+                        RawDan = -1,
+                        Label = string.Empty,
+                        Clears = 0,
+                        AlgorithmVersion = version,
+                        ComputedAt = at,
+                    });
+                    return;
+                }
+
+                foreach (var (id, verdict) in verdicts)
+                {
+                    r.Add(new EzPlayerDanSkillsetValue
+                    {
+                        Username = username,
+                        KeyCount = keyCount,
+                        Side = side,
+                        SkillsetId = string.IsNullOrEmpty(verdict.SkillsetId) ? id : verdict.SkillsetId,
+                        RawDan = verdict.RawDan,
+                        Label = verdict.Label,
+                        Clears = verdict.Clears,
+                        AlgorithmVersion = version,
+                        ComputedAt = at,
                     });
                 }
             });
+        }
+
+        /// <summary>Drop all skillset cache rows for a username (all keys/sides).</summary>
+        public void ClearDanSkillsetValues(string username)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(username);
+
+            realmAccess.Write(r =>
+            {
+                var existing = r.All<EzPlayerDanSkillsetValue>()
+                                .Where(v => v.Username == username)
+                                .ToList();
+
+                foreach (var row in existing)
+                    r.Remove(row);
+            });
+        }
+
+        /// <summary>Legacy row writer; prefer <see cref="WriteDanSkillsetVerdicts"/>.</summary>
+        public void WriteDanSkillsetValues(string username, int keyCount, string side, IEnumerable<EzPlayerDanSkillsetValue> values)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(username);
+            ArgumentNullException.ThrowIfNull(values);
+
+            var list = values as IList<EzPlayerDanSkillsetValue> ?? values.ToList();
+            var map = new Dictionary<string, EzDanSkillsetVerdict>(StringComparer.Ordinal);
+
+            foreach (var value in list)
+            {
+                if (value.SkillsetId == EzDanSkillsetBuckets.CACHE_EMPTY_SENTINEL)
+                    continue;
+
+                map[value.SkillsetId] = new EzDanSkillsetVerdict(value.SkillsetId, value.RawDan, value.Label, value.Clears);
+            }
+
+            WriteDanSkillsetVerdicts(username, keyCount, side, map);
         }
 
         private const char pattern_separator = '\u001f';

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -435,7 +435,7 @@ namespace osu.Game
             dependencies.Cache(playerSsrAggregator);
             dependencies.Cache(playerDanAggregator);
 
-            dependencies.Cache(new EzLocalProfileService(Storage, realm, ezAnalysisPersistentStore, BeatmapManager, playerSsrAggregator, playerDanAggregator, localProfileStore));
+            dependencies.Cache(new EzLocalProfileService(Storage, realm, ezAnalysisPersistentStore, BeatmapManager, playerSsrAggregator, playerDanAggregator, localProfileStore, skillProvider));
             dependencies.Cache(new EzLocalProfileOnlinePullService(API, ScoreManager, BeatmapManager, realm, Storage));
 
             if (Ez2ConfigManager.Get<bool>(Ez2Setting.EzScoreRaceServiceEnabled))


### PR DESCRIPTION
## Summary
- Write `EzPlayerDanSkillsetValue` after LocalProfile dan clears rebuild (`RefreshDanSkillsets`).
- `GetDanSkillsets` prefers Realm cache (empty sentinel distinguishes never-cached); miss computes, writes, returns.
- Rebuild chart resolve stays light (stored ChartSkillInfo only); DualPanel miss may still `TryGetOrCompute`.

## Test plan
- [ ] `dotnet test` filter `EzChartSkillInfoRealmStoreTest|EzDanSkillset`
- [ ] Rebuild Local Profile skills → DualPanel skillset chips load without re-filing every open
- [ ] Clear Realm skillset rows → first DualPanel open warms cache; second open hits cache
- [ ] 4K/7K LN empty skillset sides still cache (sentinel) and do not thrash
