### PR TITLE
feat(audio): wire acoustic loopback into InputAudioLatencyTracker

### DIFF
--- a/osu.Game/EzOsuGame/Audio/InputAudioLatencyTracker.cs
+++ b/osu.Game/EzOsuGame/Audio/InputAudioLatencyTracker.cs
@@ -9,14 +9,14 @@ using osu.Framework.Logging;
 using osu.Game.EzOsuGame.Configuration;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
-using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Scoring;
 using osuTK.Input;
 
 namespace osu.Game.EzOsuGame.Audio
 {
     /// <summary>
-    /// Bridge between gameplay (input / judgement) and framework <see cref="EzLatencyManager"/>.
+    /// 音频闭环延迟桥：游戏输入戳 → <c>Sample.Play</c> → WASAPI loopback。
+    /// 判定耗时（In→Judge）归 <see cref="Diagnostics.EzJudgmentDiagnostics"/>，不在此追踪。
     /// </summary>
     public partial class InputAudioLatencyTracker : IDisposable
     {
@@ -32,7 +32,6 @@ namespace osu.Game.EzOsuGame.Audio
         private readonly INotificationOverlay? notificationOverlay;
         private readonly EzLatencyManager latencyManager;
 
-        private ScoreProcessor? scoreProcessor;
         private Bindable<bool>? inputAudioLatencyConfigBindable;
         private Action<ValueChangedEvent<bool>>? inputAudioLatencyConfigHandler;
         private Action<ValueChangedEvent<bool>>? enabledChangedHandler;
@@ -57,11 +56,11 @@ namespace osu.Game.EzOsuGame.Audio
             if (disposed)
                 return;
 
-            scoreProcessor = processor;
+            // processor kept for call-site compatibility (Player still passes ScoreProcessor).
+            _ = processor;
 
             if (initialized)
             {
-                // Re-entering a session: keep bindings, refresh stats and judgement subscription.
                 latencyManager.ClearStatistics();
                 reportGenerated = false;
                 pushAcousticThreshold();
@@ -91,30 +90,22 @@ namespace osu.Game.EzOsuGame.Audio
             latencyManager.OnNewRecord += measurementHandler;
 
             Logger.Log(
-                $"[EzOsuLatency] tracker armed (threshold={AcousticRmsThreshold:F4}, acousticProbe={(latencyManager.AcousticProbeRunning ? "on" : "off")})",
-                Ez2ConfigManager.LOGGER_NAME,
-                LogLevel.Debug);
+                $"[EzOsuLatency] audio tracker armed (In→Play→Acou; threshold={AcousticRmsThreshold:F4}, acousticProbe={(latencyManager.AcousticProbeRunning ? "on" : "off")})",
+                Ez2ConfigManager.LOGGER_NAME);
         }
 
         public void Start()
         {
-            if (disposed || started || scoreProcessor == null)
+            if (disposed || started)
                 return;
 
             started = true;
             pushAcousticThreshold();
-            scoreProcessor.NewJudgement += OnNewJudgement;
         }
 
         public void Stop()
         {
-            if (!started)
-                return;
-
             started = false;
-
-            if (scoreProcessor != null)
-                scoreProcessor.NewJudgement -= OnNewJudgement;
         }
 
         public void RecordKeyPress(Key key)
@@ -153,39 +144,46 @@ namespace osu.Game.EzOsuGame.Audio
 
             if (!stats.HasData)
             {
-                Logger.Log("[EzOsuLatency] session ended with no complete records", Ez2ConfigManager.LOGGER_NAME, LogLevel.Debug);
+                Logger.Log("[EzOsuLatency] session ended with no complete records", Ez2ConfigManager.LOGGER_NAME);
                 return;
             }
 
-            string acousticPart = stats.AcousticRecordCount > 0
-                ? $" | Acoustic(loopback) avg/min/max={stats.AvgAcousticRoundtrip:F2}/{stats.MinAcousticRoundtrip:F2}/{stats.MaxAcousticRoundtrip:F2}ms (n={stats.AcousticRecordCount})"
-                : string.Empty;
+            string playToAcouPart = string.Empty;
+            string acousticPart = string.Empty;
+
+            if (stats.AcousticRecordCount > 0)
+            {
+                // Approximate hop avg when both segments exist (per-hit Play→Acou is exact in onMeasurement).
+                double playToAcouAvg = stats.AvgAcousticRoundtrip - stats.AvgInputToPlayback;
+                acousticPart =
+                    $" | In→Acou avg/min/max={stats.AvgAcousticRoundtrip:F2}/{stats.MinAcousticRoundtrip:F2}/{stats.MaxAcousticRoundtrip:F2}ms (n={stats.AcousticRecordCount})";
+                playToAcouPart = $" | Play→Acou≈{playToAcouAvg:F2}ms (avg)";
+            }
 
             string summary =
                 $"[EzOsuLatency] n={stats.RecordCount}"
-                + $" | Input→Audio avg/min/max={stats.AvgInputToPlayback:F2}/{stats.MinInputToPlayback:F2}/{stats.MaxInputToPlayback:F2}ms"
-                + $" | Input→Judge avg/min/max={stats.AvgInputToJudge:F2}/{stats.MinInputToJudge:F2}/{stats.MaxInputToJudge:F2}ms"
-                + $" | Audio→Judge avg/min/max={stats.AvgPlaybackToJudge:F2}/{stats.MinPlaybackToJudge:F2}/{stats.MaxPlaybackToJudge:F2}ms"
+                + $" | In→Play avg/min/max={stats.AvgInputToPlayback:F2}/{stats.MinInputToPlayback:F2}/{stats.MaxInputToPlayback:F2}ms"
+                + playToAcouPart
                 + acousticPart;
 
-            Logger.Log(summary, Ez2ConfigManager.LOGGER_NAME, LogLevel.Debug);
+            Logger.Log(summary, Ez2ConfigManager.LOGGER_NAME);
 
             if (notificationOverlay == null)
             {
-                Logger.Log("[EzOsuLatency] summary ready but INotificationOverlay is null", Ez2ConfigManager.LOGGER_NAME, LogLevel.Debug);
+                Logger.Log("[EzOsuLatency] summary ready but INotificationOverlay is null", Ez2ConfigManager.LOGGER_NAME);
             }
             else
             {
                 string notificationText =
-                    $"Latency summary (n={stats.RecordCount})\n"
-                    + $"Input→Audio  avg {stats.AvgInputToPlayback:F1}  min {stats.MinInputToPlayback:F1}  max {stats.MaxInputToPlayback:F1} ms\n"
-                    + $"Input→Judge  avg {stats.AvgInputToJudge:F1}  min {stats.MinInputToJudge:F1}  max {stats.MaxInputToJudge:F1} ms\n"
-                    + $"Audio→Judge  avg {stats.AvgPlaybackToJudge:F1}  min {stats.MinPlaybackToJudge:F1}  max {stats.MaxPlaybackToJudge:F1} ms";
+                    $"Audio latency (n={stats.RecordCount})\n"
+                    + $"In→Play  avg {stats.AvgInputToPlayback:F1}  min {stats.MinInputToPlayback:F1}  max {stats.MaxInputToPlayback:F1} ms";
 
                 if (stats.AcousticRecordCount > 0)
                 {
+                    double playToAcouAvg = stats.AvgAcousticRoundtrip - stats.AvgInputToPlayback;
                     notificationText +=
-                        $"\nAcoustic(loopback)  avg {stats.AvgAcousticRoundtrip:F1}  min {stats.MinAcousticRoundtrip:F1}  max {stats.MaxAcousticRoundtrip:F1} ms"
+                        $"\nPlay→Acou  ≈ {playToAcouAvg:F1} ms (avg)"
+                        + $"\nIn→Acou  avg {stats.AvgAcousticRoundtrip:F1}  min {stats.MinAcousticRoundtrip:F1}  max {stats.MaxAcousticRoundtrip:F1} ms"
                         + $" (n={stats.AcousticRecordCount})";
                 }
 
@@ -201,35 +199,25 @@ namespace osu.Game.EzOsuGame.Audio
 
         private void pushAcousticThreshold() => latencyManager.SetAcousticThreshold(AcousticRmsThreshold);
 
+        private static string formatMs(double? ms) => ms.HasValue ? $"{ms.Value:F2}" : "n/a";
+
         private void onMeasurement(EzLatencyRecord record)
         {
-            double softMs = record.PlaybackTime > 0 && record.InputTime > 0
+            double? inToPlay = record.PlaybackTime > 0 && record.InputTime > 0
                 ? record.PlaybackTime - record.InputTime
-                : record.MeasuredMs;
+                : null;
 
-            string acoustic = record.Note == EzLatencyAnalyzer.NOTE_ACOUSTIC_LOOPBACK ||
-                              (record.LatencyDifference > 0 && record.HardwareData.IsValid)
-                ? $" acoustic={record.LatencyDifference:F2}ms"
-                : " acoustic=n/a";
+            bool hasAcou = record.Note == EzLatencyAnalyzer.NOTE_ACOUSTIC_LOOPBACK
+                           || (record.LatencyDifference > 0 && record.HardwareData.IsValid);
+
+            double? inToAcou = hasAcou ? record.LatencyDifference : null;
+            double? playToAcou = inToPlay.HasValue && inToAcou.HasValue
+                ? inToAcou.Value - inToPlay.Value
+                : null;
 
             Logger.Log(
-                $"[EzOsuLatency] soft={softMs:F2}ms{acoustic} note={record.Note ?? "?"} key={record.InputData.KeyValue}",
-                Ez2ConfigManager.LOGGER_NAME,
-                LogLevel.Debug);
-        }
-
-        private void OnNewJudgement(JudgementResult result)
-        {
-            if (!latencyManager.Enabled.Value || !result.Type.IsScorable())
-                return;
-
-            bool isNote = result.HitObject.GetType().Name.EndsWith("Note", StringComparison.Ordinal) ||
-                          result.HitObject.GetType().Name == "Fruit" ||
-                          result.HitObject.GetType().Name == "HitCircle" ||
-                          result.HitObject.GetType().Name == "Hit";
-
-            if (isNote)
-                latencyManager.RecordJudgeEvent();
+                $"[EzOsuLatency] key={record.InputData.KeyValue} | In→Play={formatMs(inToPlay)} | Play→Acou={formatMs(playToAcou)} | In→Acou={formatMs(inToAcou)}",
+                Ez2ConfigManager.LOGGER_NAME);
         }
 
         public void Dispose()
@@ -260,7 +248,7 @@ namespace osu.Game.EzOsuGame.Audio
             if (Instance == this)
                 Instance = null;
 
-            Logger.Log("[EzOsuLatency] tracker disposed; GLOBAL.Enabled=false", Ez2ConfigManager.LOGGER_NAME, LogLevel.Debug);
+            Logger.Log("[EzOsuLatency] tracker disposed; GLOBAL.Enabled=false", Ez2ConfigManager.LOGGER_NAME);
         }
     }
 }

--- a/osu.Game/EzOsuGame/Audio/InputAudioLatencyTracker.cs
+++ b/osu.Game/EzOsuGame/Audio/InputAudioLatencyTracker.cs
@@ -20,6 +20,14 @@ namespace osu.Game.EzOsuGame.Audio
     /// </summary>
     public partial class InputAudioLatencyTracker : IDisposable
     {
+        /// <summary>
+        /// Loopback RMS threshold (linear 0–1). Expression-bodied so IDE hot reload can tune without a settings entry.
+        /// <para></para>
+        /// 信号电平换算公式:
+        /// <code>20 * log10(0.02) ≈ -34 dBFS</code>
+        /// </summary>
+        public static float AcousticRmsThreshold => 0.02f;
+
         private readonly Ez2ConfigManager ezConfig;
         private readonly INotificationOverlay? notificationOverlay;
         private readonly EzLatencyManager latencyManager;
@@ -28,6 +36,7 @@ namespace osu.Game.EzOsuGame.Audio
         private Bindable<bool>? inputAudioLatencyConfigBindable;
         private Action<ValueChangedEvent<bool>>? inputAudioLatencyConfigHandler;
         private Action<ValueChangedEvent<bool>>? enabledChangedHandler;
+        private Action<EzLatencyRecord>? measurementHandler;
         private bool initialized;
         private bool started;
         private bool disposed;
@@ -55,6 +64,7 @@ namespace osu.Game.EzOsuGame.Audio
                 // Re-entering a session: keep bindings, refresh stats and judgement subscription.
                 latencyManager.ClearStatistics();
                 reportGenerated = false;
+                pushAcousticThreshold();
                 if (latencyManager.Enabled.Value)
                     Start();
                 return;
@@ -77,7 +87,13 @@ namespace osu.Game.EzOsuGame.Audio
             };
             latencyManager.Enabled.BindValueChanged(enabledChangedHandler, true);
 
-            Logger.Log("[EzOsuLatency] tracker armed for gameplay session", Ez2ConfigManager.LOGGER_NAME, LogLevel.Debug);
+            measurementHandler = onMeasurement;
+            latencyManager.OnNewRecord += measurementHandler;
+
+            Logger.Log(
+                $"[EzOsuLatency] tracker armed (threshold={AcousticRmsThreshold:F4}, acousticProbe={(latencyManager.AcousticProbeRunning ? "on" : "off")})",
+                Ez2ConfigManager.LOGGER_NAME,
+                LogLevel.Debug);
         }
 
         public void Start()
@@ -86,6 +102,7 @@ namespace osu.Game.EzOsuGame.Audio
                 return;
 
             started = true;
+            pushAcousticThreshold();
             scoreProcessor.NewJudgement += OnNewJudgement;
         }
 
@@ -102,8 +119,11 @@ namespace osu.Game.EzOsuGame.Audio
 
         public void RecordKeyPress(Key key)
         {
-            if (latencyManager.Enabled.Value)
-                latencyManager.RecordInputEvent(key);
+            if (!latencyManager.Enabled.Value)
+                return;
+
+            pushAcousticThreshold();
+            latencyManager.RecordInputEvent(key);
         }
 
         /// <summary>
@@ -111,8 +131,11 @@ namespace osu.Game.EzOsuGame.Audio
         /// </summary>
         public void RecordColumnPress(int column)
         {
-            if (latencyManager.Enabled.Value)
-                latencyManager.RecordInputEvent(column);
+            if (!latencyManager.Enabled.Value)
+                return;
+
+            pushAcousticThreshold();
+            latencyManager.RecordInputEvent(column);
         }
 
         /// <summary>
@@ -134,15 +157,18 @@ namespace osu.Game.EzOsuGame.Audio
                 return;
             }
 
+            string acousticPart = stats.AcousticRecordCount > 0
+                ? $" | Acoustic(loopback) avg/min/max={stats.AvgAcousticRoundtrip:F2}/{stats.MinAcousticRoundtrip:F2}/{stats.MaxAcousticRoundtrip:F2}ms (n={stats.AcousticRecordCount})"
+                : string.Empty;
+
             string summary =
                 $"[EzOsuLatency] n={stats.RecordCount}"
                 + $" | Input→Audio avg/min/max={stats.AvgInputToPlayback:F2}/{stats.MinInputToPlayback:F2}/{stats.MaxInputToPlayback:F2}ms"
                 + $" | Input→Judge avg/min/max={stats.AvgInputToJudge:F2}/{stats.MinInputToJudge:F2}/{stats.MaxInputToJudge:F2}ms"
-                + $" | Audio→Judge avg/min/max={stats.AvgPlaybackToJudge:F2}/{stats.MinPlaybackToJudge:F2}/{stats.MaxPlaybackToJudge:F2}ms";
+                + $" | Audio→Judge avg/min/max={stats.AvgPlaybackToJudge:F2}/{stats.MinPlaybackToJudge:F2}/{stats.MaxPlaybackToJudge:F2}ms"
+                + acousticPart;
 
             Logger.Log(summary, Ez2ConfigManager.LOGGER_NAME, LogLevel.Debug);
-            // Also mirror to runtime so the summary is easy to find without filtering Ez logger.
-            Logger.Log(summary, LoggingTarget.Runtime, LogLevel.Debug);
 
             if (notificationOverlay == null)
             {
@@ -150,18 +176,46 @@ namespace osu.Game.EzOsuGame.Audio
             }
             else
             {
+                string notificationText =
+                    $"Latency summary (n={stats.RecordCount})\n"
+                    + $"Input→Audio  avg {stats.AvgInputToPlayback:F1}  min {stats.MinInputToPlayback:F1}  max {stats.MaxInputToPlayback:F1} ms\n"
+                    + $"Input→Judge  avg {stats.AvgInputToJudge:F1}  min {stats.MinInputToJudge:F1}  max {stats.MaxInputToJudge:F1} ms\n"
+                    + $"Audio→Judge  avg {stats.AvgPlaybackToJudge:F1}  min {stats.MinPlaybackToJudge:F1}  max {stats.MaxPlaybackToJudge:F1} ms";
+
+                if (stats.AcousticRecordCount > 0)
+                {
+                    notificationText +=
+                        $"\nAcoustic(loopback)  avg {stats.AvgAcousticRoundtrip:F1}  min {stats.MinAcousticRoundtrip:F1}  max {stats.MaxAcousticRoundtrip:F1} ms"
+                        + $" (n={stats.AcousticRecordCount})";
+                }
+
                 notificationOverlay.Post(new SimpleNotification
                 {
-                    Text =
-                        $"Latency summary (n={stats.RecordCount})\n"
-                        + $"Input→Audio  avg {stats.AvgInputToPlayback:F1}  min {stats.MinInputToPlayback:F1}  max {stats.MaxInputToPlayback:F1} ms\n"
-                        + $"Input→Judge  avg {stats.AvgInputToJudge:F1}  min {stats.MinInputToJudge:F1}  max {stats.MaxInputToJudge:F1} ms\n"
-                        + $"Audio→Judge  avg {stats.AvgPlaybackToJudge:F1}  min {stats.MinPlaybackToJudge:F1}  max {stats.MaxPlaybackToJudge:F1} ms",
+                    Text = notificationText,
                     Icon = FontAwesome.Solid.ChartLine,
                 });
             }
 
             latencyManager.ClearStatistics();
+        }
+
+        private void pushAcousticThreshold() => latencyManager.SetAcousticThreshold(AcousticRmsThreshold);
+
+        private void onMeasurement(EzLatencyRecord record)
+        {
+            double softMs = record.PlaybackTime > 0 && record.InputTime > 0
+                ? record.PlaybackTime - record.InputTime
+                : record.MeasuredMs;
+
+            string acoustic = record.Note == EzLatencyAnalyzer.NOTE_ACOUSTIC_LOOPBACK ||
+                              (record.LatencyDifference > 0 && record.HardwareData.IsValid)
+                ? $" acoustic={record.LatencyDifference:F2}ms"
+                : " acoustic=n/a";
+
+            Logger.Log(
+                $"[EzOsuLatency] soft={softMs:F2}ms{acoustic} note={record.Note ?? "?"} key={record.InputData.KeyValue}",
+                Ez2ConfigManager.LOGGER_NAME,
+                LogLevel.Debug);
         }
 
         private void OnNewJudgement(JudgementResult result)
@@ -195,6 +249,9 @@ namespace osu.Game.EzOsuGame.Audio
 
             if (inputAudioLatencyConfigBindable != null && inputAudioLatencyConfigHandler != null)
                 inputAudioLatencyConfigBindable.ValueChanged -= inputAudioLatencyConfigHandler;
+
+            if (measurementHandler != null)
+                latencyManager.OnNewRecord -= measurementHandler;
 
             // Critical: do not leave GLOBAL.Enabled true after leaving gameplay.
             latencyManager.Enabled.Value = false;

--- a/osu.Game/EzOsuGame/Audio/InputAudioLatencyTracker.cs
+++ b/osu.Game/EzOsuGame/Audio/InputAudioLatencyTracker.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Threading.Tasks;
 using osu.Framework.Audio.EzLatency;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
@@ -15,7 +16,7 @@ using osuTK.Input;
 namespace osu.Game.EzOsuGame.Audio
 {
     /// <summary>
-    /// 音频闭环延迟桥：游戏输入戳 → <c>Sample.Play</c> → WASAPI loopback。
+    /// 音频闭环延迟桥：游戏输入戳 → <c>Sample.Play</c> → WASAPI loopback（仅 NAudio Default）。
     /// 判定耗时（In→Judge）归 <see cref="Diagnostics.EzJudgmentDiagnostics"/>，不在此追踪。
     /// </summary>
     public partial class InputAudioLatencyTracker : IDisposable
@@ -91,7 +92,8 @@ namespace osu.Game.EzOsuGame.Audio
 
             Logger.Log(
                 $"[EzOsuLatency] audio tracker armed (In→Play→Acou; threshold={AcousticRmsThreshold:F4}, acousticProbe={(latencyManager.AcousticProbeRunning ? "on" : "off")})",
-                Ez2ConfigManager.LOGGER_NAME);
+                Ez2ConfigManager.LOGGER_NAME,
+                LogLevel.Debug);
         }
 
         public void Start()
@@ -130,9 +132,11 @@ namespace osu.Game.EzOsuGame.Audio
         }
 
         /// <summary>
-        /// Emit session summary (log + notification). Safe to call from results or exit; only runs once per session.
+        /// Emit session summary. Always writes ez_runtime log on exit.
+        /// Toast is only for a completed play (<paramref name="postNotification"/>), deferred so
+        /// <c>InGameFocus</c> can show a toast after leaving <c>Player</c>.
         /// </summary>
-        public void GenerateLatencyReport()
+        public void GenerateLatencyReport(bool postNotification = false)
         {
             if (disposed || reportGenerated)
                 return;
@@ -144,7 +148,12 @@ namespace osu.Game.EzOsuGame.Audio
 
             if (!stats.HasData)
             {
-                Logger.Log("[EzOsuLatency] session ended with no complete records", Ez2ConfigManager.LOGGER_NAME);
+                Logger.Log("[EzOsuLatency] session ended with no complete records", Ez2ConfigManager.LOGGER_NAME, LogLevel.Debug);
+
+                if (postNotification)
+                    postSummaryNotification("Audio latency: no complete samples this play.");
+
+                latencyManager.ClearStatistics();
                 return;
             }
 
@@ -153,7 +162,6 @@ namespace osu.Game.EzOsuGame.Audio
 
             if (stats.AcousticRecordCount > 0)
             {
-                // Approximate hop avg when both segments exist (per-hit Play→Acou is exact in onMeasurement).
                 double playToAcouAvg = stats.AvgAcousticRoundtrip - stats.AvgInputToPlayback;
                 acousticPart =
                     $" | In→Acou avg/min/max={stats.AvgAcousticRoundtrip:F2}/{stats.MinAcousticRoundtrip:F2}/{stats.MaxAcousticRoundtrip:F2}ms (n={stats.AcousticRecordCount})";
@@ -166,13 +174,9 @@ namespace osu.Game.EzOsuGame.Audio
                 + playToAcouPart
                 + acousticPart;
 
-            Logger.Log(summary, Ez2ConfigManager.LOGGER_NAME);
+            Logger.Log(summary, Ez2ConfigManager.LOGGER_NAME, LogLevel.Debug);
 
-            if (notificationOverlay == null)
-            {
-                Logger.Log("[EzOsuLatency] summary ready but INotificationOverlay is null", Ez2ConfigManager.LOGGER_NAME);
-            }
-            else
+            if (postNotification)
             {
                 string notificationText =
                     $"Audio latency (n={stats.RecordCount})\n"
@@ -187,14 +191,40 @@ namespace osu.Game.EzOsuGame.Audio
                         + $" (n={stats.AcousticRecordCount})";
                 }
 
-                notificationOverlay.Post(new SimpleNotification
-                {
-                    Text = notificationText,
-                    Icon = FontAwesome.Solid.ChartLine,
-                });
+                postSummaryNotification(notificationText);
             }
 
             latencyManager.ClearStatistics();
+        }
+
+        private void postSummaryNotification(string text)
+        {
+            if (notificationOverlay == null)
+            {
+                Logger.Log("[EzOsuLatency] summary ready but INotificationOverlay is null", Ez2ConfigManager.LOGGER_NAME, LogLevel.Debug);
+                return;
+            }
+
+            var overlay = notificationOverlay;
+            var notification = new SimpleNotification
+            {
+                Text = text,
+                Icon = FontAwesome.Solid.ChartLine,
+            };
+
+            // Defer past Player/PlayerLoader so InGameFocus allows toast + sound.
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await Task.Delay(300).ConfigureAwait(false);
+                    overlay.Post(notification);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Log($"[EzOsuLatency] deferred notification failed: {ex.Message}", Ez2ConfigManager.LOGGER_NAME, LogLevel.Debug);
+                }
+            });
         }
 
         private void pushAcousticThreshold() => latencyManager.SetAcousticThreshold(AcousticRmsThreshold);
@@ -217,7 +247,8 @@ namespace osu.Game.EzOsuGame.Audio
 
             Logger.Log(
                 $"[EzOsuLatency] key={record.InputData.KeyValue} | In→Play={formatMs(inToPlay)} | Play→Acou={formatMs(playToAcou)} | In→Acou={formatMs(inToAcou)}",
-                Ez2ConfigManager.LOGGER_NAME);
+                Ez2ConfigManager.LOGGER_NAME,
+                LogLevel.Debug);
         }
 
         public void Dispose()
@@ -225,9 +256,9 @@ namespace osu.Game.EzOsuGame.Audio
             if (disposed)
                 return;
 
-            // Last chance if results/exit hooks were skipped (e.g. abrupt teardown).
+            // Exit/teardown: log only, never toast.
             if (!reportGenerated)
-                GenerateLatencyReport();
+                GenerateLatencyReport(postNotification: false);
 
             disposed = true;
             Stop();
@@ -248,7 +279,7 @@ namespace osu.Game.EzOsuGame.Audio
             if (Instance == this)
                 Instance = null;
 
-            Logger.Log("[EzOsuLatency] tracker disposed; GLOBAL.Enabled=false", Ez2ConfigManager.LOGGER_NAME);
+            Logger.Log("[EzOsuLatency] tracker disposed; GLOBAL.Enabled=false", Ez2ConfigManager.LOGGER_NAME, LogLevel.Debug);
         }
     }
 }

--- a/osu.Game/EzOsuGame/Diagnostics/EzJudgmentDiagnostics.cs
+++ b/osu.Game/EzOsuGame/Diagnostics/EzJudgmentDiagnostics.cs
@@ -13,8 +13,8 @@ using osu.Framework.Logging;
 namespace osu.Game.EzOsuGame.Diagnostics
 {
     /// <summary>
-    /// 采集 mania 判定时序数据，用于分析"前-后-前-后"交替漂移问题。
-    /// 线程安全、低开销。仅在 DEBUG 构建中启用文件写出。
+    /// 判定诊断：时钟漂移 CSV，并含按键→判定检查耗时（InputToJudgeMs）。
+    /// 音频闭环（In→Play→Acou）见 <c>InputAudioLatencyTracker</c>，不在此采集。
     /// </summary>
     public static class EzJudgmentDiagnostics
     {
@@ -39,11 +39,14 @@ namespace osu.Game.EzOsuGame.Diagnostics
             double InterpolatedClockTime,
             double BassSourceTime,
             double InterpolatedDrift,
-            double FrameElapsed);
+            double FrameElapsed,
+            /// <summary>按键 wall 戳到本条判定检查的耗时（ms）；无有效按键戳时为 NaN。</summary>
+            double InputToJudgeMs);
 
         /// <summary>
         /// 记录一次判定的完整时序上下文。
         /// </summary>
+        /// <param name="inputToJudgeMs">按键 → 本检查点的 wall 耗时（ms）；未知传 <see cref="double.NaN"/>。</param>
         public static void Record(
             double gameTime,
             double noteStartTime,
@@ -51,7 +54,8 @@ namespace osu.Game.EzOsuGame.Diagnostics
             double interpClockTime,
             double bassSourceTime,
             double interpDrift,
-            double frameElapsed)
+            double frameElapsed,
+            double inputToJudgeMs = double.NaN)
         {
             if (!Enabled) return;
             if (samples.Count >= max_samples) return;
@@ -64,7 +68,8 @@ namespace osu.Game.EzOsuGame.Diagnostics
                 interpClockTime,
                 bassSourceTime,
                 interpDrift,
-                frameElapsed));
+                frameElapsed,
+                inputToJudgeMs));
         }
 
         /// <summary>
@@ -73,7 +78,7 @@ namespace osu.Game.EzOsuGame.Diagnostics
         public static string Flush()
         {
             var sb = new StringBuilder();
-            sb.AppendLine("WallMs,GameTime,NoteStart,TimeOffset,InterpClock,BassSource,Drift,FrameElapsed");
+            sb.AppendLine("WallMs,GameTime,NoteStart,TimeOffset,InterpClock,BassSource,Drift,FrameElapsed,InputToJudgeMs");
 
             // Drain current queue snapshot into the CSV builder.
             while (samples.TryDequeue(out var s))
@@ -85,7 +90,8 @@ namespace osu.Game.EzOsuGame.Diagnostics
                 sb.Append(s.InterpolatedClockTime.ToString("F3")).Append(',');
                 sb.Append(s.BassSourceTime.ToString("F3")).Append(',');
                 sb.Append(s.InterpolatedDrift.ToString("F3")).Append(',');
-                sb.Append(s.FrameElapsed.ToString("F3"));
+                sb.Append(s.FrameElapsed.ToString("F3")).Append(',');
+                sb.Append(double.IsNaN(s.InputToJudgeMs) ? string.Empty : s.InputToJudgeMs.ToString("F3"));
                 sb.AppendLine();
             }
 

--- a/osu.Game/EzOsuGame/Overlays/EzExperimentalSettings.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzExperimentalSettings.cs
@@ -395,9 +395,10 @@ namespace osu.Game.EzOsuGame.Overlays
             "启用 Ez 判定诊断", "Enable Ez Judgment Diagnostics");
 
         internal static readonly LocalisableString EZ_JUDGMENT_DIAG_ENABLED_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
-            "(研究功能)在游戏结束后，输出本局判定信息到.csv文件。"
+            "(研究功能)在游戏结束后，输出本局判定信息到.csv文件（含时钟漂移与 InputToJudgeMs：按键→判定检查耗时）。"
             + "\n默认输出路径：桌面/EzDiag/",
-            "(Testing feature) Output judgment information to a .csv file after the game ends."
+            "(Testing feature) Output judgment diagnostics to a .csv after the game ends "
+            + "(clock drift columns + InputToJudgeMs: key → judgment-check latency)."
             + "\nDefault output path: Desktop/EzDiag/");
 
         internal static readonly LocalisableString EZ_TIMING_TRACE_ENABLED = new EzLocalizationManager.EzLocalisableString(
@@ -415,13 +416,14 @@ namespace osu.Game.EzOsuGame.Overlays
             "输入音频延迟追踪器", "Input Audio Latency Tracker");
 
         internal static readonly LocalisableString INPUT_AUDIO_LATENCY_TRACKER_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
-            "(测试功能)启用后可追踪按键输入与音频的延迟, 用于调试和优化打击音效的同步性。在游戏结束后会弹出一个统计窗口。更详细的内容可以查看runtime.log文件。"
-            + "\n软件段：按键 → Sample.Play()；声学段：对当前输出设备做 WASAPI Loopback，电平过阈值视为听到点（非麦克风）。"
-            + "\n阈值：改 InputAudioLatencyTracker.AcousticRmsThreshold（=> 表达式，可热重载）。",
-            "(Testing feature) When enabled, it can track the latency between key input and audio, used for debugging and optimizing the synchronization of hit sound effects. "
-            + "A statistics window will pop up after the game ends. More detailed information can be found in the runtime.log file."
-            + "\nSoftware: key → Sample.Play(); Acoustic: WASAPI loopback of the current output device (level threshold = heard point; not a microphone)."
-            + "\nThreshold: edit InputAudioLatencyTracker.AcousticRmsThreshold (expression-bodied; hot-reloadable).");
+            "(测试功能)追踪按键→Sample.Play→WASAPI Loopback 的音频闭环延迟（不含判定）。局末弹统计；明细见 ez_runtime。"
+            + "\nIn→Play：软件段；Play→Acou / In→Acou：当前输出 loopback 过阈值（非麦克风）。"
+            + "\n判定耗时请开「Ez 判定诊断」CSV。阈值：改 AcousticRmsThreshold（可热重载）。",
+            "(Testing feature) Tracks key → Sample.Play → WASAPI loopback audio latency (not judgment). "
+            + "Summary after play; details in ez_runtime."
+            + "\nIn→Play: software; Play→Acou / In→Acou: current-output loopback threshold (not a mic)."
+            + "\nFor key→judgment latency, enable Ez Judgment Diagnostics CSV. "
+            + "Threshold: edit AcousticRmsThreshold (hot-reloadable).");
 
         internal static readonly LocalisableString EZ_SCORE_RACE_SERVICE_ENABLED = new EzLocalizationManager.EzLocalisableString(
             "启用角逐/时间线全局服务", "Enable Score Race / Timeline Global Service");

--- a/osu.Game/EzOsuGame/Overlays/EzExperimentalSettings.cs
+++ b/osu.Game/EzOsuGame/Overlays/EzExperimentalSettings.cs
@@ -416,10 +416,12 @@ namespace osu.Game.EzOsuGame.Overlays
 
         internal static readonly LocalisableString INPUT_AUDIO_LATENCY_TRACKER_TOOLTIP = new EzLocalizationManager.EzLocalisableString(
             "(测试功能)启用后可追踪按键输入与音频的延迟, 用于调试和优化打击音效的同步性。在游戏结束后会弹出一个统计窗口。更详细的内容可以查看runtime.log文件。"
-            + "\n延迟检测管线：按键 → 检查打击并应用 → 应用判定结果 → 播放note音频",
+            + "\n软件段：按键 → Sample.Play()；声学段：对当前输出设备做 WASAPI Loopback，电平过阈值视为听到点（非麦克风）。"
+            + "\n阈值：改 InputAudioLatencyTracker.AcousticRmsThreshold（=> 表达式，可热重载）。",
             "(Testing feature) When enabled, it can track the latency between key input and audio, used for debugging and optimizing the synchronization of hit sound effects. "
             + "A statistics window will pop up after the game ends. More detailed information can be found in the runtime.log file."
-            + "\nLatency detection pipeline: Key Press → Check Hit and Apply → Apply Hit Result → Play Note Audio");
+            + "\nSoftware: key → Sample.Play(); Acoustic: WASAPI loopback of the current output device (level threshold = heard point; not a microphone)."
+            + "\nThreshold: edit InputAudioLatencyTracker.AcousticRmsThreshold (expression-bodied; hot-reloadable).");
 
         internal static readonly LocalisableString EZ_SCORE_RACE_SERVICE_ENABLED = new EzLocalizationManager.EzLocalisableString(
             "启用角逐/时间线全局服务", "Enable Score Race / Timeline Global Service");

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -897,9 +897,11 @@ namespace osu.Game.Rulesets.Objects.Drawables
 
             // [Ez] 子帧时间修正：使用上一帧的时钟值进行判断后进行补偿。
             // 按键在上一次 FSC 时钟更新和现在之间被按下；插值到实际按键时间。
+            long keyTs = 0;
+
             if (userTriggered)
             {
-                long keyTs = InputManager.EzSubFrameTimestamp;
+                keyTs = InputManager.EzSubFrameTimestamp;
                 double rate = (Clock as IGameplayClock)?.Rate ?? 1.0;
                 timeOffset += EzSubFrameCorrection.GetCorrectionMs(keyTs, rate);
             }
@@ -916,6 +918,17 @@ namespace osu.Game.Rulesets.Objects.Drawables
                     bassSource = gcc.BassSourceCurrentTime;
                 }
 
+                double inputToJudgeMs = double.NaN;
+
+                if (keyTs > 0)
+                {
+                    inputToJudgeMs = (Stopwatch.GetTimestamp() - keyTs) / (double)Stopwatch.Frequency * 1000.0;
+
+                    // Sanity: ignore absurd gaps (stale key stamp / unrelated press).
+                    if (inputToJudgeMs < 0 || inputToJudgeMs > 1000)
+                        inputToJudgeMs = double.NaN;
+                }
+
                 EzJudgmentDiagnostics.Record(
                     Time.Current,
                     HitObject.GetEndTime(),
@@ -923,7 +936,8 @@ namespace osu.Game.Rulesets.Objects.Drawables
                     Time.Current, // interpClockTime = FSC ManualClock time
                     bassSource,
                     interpDrift,
-                    frameElapsed);
+                    frameElapsed,
+                    inputToJudgeMs);
             }
 
             CheckForResult(userTriggered, timeOffset);

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -1144,7 +1144,7 @@ namespace osu.Game.Screens.Play
                 if (EzQuickRotationCoordinator.Session.IsActive)
                 {
                     EzOsuGame.Diagnostics.EzTimingTrace.Record("ResultsDelegate.QuickRotation", "Navigating to quick rotation flow");
-                    LatencyTracker?.GenerateLatencyReport();
+                    LatencyTracker?.GenerateLatencyReport(postNotification: true);
                     (GameplayClockContainer as MasterGameplayClockContainer)?.StopUsingBeatmapClock();
 
                     if (Beatmap.Value.TrackLoaded)
@@ -1159,13 +1159,13 @@ namespace osu.Game.Screens.Play
                 if (EzFlowMode.ShouldSkipResults(this))
                 {
                     EzOsuGame.Diagnostics.EzTimingTrace.Record("ResultsDelegate.FlowMode", "Skipping results screen – returning to song select");
-                    LatencyTracker?.GenerateLatencyReport();
+                    LatencyTracker?.GenerateLatencyReport(postNotification: true);
                     EzFlowMode.ReturnToSongSelect(game as OsuGame);
                     return;
                 }
 
                 EzOsuGame.Diagnostics.EzTimingTrace.Record("ResultsDelegate.Push", "Navigating to results screen");
-                LatencyTracker?.GenerateLatencyReport();
+                LatencyTracker?.GenerateLatencyReport(postNotification: true);
                 OnShowingResults?.Invoke();
                 this.Push(CreateResults(prepareScoreForDisplayTask.GetResultSafely()));
             }, Time.Current + delay, 50);

--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -335,8 +335,8 @@ namespace osu.Game.Screens.Play
 
             statics.SetValue(Static.LastLocalUserScore, Score?.ScoreInfo.DeepClone());
 
-            // 生成延迟报告
-            LatencyTracker?.GenerateLatencyReport();
+            // 退出：只打日志，不推送（打完一局的 toast 在 Results/抽卡/心流路径）
+            LatencyTracker?.GenerateLatencyReport(postNotification: false);
 
             return exiting;
         }


### PR DESCRIPTION
## Summary
- Reuse existing Input Audio Latency Tracker switch (no new master toggle).
- Report Acoustic(loopback) separately from software Input→Audio; per-hit Debug lines and session summary go to `ez_runtime`.
- Tune RMS via hot-reloadable `InputAudioLatencyTracker.AcousticRmsThreshold` (no settings slider).
- Depends on framework PR: https://github.com/SK-la/ez2lazer-framework/pull/18 (local ProjectReference / package bump as needed).

## Test plan
- [ ] Build with framework PR #18 (or local osu-framework ProjectReference)
- [ ] Enable tracker, play with hitsounds; check `ez_runtime.log` for soft/acoustic lines and end summary
- [ ] Confirm acousticProbe=on on Windows; switching output rebinds loopback
- [ ] User-side: mute BGM when measuring hitsound-only acoustic RT (not a code feature)
