### PR TITLE
Emit latency summary on results with avg/min/max

### DIFF
--- a/osu.Game/EzOsuGame/Audio/InputAudioLatencyTracker.cs
+++ b/osu.Game/EzOsuGame/Audio/InputAudioLatencyTracker.cs
@@ -31,6 +31,7 @@ namespace osu.Game.EzOsuGame.Audio
         private bool initialized;
         private bool started;
         private bool disposed;
+        private bool reportGenerated;
 
         public static InputAudioLatencyTracker? Instance { get; private set; }
 
@@ -53,19 +54,19 @@ namespace osu.Game.EzOsuGame.Audio
             {
                 // Re-entering a session: keep bindings, refresh stats and judgement subscription.
                 latencyManager.ClearStatistics();
+                reportGenerated = false;
                 if (latencyManager.Enabled.Value)
                     Start();
                 return;
             }
 
             initialized = true;
+            reportGenerated = false;
             latencyManager.ClearStatistics();
 
             inputAudioLatencyConfigBindable = ezConfig.GetBindable<bool>(Ez2Setting.InputAudioLatencyTracker);
             inputAudioLatencyConfigHandler = v => latencyManager.Enabled.Value = v.NewValue;
             inputAudioLatencyConfigBindable.BindValueChanged(inputAudioLatencyConfigHandler, true);
-
-            // Do not subscribe OnNewRecord for per-hit logging — session summary only (avoids audio-thread log spam).
 
             enabledChangedHandler = enabled =>
             {
@@ -114,11 +115,15 @@ namespace osu.Game.EzOsuGame.Audio
                 latencyManager.RecordInputEvent(column);
         }
 
+        /// <summary>
+        /// Emit session summary (log + notification). Safe to call from results or exit; only runs once per session.
+        /// </summary>
         public void GenerateLatencyReport()
         {
-            if (disposed)
+            if (disposed || reportGenerated)
                 return;
 
+            reportGenerated = true;
             Stop();
 
             var stats = latencyManager.GetStatistics();
@@ -129,17 +134,32 @@ namespace osu.Game.EzOsuGame.Audio
                 return;
             }
 
-            Logger.Log(
-                $"[EzOsuLatency] Input→Judge={stats.AvgInputToJudge:F2}ms Input→Audio={stats.AvgInputToPlayback:F2}ms Audio→Judge={stats.AvgPlaybackToJudge:F2}ms n={stats.RecordCount}",
-                Ez2ConfigManager.LOGGER_NAME,
-                LogLevel.Debug);
+            string summary =
+                $"[EzOsuLatency] n={stats.RecordCount}"
+                + $" | Input→Audio avg/min/max={stats.AvgInputToPlayback:F2}/{stats.MinInputToPlayback:F2}/{stats.MaxInputToPlayback:F2}ms"
+                + $" | Input→Judge avg/min/max={stats.AvgInputToJudge:F2}/{stats.MinInputToJudge:F2}/{stats.MaxInputToJudge:F2}ms"
+                + $" | Audio→Judge avg/min/max={stats.AvgPlaybackToJudge:F2}/{stats.MinPlaybackToJudge:F2}/{stats.MaxPlaybackToJudge:F2}ms";
 
-            notificationOverlay?.Post(new SimpleNotification
+            Logger.Log(summary, Ez2ConfigManager.LOGGER_NAME, LogLevel.Debug);
+            // Also mirror to runtime so the summary is easy to find without filtering Ez logger.
+            Logger.Log(summary, LoggingTarget.Runtime, LogLevel.Debug);
+
+            if (notificationOverlay == null)
             {
-                Text =
-                    $"Latency analysis complete!\nInput→Judge: {stats.AvgInputToJudge:F1}ms\nInput→Audio: {stats.AvgInputToPlayback:F1}ms\nAudio→Judge: {stats.AvgPlaybackToJudge:F1}ms\nRecords: {stats.RecordCount}",
-                Icon = FontAwesome.Solid.ChartLine,
-            });
+                Logger.Log("[EzOsuLatency] summary ready but INotificationOverlay is null", Ez2ConfigManager.LOGGER_NAME, LogLevel.Debug);
+            }
+            else
+            {
+                notificationOverlay.Post(new SimpleNotification
+                {
+                    Text =
+                        $"Latency summary (n={stats.RecordCount})\n"
+                        + $"Input→Audio  avg {stats.AvgInputToPlayback:F1}  min {stats.MinInputToPlayback:F1}  max {stats.MaxInputToPlayback:F1} ms\n"
+                        + $"Input→Judge  avg {stats.AvgInputToJudge:F1}  min {stats.MinInputToJudge:F1}  max {stats.MaxInputToJudge:F1} ms\n"
+                        + $"Audio→Judge  avg {stats.AvgPlaybackToJudge:F1}  min {stats.MinPlaybackToJudge:F1}  max {stats.MaxPlaybackToJudge:F1} ms",
+                    Icon = FontAwesome.Solid.ChartLine,
+                });
+            }
 
             latencyManager.ClearStatistics();
         }
@@ -162,6 +182,10 @@ namespace osu.Game.EzOsuGame.Audio
         {
             if (disposed)
                 return;
+
+            // Last chance if results/exit hooks were skipped (e.g. abrupt teardown).
+            if (!reportGenerated)
+                GenerateLatencyReport();
 
             disposed = true;
             Stop();

--- a/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileAggregator.cs
+++ b/osu.Game/EzOsuGame/LocalProfile/EzLocalProfileAggregator.cs
@@ -98,6 +98,9 @@ namespace osu.Game.EzOsuGame.LocalProfile
         /// Also returns detached mania scores from the same Realm pass (for skill/dan compute).
         /// Does not merge online contributions — that happens when rebuilding display totals.
         /// </summary>
+        /// <param name="usernames">The usernames to aggregate.</param>
+        /// <param name="progress">The progress reporter.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="cachedAvgAbsOffsets">
         /// Previously stored drill offsets keyed by score id (HitEvents are not in Realm; bulk compute must not re-run sessions).
         /// </param>

--- a/osu.Game/EzOsuGame/Skills/Dan/EzDanLadder.cs
+++ b/osu.Game/EzOsuGame/Skills/Dan/EzDanLadder.cs
@@ -5,13 +5,11 @@ using System;
 using System.Text.RegularExpressions;
 using osu.Framework.Graphics;
 
-#pragma warning disable CS1574 // XML 注释中有无法解析的 cref 特性
-
 namespace osu.Game.EzOsuGame.Skills.Dan
 {
     /// <summary>
     /// Known community dan ladders. 5K / 8K / 9K fall back to <see cref="Reform4K"/> text labels until dedicated tables exist.
-    /// Reserved: add <see cref="IEzDanLadder"/> implementations and wire them in <see cref="EzDanLadders.For"/> —
+    /// Reserved: add <see cref="IEzDanLadder"/> implementations and wire them in <see cref="EzDanLadders.For(int, EzDanSide)"/> —
     /// do not treat the Reform fallback as the permanent multi-key solution.
     /// </summary>
     public enum EzDanLadderKind
@@ -133,7 +131,7 @@ namespace osu.Game.EzOsuGame.Skills.Dan
         }
 
         /// <summary>
-        /// DLL-embedded path for <see cref="TryGetTexturePath"/> when a folder starts with a digit
+        /// DLL-embedded path for <see cref="TryGetTexturePath(int, EzDanSide, string)"/> when a folder starts with a digit
         /// (MSBuild → <c>_6k</c> / <c>_7k</c>). Null if unchanged.
         /// </summary>
         public static string? TryGetEmbeddedTexturePath(string relativePathWithoutExtension)

--- a/osu.Game/EzOsuGame/Skills/EzBeatmapSkillValue.cs
+++ b/osu.Game/EzOsuGame/Skills/EzBeatmapSkillValue.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Game.Beatmaps;
 using Realms;
 
 namespace osu.Game.EzOsuGame.Skills
@@ -18,7 +19,7 @@ namespace osu.Game.EzOsuGame.Skills
         [Indexed]
         public string BeatmapHash { get; set; } = string.Empty;
 
-        /// <summary>Optional <see cref="Beatmaps.BeatmapInfo.ID"/> for maintenance when hash changes.</summary>
+        /// <summary>Optional <see cref="BeatmapInfo.ID"/> for maintenance when hash changes.</summary>
         [Indexed]
         public Guid BeatmapId { get; set; } = Guid.Empty;
 

--- a/osu.Game/EzOsuGame/Skills/EzDanSkillsetBuckets.cs
+++ b/osu.Game/EzOsuGame/Skills/EzDanSkillsetBuckets.cs
@@ -22,7 +22,7 @@ namespace osu.Game.EzOsuGame.Skills
     ///     Hub <c>danSkillsetBuckets</c> slot table for DualPanel layout.
     ///     Filing / verdicts: <see cref="EzDanSkillsetFiling"/>.
     ///     <para>
-    ///         Capability matrix (always call <see cref="Slots"/> for layout):
+    ///         Capability matrix (always call <see cref="Slots(int, EzDanSide)"/> for layout):
     ///         4K RC: jack/tech/speed/stamina (MSD + chart overrides);
     ///         6/7K RC: jack/tech/speed/stream (pattern tags / LeoBlack clusters when chart present);
     ///         4K/6K LN: empty slots (side aggregate only);

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -1144,6 +1144,7 @@ namespace osu.Game.Screens.Play
                 if (EzQuickRotationCoordinator.Session.IsActive)
                 {
                     EzOsuGame.Diagnostics.EzTimingTrace.Record("ResultsDelegate.QuickRotation", "Navigating to quick rotation flow");
+                    LatencyTracker?.GenerateLatencyReport();
                     (GameplayClockContainer as MasterGameplayClockContainer)?.StopUsingBeatmapClock();
 
                     if (Beatmap.Value.TrackLoaded)
@@ -1158,11 +1159,13 @@ namespace osu.Game.Screens.Play
                 if (EzFlowMode.ShouldSkipResults(this))
                 {
                     EzOsuGame.Diagnostics.EzTimingTrace.Record("ResultsDelegate.FlowMode", "Skipping results screen – returning to song select");
+                    LatencyTracker?.GenerateLatencyReport();
                     EzFlowMode.ReturnToSongSelect(game as OsuGame);
                     return;
                 }
 
                 EzOsuGame.Diagnostics.EzTimingTrace.Record("ResultsDelegate.Push", "Navigating to results screen");
+                LatencyTracker?.GenerateLatencyReport();
                 OnShowingResults?.Invoke();
                 this.Push(CreateResults(prepareScoreForDisplayTask.GetResultSafely()));
             }, Time.Current + delay, 50);


### PR DESCRIPTION
## Summary
- Call `GenerateLatencyReport` when entering results / flow / quick-rotation paths (pass no longer skipped because `Player` stays under Results without `OnExiting`).
- Show avg/min/max for Input→Audio, Input→Judge, Audio→Judge in notification + Debug log (`ez_runtime` and `runtime`).
- Idempotent report flag; `OnExiting` / `Dispose` remain fallbacks.

Requires framework commit that adds min/max fields on `EzLatencyStatistics` (push on `audio-latency-tracker-harden` / follow-up PR).

## Test plan
- [ ] Enable Input Audio Latency Tracker, finish a map to results → notification with avg/min/max
- [ ] `ez_runtime.log` / `runtime.log` contain `[EzOsuLatency] n=... Input→Audio avg/min/max=...`
- [ ] Quit mid-map still reports once
- [ ] No double notification when leaving results afterward
