### PR TITLE
perf(skills): MSD backfill progress + skillset refresh prefetch

### DIFF
--- a/osu.Game.Tests/Database/BeatmapImporterTests.cs
+++ b/osu.Game.Tests/Database/BeatmapImporterTests.cs
@@ -91,7 +91,24 @@ namespace osu.Game.Tests.Database
                     // Detach at the BeatmapInfo point, similar to what GetWorkingBeatmap does.
                     BeatmapInfo? detachedBeatmap = null;
 
-                    beatmapSet.PerformRead(s => detachedBeatmap = s.Beatmaps.First().Detach());
+                    beatmapSet.PerformRead(s =>
+                    {
+                        var live = s.Beatmaps.First();
+                        ClassicAssert.NotNull(live.File);
+                        ClassicAssert.NotNull(live.Path);
+
+                        detachedBeatmap = live.Detach();
+
+                        // Nested RealmFile hashes must survive BeatmapInfo.Detach (MaxDepth).
+                        // Otherwise WorkingBeatmap.Path is null and MSD/difficulty loads empty charts.
+                        ClassicAssert.NotZero(detachedBeatmap.BeatmapSet!.Files.Count);
+                        ClassicAssert.IsTrue(detachedBeatmap.BeatmapSet.Files.All(f => f.File != null && !string.IsNullOrEmpty(f.File.Hash)));
+                        ClassicAssert.NotNull(detachedBeatmap.File);
+                        ClassicAssert.NotNull(detachedBeatmap.Path);
+                        ClassicAssert.AreEqual(live.Path, detachedBeatmap.Path);
+                        ClassicAssert.AreEqual(live.Ruleset.Available, detachedBeatmap.Ruleset.Available);
+                        ClassicAssert.AreEqual(live.Ruleset.OnlineID, detachedBeatmap.Ruleset.OnlineID);
+                    });
 
                     BeatmapSetInfo? detachedBeatmapSet = detachedBeatmap?.BeatmapSet;
 

--- a/osu.Game.Tests/EzOsuGame/Skills/EzChartSkillInfoRealmStoreTest.cs
+++ b/osu.Game.Tests/EzOsuGame/Skills/EzChartSkillInfoRealmStoreTest.cs
@@ -140,6 +140,40 @@ namespace osu.Game.Tests.EzOsuGame.Skills
         }
 
         [Test]
+        public void Batch_prefetch_msd_and_chart_skill_info_for_hashes()
+        {
+            RunTestWithRealm((realm, _) =>
+            {
+                var store = new EzSkillStore(realm);
+                const string hash_a = "batch-hash-a";
+                const string hash_b = "batch-hash-b";
+
+                store.WriteBeatmapMsd(hash_a, new EzSkillsetVector(10, 1, 2, 3, 4, 5, 6, 7), holdRatio: 0.2);
+                store.WriteBeatmapMsd(hash_b, new EzSkillsetVector(11, 1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1), holdRatio: 0.3);
+
+                store.UpsertChartSkillInfo(hash_a, new EzChartSkillInfo
+                {
+                    Patterns = new[] { "jack" },
+                    TechScore = 0.5,
+                    ChordjackScore = 0.8,
+                    LnRatio = 0.1,
+                    DanEligible = true,
+                    KeyCount = 4,
+                });
+
+                var msdBatch = store.GetBeatmapSkillsForHashes(new[] { hash_a, hash_b, "missing" }, EzSkillSystems.BEATMAP_MSD);
+                Assert.That(msdBatch.Keys, Is.EquivalentTo(new[] { hash_a, hash_b }));
+                Assert.That(msdBatch[hash_a][EzSkillSystems.MsdHoldRatioSkillId], Is.EqualTo(0.2).Within(1e-9));
+                Assert.That(msdBatch[hash_b][EzMinaSkillAxis.Overall.ToMsdSkillId()], Is.EqualTo(11).Within(1e-9));
+
+                var chartBatch = store.GetChartSkillInfoForHashes(new[] { hash_a, hash_b, "missing" });
+                Assert.That(chartBatch.Keys, Is.EquivalentTo(new[] { hash_a }));
+                Assert.That(chartBatch[hash_a].Patterns, Is.EquivalentTo(new[] { "jack" }));
+                Assert.That(chartBatch[hash_a].ChordjackScore, Is.EqualTo(0.8).Within(1e-9));
+            });
+        }
+
+        [Test]
         public void File_schema_version_is_ez9()
         {
             Assert.That(RealmAccess.EZ_REALM_SCHEMA_VERSION, Is.EqualTo(9));

--- a/osu.Game.Tests/EzOsuGame/Skills/EzMinaCalcFacadeTest.cs
+++ b/osu.Game.Tests/EzOsuGame/Skills/EzMinaCalcFacadeTest.cs
@@ -58,6 +58,83 @@ namespace osu.Game.Tests.EzOsuGame.Skills
             Assert.That(EzMinaCalcFacade.EngineVersion, Is.GreaterThan(0));
         }
 
+        [Test]
+        public void Msd_from_osu_text_rates_7k()
+        {
+            string chart = buildManiaChart(keyCount: 7, rows: 40);
+
+            using var calc = new EzMinaCalcFacade();
+            var msd = calc.CalculateMsdFromOsuText(chart, "7k.osu");
+
+            Assert.That(msd.Overall, Is.GreaterThan(0));
+            Assert.That(EzMinaCalcFacade.SupportsOsuTextKeyCount(7), Is.True);
+            Assert.That(EzMinaCalcFacade.SupportsNoteArrayKeyCount(7), Is.False);
+        }
+
+        [Test]
+        public void Note_array_7k_yields_zero_on_current_package()
+        {
+            var notes = new MinaCalcNote[32];
+
+            for (int i = 0; i < notes.Length; i++)
+            {
+                notes[i] = new MinaCalcNote
+                {
+                    Notes = 1u << (i % 7),
+                    RowTime = i * 0.1f,
+                };
+            }
+
+            using var calc = new EzMinaCalcFacade();
+            var msd = calc.CalculateMsd(notes, 1f);
+
+            // Documents why MSD backfill must use FromOsuText for non-4K.
+            Assert.That(msd.Overall, Is.EqualTo(0));
+            Assert.That(msd.Stream, Is.EqualTo(0));
+        }
+
+        private static string buildManiaChart(int keyCount, int rows)
+        {
+            var sb = new System.Text.StringBuilder();
+            sb.AppendLine("osu file format v14");
+            sb.AppendLine();
+            sb.AppendLine("[General]");
+            sb.AppendLine("AudioFilename: virtual");
+            sb.AppendLine("Mode: 3");
+            sb.AppendLine();
+            sb.AppendLine("[Metadata]");
+            sb.AppendLine("Title:t");
+            sb.AppendLine("TitleUnicode:t");
+            sb.AppendLine("Artist:a");
+            sb.AppendLine("ArtistUnicode:a");
+            sb.AppendLine("Creator:c");
+            sb.AppendLine($"Version:{keyCount}k");
+            sb.AppendLine("Source:");
+            sb.AppendLine("Tags:");
+            sb.AppendLine();
+            sb.AppendLine("[Difficulty]");
+            sb.AppendLine("HPDrainRate:8");
+            sb.AppendLine($"CircleSize:{keyCount}");
+            sb.AppendLine("OverallDifficulty:8");
+            sb.AppendLine("ApproachRate:5");
+            sb.AppendLine("SliderMultiplier:1.4");
+            sb.AppendLine("SliderTickRate:1");
+            sb.AppendLine();
+            sb.AppendLine("[TimingPoints]");
+            sb.AppendLine("0,500,4,2,0,100,1,0");
+            sb.AppendLine();
+            sb.AppendLine("[HitObjects]");
+
+            for (int i = 0; i < rows; i++)
+            {
+                int col = i % keyCount;
+                int x = (int)Math.Floor((col + 0.5) * 512.0 / keyCount);
+                sb.AppendLine($"{x},192,{i * 100},1,0,0:0:0:0:");
+            }
+
+            return sb.ToString();
+        }
+
         private static MinaCalcNote[] createStreamNotes()
         {
             var notes = new MinaCalcNote[32];

--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -529,26 +529,33 @@ namespace osu.Game.Database
         {
             const int current_version = EzManiaSkillAlgorithm.VERSION;
 
-            foreach (var ruleset in rulesetStore.AvailableRulesets)
+            // Read the live Realm row — AvailableRulesets clones historically omitted
+            // LastAppliedManiaSkillVersion and would wipe MSD on every startup.
+            var liveState = realmAccess.Run(r =>
             {
-                if (ruleset.OnlineID != 3)
-                    continue;
+                var live = r.All<RulesetInfo>().FirstOrDefault(x => x.OnlineID == 3);
+                return live == null
+                    ? ((string?)null, 0)
+                    : (live.ShortName, live.LastAppliedManiaSkillVersion);
+            });
 
-                if (ruleset.LastAppliedManiaSkillVersion >= current_version)
-                    continue;
+            if (liveState.Item1 == null)
+                return;
 
-                Logger.Log($"Resetting beatmap MSD for {ruleset.Name} (mania skill version updated from {ruleset.LastAppliedManiaSkillVersion} to {current_version})");
+            if (liveState.Item2 >= current_version)
+                return;
 
-                skillStore.ClearBeatmapMsd();
+            Logger.Log($"Resetting beatmap MSD for mania (mania skill version updated from {liveState.Item2} to {current_version})");
 
-                realmAccess.Write(r =>
-                {
-                    if (r.Find<RulesetInfo>(ruleset.ShortName) is RulesetInfo live)
-                        live.LastAppliedManiaSkillVersion = current_version;
-                });
+            skillStore.ClearBeatmapMsd();
 
-                Logger.Log($"Finished resetting beatmap MSD for {ruleset.Name}");
-            }
+            realmAccess.Write(r =>
+            {
+                if (r.Find<RulesetInfo>(liveState.Item1) is RulesetInfo live)
+                    live.LastAppliedManiaSkillVersion = current_version;
+            });
+
+            Logger.Log("Finished resetting beatmap MSD for mania");
         }
 
         private void runEzRealmMetadataBackfill()

--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -857,13 +857,13 @@ namespace osu.Game.Database
 
             int processedCount = 0;
             int failedCount = 0;
+            int attemptedCount = 0;
+            const int log_every = 25;
 
             foreach (var (id, _) in missing)
             {
                 if (notification?.State == ProgressNotificationState.Cancelled)
                     break;
-
-                updateNotificationProgress(notification, processedCount, missing.Count);
 
                 sleepIfRequired();
 
@@ -872,6 +872,8 @@ namespace osu.Game.Database
                 if (beatmap == null)
                 {
                     ++failedCount;
+                    ++attemptedCount;
+                    updateNotificationProgress(notification, attemptedCount, missing.Count);
                     continue;
                 }
 
@@ -887,6 +889,12 @@ namespace osu.Game.Database
                     Logger.Log($"Background MSD processing failed on {beatmap}: {e}");
                     ++failedCount;
                 }
+
+                ++attemptedCount;
+                updateNotificationProgress(notification, attemptedCount, missing.Count);
+
+                if (attemptedCount % log_every == 0 || attemptedCount >= missing.Count)
+                    Logger.Log($"MSD backfill progress: {attemptedCount} of {missing.Count} (ok={processedCount}, fail={failedCount})");
             }
 
             completeNotification(notification, processedCount, missing.Count, failedCount);
@@ -1901,7 +1909,7 @@ namespace osu.Game.Database
 
         private int lastNotificationProgressReported = -1;
 
-        private const int notification_progress_update_interval = 50;
+        private const int notification_progress_update_interval = 25;
 
         private void updateNotificationProgress(ProgressNotification? notification, int processedCount, int totalCount)
         {
@@ -1930,7 +1938,7 @@ namespace osu.Game.Database
                 notification.Progress = (float)processedCount / totalCount;
             });
 
-            if (processedCount > 0 && processedCount % 100 == 0)
+            if (processedCount > 0 && processedCount % 25 == 0)
                 Logger.Log($"Background progress: {processedCount} of {totalCount}");
         }
 

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileService.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileService.cs
@@ -258,7 +258,7 @@ namespace osu.Game.EzOsuGame.LocalProfile
                 {
                     danAggregator!.ComputeAndStore(username, scores, token, tick);
                     Store.ReplaceDanClears(username, danAggregator.PendingEvidence);
-                    skillProvider?.RefreshDanSkillsets(username);
+                    skillProvider?.RefreshDanSkillsets(username, tick);
                 },
                 danAggregator != null,
                 "[EzLocalProfile] Failed to compute/persist player Dan estimates after profile save.");

--- a/osu.Game/EzOsuGame/Skills/EzBeatmapMsdComputer.cs
+++ b/osu.Game/EzOsuGame/Skills/EzBeatmapMsdComputer.cs
@@ -56,7 +56,17 @@ namespace osu.Game.EzOsuGame.Skills
 
             double holdRatio = EzChartDanEstimator.ComputeHoldRatio(playable);
             skillStore.WriteBeatmapMsd(beatmapInfo.Hash, vector, beatmapInfo.ID, holdRatio: holdRatio);
-            return skillStore.GetBeatmapSkills(beatmapInfo.Hash, EzSkillSystems.BEATMAP_MSD);
+
+            // Return the just-written values without a second Realm round-trip.
+            var result = new Dictionary<string, double>(StringComparer.Ordinal);
+
+            foreach (var (axis, value) in vector.Enumerate())
+                result[axis.ToMsdSkillId()] = value;
+
+            if (double.IsFinite(holdRatio))
+                result[EzSkillSystems.MsdHoldRatioSkillId] = Math.Clamp(holdRatio, 0, 1);
+
+            return result;
         }
 
         /// <summary>

--- a/osu.Game/EzOsuGame/Skills/EzBeatmapMsdComputer.cs
+++ b/osu.Game/EzOsuGame/Skills/EzBeatmapMsdComputer.cs
@@ -3,7 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using osu.Framework.Logging;
 using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.Formats;
+using osu.Game.IO;
 
 namespace osu.Game.EzOsuGame.Skills
 {
@@ -45,14 +50,40 @@ namespace osu.Game.EzOsuGame.Skills
             if (beatmapInfo.Ruleset.OnlineID != 3)
                 return null;
 
+            if (!beatmapInfo.Ruleset.Available)
+                beatmapInfo.Ruleset.Available = true;
+
             var working = beatmapManager.GetWorkingBeatmap(beatmapInfo);
-            var playable = working.GetPlayableBeatmap(beatmapInfo.Ruleset);
+
+            if (!working.BeatmapInfo.Ruleset.Available)
+                working.BeatmapInfo.Ruleset.Available = true;
+
+            var playable = working.GetPlayableBeatmap(working.BeatmapInfo.Ruleset);
+
+            int keyCount = EzMinaNoteConverter.ResolveKeyCount(playable);
 
             using var calc = new EzMinaCalcFacade();
-            var vector = calc.CalculateMsd(playable);
+            EzSkillsetVector vector;
+
+            try
+            {
+                vector = calculateMsd(calc, working, playable, beatmapInfo, keyCount);
+            }
+            catch (Exception e)
+            {
+                Logger.Log($"MSD compute failed for {beatmapInfo} (keys={keyCount}): {e.Message}");
+                return null;
+            }
 
             if (vector.Overall <= 0 && vector.Stream <= 0)
+            {
+                if (!EzMinaCalcFacade.SupportsOsuTextKeyCount(keyCount) && !EzMinaCalcFacade.SupportsNoteArrayKeyCount(keyCount))
+                    Logger.Log($"MSD skip unsupported keymode {keyCount}K for {beatmapInfo}");
+                else
+                    Logger.Log($"MSD zero vector for {beatmapInfo} (keys={keyCount})");
+
                 return null;
+            }
 
             double holdRatio = EzChartDanEstimator.ComputeHoldRatio(playable);
             skillStore.WriteBeatmapMsd(beatmapInfo.Hash, vector, beatmapInfo.ID, holdRatio: holdRatio);
@@ -67,6 +98,73 @@ namespace osu.Game.EzOsuGame.Skills
                 result[EzSkillSystems.MsdHoldRatioSkillId] = Math.Clamp(holdRatio, 0, 1);
 
             return result;
+        }
+
+        private static EzSkillsetVector calculateMsd(
+            EzMinaCalcFacade calc,
+            WorkingBeatmap working,
+            IBeatmap playable,
+            BeatmapInfo beatmapInfo,
+            int keyCount)
+        {
+            // Prefer .osu text so MinaCalc reads CircleSize (required for 6K/7K on 0.4.2).
+            if (EzMinaCalcFacade.SupportsOsuTextKeyCount(keyCount))
+            {
+                string? osuText = tryReadOsuText(working, beatmapInfo) ?? tryEncodePlayable(working, playable);
+
+                if (!string.IsNullOrWhiteSpace(osuText))
+                    return calc.CalculateMsdFromOsuText(osuText, beatmapInfo.Path ?? $"{keyCount}k.osu");
+            }
+
+            // Note-array path: 4K only on this package.
+            return calc.CalculateMsd(playable);
+        }
+
+        private static string? tryReadOsuText(WorkingBeatmap working, BeatmapInfo beatmapInfo)
+        {
+            string? chartPath = beatmapInfo.Path;
+            if (string.IsNullOrEmpty(chartPath))
+                return null;
+
+            try
+            {
+                string? storagePath = beatmapInfo.BeatmapSet?.GetPathForFile(chartPath);
+                Stream? stream = null;
+
+                if (!string.IsNullOrEmpty(storagePath))
+                    stream = working.GetStream(storagePath);
+
+                stream ??= working.GetStream(chartPath);
+
+                if (stream == null)
+                    return null;
+
+                using (stream)
+                using (var reader = new LineBufferedReader(stream))
+                    return reader.ReadToEnd();
+            }
+            catch (Exception e)
+            {
+                Logger.Log($"MSD: failed reading .osu for {beatmapInfo}: {e.Message}");
+                return null;
+            }
+        }
+
+        private static string? tryEncodePlayable(WorkingBeatmap working, IBeatmap playable)
+        {
+            try
+            {
+                var sb = new StringBuilder();
+                using (var writer = new StringWriter(sb))
+                    new LegacyBeatmapEncoder(playable, working.Skin, null).Encode(writer);
+
+                return sb.ToString();
+            }
+            catch (Exception e)
+            {
+                Logger.Log($"MSD: failed encoding playable: {e.Message}");
+                return null;
+            }
         }
 
         /// <summary>

--- a/osu.Game/EzOsuGame/Skills/EzChartDanEstimator.cs
+++ b/osu.Game/EzOsuGame/Skills/EzChartDanEstimator.cs
@@ -3,8 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text;
 using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.Formats;
 using osu.Game.EzOsuGame.Analysis;
 using osu.Game.EzOsuGame.Skills.Dan;
 using osu.Game.Rulesets.Mods;
@@ -54,7 +57,30 @@ namespace osu.Game.EzOsuGame.Skills
             else
             {
                 using var calc = new EzMinaCalcFacade();
-                var vector = calc.CalculateMsd(playable, rate);
+                int keyCount = EzMinaNoteConverter.ResolveKeyCount(playable);
+                EzSkillsetVector vector;
+
+                if (EzMinaCalcFacade.SupportsNoteArrayKeyCount(keyCount))
+                {
+                    vector = calc.CalculateMsd(playable, rate);
+                }
+                else if (EzMinaCalcFacade.SupportsOsuTextKeyCount(keyCount))
+                {
+                    var sb = new StringBuilder();
+                    using (var writer = new StringWriter(sb))
+                        new LegacyBeatmapEncoder(playable, working.Skin, null).Encode(writer);
+
+                    string osuText = sb.ToString();
+                    if (string.IsNullOrWhiteSpace(osuText))
+                        return null;
+
+                    vector = calc.CalculateMsdFromOsuText(osuText, beatmapInfo.Path ?? $"{keyCount}k.osu", rate);
+                }
+                else
+                {
+                    return null;
+                }
+
                 if (vector.Overall <= 0 && vector.Stream <= 0)
                     return null;
 

--- a/osu.Game/EzOsuGame/Skills/EzMinaCalcFacade.cs
+++ b/osu.Game/EzOsuGame/Skills/EzMinaCalcFacade.cs
@@ -11,12 +11,25 @@ namespace osu.Game.EzOsuGame.Skills
     /// Thread-affine wrapper around <see cref="Calculator"/>.
     /// MinaCalc 0.4.2: last bool is MSD when false, SSR (goal-sensitive) when true.
     /// </summary>
+    /// <remarks>
+    /// The note-array overloads only rate 4K correctly in 0.4.2 (columns above bit3
+    /// yield an all-zero "junk" vector). 6K/7K must go through
+    /// <see cref="CalculateMsdFromOsuText"/> / <see cref="CalculateSsrFromOsuText"/>,
+    /// which let the native parser read CircleSize. 5K and 8K+ return engine error -3
+    /// on this package (newer wasm hubs support 4–18K).
+    /// </remarks>
     public sealed class EzMinaCalcFacade : IDisposable
     {
         private readonly Calculator calculator = new Calculator();
         private bool disposed;
 
         public static int EngineVersion => Calculator.Version;
+
+        /// <summary>Keymodes the note-array API rates non-zero on MinaCalc 0.4.2.</summary>
+        public static bool SupportsNoteArrayKeyCount(int keyCount) => keyCount == 4;
+
+        /// <summary>Keymodes <c>CalculateAtRateFromString</c> accepts on MinaCalc 0.4.2.</summary>
+        public static bool SupportsOsuTextKeyCount(int keyCount) => keyCount is 4 or 6 or 7;
 
         /// <summary>Chart difficulty (MSD). Goal is ignored by the engine in this mode.</summary>
         public EzSkillsetVector CalculateMsd(MinaCalcNote[] notes, float rate = 1f)
@@ -40,11 +53,54 @@ namespace osu.Game.EzOsuGame.Skills
             return EzSkillsetVector.FromMina(calculator.CalculateAtRate(notes, rate, goal, true));
         }
 
-        public EzSkillsetVector CalculateMsd(IBeatmap beatmap, float rate = 1f)
-            => CalculateMsd(EzMinaNoteConverter.Convert(beatmap), rate);
+        /// <summary>
+        /// MSD from raw <c>.osu</c> text. Prefers this for 6K/7K (and is fine for 4K).
+        /// </summary>
+        public EzSkillsetVector CalculateMsdFromOsuText(string osuText, string fileHint = "chart.osu", float rate = 1f)
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+            ArgumentException.ThrowIfNullOrWhiteSpace(osuText);
 
+            return EzSkillsetVector.FromMina(calculator.CalculateAtRateFromString(osuText, fileHint, rate, 0.93f, false));
+        }
+
+        /// <summary>
+        /// SSR from raw <c>.osu</c> text. Prefers this for 6K/7K (and is fine for 4K).
+        /// </summary>
+        public EzSkillsetVector CalculateSsrFromOsuText(string osuText, string fileHint, float rate, float goal)
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+            ArgumentException.ThrowIfNullOrWhiteSpace(osuText);
+
+            goal = Math.Clamp(goal, 0.8f, 0.9975f);
+            return EzSkillsetVector.FromMina(calculator.CalculateAtRateFromString(osuText, fileHint, rate, goal, true));
+        }
+
+        /// <summary>
+        /// MSD from a playable beatmap via the note-array API (4K only on 0.4.2).
+        /// Prefer <see cref="CalculateMsdFromOsuText"/> when the chart is 6K/7K.
+        /// </summary>
+        public EzSkillsetVector CalculateMsd(IBeatmap beatmap, float rate = 1f)
+        {
+            int keys = EzMinaNoteConverter.ResolveKeyCount(beatmap);
+            if (!SupportsNoteArrayKeyCount(keys))
+                return default;
+
+            return CalculateMsd(EzMinaNoteConverter.Convert(beatmap), rate);
+        }
+
+        /// <summary>
+        /// SSR from a playable beatmap via the note-array API (4K only on 0.4.2).
+        /// Prefer <see cref="CalculateSsrFromOsuText"/> when the chart is 6K/7K.
+        /// </summary>
         public EzSkillsetVector CalculateSsr(IBeatmap beatmap, float rate, float goal)
-            => CalculateSsr(EzMinaNoteConverter.Convert(beatmap), rate, goal);
+        {
+            int keys = EzMinaNoteConverter.ResolveKeyCount(beatmap);
+            if (!SupportsNoteArrayKeyCount(keys))
+                return default;
+
+            return CalculateSsr(EzMinaNoteConverter.Convert(beatmap), rate, goal);
+        }
 
         public void Dispose()
         {

--- a/osu.Game/EzOsuGame/Skills/EzPlayerSsrAggregator.cs
+++ b/osu.Game/EzOsuGame/Skills/EzPlayerSsrAggregator.cs
@@ -3,8 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
 using System.Threading;
 using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.Formats;
 using osu.Game.Scoring;
 
 namespace osu.Game.EzOsuGame.Skills
@@ -68,10 +71,30 @@ namespace osu.Game.EzOsuGame.Skills
                         continue;
 
                     var notes = EzMinaNoteConverter.Convert(playable);
-                    if (notes.Length == 0)
-                        continue;
+                    EzSkillsetVector vector;
 
-                    var vector = calc.CalculateSsr(notes, rate, goalValue);
+                    if (EzMinaCalcFacade.SupportsNoteArrayKeyCount(keyCount) && notes.Length > 0)
+                    {
+                        vector = calc.CalculateSsr(notes, rate, goalValue);
+                    }
+                    else if (EzMinaCalcFacade.SupportsOsuTextKeyCount(keyCount))
+                    {
+                        // Note-array API is 4K-only; encode playable (mods applied) for 6K/7K.
+                        var sb = new StringBuilder();
+                        using (var writer = new StringWriter(sb))
+                            new LegacyBeatmapEncoder(playable, working.Skin, null).Encode(writer);
+
+                        string osuText = sb.ToString();
+                        if (string.IsNullOrWhiteSpace(osuText))
+                            continue;
+
+                        vector = calc.CalculateSsrFromOsuText(osuText, score.BeatmapHash + ".osu", rate, goalValue);
+                    }
+                    else
+                    {
+                        continue;
+                    }
+
                     if (vector.Overall <= 0)
                         continue;
 

--- a/osu.Game/EzOsuGame/Skills/EzSkillProvider.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSkillProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.EzOsuGame.Analysis;
 using osu.Game.EzOsuGame.LocalProfile;
@@ -155,9 +156,10 @@ namespace osu.Game.EzOsuGame.Skills
 
         /// <summary>
         /// Recompute and persist skillset caches for a user after dan clears are replaced.
-        /// Chart resolve uses stored ChartSkillInfo only (no WorkingBeatmap load) so profile rebuild stays light.
+        /// Prefetches MSD + ChartSkillInfo for all clear hashes in one Realm pass (no per-clear Run).
+        /// Chart resolve uses stored ChartSkillInfo only (no WorkingBeatmap load).
         /// </summary>
-        public void RefreshDanSkillsets(string username)
+        public void RefreshDanSkillsets(string username, Action? tick = null)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(username);
 
@@ -167,18 +169,65 @@ namespace osu.Game.EzOsuGame.Skills
             if (!string.Equals(resolvedUser, username, StringComparison.Ordinal))
                 store.ClearDanSkillsetValues(username);
 
+            var allClears = GetDanClears(resolvedUser, algorithmVersion: EzDanAlgorithm.VERSION);
+            var hashes = allClears
+                         .Select(c => c.BeatmapHash)
+                         .Where(static h => !string.IsNullOrEmpty(h))
+                         .Distinct(StringComparer.Ordinal)
+                         .ToList();
+
+            var msdByHash = store.GetBeatmapSkillsForHashes(hashes, EzSkillSystems.BEATMAP_MSD);
+            var chartByHash = store.GetChartSkillInfoForHashes(hashes);
+
             foreach (int keyCount in tracked_skillset_key_counts)
             {
                 foreach (var side in new[] { EzDanSide.Rc, EzDanSide.Ln })
                 {
                     string sideId = side.ToId();
-                    var verdicts = computeDanSkillsets(resolvedUser, keyCount, sideId, allowComputeChart: false);
+                    var clears = filterClears(allClears, keyCount, sideId);
+
+                    if (clears.Count == 0 && EzDanSkillsetBuckets.Slots(keyCount, side).Count == 0)
+                    {
+                        // No evidence and no UI slots — skip writing a cache stamp.
+                        tick?.Invoke();
+                        continue;
+                    }
+
+                    var verdicts = EzDanSkillsetBuckets.ComputeFromClears(
+                        keyCount,
+                        side,
+                        clears,
+                        hash => msdByHash.TryGetValue(hash, out var msd) && msd.Count > 0 ? msd : null,
+                        hash => chartByHash.TryGetValue(hash, out var chart) ? chart : null);
+
                     store.WriteDanSkillsetVerdicts(resolvedUser, keyCount, sideId, verdicts);
+                    tick?.Invoke();
                 }
             }
         }
 
         private static readonly int[] tracked_skillset_key_counts = { 4, 5, 6, 7, 8, 9 };
+
+        private static IReadOnlyList<EzDanClearEvidenceRow> filterClears(
+            IReadOnlyList<EzDanClearEvidenceRow> clears,
+            int keyCount,
+            string sideId)
+        {
+            var list = new List<EzDanClearEvidenceRow>();
+
+            foreach (var clear in clears)
+            {
+                if (clear.KeyCount != keyCount)
+                    continue;
+
+                if (!string.Equals(clear.Side, sideId, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                list.Add(clear);
+            }
+
+            return list;
+        }
 
         private IReadOnlyDictionary<string, EzDanSkillsetVerdict> danSkillsetsFromCache(string username, int keyCount, string side)
         {
@@ -199,24 +248,27 @@ namespace osu.Game.EzOsuGame.Skills
         {
             var sideEnum = EzDanSideExtensions.ParseOrRc(side);
             var clears = GetDanClears(username, keyCount, side, EzDanAlgorithm.VERSION);
+
+            var hashes = clears
+                         .Select(c => c.BeatmapHash)
+                         .Where(static h => !string.IsNullOrEmpty(h))
+                         .Distinct(StringComparer.Ordinal)
+                         .ToList();
+
+            var msdByHash = store.GetBeatmapSkillsForHashes(hashes, EzSkillSystems.BEATMAP_MSD);
+            var chartByHash = store.GetChartSkillInfoForHashes(hashes);
+
             return EzDanSkillsetBuckets.ComputeFromClears(
                 keyCount,
                 sideEnum,
                 clears,
+                hash => msdByHash.TryGetValue(hash, out var msd) && msd.Count > 0 ? msd : null,
                 hash =>
                 {
-                    var msd = GetBeatmapMsd(hash);
-                    return msd.Count == 0 ? null : msd;
-                },
-                hash =>
-                {
-                    if (string.IsNullOrEmpty(hash))
-                        return null;
-
-                    if (store.TryGetChartSkillInfo(hash, out var stored) && stored != null)
+                    if (chartByHash.TryGetValue(hash, out var stored))
                         return stored;
 
-                    if (!allowComputeChart || beatmapManager == null)
+                    if (!allowComputeChart || beatmapManager == null || string.IsNullOrEmpty(hash))
                         return null;
 
                     var info = beatmapManager.QueryBeatmap(b => b.Hash == hash);

--- a/osu.Game/EzOsuGame/Skills/EzSkillStore.cs
+++ b/osu.Game/EzOsuGame/Skills/EzSkillStore.cs
@@ -36,6 +36,42 @@ namespace osu.Game.EzOsuGame.Skills
             });
         }
 
+        /// <summary>
+        /// Batch-read beatmap MSD (or other system) rows for many hashes in one Realm run.
+        /// Missing hashes are omitted from the result.
+        /// </summary>
+        public IReadOnlyDictionary<string, IReadOnlyDictionary<string, double>> GetBeatmapSkillsForHashes(
+            IEnumerable<string> beatmapHashes,
+            string systemId,
+            int? algorithmVersion = null)
+        {
+            ArgumentNullException.ThrowIfNull(beatmapHashes);
+
+            var hashSet = beatmapHashes
+                          .Where(static h => !string.IsNullOrEmpty(h))
+                          .ToHashSet(StringComparer.Ordinal);
+
+            if (hashSet.Count == 0)
+                return new Dictionary<string, IReadOnlyDictionary<string, double>>(StringComparer.Ordinal);
+
+            int version = algorithmVersion ?? EzManiaSkillAlgorithm.VERSION;
+
+            return realmAccess.Run(r =>
+            {
+                var result = new Dictionary<string, IReadOnlyDictionary<string, double>>(hashSet.Count, StringComparer.Ordinal);
+
+                var rows = r.All<EzBeatmapSkillValue>()
+                            .Where(v => v.SystemId == systemId && v.AlgorithmVersion == version)
+                            .AsEnumerable()
+                            .Where(v => hashSet.Contains(v.BeatmapHash));
+
+                foreach (var group in rows.GroupBy(v => v.BeatmapHash, StringComparer.Ordinal))
+                    result[group.Key] = group.ToDictionary(v => v.SkillId, v => v.Value, StringComparer.Ordinal);
+
+                return result;
+            });
+        }
+
         public bool TryGetBeatmapSkill(string beatmapHash, string skillId, out double value, int? algorithmVersion = null)
         {
             int version = algorithmVersion ?? EzManiaSkillAlgorithm.VERSION;
@@ -439,6 +475,37 @@ namespace osu.Game.EzOsuGame.Skills
                     LengthSeconds = info.LengthSeconds ?? -1,
                     KeyCount = info.KeyCount ?? -1,
                 });
+            });
+        }
+
+        /// <summary>
+        /// Batch-read typed ChartSkillInfo rows for many hashes in one Realm run.
+        /// Missing / wrong-version hashes are omitted.
+        /// </summary>
+        public IReadOnlyDictionary<string, EzChartSkillInfo> GetChartSkillInfoForHashes(IEnumerable<string> beatmapHashes)
+        {
+            ArgumentNullException.ThrowIfNull(beatmapHashes);
+
+            var hashSet = beatmapHashes
+                          .Where(static h => !string.IsNullOrEmpty(h))
+                          .ToHashSet(StringComparer.Ordinal);
+
+            if (hashSet.Count == 0)
+                return new Dictionary<string, EzChartSkillInfo>(StringComparer.Ordinal);
+
+            return realmAccess.Run(r =>
+            {
+                var result = new Dictionary<string, EzChartSkillInfo>(hashSet.Count, StringComparer.Ordinal);
+
+                var rows = r.All<EzBeatmapChartSkillInfo>()
+                            .Where(v => v.InfoVersion == EzChartSkillInfo.VERSION)
+                            .AsEnumerable()
+                            .Where(v => hashSet.Contains(v.BeatmapHash));
+
+                foreach (var row in rows)
+                    result[row.BeatmapHash] = chartSkillInfoToDto(row);
+
+                return result;
             });
         }
 

--- a/osu.Game/Rulesets/RulesetInfo.cs
+++ b/osu.Game/Rulesets/RulesetInfo.cs
@@ -105,6 +105,7 @@ namespace osu.Game.Rulesets
             Available = Available,
             LastAppliedDifficultyVersion = LastAppliedDifficultyVersion,
             LastAppliedXxySrVersion = LastAppliedXxySrVersion,
+            LastAppliedManiaSkillVersion = LastAppliedManiaSkillVersion,
         };
 
         public Ruleset CreateInstance()


### PR DESCRIPTION
## Summary
- MSD backfill: tick notification progress after every attempt, log every 25 maps, and return the in-memory vector from `ComputeAndStore` without a post-write Realm reread.
- `RefreshDanSkillsets` / `computeDanSkillsets`: one-shot prefetch of MSD + ChartSkillInfo for clear hashes (`GetBeatmapSkillsForHashes` / `GetChartSkillInfoForHashes`), skip empty key×side with no slots, and pass LocalProfile `tick` through so Skills no longer look frozen.
- Unit test covers batch prefetch APIs. No EZ schema bump.

## Test plan
- [ ] `dotnet test --filter FullyQualifiedName~EzChartSkillInfoRealmStoreTest` (Batch_prefetch case)
- [ ] Restart after canceling a stuck \"Reprocessing beatmap MSD\" run — remaining missing hashes should resume; notification should advance (every ~25 or total/20)
- [ ] Rebuild Local Profile Skills — skillset phase should tick and finish without multi-minute hang after dan clears
- [ ] Confirm logs: `Found N beatmaps which require MSD reprocessing` and periodic `MSD backfill progress: …`

## User note
Libraries that went through EZ8 (MSD wipe) still need one full MSD pass; this PR makes that pass visible and slightly cheaper per map, not parallel MinaCalc.