### PR TITLE
Harden InputAudioLatencyTracker session lifecycle

### DIFF
--- a/osu.Game/EzOsuGame/Audio/InputAudioLatencyTracker.cs
+++ b/osu.Game/EzOsuGame/Audio/InputAudioLatencyTracker.cs
@@ -106,7 +106,7 @@ namespace osu.Game.EzOsuGame.Audio
         }
 
         /// <summary>
-        /// Mania column press (may arrive shortly after framework KeyDown; analyzer coalesces within 2ms).
+        /// Mania column press (may follow framework KeyDown for the same key; analyzer upgrades Key→column only).
         /// </summary>
         public void RecordColumnPress(int column)
         {

--- a/osu.Game/EzOsuGame/Audio/InputAudioLatencyTracker.cs
+++ b/osu.Game/EzOsuGame/Audio/InputAudioLatencyTracker.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Framework.Allocation;
 using osu.Framework.Audio.EzLatency;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
@@ -17,56 +16,57 @@ using osuTK.Input;
 namespace osu.Game.EzOsuGame.Audio
 {
     /// <summary>
-    /// Unified latency measurement manager that coordinates between game input events and the EzLatency system.
-    /// Acts as the central bridge between osu! game events and framework-level latency tracking.
+    /// Bridge between gameplay (input / judgement) and framework <see cref="EzLatencyManager"/>.
     /// </summary>
     public partial class InputAudioLatencyTracker : IDisposable
     {
-        [Resolved(canBeNull: true)]
-        private INotificationOverlay? notificationOverlay { get; set; }
-
-        private Ez2ConfigManager ezConfig { get; set; }
+        private readonly Ez2ConfigManager ezConfig;
+        private readonly INotificationOverlay? notificationOverlay;
+        private readonly EzLatencyManager latencyManager;
 
         private ScoreProcessor? scoreProcessor;
-
-        private readonly EzLatencyManager latencyManager;
         private Bindable<bool>? inputAudioLatencyConfigBindable;
         private Action<ValueChangedEvent<bool>>? inputAudioLatencyConfigHandler;
         private Action<ValueChangedEvent<bool>>? enabledChangedHandler;
+        private bool initialized;
+        private bool started;
+        private bool disposed;
 
-        /// <summary>
-        /// Global instance for unified access
-        /// </summary>
         public static InputAudioLatencyTracker? Instance { get; private set; }
 
-        public InputAudioLatencyTracker(Ez2ConfigManager ez2ConfigManager)
+        public InputAudioLatencyTracker(Ez2ConfigManager ez2ConfigManager, INotificationOverlay? notificationOverlay = null)
         {
             ezConfig = ez2ConfigManager;
+            this.notificationOverlay = notificationOverlay;
             Instance = this;
-
-            // 使用全局的 EzLatencyManager 实例以与框架层的全局插桩一致
             latencyManager = EzLatencyManager.GLOBAL;
         }
 
         public void Initialize(ScoreProcessor processor)
         {
-            Logger.Log("InputAudioLatencyTracker.Initialize called", Ez2ConfigManager.LOGGER_NAME, LogLevel.Debug);
+            if (disposed)
+                return;
+
             scoreProcessor = processor;
 
-            // Start each gameplay session from a clean latency dataset.
+            if (initialized)
+            {
+                // Re-entering a session: keep bindings, refresh stats and judgement subscription.
+                latencyManager.ClearStatistics();
+                if (latencyManager.Enabled.Value)
+                    Start();
+                return;
+            }
+
+            initialized = true;
             latencyManager.ClearStatistics();
 
-            // 将 Ez2Setting 的启用状态绑定到 EzLatencyManager
             inputAudioLatencyConfigBindable = ezConfig.GetBindable<bool>(Ez2Setting.InputAudioLatencyTracker);
-            // Avoid BindTo here to prevent repeated double-binding errors when Initialize is called multiple times.
-            // Use a one-way update from config -> latencyManager instead.
             inputAudioLatencyConfigHandler = v => latencyManager.Enabled.Value = v.NewValue;
             inputAudioLatencyConfigBindable.BindValueChanged(inputAudioLatencyConfigHandler, true);
 
-            // 订阅延迟记录事件，用于日志输出
-            latencyManager.OnNewRecord += OnLatencyRecordGenerated;
+            // Do not subscribe OnNewRecord for per-hit logging — session summary only (avoids audio-thread log spam).
 
-            // 绑定启用状态变化，控制生命周期
             enabledChangedHandler = enabled =>
             {
                 if (enabled.NewValue)
@@ -74,27 +74,24 @@ namespace osu.Game.EzOsuGame.Audio
                 else
                     Stop();
             };
-
             latencyManager.Enabled.BindValueChanged(enabledChangedHandler, true);
-        }
 
-        private bool started;
+            Logger.Log("[EzOsuLatency] tracker armed for gameplay session", Ez2ConfigManager.LOGGER_NAME, LogLevel.Debug);
+        }
 
         public void Start()
         {
-            if (started) return;
+            if (disposed || started || scoreProcessor == null)
+                return;
 
             started = true;
-
-            Logger.Log("InputAudioLatencyTracker.Start called", Ez2ConfigManager.LOGGER_NAME, LogLevel.Debug);
-
-            if (scoreProcessor != null)
-                scoreProcessor.NewJudgement += OnNewJudgement;
+            scoreProcessor.NewJudgement += OnNewJudgement;
         }
 
         public void Stop()
         {
-            if (!started) return;
+            if (!started)
+                return;
 
             started = false;
 
@@ -102,60 +99,41 @@ namespace osu.Game.EzOsuGame.Audio
                 scoreProcessor.NewJudgement -= OnNewJudgement;
         }
 
-        /// <summary>
-        /// Records a key press event for latency measurement.
-        /// Call this when the player presses a key.
-        /// </summary>
-        /// <param name="key">The key that was pressed</param>
         public void RecordKeyPress(Key key)
         {
             if (latencyManager.Enabled.Value)
-            {
-                // 记录输入事件
                 latencyManager.RecordInputEvent(key);
-            }
         }
 
         /// <summary>
-        /// Records a column press event for mania ruleset.
+        /// Mania column press (may arrive shortly after framework KeyDown; analyzer coalesces within 2ms).
         /// </summary>
-        /// <param name="column">The column that was pressed</param>
         public void RecordColumnPress(int column)
         {
             if (latencyManager.Enabled.Value)
-            {
-                // 记录输入事件 (使用 column 作为标识)
                 latencyManager.RecordInputEvent(column);
-            }
         }
 
-        /// <summary>
-        /// Call this when the game exits to generate latency statistics.
-        /// </summary>
         public void GenerateLatencyReport()
         {
-            if (!latencyManager.Enabled.Value)
+            if (disposed)
                 return;
 
-            // 停止收集新数据
             Stop();
 
-            // 从 EzLatencyManager 获取统计数据
             var stats = latencyManager.GetStatistics();
 
             if (!stats.HasData)
             {
-                Logger.Log("[EzOsuLatency] No latency data available for analysis", Ez2ConfigManager.LOGGER_NAME, LogLevel.Debug);
+                Logger.Log("[EzOsuLatency] session ended with no complete records", Ez2ConfigManager.LOGGER_NAME, LogLevel.Debug);
                 return;
             }
 
-            // 输出统计日志
-            string message =
-                $"Input→Judgement: {stats.AvgInputToJudge:F2}ms, \nInput→Audio: {stats.AvgInputToPlayback:F2}ms, \nAudio→Judgement: {stats.AvgPlaybackToJudge:F2}ms \n(based on {stats.RecordCount} complete records)";
+            Logger.Log(
+                $"[EzOsuLatency] Input→Judge={stats.AvgInputToJudge:F2}ms Input→Audio={stats.AvgInputToPlayback:F2}ms Audio→Judge={stats.AvgPlaybackToJudge:F2}ms n={stats.RecordCount}",
+                Ez2ConfigManager.LOGGER_NAME,
+                LogLevel.Debug);
 
-            Logger.Log($"[EzOsuLatency] Latency Analysis: {message}", Ez2ConfigManager.LOGGER_NAME, LogLevel.Debug);
-
-            // 显示通知
             notificationOverlay?.Post(new SimpleNotification
             {
                 Text =
@@ -168,31 +146,25 @@ namespace osu.Game.EzOsuGame.Audio
 
         private void OnNewJudgement(JudgementResult result)
         {
-            if (!latencyManager.Enabled.Value)
+            if (!latencyManager.Enabled.Value || !result.Type.IsScorable())
                 return;
 
-            if (result.Type.IsScorable())
-            {
-                // 检查是否为普通note且判定为Perfect
-                bool isNote = result.HitObject.GetType().Name.EndsWith("Note", StringComparison.Ordinal) ||
-                              result.HitObject.GetType().Name == "Fruit" ||
-                              result.HitObject.GetType().Name == "HitCircle" ||
-                              result.HitObject.GetType().Name == "Hit";
+            bool isNote = result.HitObject.GetType().Name.EndsWith("Note", StringComparison.Ordinal) ||
+                          result.HitObject.GetType().Name == "Fruit" ||
+                          result.HitObject.GetType().Name == "HitCircle" ||
+                          result.HitObject.GetType().Name == "Hit";
 
-                // 记录所有可计分的 note 判定，以便收集判定时间戳（不局限于 Perfect）
-                if (isNote)
-                {
-                    latencyManager.RecordJudgeEvent();
-                }
-            }
+            if (isNote)
+                latencyManager.RecordJudgeEvent();
         }
 
         public void Dispose()
         {
-            Stop();
+            if (disposed)
+                return;
 
-            // 解绑事件
-            latencyManager.OnNewRecord -= OnLatencyRecordGenerated;
+            disposed = true;
+            Stop();
 
             if (enabledChangedHandler != null)
                 latencyManager.Enabled.ValueChanged -= enabledChangedHandler;
@@ -200,36 +172,14 @@ namespace osu.Game.EzOsuGame.Audio
             if (inputAudioLatencyConfigBindable != null && inputAudioLatencyConfigHandler != null)
                 inputAudioLatencyConfigBindable.ValueChanged -= inputAudioLatencyConfigHandler;
 
+            // Critical: do not leave GLOBAL.Enabled true after leaving gameplay.
+            latencyManager.Enabled.Value = false;
             latencyManager.ClearStatistics();
 
-            Instance = null;
-        }
+            if (Instance == this)
+                Instance = null;
 
-        /// <summary>
-        /// 处理从 framework 层传来的延迟记录，输出详细日志
-        /// </summary>
-        private void OnLatencyRecordGenerated(EzLatencyRecord r)
-        {
-            try
-            {
-                var inputData = r.InputData;
-                var hw = r.HardwareData;
-
-                string keyVal = inputData.KeyValue?.ToString() ?? "-";
-
-                string line =
-                    $"[EzOsuLatency] {r.Timestamp:O} | {r.MeasuredMs:F2} ms | note={r.Note} | in={r.InputTime:F2} | key={keyVal} | play={r.PlaybackTime:F2} | judge={r.JudgeTime:F2} | driver={r.DriverTime:F2} | out_hw={r.OutputHardwareTime:F2} | in_hw={r.InputHardwareTime:F2} | diff={r.LatencyDifference:F2}";
-
-                // extra low-level structs
-                string extra = $" | input_struct=(in={inputData.InputTime:F2}, key={inputData.KeyValue ?? "-"}, judge={inputData.JudgeTime:F2}, play={inputData.PlaybackTime:F2})" +
-                               $" | hw_struct=(driver={hw.DriverTime:F2}, out_hw={hw.OutputHardwareTime:F2}, in_hw={hw.InputHardwareTime:F2}, diff={hw.LatencyDifference:F2})";
-
-                Logger.Log(line + extra, Ez2ConfigManager.LOGGER_NAME, LogLevel.Debug);
-            }
-            catch (Exception ex)
-            {
-                Logger.Log($"InputAudioLatencyTracker: failed to handle new record: {ex.Message}", Ez2ConfigManager.LOGGER_NAME, LogLevel.Error);
-            }
+            Logger.Log("[EzOsuLatency] tracker disposed; GLOBAL.Enabled=false", Ez2ConfigManager.LOGGER_NAME, LogLevel.Debug);
         }
     }
 }

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -195,6 +195,9 @@ namespace osu.Game.Screens.Play
         [Resolved]
         private OsuGameBase game { get; set; }
 
+        [Resolved(canBeNull: true)]
+        private INotificationOverlay notificationOverlay { get; set; }
+
         public GameplayState GameplayState { get; private set; }
 
         private Ruleset ruleset;
@@ -326,7 +329,7 @@ namespace osu.Game.Screens.Play
             // 初始化InputAudioLatencyTracker
             if (GlobalConfigStore.EzConfig.Get<bool>(Ez2Setting.InputAudioLatencyTracker))
             {
-                LatencyTracker = new InputAudioLatencyTracker(ez2Config);
+                LatencyTracker = new InputAudioLatencyTracker(ez2Config, notificationOverlay);
                 dependencies.CacheAs(LatencyTracker);
                 LatencyTracker.Initialize(ScoreProcessor);
                 LatencyTracker.Start();


### PR DESCRIPTION
## Summary
- Set `EzLatencyManager.GLOBAL.Enabled=false` on dispose so instrumentation does not leak after leaving gameplay.
- Inject `INotificationOverlay` from `Player` so the end-of-session summary notification actually works.
- Remove per-hit Debug logging; keep only session-arm / dispose / summary Debug lines.

Depends on / stacks on #118 (`audio-naudio-default-output`). Pair with ez2lazer-framework #17.

## Test plan
- [ ] Enable Input Audio Latency Tracker, enter and exit play multiple times without hang/crash
- [ ] After exit, menu/UI sample playback should not keep feeding latency measurement
- [ ] End of play: one summary notification + one Debug summary in runtime/Ez log
- [ ] Works with framework #17 applied
